### PR TITLE
Install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ either distributed via the offical R CRAN or via a separate repository hosted at
 PIK (PIK-CRAN). Before proceeding PIK-CRAN should be added to the list of
 available repositories via:
 ```
-options(repos = c(CRAN = "@CRAN@", pik = "https://rse.pik-potsdam.de/r/packages"))
+options(repos = c(CRAN = getOption("repos")["CRAN"], pik = "https://rse.pik-potsdam.de/r/packages"))
 ```
 
 On Windows you need to install Rtools

--- a/README.md
+++ b/README.md
@@ -89,12 +89,14 @@ variable. After that you can run the following lines of code:
 All packages can be installed via `install.packages`
 
 ```
-pkgs <- c("gdxrrw",
+pkgs <- c("dplyr",
+          "gdxrrw",
           "ggplot2",
           "curl",
           "gdx",
           "magclass",
           "madrat",
+          "backports",
           "mip",
           "lucode",
           "remind",


### PR DESCRIPTION
Hi all,

First and foremost, I'm incredibly happy REMIND was able to go open source! I tried to give it a spin this holiday weekend and ran into a few issues trying to install everything. 

I needed the changes in this PR to get going (happy to discuss them individually as needed.

But I failed in my attempt when trying to install the R package `remind`. Here is the error I got:

```
** testing if installed package can be loaded
Error: package or namespace load failed for ‘igraph’ in dyn.load(file, DLLpath = DLLpath, ...):
 unable to load shared object '/home/gidden/work/R/library/igraph/libs/igraph.so':
  libopenblas.so.0: cannot open shared object file: No such file or directory
Error: loading failed
Execution halted
ERROR: loading failed
* removing ‘/home/gidden/work/R/library/igraph’
ERROR: dependencies ‘Hmisc’, ‘rms’ are not available for package ‘nonparaeff’
* removing ‘/home/gidden/work/R/library/nonparaeff’
ERROR: dependency ‘Hmisc’ is not available for package ‘luplot’
* removing ‘/home/gidden/work/R/library/luplot’
ERROR: dependency ‘igraph’ is not available for package ‘highcharter’
* removing ‘/home/gidden/work/R/library/highcharter’
ERROR: dependencies ‘nonparaeff’, ‘luplot’ are not available for package ‘magpie4’
* removing ‘/home/gidden/work/R/library/magpie4’
ERROR: dependency ‘nonparaeff’ is not available for package ‘magpie’
* removing ‘/home/gidden/work/R/library/magpie’
ERROR: dependencies ‘luplot’, ‘magpie4’ are not available for package ‘remulator’
* removing ‘/home/gidden/work/R/library/remulator’
ERROR: dependencies ‘luplot’, ‘remulator’, ‘magpie’, ‘highcharter’ are not available for package ‘remind’
* removing ‘/home/gidden/work/R/library/remind’

The downloaded source packages are in
	‘/tmp/RtmpU79IdI/downloaded_packages’
Warning messages:
1: In install.packages("remind", lib = "~/work/R/library") :
  installation of package ‘Hmisc’ had non-zero exit status
2: In install.packages("remind", lib = "~/work/R/library") :
  installation of package ‘igraph’ had non-zero exit status
3: In install.packages("remind", lib = "~/work/R/library") :
  installation of package ‘nonparaeff’ had non-zero exit status
4: In install.packages("remind", lib = "~/work/R/library") :
  installation of package ‘luplot’ had non-zero exit status
5: In install.packages("remind", lib = "~/work/R/library") :
  installation of package ‘highcharter’ had non-zero exit status
6: In install.packages("remind", lib = "~/work/R/library") :
  installation of package ‘magpie4’ had non-zero exit status
7: In install.packages("remind", lib = "~/work/R/library") :
  installation of package ‘magpie’ had non-zero exit status
8: In install.packages("remind", lib = "~/work/R/library") :
  installation of package ‘remulator’ had non-zero exit status
9: In install.packages("remind", lib = "~/work/R/library") :
  installation of package ‘remind’ had non-zero exit status
```
apart from `igraph`, I tried installing `Hmisc` which led me to `latticeExtra`, which failed with this error:

```
> install.packages('latticeExtra', lib='~/work/R/library')
Warning message:
package ‘latticeExtra’ is not available (for R version 3.4.4) 
```

So, I'm happy to be your guinea pig if you can help me further with installation, but I will confess I am an R noobie. Be gentle!