### PR TITLE
MAgPIE coupling: removed s56_ghgprice_start from coupling script, sin…

### DIFF
--- a/start_bundle_coupled.R
+++ b/start_bundle_coupled.R
@@ -269,9 +269,6 @@ for(scen in common){
       }
   }
 
-  # set start year of GHG emission pricing phase-in (only used in price_jan19)
-  cfg_mag$gms$s56_ghgprice_start <- cfg_rem$gms$cm_startyear
-  
   save(path_remind,path_magpie,cfg_rem,cfg_mag,runname,max_iterations,start_iter,n600_iterations,path_report,LU_pricing,file=paste0(runname,".RData"))
 
   # Define colors for output


### PR DESCRIPTION
…ce the start year of the CO2 price is solely defined by the data transfered from REMIND. The parameter was once introduced to define the beginning of the CO2 price phase-in in MAgPIE. Since the phase-in is now done in REMIND and no longer in MAgPIE, the parameter is no longer needed in the coupling.