### PR TITLE
Revert the formulation of biofuel limit to apply only to the transport sector

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -277,7 +277,7 @@ cfg$gms$cm_ccapturescen        <-  1  #  def  <-  1
 cfg$gms$c_bioliqscen           <-  1  #  def  <-  1
 cfg$gms$c_bioh2scen            <-  1  #  def  <-  1
 cfg$gms$c_shGreenH2            <-  0  #  def  <-  0
-cfg$gms$c_shBioliq             <-  1  #  def  <-  1
+cfg$gms$c_shBioTrans           <-  1  #  def  <-  1
 cfg$gms$cm_shSynTrans          <-  0  #  def  <-  0
 cfg$gms$cm_IndCCSscen          <-  1  #  def  <-  1
 cfg$gms$cm_optimisticMAC       <-  0  #  def  <-  0
@@ -538,7 +538,7 @@ cfg$RunsUsingTHISgdxAsBAU <- NA
 #  (1): all technologies
 # c_shGreenH2       "lower bound on share of green hydrogen in all hydrogen by 2030"
 #  (a number between 0 and 1): share
-# c_shBioliq       "upper bound on share of bioliquids from 2025 onwards"
+# c_shBioTrans       "upper bound on share of bioliquids in transport from 2025 onwards"
 #  (a number between 0 and 1): share
 # cm_shSynTrans       "lower bound on share of synfuels in transport fuels by 2035"
 #  (a number between 0 and 1): share

--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -508,6 +508,6 @@ v_shGreenH2.lo(t,regi)$(t.val gt 2025) = c_shGreenH2;
 *** upper bound on bioliquids as a share of transport liquids
 ***----------------------------------------------------------------------------
 
-v_shBioliq.up(t,regi)$(t.val > 2020) = c_shBioliq;
+v_shBioTrans.up(t,regi)$(t.val > 2020) = c_shBioTrans;
 
 *** EOF ./core/bounds.gms

--- a/core/declarations.gms
+++ b/core/declarations.gms
@@ -303,7 +303,7 @@ vm_demSeOth(ttot,all_regi,all_enty,all_te)	         "other sety demand from cert
 vm_prodSeOth(ttot,all_regi,all_enty,all_te)	         "other sety production from certain technologies, have to be calculated in additional equations [TWa]"	
 
 v_shGreenH2(ttot,all_regi)   "share of green hydrogen in all hydrogen by 2030 [0..1]"
-v_shBioliq(ttot,all_regi)    "Share of biofuels in SE liquids from 2025 onwards. Value between 0 and 1."
+v_shBioTrans(ttot,all_regi)    "Share of biofuels in transport liquids from 2025 onwards. Value between 0 and 1."
 
 *** ES layer variables
 vm_demFeForEs(ttot,all_regi,all_enty,all_esty,all_teEs)     "Final energy which will be used in the ES layer."
@@ -394,7 +394,7 @@ q_es2ppfen(ttot,all_regi,all_in)                          "Energy services are h
 q_shFeCes(ttot,all_regi,all_enty,all_in,all_teEs)         "Shares of final energies in production factors."
 *q_shFeCesNorm(ttot,all_regi,all_in)                      "Shares have to sum to 1."
 q_shGreenH2(ttot,all_regi)  "share of green hydrogen in all hydrogen"
-q_shBioliq(ttot,all_regi)  "Define the share of biofuels in SE liquids from 2025 on."
+q_shBioTrans(ttot,all_regi)  "Define the share of biofuels in transport liquids from 2025 on."
 
 ***----------------------------------------------------------------------------------------
 ***----------------------------------------------trade module------------------------------

--- a/core/equations.gms
+++ b/core/equations.gms
@@ -832,7 +832,7 @@ q_shGreenH2(t,regi)..
 *' Share of biofuels in transport liquids
 ***---------------------------------------------------------------------------
 q_shBioliq(t,regi)..
-    sum(se2se(entyPe,"seliqbio",te), vm_prodSe(t,regi,entyPe,"seliqbio",te))
+    sum(pe2se(entyPe,"seliqbio",te), vm_prodSe(t,regi,entyPe,"seliqbio",te))
     =e=
     (
 	sum(pe2se(entyPe,entySe,te)$seAgg2se("all_seliq",entySe), vm_prodSe(t,regi,entyPe,entySe,te))

--- a/core/equations.gms
+++ b/core/equations.gms
@@ -831,13 +831,11 @@ q_shGreenH2(t,regi)..
 ***---------------------------------------------------------------------------
 *' Share of biofuels in transport liquids
 ***---------------------------------------------------------------------------
-q_shBioliq(t,regi)..
-    sum(pe2se(entyPe,"seliqbio",te), vm_prodSe(t,regi,entyPe,"seliqbio",te))
-    =e=
-    (
-	sum(pe2se(entyPe,entySe,te)$seAgg2se("all_seliq",entySe), vm_prodSe(t,regi,entyPe,entySe,te))
-	+ sum(se2se(entySe,entySe2,te)$seAgg2se("all_seliq",entySe2), vm_prodSe(t,regi,entySe,entySe2,te))
-    ) * v_shBioliq(t,regi)
+q_shBioTrans(t,regi)..
+  sum(se2fe(entySe,entyFeTrans,te)$seAgg2se("all_seliq",entySe), vm_prodFe(t,regi,entySe,entyFeTrans,te) )
+  * v_shBioTrans(t,regi)
+  =e=
+  sum(se2fe("seliqbio",entyFeTrans,te), vm_prodFe(t,regi,"seliqbio",entyFeTrans,te) )
 ;
 
  

--- a/main.gms
+++ b/main.gms
@@ -221,7 +221,7 @@ cm_ccapturescen       "carbon capture option choice"
 c_bioliqscen          "bioenergy liquids technology choise"
 c_bioh2scen           "bioenergy hydrogen technology choice"
 c_shGreenH2           "lower bound on share of green hydrogen in all hydrogen by 2030"
-c_shBioliq            "upper bound on share of bioliquids in SE liquids from 2025 onwards"
+c_shBioTrans          "upper bound on share of bioliquids in transport from 2025 onwards"
 cm_shSynTrans         "lower bound on share of synthetic fuels in all transport fuels by 2035"
 cm_IndCCSscen        "CCS for Industry"
 cm_optimisticMAC     "assume optimistic Industry MAC from AR5 Ch. 10?"
@@ -313,7 +313,7 @@ cm_ccapturescen  = 1;        !! def = 1
 c_bioliqscen     = 1;        !! def = 1
 c_bioh2scen      = 1;        !! def = 1
 c_shGreenH2      = 0;        !! def = 0
-c_shBioliq       = 1;        !! def = 1
+c_shBioTrans     = 1;        !! def = 1
 cm_shSynTrans    = 0;        !! def = 0
 c_solscen        = 1;        !! def = 1
 


### PR DESCRIPTION
The other formulation which applied to all liquids is more consistent with the reporting (on blend serves them all), but to only constrain the biofuel supplies to the transport sector leaves more flexibility to REMIND.

Sorry for the back-and-forth.