### PR TITLE
Move some declarations from the core to the modules

### DIFF
--- a/core/declarations.gms
+++ b/core/declarations.gms
@@ -261,9 +261,7 @@ vm_emiFgas(tall,all_regi,all_enty)                   "F-gas emissions by single 
 positive variables
 ***----------------------------------------------------------------------------------------
 ***-------------------------------------------------MACRO module---------------------------
-vm_effGr(ttot,all_regi,all_in)                       "growth of factor efficiency"
 vm_enerSerAdj(tall,all_regi,all_in)                  "adjustment costs for energy service transformations"
-vm_damageFactor(ttot,all_regi)                       "damage factor reducing GDP"
 vm_esCapInv(ttot,all_regi,all_teEs)                   "investment for energy end-use capital at the energy service level"
 ***----------------------------------------------------------------------------------------
 *-----------------------------------------------ESM module---------------------------------

--- a/modules/20_growth/exogenous/declarations.gms
+++ b/modules/20_growth/exogenous/declarations.gms
@@ -4,13 +4,8 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/50_damages/BurkeLike/declarations.gms
-parameters
-p50_damageFuncCoef1     "coef1 of damamge function",
-p50_damageFuncCoef2     "coef2 of damamge function"
+*** SOF ./modules/20_growth/exogenous/declarations.gms
+positive variables
+vm_effGr(ttot,all_regi,all_in)            "growth of factor efficiency"
 ;
-
-positive variable
-vm_damageFactor(ttot,all_regi)      "damage factor reducing GDP"
-;
-*** EOF ./modules/50_damages/BurkeLike/declarations.gms
+*** EOF ./modules/20_growth/exogenous/declarations.gms

--- a/modules/20_growth/spillover/declarations.gms
+++ b/modules/20_growth/spillover/declarations.gms
@@ -24,6 +24,7 @@ Parameters
 
 *mlb*  vm_invInno and  vm_invImi and pm_cumEff shifted to the core folder
 Positive variables
+ vm_effGr(ttot,all_regi,all_in)            "growth of factor efficiency"
  v20_effInno(ttot,all_regi,all_in)         "efficiency improvement by innovation"
  v20_effImi(ttot,all_regi,all_in)          "efficiency improvement by imitation"
 ;

--- a/modules/50_damages/DiceLike/declarations.gms
+++ b/modules/50_damages/DiceLike/declarations.gms
@@ -4,7 +4,13 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/50_damages/DiceLike/declarations.gms
 parameters
 p50_damageFuncCoef1			"damage function coefficient, linear in temperature"
 p50_damageFuncCoef2 			"damage function coefficient, quadratic in temperture"
 ;
+
+positive variable
+vm_damageFactor(ttot,all_regi)      "damage factor reducing GDP"
+;
+*** EOF ./modules/50_damages/DiceLike/declarations.gms

--- a/modules/50_damages/off/declarations.gms
+++ b/modules/50_damages/off/declarations.gms
@@ -4,13 +4,8 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/50_damages/BurkeLike/declarations.gms
-parameters
-p50_damageFuncCoef1     "coef1 of damamge function",
-p50_damageFuncCoef2     "coef2 of damamge function"
-;
-
+*** SOF ./modules/50_damages/off/declarations.gms
 positive variable
 vm_damageFactor(ttot,all_regi)      "damage factor reducing GDP"
 ;
-*** EOF ./modules/50_damages/BurkeLike/declarations.gms
+*** EOF ./modules/50_damages/off/declarations.gms


### PR DESCRIPTION
Is it ok if vm_effGr and vm_damageFactor are declared in the modules 20_growth and 50_damages, respectively, instead of in the core?