### PR TITLE
Tax conv

### DIFF
--- a/modules/80_optimization/nash/postsolve.gms
+++ b/modules/80_optimization/nash/postsolve.gms
@@ -186,7 +186,7 @@ if(sm_fadeoutPriceAnticip gt 1E-4, s80_bool = 0);
 ***additional criterion: did taxes converge?
 loop(regi,
   loop(t,
-    if( (abs(vm_taxrev.l(t,regi)) gt 1E-4),
+    if( (abs(vm_taxrev.l(t,regi)) gt 1E-3),
      s80_bool = 0;
      p80_messageShow("taxconv") = YES;
     );
@@ -226,7 +226,7 @@ if( (s80_bool eq 0) and (iteration.val eq cm_iteration_max),     !! reached max 
 	     );	 
 	     if(sameas(convMessage80, "taxconv"),
 		 display "####";
-		 display "#### Taxes did not converge in all regions and time steps. Check the absolute level of vm_taxrev (gt 1e-4)!";
+		 display "#### Taxes did not converge in all regions and time steps. Check the absolute level of vm_taxrev (gt 1e-3)!";
 	     );	
 	 );
 	 display "#### Info: These residual market surplusses in current monetary values are:";

--- a/modules/80_optimization/nash/postsolve.gms
+++ b/modules/80_optimization/nash/postsolve.gms
@@ -183,6 +183,17 @@ loop(regi,
 if(sm_fadeoutPriceAnticip gt 1E-4, s80_bool = 0);
 **
 
+***additional criterion: did taxes converge?
+loop(regi,
+  loop(t,
+    if( (abs(vm_taxrev.l(t,regi)) gt 1E-4),
+     s80_bool = 0;
+     p80_messageShow("taxconv") = YES;
+    );
+  );
+);
+
+
 ***end with failure message if max number of iterations is reached w/o convergence:
 if( (s80_bool eq 0) and (iteration.val eq cm_iteration_max),     !! reached max number of iteration, still no convergence
      OPTION decimals = 3;
@@ -213,6 +224,10 @@ if( (s80_bool eq 0) and (iteration.val eq cm_iteration_max),     !! reached max 
 		 display "#### We can't accept this solution, because it is non-optimal, and too far away from the last known optimal solution. ";
 		 display "#### Just trying a different gdx may help.";
 	     );	 
+	     if(sameas(convMessage80, "taxconv"),
+		 display "####";
+		 display "#### Taxes did not converge in all regions and time steps. Check the absolute level of vm_taxrev (gt 1e-4)!";
+	     );	
 	 );
 	 display "#### Info: These residual market surplusses in current monetary values are:";
 	 display  p80_defic_trade;

--- a/modules/80_optimization/nash/sets.gms
+++ b/modules/80_optimization/nash/sets.gms
@@ -26,7 +26,7 @@ solvestat, modelstat, resusd, objval
 
 convMessage80   "contains possible reasons for failed convergence"
 /
-infes,surplus,nonopt
+infes,surplus,nonopt,taxconv
 /
 nash_sol_itr80  "nash iterations"
 /


### PR DESCRIPTION
This would introduce a convergence check for tax revenues in the Nash algorithm. In addition to the prior criteria, Nash only stops now if abs(vm_taxrev) < 1e-3 for all regions and time steps. This 1.) helps detecting problems when you implement taxes as tax convergence was not automatically checked before. 2.) It lets all tax revenues converge to a 1e-3 which is  ~1% of the smallest GDPs we now have with REMIND EU. It ensures that taxes do not create or eat money.  The precision may be up for debate as there is a trade-off between longer run time and better tax convergence. In my test runs (see below) iterations increased, but only in one case up to 100 (SDP900). 
![image](https://user-images.githubusercontent.com/42831977/89996710-6b7adb80-dc8b-11ea-9041-27c9c6f87985.png)

![image](https://user-images.githubusercontent.com/42831977/89996761-7cc3e800-dc8b-11ea-8828-71e7ae1a96c3.png)
