### PR TITLE
improvement of wind and solar capacity factor calibration: -make sure…

### DIFF
--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -36,9 +36,17 @@ loop(regi,
   loop(teRe2rlfDetail(te,rlf),
     if( (pm_dataren(regi,"maxprod",rlf,te) gt 0),
         vm_capDistr.lo(t,regi,te,rlf)$(t.val gt 2011) = 1e-8;
+*cb* make sure that grade distribution in early time steps with capacity fixing is close to optimal one assumed for vm_capFac calibration
+       vm_capDistr.lo("2015",regi,te,rlf) = 0.99*p_aux_capThisGrade(regi,te,rlf);
+       vm_capDistr.lo("2020",regi,te,rlf) = 0.99*p_aux_capThisGrade(regi,te,rlf);
     );
   );
 );
+
+*cb* make sure no grades > 9 are used. Only cosmetic to avoid entries in lst file
+vm_capDistr.fx(t,regi,te,rlf)$(rlf.val gt 9) = 0;
+
+
 
 *RP* no battery storage in 2010:
 vm_cap.up("2010",regi,teStor,"1") = 0;
@@ -281,18 +289,20 @@ vm_emiMac.fx(t,regi,"oc") = 0;
 loop(te$(sameas(te,"spv") OR sameas(te,"csp") OR sameas(te,"wind")),
   vm_cap.lo("2015",regi,te,"1") = 0.95 * p_histCap("2015",regi,te)$(p_histCap("2015",regi,te) gt 1e-10);
   vm_cap.up("2015",regi,te,"1") = 1.05 * p_histCap("2015",regi,te)$(p_histCap("2015",regi,te) gt 1e-10);
-*additional bound on 2020 expansion: at least yearly as much as in 2016,2017 average
-  vm_deltaCap.lo("2020",regi,te,"1") = (p_histCap("2018",regi,te)-p_histCap("2015",regi,te))/3;
+*additional bound on 2020 expansion: at least yearly as much as 80% of in 2015-2019 average
+  vm_deltaCap.lo("2020",regi,te,"1") = 0.8*(p_histCap("2019",regi,te)-p_histCap("2015",regi,te))/4;
 );
 vm_cap.up("2015",regi,"csp",'1') = 1e-5 + 1.05 * vm_cap.lo("2015",regi,"csp","1"); !! allow offset of 10MW even for countries with no CSP installations to help the solver
 
-*RR* set lower bounds to spv installed capacity in 2020 to reflect the massive deployment in recent years to 2018 historical values plus a conservative estimation of expected additional deployment until 2020 (+10% per year).
-vm_cap.lo("2020",regi,"spv","1")$(p_histCap("2018",regi,"spv")) = p_histCap("2018",regi,"spv")*(1+0.1)**2;
+*RR* set lower bounds to spv installed capacity in 2020 to reflect the massive deployment in recent years to 90% of 2019 historical value
+vm_cap.lo("2020",regi,"spv","1")$(p_histCap("2019",regi,"spv")) = 0.9*p_histCap("2019",regi,"spv");
 
-*CB* additional upper bound on 2020 deployment: doubling of historic rate plus 2 GW for solar and wind, and 500 MW for CSP
+*CB* additional upper bound on 2020 deployment
 loop(regi,
 loop(te$(sameas(te,"spv") OR sameas(te,"csp") OR sameas(te,"wind")),
-vm_deltaCap.up("2020",regi,te,"1") = max(2*(p_histCap("2018",regi,te)-p_histCap("2015",regi,te))/3,2*(p_histCap("2018",regi,te)-p_histCap("2017",regi,te)),0.006$(sameas(te,"spv")) + 0.0055$(sameas(te,"wind"))+0.0005$(sameas(te,"csp")));
+vm_deltaCap.up("2020",regi,te,"1") = max(1.2*(p_histCap("2019",regi,te)-p_histCap("2015",regi,te))/4,!!20% more than the 4 year average might be relevant for regions with low 2019 insta
+                                         1.25*(p_histCap("2019",regi,te)-p_histCap("2018",regi,te)),!!for most countries this will be binding
+										 0.005$(sameas(te,"spv")) + 0.0045$(sameas(te,"wind"))+0.0005$(sameas(te,"csp")));!! for small regions
 );
 );
 

--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -674,14 +674,23 @@ $offdelim
 
 *** RP rescale wind capacity factors in REMIND to account for very different real-world CF (potentially partially due to assumed low-wind turbine set-ups in the NREL data)
 *** Because of the lag effect (turbines in the 2000s were much smaller and thus yielded lower CFs), only implement half of the calculated ratio of historic to REMIND capFac as rescaling for the new CFs - realised as (x+1)/2
+
+*cb* CF calibration analogously for wind and spv: calibrate 2015, and assume gradual phase-in of grade-based CF (until 2045 for wind, until 2030 for spv)
 p_aux_capacityFactorHistOverREMIND(regi,"wind")$p_avCapFac2015(regi,"wind") =  p_histCapFac("2015",regi,"wind") / p_avCapFac2015(regi,"wind");
-loop(te$sameas(te,"wind"),
-  pm_dataren(regi,"maxprod",rlf,te) = pm_dataren(regi,"maxprod",rlf,te) * ( p_aux_capacityFactorHistOverREMIND(regi,te) + 1) / 2 ;
-  pm_dataren(regi,"nur",rlf,te)     = pm_dataren(regi,"nur",rlf,te)     * ( p_aux_capacityFactorHistOverREMIND(regi,te) + 1) / 2 ;
+
+loop(t$(t.val ge 2015 AND t.val le 2045 ),
+pm_cf(t,regi,"wind") =
+(2045 - pm_ttot_val(t)) / 30 * p_aux_capacityFactorHistOverREMIND(regi,"wind") *pm_cf(t,regi,"wind")
++
+(pm_ttot_val(t) - 2015) / 30 * pm_cf(t,regi,"wind")
 );
+
+
 
 p_aux_capacityFactorHistOverREMIND(regi,"spv")$p_avCapFac2015(regi,"spv") =  p_histCapFac("2015",regi,"spv") / p_avCapFac2015(regi,"spv");
 pm_cf("2015",regi,"spv") = pm_cf("2015",regi,"spv") * p_aux_capacityFactorHistOverREMIND(regi,"spv");
+pm_cf("2020",regi,"spv") = pm_cf("2020",regi,"spv") * (p_aux_capacityFactorHistOverREMIND(regi,"spv")+1)/2;
+pm_cf("2025",regi,"spv") = pm_cf("2025",regi,"spv") * (p_aux_capacityFactorHistOverREMIND(regi,"spv")+3)/4;
 
 *** RP rescale CSP capacity factors in REMIND - in the DLR resource data input files, the numbers are based on a SM3/12h setup, while the cost data from IEA seems rather based on a SM2/6h setup (with 40% average CF)
 *** Accordingly, decrease CF in REMIND to 2/3 of the DLR values (no need to correct maxprod, as here no miscalculation of total energy yield takes place, in contrast to wind)


### PR DESCRIPTION
… that capacities in 2015 and 2020 are used optimally, and only adjust vm_capFac (via pm_cf), instead of "nur" and "maxprod" values. Phase-out of calibration for reduced capacity factor until 2030 for spv and 2045 for wind (evoloving turbing design). improvement of 2020 bounds: include 2019 capacity data (thus raising the lower bound), and lower upper bounds to 25% over 2019 (or alternatively 20% over 2015-2019 average, or seed values for small) as growth from 2019-2020 will be limited.