### PR TITLE
Patch to README and Tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ The macro-economic core of REMIND is a Ramsey-type optimal growth model
 in which intertemporal global welfare is optimized subject to equilibrium constraints.
 
 ## DOCUMENTATION
-The model documentation for version 2.1 can be found at XXX.
-
+<!-- The model documentation for version 2.1 can be found at XXX.-->
 A most recent version of the documentation can also be extracted from the
 model source code via the R package goxygen
 (https://github.com/pik-piam/goxygen). To extract the documentation, install the
@@ -26,6 +25,12 @@ Please pay attention to the REMIND Coding Etiquette when you modify the code
 (if you plan on contributing to the REMIND official repository).
 The Coding Etiquette is found in the documentation section of the file main.gms.
 It explains also the used name conventions and other structural characteristics.
+
+## TUTORIALS
+
+Tutorials can be found in the form of markdown files in the repository:
+
+https://github.com/remindmodel/remind/tree/develop/tutorials
 
 ## COPYRIGHT
 Copyright 2006-2019 Potsdam Institute for Climate Impact Research (PIK)

--- a/start.R
+++ b/start.R
@@ -1,6 +1,26 @@
 #!/usr/bin/env Rscript
 library(lucode)
 
+#' Usage:
+#' Rscript start.R [options]
+#' Rscript start.R file
+#'
+#' Without additional arguments this starts a single REMIND runs using the settings
+#' from `config/default.cfg`.
+#'
+#' Control the script's behavior by providing additional arguments:
+#'
+#' --testOneRegi: Starting a single REMIND run in OneRegi mode using the
+#'   settings from `config/default.cfg`
+#'
+#' --restart: Restart a run.
+#'
+#' Starting a bundle of REMIND runs using the settings from a scenario_config_XYZ.csv:
+#'
+#'   Rscript start.R config/scenario_config_XYZ.csv
+#'
+
+
 source("scripts/start/submit.R")
 source("scripts/start/choose_slurmConfig.R")
 

--- a/tutorials/2_RunningREMIND.md
+++ b/tutorials/2_RunningREMIND.md
@@ -3,15 +3,15 @@ Start running REMIND with default settings
 Felix Schreyer (<felix.schreyeru@pik-potsdam.de>), Lavinia Baumstark (<baumstark@pik-potsdam.de>), David Klein (<dklein@pik-potsdam.de>)
 30 April, 2019
 
--   [1. Your first run](#Your first run)
+-   [1. Your first run](#1._Your_first_run)
     -   [Default configurations](#Default_Configurations)
     -   [Configuration with scenario_config.csv](#configuration_with_scenario_config)
-    -   [Starting the run](#Starting the Run)
--   [2. What happens during a REMIND run?](#2. What happens during a REMIND run?)
--   [3. What happens once you start REMIND on the cluster? ](#3. What happens once you start REMIND on the cluster? )
-    -   [a) Input data preparation](#Input Data Preparation)
+    -   [Starting the run](#Starting_the_Run)
+-   [2. What happens during a REMIND run?](#2._What_happens_during_a_REMIND_run?)
+-   [3. What happens once you start REMIND on the cluster? ](#3._What_happens_once_you_start_REMIND_on_the_cluster?)
+    -   [a) Input data preparation](#Input_Data_Preparation)
     -   [b) Optimization](#Optimization)
-    -   [c) Output processing](#Output Processing)
+    -   [c) Output processing](#Output_Processing)
 
 
 1. Your first run

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -1,10 +1,5 @@
-# |  (C) 2006-2019 Potsdam Institute for Climate Impact Research (PIK)
-# |  authors, and contributors see CITATION.cff file. This file is part
-# |  of REMIND and licensed under AGPL-3.0-or-later. Under Section 7 of
-# |  AGPL-3.0, you are granted additional permissions described in the
-# |  REMIND License Exception, version 1.0 (see LICENSE file).
-# |  Contact: remind@pik-potsdam.de
-README: how to use .md or .Rmd files
+## REMIND Tutorials
+# How to use .md or .Rmd files in RStudio
 
 1. open the file in RStudio (right-click, choose "open with ..." and then RStudio)
 2. for .md files: click "Preview" (upper border of the file window, below "Session" in the Menu Bar). Or press Ctrl+Shift+k


### PR DESCRIPTION
- README now includes a section on Tutorials.
- Tutorials `README.txt` is now a markdown.
- In the `Running REMIND` tutorial, the TOC links are fixed.
- There is now documentation on the usage of `start.R` within the file, see also #117