### PR TITLE
Add Zenodo JSON

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -145,5 +145,5 @@
     },
     "publication_date": "2019-05-02",
     "title": "REMIND - REgional Model of INvestments and Development",
-    "version": 4.0
+    "version": "4.0"
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,149 @@
+{
+    "creators": [
+        {
+            "name": "Aboumahboub, Tino"
+        },
+        {
+            "affiliation": "Potsdam Institute for Climate Impact Research",
+            "name": "Auer, Cornelia"
+        },
+        {
+            "affiliation": "Potsdam Institute for Climate Impact Research",
+            "name": "Bauer, Nico"
+        },
+        {
+            "affiliation": "Potsdam Institute for Climate Impact Research",
+            "name": "Baumstark, Lavinia"
+        },
+        {
+            "affiliation": "Potsdam Institute for Climate Impact Research",
+            "name": "Bertram, Christoph"
+        },
+        {
+            "affiliation": "Potsdam Institute for Climate Impact Research",
+            "name": "Dietrich, Jan"
+        },
+        {
+            "affiliation": "Potsdam Institute for Climate Impact Research",
+            "name": "Dirnaichner, Alois",
+            "orcid": "0000-0002-3240-2608"
+        },
+        {
+            "affiliation": "Potsdam Institute for Climate Impact Research",
+            "name": "Giannousakis, Anastasis"
+        },
+        {
+            "name": "Haller, Markus"
+        },
+        {
+            "affiliation": "Potsdam Institute for Climate Impact Research",
+            "name": "Hilaire, Jerome"
+        },
+        {
+            "affiliation": "Potsdam Institute for Climate Impact Research",
+            "name": "Klein, David"
+        },
+        {
+            "name": "Körner, Alexander"
+        },
+        {
+            "affiliation": "Potsdam Institute for Climate Impact Research",
+            "name": "Kriegler, Elmar"
+        },
+        {
+            "affiliation": "Potsdam Institute for Climate Impact Research",
+            "name": "Leimbach, Marian"
+        },
+        {
+            "affiliation": "Potsdam Institute for Climate Impact Research",
+            "name": "Levesque, Antoine"
+        },
+        {
+            "name": "Lorenz, Alexander"
+        },
+        {
+            "affiliation": "Potsdam Institute for Climate Impact Research",
+            "name": "Luderer, Gunnar"
+        },
+        {
+            "name": "Ludig, Sylvie"
+        },
+        {
+            "name": "Lüken, Michael"
+        },
+        {
+            "affiliation": "Potsdam Institute for Climate Impact Research",
+            "name": "Malik, Aman"
+        },
+        {
+            "name": "Manger, Susanne"
+        },
+        {
+            "name": "Mouratiadou, Ioanna"
+        },
+        {
+            "affiliation": "Potsdam Institute for Climate Impact Research",
+            "name": "Pehl, Michaja"
+        },
+        {
+            "affiliation": "Potsdam Institute for Climate Impact Research",
+            "name": "Pietzker, Robert"
+        },
+        {
+            "affiliation": "Potsdam Institute for Climate Impact Research",
+            "name": "Piontek, Franziska"
+        },
+        {
+            "name": "Popin, Laura"
+        },
+        {
+            "affiliation": "Potsdam Institute for Climate Impact Research",
+            "name": "Rauner, Sebastian"
+        },
+        {
+            "affiliation": "Potsdam Institute for Climate Impact Research",
+            "name": "Rodrigues, Renato"
+        },
+        {
+            "name": "Roming, Niklas"
+        },
+        {
+            "affiliation": "Potsdam Institute for Climate Impact Research",
+            "name": "Rottoli, Marianna"
+        },
+        {
+            "name": "Schmidt, Eva"
+        },
+        {
+            "affiliation": "Potsdam Institute for Climate Impact Research",
+            "name": "Schreyer, Felix"
+        },
+        {
+            "affiliation": "Potsdam Institute for Climate Impact Research",
+            "name": "Schultes, Anselm"
+        },
+        {
+            "affiliation": "Potsdam Institute for Climate Impact Research",
+            "name": "Sörgel, Björn"
+        },
+        {
+            "affiliation": "Potsdam Institute for Climate Impact Research",
+            "name": "Strefler, Jessica"
+        },
+        {
+            "affiliation": "Potsdam Institute for Climate Impact Research",
+            "name": "Ueckerdt, Falko"
+        }
+    ],
+    "keywords": [
+        "energy",
+        "economy",
+        "modeling"
+    ],
+    "license": {
+        "id": "AGPL-3.0-or-later"
+    },
+    "publication_date": "2019-05-02",
+    "title": "REMIND - REgional Model of INvestments and Development",
+    "version": 4.0
+}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,139 +2,139 @@ cff-version: 1.0.3
 message: If you use this model, please cite it as below.
 authors:
 
-    - family-names:	Aboumahboub	    
-      given-names: 	Tino	    
-      
-    - family-names:	Auer	    
-      given-names: 	Cornelia	    
-      affiliation: "Potsdam Institute for Climate Impact Research"
-      
-    - family-names:	Bauer	    
-      given-names: 	Nico	    
-      affiliation: "Potsdam Institute for Climate Impact Research"
-      
-    - family-names:	Baumstark	    
-      given-names: 	Lavinia	    
-      affiliation: "Potsdam Institute for Climate Impact Research"
-      
-    - family-names:	Bertram	    
-      given-names: 	Christoph	    
-      affiliation: "Potsdam Institute for Climate Impact Research"
-      
-    - family-names:	Dietrich	    
-      given-names: 	Jan	    
-      affiliation: "Potsdam Institute for Climate Impact Research"
-      
-    - family-names:	Dirnaichner	    
-      given-names: 	Alois
-      orcid: https://orcid.org/0000-0002-3240-2608
-      affiliation: "Potsdam Institute for Climate Impact Research"
-      
-    - family-names:	Giannousakis	    
-      given-names: 	Anastasis	    
-      affiliation: "Potsdam Institute for Climate Impact Research"
-      
-    - family-names:	Haller	    
-      given-names: 	Markus	    
-      
-    - family-names:	Hilaire	    
-      given-names: 	Jerome	    
-      affiliation: "Potsdam Institute for Climate Impact Research"
-      
-    - family-names:	Klein	    
-      given-names: 	David	    
-      affiliation: "Potsdam Institute for Climate Impact Research"
-      
-    - family-names:	Körner	    
-      given-names: 	Alexander	    
-      
-    - family-names:	Kriegler	    
-      given-names: 	Elmar	    
-      affiliation: "Potsdam Institute for Climate Impact Research"
-      
-    - family-names:	Leimbach	    
-      given-names: 	Marian	    
-      affiliation: "Potsdam Institute for Climate Impact Research"
-      
-    - family-names:	Levesque	    
-      given-names: 	Antoine	    
-      affiliation: "Potsdam Institute for Climate Impact Research"
-      
-    - family-names:	Lorenz	    
-      given-names: 	Alexander	    
-      
-    - family-names:	Luderer	    
-      given-names: 	Gunnar	    
-      affiliation: "Potsdam Institute for Climate Impact Research"
-      
-    - family-names:	Ludig	    
-      given-names: 	Sylvie	    
-      
-    - family-names:	Lüken	    
-      given-names: 	Michael	    
-      
-    - family-names:	Malik	    
-      given-names: 	Aman	    
-      affiliation: "Potsdam Institute for Climate Impact Research"
-      
-    - family-names:	Manger	    
-      given-names: 	Susanne	    
-      
-    - family-names:	Mouratiadou	    
-      given-names: 	Ioanna	    
-      
-    - family-names:	Pehl	    
-      given-names: 	Michaja	    
-      affiliation: "Potsdam Institute for Climate Impact Research"
-      
-    - family-names:	Pietzker	    
-      given-names: 	Robert	    
-      affiliation: "Potsdam Institute for Climate Impact Research"
-      
-    - family-names:	Piontek	    
-      given-names: 	Franziska	    
-      affiliation: "Potsdam Institute for Climate Impact Research"
-      
-    - family-names:	Popin	    
-      given-names: 	Laura	    
-      
-    - family-names:	Rauner	    
-      given-names: 	Sebastian	    
-      affiliation: "Potsdam Institute for Climate Impact Research"
-      
-    - family-names:	Rodrigues	    
-      given-names: 	Renato	    
-      affiliation: "Potsdam Institute for Climate Impact Research"
-      
-    - family-names:	Roming	    
-      given-names: 	Niklas	    
-      
-    - family-names:	Rottoli	    
-      given-names: 	Marianna	    
-      affiliation: "Potsdam Institute for Climate Impact Research"
-      
-    - family-names:	Schmidt	    
-      given-names: 	Eva	    
-      
-    - family-names:	Schreyer	    
-      given-names: 	Felix	    
-      affiliation: "Potsdam Institute for Climate Impact Research"
-      
-    - family-names:	Schultes	    
-      given-names: 	Anselm	    
-      affiliation: "Potsdam Institute for Climate Impact Research"
-      
-    - family-names:	Sörgel	    
-      given-names: 	Björn	    
-      affiliation: "Potsdam Institute for Climate Impact Research"
-      
-    - family-names:	Strefler	    
-      given-names: 	Jessica	    
-      affiliation: "Potsdam Institute for Climate Impact Research"
-      
-    - family-names:	Ueckerdt	    
-      given-names: 	Falko	    
-      affiliation: "Potsdam Institute for Climate Impact Research"
+- family-names: Aboumahboub
+  given-names:  Tino
+
+- family-names: Auer
+  given-names:  Cornelia
+  affiliation: "Potsdam Institute for Climate Impact Research"
+
+- family-names: Bauer
+  given-names:  Nico
+  affiliation: "Potsdam Institute for Climate Impact Research"
+
+- family-names: Baumstark
+  given-names:  Lavinia
+  affiliation: "Potsdam Institute for Climate Impact Research"
+
+- family-names: Bertram
+  given-names:  Christoph
+  affiliation: "Potsdam Institute for Climate Impact Research"
+
+- family-names: Dietrich
+  given-names:  Jan
+  affiliation: "Potsdam Institute for Climate Impact Research"
+
+- family-names: Dirnaichner
+  given-names:  Alois
+  orcid: https://orcid.org/0000-0002-3240-2608
+  affiliation: "Potsdam Institute for Climate Impact Research"
+
+- family-names: Giannousakis
+  given-names:  Anastasis
+  affiliation: "Potsdam Institute for Climate Impact Research"
+
+- family-names: Haller
+  given-names:  Markus
+
+- family-names: Hilaire
+  given-names:  Jerome
+  affiliation: "Potsdam Institute for Climate Impact Research"
+
+- family-names: Klein
+  given-names:  David
+  affiliation: "Potsdam Institute for Climate Impact Research"
+
+- family-names: Körner
+  given-names:  Alexander
+
+- family-names: Kriegler
+  given-names:  Elmar
+  affiliation: "Potsdam Institute for Climate Impact Research"
+
+- family-names: Leimbach
+  given-names:  Marian
+  affiliation: "Potsdam Institute for Climate Impact Research"
+
+- family-names: Levesque
+  given-names:  Antoine
+  affiliation: "Potsdam Institute for Climate Impact Research"
+
+- family-names: Lorenz
+  given-names:  Alexander
+
+- family-names: Luderer
+  given-names:  Gunnar
+  affiliation: "Potsdam Institute for Climate Impact Research"
+
+- family-names: Ludig
+  given-names:  Sylvie
+
+- family-names: Lüken
+  given-names:  Michael
+
+- family-names: Malik
+  given-names:  Aman
+  affiliation: "Potsdam Institute for Climate Impact Research"
+
+- family-names: Manger
+  given-names:  Susanne
+
+- family-names: Mouratiadou
+  given-names:  Ioanna
+
+- family-names: Pehl
+  given-names:  Michaja
+  affiliation: "Potsdam Institute for Climate Impact Research"
+
+- family-names: Pietzker
+  given-names:  Robert
+  affiliation: "Potsdam Institute for Climate Impact Research"
+
+- family-names: Piontek
+  given-names:  Franziska
+  affiliation: "Potsdam Institute for Climate Impact Research"
+
+- family-names: Popin
+  given-names:  Laura
+
+- family-names: Rauner
+  given-names:  Sebastian
+  affiliation: "Potsdam Institute for Climate Impact Research"
+
+- family-names: Rodrigues
+  given-names:  Renato
+  affiliation: "Potsdam Institute for Climate Impact Research"
+
+- family-names: Roming
+  given-names:  Niklas
+
+- family-names: Rottoli
+  given-names:  Marianna
+  affiliation: "Potsdam Institute for Climate Impact Research"
+
+- family-names: Schmidt
+  given-names:  Eva
+
+- family-names: Schreyer
+  given-names:  Felix
+  affiliation: "Potsdam Institute for Climate Impact Research"
+
+- family-names: Schultes
+  given-names:  Anselm
+  affiliation: "Potsdam Institute for Climate Impact Research"
+
+- family-names: Sörgel
+  given-names:  Björn
+  affiliation: "Potsdam Institute for Climate Impact Research"
+
+- family-names: Strefler
+  given-names:  Jessica
+  affiliation: "Potsdam Institute for Climate Impact Research"
+
+- family-names: Ueckerdt
+  given-names:  Falko
+  affiliation: "Potsdam Institute for Climate Impact Research"
 
 
 title: REMIND - REgional Model of INvestments and Development
@@ -142,7 +142,7 @@ version: 4.0
 date-released: 2019-05-02
 repository-code: https://github.com/remindmodel/remind
 keywords:
-  - energy 
+  - energy
   - economy
   - modeling
 license: AGPL-3.0-or-later

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -138,7 +138,7 @@ authors:
 
 
 title: REMIND - REgional Model of INvestments and Development
-version: 4.0
+version: "4.0"
 date-released: 2019-05-02
 repository-code: https://github.com/remindmodel/remind
 keywords:


### PR DESCRIPTION
This PR fixes some issues in CITATION.cff and creates a corresponding .zenodo.json to be picked up by Zenodo's GitHub integration.

https://guide.esciencecenter.nl/citable_software/making_software_citable.html