### PR TITLE
Add check of R library to guarantee package loads

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -2,6 +2,19 @@
 # DO NOT EDIT THIS LINE!
 if(file.exists("~/.Rprofile")) source("~/.Rprofile")
 
+# Check if the library folder is currently being updated and if so use lattest snapshot.
+if (any(grepl("^00LOCK.*", system(paste0("ls ", .libPaths()[1]), intern = TRUE)))) {
+    cat("\nPackages in the default R library are currently being updated. Packages will be loaded from the library's lattest snapshot instead.\n")
+    
+    snapshot_folder <- "/p/projects/rd3mod/R/libraries/snapshots/"
+    snapshot_dates <- system(paste0("ls ", snapshot_folder), intern = TRUE)
+    lattest_snapshot <- paste0(snapshot_folder, snapshot_dates[length(snapshot_dates)])
+
+    if(file.exists(lattest_snapshot)) {
+        .libPaths(lattest_snapshot)
+    }
+}
+
 
 # This profile can be used to link the model to a specified library snapshot
 # (e.g. if your model version is from an older date and does not work with the
@@ -12,8 +25,7 @@ if(file.exists("~/.Rprofile")) source("~/.Rprofile")
 # to the model output folder. Otherwise, the run itself will again use the
 # default library set!
 
-
-# snapshot <- "/p/projects/rd3mod/R/libraries/snapshots/2019_02_26"
+# snapshot <- "/p/projects/rd3mod/R/libraries/snapshots/2020_03_10"
 # if(file.exists(snapshot)) {
 # cat("Set libPaths to",snapshot,"\n")
 # .libPaths(snapshot)


### PR DESCRIPTION
Hey, so I'm 99% sure that a check for a "^00LOCK.*" folder is enough to figure out if a package is being updated. 
What I've implemented now is a bit heavy-handed, since as soon as any single package is being updated, all packages are loaded from the snapshot library. One could probably have something that only gets the package-being-updated from the snapshot, but oh well...

Do you think this is ok?