### PR TITLE
Add a switch for green hydrogen

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -530,7 +530,7 @@ cfg$RunsUsingTHISgdxAsBAU <- NA
 #  (0): no technologies
 #  (1): all technologies
 # c_greenh2       "lower bound on share of green hydrogen in all hydrogen by 2030"
-#  (any number >= 0): share
+#  (a number between 0 and 1): share
 # c_solscen      "solar option choice"
 #  (1): yes
 #  (2): no solar

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -273,7 +273,7 @@ cfg$gms$cm_nucscen             <-  2  #  def  <-  2
 cfg$gms$cm_ccapturescen        <-  1  #  def  <-  1
 cfg$gms$c_bioliqscen           <-  1  #  def  <-  1
 cfg$gms$c_bioh2scen            <-  1  #  def  <-  1
-cfg$gms$c_greenh2              <-  0.9  #  def  <-  0
+cfg$gms$c_shGreenh2            <-  0  #  def  <-  0
 cfg$gms$cm_IndCCSscen          <-  1  #  def  <-  1
 cfg$gms$cm_optimisticMAC       <-  0  #  def  <-  0
 cfg$gms$cm_CCS_cement          <-  1  #  def  <-  1

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -273,7 +273,7 @@ cfg$gms$cm_nucscen             <-  2  #  def  <-  2
 cfg$gms$cm_ccapturescen        <-  1  #  def  <-  1
 cfg$gms$c_bioliqscen           <-  1  #  def  <-  1
 cfg$gms$c_bioh2scen            <-  1  #  def  <-  1
-cfg$gms$c_greenh2              <-  0.1  #  def  <-  0
+cfg$gms$c_greenh2              <-  0.9  #  def  <-  0
 cfg$gms$cm_IndCCSscen          <-  1  #  def  <-  1
 cfg$gms$cm_optimisticMAC       <-  0  #  def  <-  0
 cfg$gms$cm_CCS_cement          <-  1  #  def  <-  1

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -273,6 +273,7 @@ cfg$gms$cm_nucscen             <-  2  #  def  <-  2
 cfg$gms$cm_ccapturescen        <-  1  #  def  <-  1
 cfg$gms$c_bioliqscen           <-  1  #  def  <-  1
 cfg$gms$c_bioh2scen            <-  1  #  def  <-  1
+cfg$gms$c_greenh2              <-  0.1  #  def  <-  0
 cfg$gms$cm_IndCCSscen          <-  1  #  def  <-  1
 cfg$gms$cm_optimisticMAC       <-  0  #  def  <-  0
 cfg$gms$cm_CCS_cement          <-  1  #  def  <-  1
@@ -528,6 +529,8 @@ cfg$RunsUsingTHISgdxAsBAU <- NA
 # c_bioh2scen       "switch hydrogen producing technology on or off"
 #  (0): no technologies
 #  (1): all technologies
+# c_greenh2       "lower bound on share of green hydrogen in all hydrogen by 2030"
+#  (any number >= 0): share
 # c_solscen      "solar option choice"
 #  (1): yes
 #  (2): no solar

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -529,7 +529,7 @@ cfg$RunsUsingTHISgdxAsBAU <- NA
 # c_bioh2scen       "switch hydrogen producing technology on or off"
 #  (0): no technologies
 #  (1): all technologies
-# c_greenh2       "lower bound on share of green hydrogen in all hydrogen by 2030"
+# c_shGreenH2       "lower bound on share of green hydrogen in all hydrogen by 2030"
 #  (a number between 0 and 1): share
 # c_solscen      "solar option choice"
 #  (1): yes

--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -501,8 +501,8 @@ loop ((t, regi) $ ( (sameAs(t,"2010") OR sameAs(t,"2015"))
 *** lower bound on share of green hydrogen starting from 2030 (c_greenH2)
 ***----------------------------------------------------------------------------
 
-v_shGreenH2.lo(t,regi)$(t.val eq 2025) = %c_greenh2% * 2/3;
-v_shGreenH2.lo(t,regi)$(t.val gt 2025) = %c_greenh2%;
+v_shGreenH2.lo(t,regi)$(t.val eq 2025) = %c_shGreenH2% * 2/3;
+v_shGreenH2.lo(t,regi)$(t.val gt 2025) = %c_shGreenH2%;
 
 
 *** EOF ./core/bounds.gms

--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -496,4 +496,12 @@ loop ((t, regi) $ ( (sameAs(t,"2010") OR sameAs(t,"2015"))
       vm_prodSe.up(t,regi,"pegas","sehe","gashp")   = 0;
 );
 );
+
+***----------------------------------------------------------------------------
+*** lower bound on share of green hydrogen starting from 2030 (c_greenH2)
+***----------------------------------------------------------------------------
+
+v_shGreenH2.lo(t,regi)$(t.val gt 2025) = %c_greenH2%;
+
+
 *** EOF ./core/bounds.gms

--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -501,8 +501,8 @@ loop ((t, regi) $ ( (sameAs(t,"2010") OR sameAs(t,"2015"))
 *** lower bound on share of green hydrogen starting from 2030 (c_greenH2)
 ***----------------------------------------------------------------------------
 
-v_shGreenH2.lo(t,regi)$(t.val eq 2025) = %c_shGreenH2% * 2/3;
-v_shGreenH2.lo(t,regi)$(t.val gt 2025) = %c_shGreenH2%;
+v_shGreenH2.lo(t,regi)$(t.val eq 2025) = c_shGreenH2 * 2/3;
+v_shGreenH2.lo(t,regi)$(t.val gt 2025) = c_shGreenH2;
 
 
 *** EOF ./core/bounds.gms

--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -501,7 +501,7 @@ loop ((t, regi) $ ( (sameAs(t,"2010") OR sameAs(t,"2015"))
 *** lower bound on share of green hydrogen starting from 2030 (c_greenH2)
 ***----------------------------------------------------------------------------
 
-v_shGreenH2.lo(t,regi)$(t.val eq 2025) = %c_greenh2%/2;
+v_shGreenH2.lo(t,regi)$(t.val eq 2025) = %c_greenh2% * 2/3;
 v_shGreenH2.lo(t,regi)$(t.val gt 2025) = %c_greenh2%;
 
 

--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -501,7 +501,8 @@ loop ((t, regi) $ ( (sameAs(t,"2010") OR sameAs(t,"2015"))
 *** lower bound on share of green hydrogen starting from 2030 (c_greenH2)
 ***----------------------------------------------------------------------------
 
-v_shGreenH2.lo(t,regi)$(t.val gt 2025) = %c_greenH2%;
+v_shGreenH2.lo(t,regi)$(t.val eq 2025) = %c_greenh2%/2;
+v_shGreenH2.lo(t,regi)$(t.val gt 2025) = %c_greenh2%;
 
 
 *** EOF ./core/bounds.gms

--- a/core/declarations.gms
+++ b/core/declarations.gms
@@ -300,6 +300,8 @@ vm_otherFEdemand(ttot,all_regi,all_enty)             "final energy demand from n
 vm_demSeOth(ttot,all_regi,all_enty,all_te)	         "other sety demand from certain technologies, have to calculated in additional equations [TWa]"
 vm_prodSeOth(ttot,all_regi,all_enty,all_te)	         "other sety production from certain technologies, have to be calculated in additional equations [TWa]"	
 
+v_shGreenH2(ttot,all_regi)   "share of green hydrogen in all hydrogen by 2030 [0..1]"
+
 *** ES layer variables
 vm_demFeForEs(ttot,all_regi,all_enty,all_esty,all_teEs)     "Final energy which will be used in the ES layer."
 v_prodEs(ttot,all_regi,all_enty,all_esty,all_teEs)          "Energy services (unit determined by conversion factor pm_fe2es)."
@@ -388,6 +390,7 @@ q_transFe2Es(ttot,all_regi,all_enty,all_esty,all_teEs)    "Conversion from final
 q_es2ppfen(ttot,all_regi,all_in)                          "Energy services are handed to the CES tree."
 q_shFeCes(ttot,all_regi,all_enty,all_in,all_teEs)         "Shares of final energies in production factors."
 *q_shFeCesNorm(ttot,all_regi,all_in)                      "Shares have to sum to 1."
+q_shGreenH2(ttot,all_regi)  "share of green hydrogen in all hydrogen"
 
 ***----------------------------------------------------------------------------------------
 ***----------------------------------------------trade module------------------------------

--- a/core/equations.gms
+++ b/core/equations.gms
@@ -813,6 +813,16 @@ q_PE_histCap(t,regi,entyPe,entySe)$(p_PE_histCap(t,regi,entyPe,entySe))..
     =g=
     0.9 * p_PE_histCap(t,regi,entyPe,entySe)
 ;
- 
+
+
+***---------------------------------------------------------------------------
+*' Share of green hydrogen in all hydrogen.
+***---------------------------------------------------------------------------
+q_shGreenH2(t,regi)..
+    sum(te, vm_prodSe(t,regi,"seel","seh2",te))
+    =e=
+    sum(pe2se(enty,"seh2",te), vm_prodSe(t,regi,enty,"seh2",te)) * v_shGreenH2(t,regi)
+;
+
  
 *** EOF ./core/equations.gms

--- a/core/equations.gms
+++ b/core/equations.gms
@@ -819,7 +819,7 @@ q_PE_histCap(t,regi,entyPe,entySe)$(p_PE_histCap(t,regi,entyPe,entySe))..
 *' Share of green hydrogen in all hydrogen.
 ***---------------------------------------------------------------------------
 q_shGreenH2(t,regi)..
-    sum(te, vm_prodSe(t,regi,"seel","seh2",te))
+    sum(se2se("seel","seh2",te), vm_prodSe(t,regi,"seel","seh2",te))
     =e=
     (
 	sum(pe2se(entyPe,"seh2",te), vm_prodSe(t,regi,entyPe,"seh2",te))

--- a/core/equations.gms
+++ b/core/equations.gms
@@ -821,7 +821,10 @@ q_PE_histCap(t,regi,entyPe,entySe)$(p_PE_histCap(t,regi,entyPe,entySe))..
 q_shGreenH2(t,regi)..
     sum(te, vm_prodSe(t,regi,"seel","seh2",te))
     =e=
-    sum(pe2se(enty,"seh2",te), vm_prodSe(t,regi,enty,"seh2",te)) * v_shGreenH2(t,regi)
+    (
+	sum(pe2se(entyPe,"seh2",te), vm_prodSe(t,regi,entyPe,"seh2",te))
+	+ sum(se2se(entySe,"seh2",te), vm_prodSe(t,regi,entySe,"seh2",te))
+    ) * v_shGreenH2(t,regi)
 ;
 
  

--- a/main.gms
+++ b/main.gms
@@ -220,6 +220,7 @@ cm_nucscen            "nuclear option choice"
 cm_ccapturescen       "carbon capture option choice"
 c_bioliqscen          "bioenergy liquids technology choise"
 c_bioh2scen           "bioenergy hydrogen technology choice"
+c_shGreenH2           "share of green hydrogen in all hydrogen by 2030"
 cm_IndCCSscen        "CCS for Industry"
 cm_optimisticMAC     "assume optimistic Industry MAC from AR5 Ch. 10?"
 cm_CCS_cement        "CCS for cement sub-sector"
@@ -309,7 +310,7 @@ cm_nucscen       = 2;        !! def = 2
 cm_ccapturescen  = 1;        !! def = 1
 c_bioliqscen     = 1;        !! def = 1
 c_bioh2scen      = 1;        !! def = 1
-$setglobal c_greenh2  0.1
+c_shGreenH2      = 0;        !! def = 0
 c_solscen        = 1;        !! def = 1
 
 cm_IndCCSscen          = 1;        !! def = 1

--- a/main.gms
+++ b/main.gms
@@ -84,7 +84,7 @@
 * 
 * Input data revision: 5.942
 * 
-* Last modification (input data): Tue Apr 21 12:02:34 2020
+* Last modification (input data): Thu Apr 23 11:28:04 2020
 * 
 *###################### R SECTION END (VERSION INFO) ###########################
 
@@ -309,6 +309,7 @@ cm_nucscen       = 2;        !! def = 2
 cm_ccapturescen  = 1;        !! def = 1
 c_bioliqscen     = 1;        !! def = 1
 c_bioh2scen      = 1;        !! def = 1
+$setglobal c_greenh2  0.1
 c_solscen        = 1;        !! def = 1
 
 cm_IndCCSscen          = 1;        !! def = 1


### PR DESCRIPTION
The switch `c_greenh2` defines the share of green hydrogen, i.e., hydrogen made from electricity within overall SE level hydrogen production. To that end

- an equation and a variable is added to `core`,
- the switch and the corresponding documentation is added to `config/default.cfg`.
- the outcomes are tested in a nash run and seem consistent with the reporting.