### PR TITLE
update input data revision, remove references to additional industry/subsectors data

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -22,7 +22,7 @@ cfg$title <- "default"
 cfg$regionmapping <- "config/regionmappingH12.csv"
 
 #### Current input data revision (<mainrevision>.<subrevision>) ####
-cfg$revision <- 5.947
+cfg$revision <- 5.948
 
 #### Force the model to download new input data ####
 cfg$force_download <- FALSE

--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -1192,11 +1192,9 @@ Parameter
   /
 $ondelim
 $include "./core/input/pm_fe_demand.cs4r"
-$ifthen "%industry%" == "subsectors"   !! industry
-$include "./core/input/pm_fe_demand_industry.cs4r"
-$endif
 $offdelim
   /
 ;
 
 *** EOF ./core/datainput.gms
+

--- a/modules/29_CES_parameters/calibrate/datainput.gms
+++ b/modules/29_CES_parameters/calibrate/datainput.gms
@@ -178,9 +178,6 @@ p29_efficiency_growth       "efficency growth for ppf beyond calibration"
 /
 $ondelim
 $include "./modules/29_CES_parameters/calibrate/input/p29_efficiency_growth.cs4r"
-$ifthen "%industry%" == "subsectors"   !! industry
-$include "./modules/29_CES_parameters/calibrate/input/p29_efficiency_growth_industry.cs4r"
-$endif
 $offdelim
 
 /
@@ -200,9 +197,6 @@ p29_capitalQuantity                    "capital quantities"
 /
 $ondelim
 $include "./modules/29_CES_parameters/calibrate/input/p29_capitalQuantity.cs4r"
-$ifthen "%industry%" == "subsectors"   !! industry
-$include "./modules/29_CES_parameters/calibrate/input/p29_capitalQuantity_industry.cs4r"
-$endif
 $offdelim
 /
 ;
@@ -377,3 +371,4 @@ p29_esubGrowth = 1;
 $endif.growth
 ;
 *** EOF ./modules/29_CES_parameters/calibrate/datainput.gms
+


### PR DESCRIPTION
- data required for calibrating industry/subsectors has been
  incorporated with mrremind 0.14.0, and is now available for all
  regionmappings