### PR TITLE
update start.R with env shebang and set executable flag

### DIFF
--- a/start.R
+++ b/start.R
@@ -1,3 +1,4 @@
+#!/usr/bin/env Rscript
 library(lucode)
 
 source("scripts/start/submit.R")


### PR DESCRIPTION
- makes it executable from the command line without invoking `Rscript`
  explicitly
- saves on typing, makes for more relaxed REMIND work ;)
- could be applied to other `.R` scripts as well