### PR TITLE
Calibration hotfix of a bug introduced by the EDGE-T merger

### DIFF
--- a/modules/29_CES_parameters/calibrate/datainput.gms
+++ b/modules/29_CES_parameters/calibrate/datainput.gms
@@ -161,7 +161,6 @@ $offdelim
 /
 
 
-
 p29_esdemand       "energy service demand"
 /
 $ondelim
@@ -169,12 +168,14 @@ $include "./modules/29_CES_parameters/calibrate/input/pm_es_demand.cs4r"
 $offdelim
 /
 
+$ifthen.edgesm %transport% ==  "edge_esm"
 p29_trpdemand       "transport demand"
 /
 $ondelim
 $include "./modules/29_CES_parameters/calibrate/input/pm_trp_demand.cs4r"
 $offdelim
 /
+$endif.edgesm
 
 
 p29_efficiency_growth       "efficency growth for ppf beyond calibration"

--- a/modules/29_CES_parameters/calibrate/declarations.gms
+++ b/modules/29_CES_parameters/calibrate/declarations.gms
@@ -17,7 +17,9 @@ Parameters
   p29_effGr(tall,all_regi,all_in)                                   "growth of factor efficiency from input.gdx"
   p29_fedemand(tall,all_regi,all_GDPscen,all_in)                  "final energy demand"
   p29_cesdata_price(tall,all_regi,all_in)                          "exogenous prices in case they are needed"
+$ifthen.edgesm %transport% ==  "edge_esm"
   p29_trpdemand(tall,all_regi,all_GDPscen,EDGE_scenario_all,all_in) "transport demand for the edge_esm transport module, unit: trillion passenger/ton km"
+$endif.edgesm
   p29_esdemand(tall,all_regi,all_GDPscen,all_in)                  "energy service demand"
   p29_efficiency_growth(tall,all_regi,all_GDPscen,all_in)         "efficency level paths for ppf beyond calibration"
   p29_capitalQuantity(tall,all_regi,all_GDPscen,all_in)            "capital quantities"

--- a/modules/29_CES_parameters/calibrate/input/files
+++ b/modules/29_CES_parameters/calibrate/input/files
@@ -2,6 +2,7 @@ p29_capitalQuantity.cs4r
 p29_efficiency_growth.cs4r
 pm_es_demand.cs4r
 pm_fe_demand.cs4r
+pm_trp_demand.cs4r
 p29_cesdata_price.cs4r
 f29_capitalUnitProjections.cs4r
 


### PR DESCRIPTION
- In the calibration mode, the set `EDGE_scenario_all` has not been defined when using the `complex` transport module. The respective parameters are now only defined if the `edge_esm` transport module is used.
- The energy service demand input file `pm_trp_demand.cs4r` has been missing from the input file listing for the calibration -> fixed.