### PR TITLE
fix missing lower bounds in industry/fixed_shares

### DIFF
--- a/modules/37_industry/fixed_shares/bounds.gms
+++ b/modules/37_industry/fixed_shares/bounds.gms
@@ -14,5 +14,7 @@ loop ((secInd37,enty)$( NOT macBaseInd37(enty,secInd37) ),
   vm_macBaseInd.fx(ttot,regi,enty,secInd37)$( ttot.val ge 2005 ) = 0;
 );
 
+vm_cesIO.lo(t,regi,in_industry_dyn37(in)) = 1e-6;
+
 *** EOF ./modules/37_industry/fixed_shares/bounds.gms
 


### PR DESCRIPTION
- industry quantities are excluded from global 1e-6 lower bound with
  subsectors module, since they are too low
- default lower bounds were missing from fixed_shares realisation