### PR TITLE
Ignore the doc/images folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ doc/documentation.*
 doc/goxygen_pdflatex.log
 doc/html/
 doc/markdown/
+doc/images/
 Rplots.pdf
 core/input/f_cf.cs3r
 core/input/f_dataRegiSolar.cs3r


### PR DESCRIPTION
Is there a reason why the images folder wasn't included until now? Or can it be added?