### PR TITLE
fix 9860fb0

### DIFF
--- a/modules/29_CES_parameters/calibrate/datainput.gms
+++ b/modules/29_CES_parameters/calibrate/datainput.gms
@@ -323,7 +323,7 @@ loop ((t_29hist(t),regi_dyn29(regi))$(
   pm_cesdata(t,regi,"fehe_otherInd","offset_quantity")
   = -pm_cesdata(t,regi,"fehe_otherInd","quantity");
 );
-$else
+$else.subsectors
 *** Special treatment for fehei, which is part of ppfen_industry_dyn37, yet 
 *** needs an offset value for some regions under fixed_shares
 loop ((t,regi,in)$(    sameas(in,"fehei") 


### PR DESCRIPTION
- matching tags on $else directive are needed, but only cause an error when
  $if clause fails