### PR TITLE
change tax convergence criterion for nash runs such that tax revenues need to be below one percent GDP

### DIFF
--- a/modules/80_optimization/nash/postsolve.gms
+++ b/modules/80_optimization/nash/postsolve.gms
@@ -186,7 +186,7 @@ if(sm_fadeoutPriceAnticip gt 1E-4, s80_bool = 0);
 ***additional criterion: did taxes converge?
 loop(regi,
   loop(t,
-    if( (abs(vm_taxrev.l(t,regi)) gt 1E-3),
+    if( (abs(vm_taxrev.l(t,regi)) / vm_cesIO.l(t,regi,"inco")) gt 1E-2,
      s80_bool = 0;
      p80_messageShow("taxconv") = YES;
     );
@@ -226,7 +226,7 @@ if( (s80_bool eq 0) and (iteration.val eq cm_iteration_max),     !! reached max 
 	     );	 
 	     if(sameas(convMessage80, "taxconv"),
 		 display "####";
-		 display "#### Taxes did not converge in all regions and time steps. Check the absolute level of vm_taxrev (gt 1e-3)!";
+		 display "#### Taxes did not converge in all regions and time steps. Check the absolute level of tax revenue vm_taxrev, must be smaller than 1 percent of GDP";
 	     );	
 	 );
 	 display "#### Info: These residual market surplusses in current monetary values are:";

--- a/modules/80_optimization/negishi/not_used.txt
+++ b/modules/80_optimization/negishi/not_used.txt
@@ -29,5 +29,6 @@ qm_co2eqCum, equation, ???
 sm_endBudgetCO2eq,scalar,???
 sm_fadeoutPriceAnticip,scalar,???
 vm_co2eq,variable,???
+vm_cesIO,variable,???
 
 pm_nfa_start,input,questionnaire

--- a/modules/80_optimization/testOneRegi/not_used.txt
+++ b/modules/80_optimization/testOneRegi/not_used.txt
@@ -35,3 +35,4 @@ cm_emiscen,switch,???
 pm_pvpRegi,parameter,???
 pm_nfa_start,input,questionnaire
 vm_dummyBudget,input,questionnaire
+vm_cesIO,variable,???


### PR DESCRIPTION
Change tax convergence criterion for nash runs. Now tax revenues in all regions and time steps need to be below one percent of GDP. In a suite of SSP2 and SDP standard test runs, this did not significantly increase the number of iterations relative to the version without tax convergence check. 

Would be nice if sombody from RSE could add this criterion to the rs script. So that if p80_messageShow("taxconv") = YES, i.e. taxes did not converge, this also shows up in the rs. 
