### PR TITLE
Update the Bioshare Parameter to address Bioliquid shares on the SE level

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -277,7 +277,7 @@ cfg$gms$cm_ccapturescen        <-  1  #  def  <-  1
 cfg$gms$c_bioliqscen           <-  1  #  def  <-  1
 cfg$gms$c_bioh2scen            <-  1  #  def  <-  1
 cfg$gms$c_shGreenH2            <-  0  #  def  <-  0
-cfg$gms$c_shBioTrans           <-  1  #  def  <-  1
+cfg$gms$c_shBioliq             <-  1  #  def  <-  1
 cfg$gms$cm_shSynTrans          <-  0  #  def  <-  0
 cfg$gms$cm_IndCCSscen          <-  1  #  def  <-  1
 cfg$gms$cm_optimisticMAC       <-  0  #  def  <-  0
@@ -538,7 +538,7 @@ cfg$RunsUsingTHISgdxAsBAU <- NA
 #  (1): all technologies
 # c_shGreenH2       "lower bound on share of green hydrogen in all hydrogen by 2030"
 #  (a number between 0 and 1): share
-# c_shBioTrans       "upper bound on share of biofuels in transport fuels from 2020 onwards"
+# c_shBioliq       "upper bound on share of bioliquids from 2025 onwards"
 #  (a number between 0 and 1): share
 # cm_shSynTrans       "lower bound on share of synfuels in transport fuels by 2035"
 #  (a number between 0 and 1): share

--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -508,6 +508,6 @@ v_shGreenH2.lo(t,regi)$(t.val gt 2025) = c_shGreenH2;
 *** upper bound on bioliquids as a share of transport liquids
 ***----------------------------------------------------------------------------
 
-v_shBioTrans.up(t,regi)$(t.val > 2020) = c_shBioTrans;
+v_shBioliq.up(t,regi)$(t.val > 2020) = c_shBioliq;
 
 *** EOF ./core/bounds.gms

--- a/core/declarations.gms
+++ b/core/declarations.gms
@@ -303,7 +303,7 @@ vm_demSeOth(ttot,all_regi,all_enty,all_te)	         "other sety demand from cert
 vm_prodSeOth(ttot,all_regi,all_enty,all_te)	         "other sety production from certain technologies, have to be calculated in additional equations [TWa]"	
 
 v_shGreenH2(ttot,all_regi)   "share of green hydrogen in all hydrogen by 2030 [0..1]"
-v_shBioTrans(ttot,all_regi)   "Share of biofuels in all final energies used for transportation. Value between 0 and 1."
+v_shBioliq(ttot,all_regi)    "Share of biofuels in SE liquids from 2025 onwards. Value between 0 and 1."
 
 *** ES layer variables
 vm_demFeForEs(ttot,all_regi,all_enty,all_esty,all_teEs)     "Final energy which will be used in the ES layer."
@@ -394,7 +394,7 @@ q_es2ppfen(ttot,all_regi,all_in)                          "Energy services are h
 q_shFeCes(ttot,all_regi,all_enty,all_in,all_teEs)         "Shares of final energies in production factors."
 *q_shFeCesNorm(ttot,all_regi,all_in)                      "Shares have to sum to 1."
 q_shGreenH2(ttot,all_regi)  "share of green hydrogen in all hydrogen"
-q_shBioTrans(ttot,all_regi)  "Define the share of biofuels in all final energies for transportation."
+q_shBioliq(ttot,all_regi)  "Define the share of biofuels in SE liquids from 2025 on."
 
 ***----------------------------------------------------------------------------------------
 ***----------------------------------------------trade module------------------------------

--- a/core/equations.gms
+++ b/core/equations.gms
@@ -832,10 +832,12 @@ q_shGreenH2(t,regi)..
 *' Share of biofuels in transport liquids
 ***---------------------------------------------------------------------------
 q_shBioTrans(t,regi)..
-  sum(se2fe(entySe,entyFeTrans,te)$seAgg2se("all_seliq",entySe), vm_prodFe(t,regi,entySe,entyFeTrans,te) )
-  * v_shBioTrans(t,regi)
-  =e=
-  sum(se2fe("seliqbio",entyFeTrans,te), vm_prodFe(t,regi,"seliqbio",entyFeTrans,te) )
+    sum(se2se(entyPe,"seliqbio",te), vm_prodSe(t,regi,entyPe,"seliqbio",te))
+    =e=
+    (
+	sum(pe2se(entyPe,entySe,te)$seAgg2se("all_seliq",entySe), vm_prodSe(t,regi,entyPe,entySe,te))
+	+ sum(se2se(entySe,entySe2,te)$seAgg2se("all_seliq",entySe2), vm_prodSe(t,regi,entySe,entySe2,te))
+    ) * v_shGreenH2(t,regi)
 ;
 
  

--- a/core/equations.gms
+++ b/core/equations.gms
@@ -831,7 +831,7 @@ q_shGreenH2(t,regi)..
 ***---------------------------------------------------------------------------
 *' Share of biofuels in transport liquids
 ***---------------------------------------------------------------------------
-q_shBioTrans(t,regi)..
+q_shBioliq(t,regi)..
     sum(se2se(entyPe,"seliqbio",te), vm_prodSe(t,regi,entyPe,"seliqbio",te))
     =e=
     (

--- a/main.gms
+++ b/main.gms
@@ -221,7 +221,7 @@ cm_ccapturescen       "carbon capture option choice"
 c_bioliqscen          "bioenergy liquids technology choise"
 c_bioh2scen           "bioenergy hydrogen technology choice"
 c_shGreenH2           "lower bound on share of green hydrogen in all hydrogen by 2030"
-c_shBioTrans          "upper bound on share of bioliquids in all transport liquids from 2020 onwards"
+c_shBioliq            "upper bound on share of bioliquids in SE liquids from 2025 onwards"
 cm_shSynTrans         "lower bound on share of synthetic fuels in all transport fuels by 2035"
 cm_IndCCSscen        "CCS for Industry"
 cm_optimisticMAC     "assume optimistic Industry MAC from AR5 Ch. 10?"
@@ -313,7 +313,7 @@ cm_ccapturescen  = 1;        !! def = 1
 c_bioliqscen     = 1;        !! def = 1
 c_bioh2scen      = 1;        !! def = 1
 c_shGreenH2      = 0;        !! def = 0
-c_shBioTrans     = 1;        !! def = 1
+c_shBioliq       = 1;        !! def = 1
 cm_shSynTrans    = 0;        !! def = 0
 c_solscen        = 1;        !! def = 1
 

--- a/modules/35_transport/edge_esm/declarations.gms
+++ b/modules/35_transport/edge_esm/declarations.gms
@@ -9,10 +9,4 @@ Parameters
 pm_bunker_share_in_nonldv_fe(tall,all_regi)   "Share of bunkers in non-LDV transport - fedie"
 ;
 
-Positive variables
-;
-
-Equations
-;
-
 *** EOF ./modules/35_transport/edge_esm/declarations.gms


### PR DESCRIPTION
The parameter `c_shBioTrans` was introduced to provide a configurable upper bound on biofuel shares in the transport sector. To avoid inconsistencies and *redistribution* of bioliquids to other sectors, the new parameter `c_shBioliq` defines the share of bioliquids purely on the SE level.

This is in line with the understanding of a *blend* that is supplied to all FE demand sectors. It also enables the consistency check with what is currently in the reporting. There, the bioliquid share in transport is also determined by the *SE level share* of bioliquids (and not by the actual amounts produced via `tdbiopet` and `tdbiodie`).