### PR TITLE
fix industry/subsector steel figures rounding error from mrremind

### DIFF
--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -1187,6 +1187,9 @@ loop(te,
 *** -------- initial declaration of parameters for iterative target adjustment
 o_reached_until2150pricepath(iteration) = 0;
 
+*** ---- FE demand trajectories for calibration -------------------------------
+*** also used for limiting secondary steel demand in baseline and policy 
+*** scenarios
 Parameter
   pm_fedemand   "final energy demand"
   /
@@ -1195,6 +1198,46 @@ $include "./core/input/pm_fe_demand.cs4r"
 $offdelim
   /
 ;
+
+$ifthen.subsectors "%industry%" == "subsectors"   !! industry
+*** Limit secondary steel production to 90 %.  This might be slightly off due 
+*** to rounding in the mrremind package.
+if (9 lt smax((t,regi,all_GDPscen)$(
+                           pm_fedemand(t,regi,all_GDPscen,"ue_steel_primary") ), 
+           pm_fedemand(t,regi,all_GDPscen,"ue_steel_secondary")
+         / pm_fedemand(t,regi,all_GDPscen,"ue_steel_primary")
+         ),
+  put logfile;
+  logfile.nd = 15;
+  put ">>> rescaling steel production figures because of mrremind rounding" /;
+
+  loop ((t,regi,all_GDPscen)$(
+                           pm_fedemand(t,regi,all_GDPscen,"ue_steel_primary") ),
+    if (9 lt ( pm_fedemand(t,regi,all_GDPscen,"ue_steel_secondary")
+             / pm_fedemand(t,regi,all_GDPscen,"ue_steel_primary")),
+  
+      put t.tl, " ", regi.tl, " ", all_GDPscen.tl, ": ";
+      put @20 "(", pm_fedemand(t,regi,all_GDPscen,"ue_steel_primary"), ",";
+      put pm_fedemand(t,regi,all_GDPscen,"ue_steel_secondary"), ") -> ";
+  
+      pm_fedemand(t,regi,all_GDPscen,"ue_steel_primary")
+      = 0.1
+      * ( pm_fedemand(t,regi,all_GDPscen,"ue_steel_primary")
+        + pm_fedemand(t,regi,all_GDPscen,"ue_steel_secondary")
+        );
+  
+      pm_fedemand(t,regi,all_GDPscen,"ue_steel_secondary")
+      = 9 * pm_fedemand(t,regi,all_GDPscen,"ue_steel_primary");
+  
+      put "(", pm_fedemand(t,regi,all_GDPscen,"ue_steel_primary"), ",";
+      put pm_fedemand(t,regi,all_GDPscen,"ue_steel_secondary"), ")" /;
+    );
+  );
+
+  logfile.nd = 3;
+  putclose logfile;
+);
+$endif.subsectors
 
 *** EOF ./core/datainput.gms
 

--- a/modules/37_industry/subsectors/equations.gms
+++ b/modules/37_industry/subsectors/equations.gms
@@ -17,7 +17,6 @@ q37_energy_limits(ttot,regi,industry_ue_calibration_target_dyn37(out))$(
 ;
 
 *** No more than 90% of steel from secondary production
-*** FIXME: add check to ensure calibration data abides by this rule
 q37_limit_secondary_steel_share(ttot,regi)$( ttot.val ge cm_startyear ) .. 
   9 * vm_cesIO(ttot,regi,"ue_steel_primary")
   =g=


### PR DESCRIPTION
- primary steel production is limited to at least 90 % in the subsectors
  realisation
- data in pm_fedemand might not adhere to this limit, since mrremind
  rounds to 6 decimal digits, not significant digits

- pm_fedemand data for ue_steel_primary and ue_steel_secondary is
  rescaled accordingly, changes are reported to the log