### PR TITLE
fix calculation of industry CO2/CCS emissions

### DIFF
--- a/core/equations.gms
+++ b/core/equations.gms
@@ -172,10 +172,11 @@ $endif
 ***---------------------------------------------------------------------------
 *' Transformation from secondary to final energy:
 ***---------------------------------------------------------------------------
-q_transSe2fe(t,regi,se2fe(enty,enty2,te))..
-         pm_eta_conv(t,regi,te) * vm_demSe(t,regi,enty,enty2,te)
-         =e=
-         vm_prodFe(t,regi,enty,enty2,te) 
+q_transSe2fe(t,regi,se2fe(entySE,entyFE,te)) .. 
+    pm_eta_conv(t,regi,te)
+  * vm_demSE(t,regi,entySE,entyFE,te)
+  =e=
+  vm_prodFE(t,regi,entySE,entyFE,te) 
 ;
 
 
@@ -506,34 +507,35 @@ q_emiTeDetail(t,regi,enty,enty2,te,enty3)$(   emi2te(enty,enty2,te,enty3)
 *' Total energy-emissions:
 ***--------------------------------------------------
 *mh calculate total energy system emissions for each region and timestep:
-q_emiTe(t,regi,emiTe(enty))..
+q_emiTe(t,regi,emiTe(enty)) .. 
   vm_emiTe(t,regi,enty)
   =e=
-***   emissions from fuel combustion
+    !! emissions from fuel combustion
     sum(emi2te(enty2,enty3,te,enty),     
       vm_emiTeDetail(t,regi,enty2,enty3,te,enty)
     )
-***   emissions from non-conventional fuel extraction
+    !! emissions from non-conventional fuel extraction
   + sum(emi2fuelMine(enty,enty2,rlf),       
       p_cint(regi,enty,enty2,rlf)
     * vm_fuExtr(t,regi,enty2,rlf)
     )$( c_cint_scen eq 1 )
-***   emissions from conventional fuel extraction
-  + sum(pe2rlf(enty3,rlf2),sum(enty2,       
-     (p_cintraw(enty2)
-      * pm_fuExtrOwnCons(regi, enty2, enty3) 
-      * vm_fuExtr(t,regi,enty3,rlf2)
-     )$(pm_fuExtrOwnCons(regi, enty, enty2) gt 0)    
-    ))
-***   Industry CCS emissions
+    !! emissions from conventional fuel extraction
+  + sum((pe2rlf(enty3,rlf2),enty2)$( pm_fuExtrOwnCons(regi,enty,enty2) gt 0 ),
+      p_cintraw(enty2)
+    * pm_fuExtrOwnCons(regi,enty2,enty3) 
+    * vm_fuExtr(t,regi,enty3,rlf2)
+    )
+    !! Industry CCS emissions
   - sum(emiMac2mac(emiInd37_fuel,enty2),
       vm_emiIndCCS(t,regi,emiInd37_fuel)
     )$( sameas(enty,"co2") )
-	
-***   LP, Valve from cco2 capture step, to mangage if capture capacity and CCU/CCS capacity don't have the same lifetime
+    !! Valve from cco2 capture step, to mangage if capture capacity and CCU/CCS 
+    !! capacity don't have the same lifetime
   + v_co2capturevalve(t,regi)$( sameas(enty,"co2") )
-***  JS CO2 from short-term CCU
-  + sum(teCCU2rlf(te2,rlf), vm_co2CCUshort(t,regi,"cco2","ccuco2short",te2,rlf) )
+    !! CO2 from short-term CCU
+  + sum(teCCU2rlf(te2,rlf), 
+      vm_co2CCUshort(t,regi,"cco2","ccuco2short",te2,rlf)
+    )
 ;
 
 ***------------------------------------------------------

--- a/core/sets.gms
+++ b/core/sets.gms
@@ -1939,23 +1939,16 @@ steps         "iterator for MAC steps"
 ***                             Helpful constructs: alias
 ***-----------------------------------------------------------------------------
 ***-----------------------------------------------------------------------------
-alias(t,t2);
-alias(t,t3);
-alias(tall,tall2);
-alias(tall,tall3);
+alias(t,t2,t3);
+alias(tall,tall2,tall3);
 alias(ttot,ttot2);
 alias(opTimeYr,opTimeYr2);
 alias(teVRE,teVRE2);
 alias(teLoc,teLoc2);
 alias(all_te,all_te2);
-alias(te,te2);
+alias(te,te2,te3);
 alias(all_enty,all_enty2);
-alias(enty,enty2);
-alias(enty,enty3);
-alias(enty,enty4);
-alias(enty,enty5);
-alias(enty,enty6);
-alias(enty,enty7);
+alias(enty,enty2,enty3,enty4,enty5,enty6,enty7);
 alias(entyPE,entyPE2);
 alias(entySe,entySe2);
 alias(entyFe,entyFe2);
@@ -2522,5 +2515,6 @@ es2ppfen(all_esty,all_in)      "matching ES in ESM to ppfEn in MACRO"
 
 alias(ccs2te,ccs2te2);
 alias(pe2se,pe2se2);
+alias(se2fe,se2fe2);
 
 *** EOF ./core/sets.gms

--- a/modules/37_industry/fixed_shares/postsolve.gms
+++ b/modules/37_industry/fixed_shares/postsolve.gms
@@ -17,6 +17,12 @@ loop (enty$( sameas(enty,"co2") OR sameas(enty,"cco2") ),
           * p37_shIndFE(regi,in,secInd37)
           )
         * p37_fctEmi(entyFE)
+        !! share of SE in FE production
+        * ( vm_prodFE.l(ttot,regi,entySE,entyFE,te2)
+          / sum(se2fe2(entySE2,entyFE,te3),
+              vm_prodSE.l(ttot,regi,entySE2,entyFE,te3)
+            )
+          )
         )
         !! share of PE in SE production
       * ( vm_prodSE.l(ttot,regi,entyPE,entySE,te)


### PR DESCRIPTION
- splitting `sety` into fossil and biomass components [db8b039](https://gitlab.pik-potsdam.de/REMIND/REMIND/commit/db8b039d20d34bdd182320d4e712d03491871118) broke the calculation of `o37_emiInd` which was based on a one-to-one mapping of `sety` to `fety`
- keeping track of the share of `sety` in `fety` production explicitly in the calculation solves this issue
- this only affected variables of the `Emi|C?CO2|FFaI|Industry` group