### PR TITLE
Add library choice explanations to .Rprofile

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -4,12 +4,19 @@ if(file.exists("~/.Rprofile")) source("~/.Rprofile")
 
 # Check if the library folder is currently being updated and if so use lattest snapshot.
 if (any(grepl("^00LOCK.*", system(paste0("ls ", .libPaths()[1]), intern = TRUE)))) {
-    cat("\nPackages in the default R library are currently being updated. Packages will be loaded from the library's lattest snapshot instead.\n")
-    
+    lock_folders <- grep("^00LOCK.*", system(paste0("ls ", .libPaths()[1]), intern = TRUE), value=TRUE)
+    bad_pacakges <- gsub("^00LOCK-","", lock_folders)
+
     snapshot_folder <- "/p/projects/rd3mod/R/libraries/snapshots/"
     snapshot_dates <- system(paste0("ls ", snapshot_folder), intern = TRUE)
     lattest_snapshot <- paste0(snapshot_folder, snapshot_dates[length(snapshot_dates)])
 
+    # Give user diagnosis
+    cat("\nThe following lock folders were found at", .libPaths()[1],":\n\t", lock_folders,"\n")
+    cat("That means that the ",bad_pacakges,"package(s) is(are) currently being updated.\n") 
+    cat("Packages will be loaded from the library's lattest snapshot instead:\n",lattest_snapshot,"\n")
+    cat("(If the lock folder isn't deleted automatically in the next couple of minutes, that means the package failed to update/install and that the folder has to be removed manually!)\n")
+    
     if(file.exists(lattest_snapshot)) {
         .libPaths(lattest_snapshot)
     }


### PR DESCRIPTION
I added some cat() explanations in the case the library's snapshot is used. 