### PR TITLE
add writing of abort.gdx to facilitate debugging

### DIFF
--- a/modules/31_fossil/grades2poly/preloop.gms
+++ b/modules/31_fossil/grades2poly/preloop.gms
@@ -8,20 +8,26 @@
 ***--------------------------------------
 *** URANIUM BOUND
 ***--------------------------------------
-model m31_uran_bound_dummy /q31_mc_dummy, q31_totfuex_dummy/;
- if(cm_limit_peur_scen eq 1,
+model m31_uran_bound_dummy / q31_mc_dummy, q31_totfuex_dummy /;
+
+if (cm_limit_peur_scen eq 1,
 *** Small CNS model to initiate regional bounds on uranium extraction
-     v31_fuExtrCumMax.l(regi,peExPol(enty), "1")=0.001;
- solve m31_uran_bound_dummy minimizing v31_squaredDiff using nlp;
- solve m31_uran_bound_dummy minimizing v31_squaredDiff using nlp;
-if(not (m31_uran_bound_dummy.modelstat eq 1 OR m31_uran_bound_dummy.modelstat eq 2),
-  abort "Uranium bound model m31_uran_bound_dummy could not be solved, aborting!";
-);
+  v31_fuExtrCumMax.l(regi,peExPol(enty), "1")=0.001;
+  solve m31_uran_bound_dummy minimizing v31_squaredDiff using nlp;
+  solve m31_uran_bound_dummy minimizing v31_squaredDiff using nlp;
+
+  if (NOT (   m31_uran_bound_dummy.modelstat eq 1 
+           OR m31_uran_bound_dummy.modelstat eq 2),
+    execute_unload "abort.gdx";
+    abort "Uranium bound model m31_uran_bound_dummy could not be solved, aborting!";
+  );
 
 *AJS* use parameter to save the result of the CNS model
-     p31_fuExtrCumMaxBound(regi,"peur", "1") = v31_fuExtrCumMax.l(regi,"peur", "1");
+  p31_fuExtrCumMaxBound(regi,"peur","1") = v31_fuExtrCumMax.l(regi,"peur","1");
 );
 
-display v31_squaredDiff.l, p31_fuExtrCumMaxBound, v31_fuExtrMC.l, s31_max_disp_peur;
+display v31_squaredDiff.l, p31_fuExtrCumMaxBound, v31_fuExtrMC.l, 
+  s31_max_disp_peur;
 
 *** EOF ./modules/31_fossil/grades2poly/preloop.gms
+

--- a/modules/36_buildings/services_putty/preloop.gms
+++ b/modules/36_buildings/services_putty/preloop.gms
@@ -24,7 +24,8 @@ q36_putty_obj
 solve putty_paths_floor minimizing v36_putty_obj using nlp;
 
 if ( NOT ( putty_paths_floor.solvestat eq 1  AND (putty_paths_floor.modelstat eq 1 OR putty_paths_floor.modelstat eq 2)),
-abort "model putty_paths_floor is infeasible";
+  execute_unload "abort.gdx";
+  abort "model putty_paths_floor is infeasible";
 );
 
 p36_floorspace_delta(ttot,regi_dyn36(regi)) $ v36_floorspace_delta.L(ttot,regi) = v36_floorspace_delta.L(ttot,regi);
@@ -38,3 +39,4 @@ p36_kapPriceImplicit(t,regi_dyn36(regi),teEs) = p36_kapPrice(t,regi) + p36_impli
 );
 
 *** EOF ./modules/36_buildings/services_putty/preloop.gms
+

--- a/modules/36_buildings/services_putty/presolve.gms
+++ b/modules/36_buildings/services_putty/presolve.gms
@@ -140,6 +140,7 @@ p36_shUeCesDelta(ttot,regi_dyn36(regi),entyFe,in,teEs) = (p36_prodEs(ttot,regi,e
      put p36_prodEs.tn(ttot,regi,entyFe,esty,teEs) , " = ", p36_prodEs(ttot,regi,entyFe,esty,teEs) /;
      put p36_prodUEintern.tn(ttot,regi,entyFe,esty,teEs), " = ", p36_prodUEintern(ttot,regi,entyFe,esty,teEs) /;
      putclose;
+     execute_unload "abort.gdx";
      abort "some share was decreasing faster than planned. Look at the logfile for more information";
      );
      );                                        
@@ -337,3 +338,4 @@ put "%c_expname%", iteration.tl, t.tl,regi.tl, "norm_diff", "NA" ,in.tl, p36_log
 putclose;
 
 *** EOF ./modules/36_buildings/services_putty/presolve.gms
+

--- a/modules/36_buildings/services_with_capital/presolve.gms
+++ b/modules/36_buildings/services_with_capital/presolve.gms
@@ -141,6 +141,7 @@ p36_shUeCesDelta(ttot,regi_dyn36(regi),entyFe,in,teEs) = (p36_prodEs(ttot,regi,e
      put p36_prodEs.tn(ttot,regi,entyFe,esty,teEs) , " = ", p36_prodEs(ttot,regi,entyFe,esty,teEs) /;
      put p36_prodUEintern.tn(ttot,regi,entyFe,esty,teEs), " = ", p36_prodUEintern(ttot,regi,entyFe,esty,teEs) /;
      putclose;
+     execute_unload "abort.gdx";
      abort "some share was decreasing faster than planned. Look at the logfile for more information";
      );
      );                                        
@@ -337,3 +338,4 @@ put "%c_expname%", iteration.tl, t.tl,regi.tl, "norm_diff", "NA" ,in.tl, p36_log
 putclose;
 
 *** EOF ./modules/36_buildings/services_with_capital/presolve.gms
+

--- a/modules/37_industry/subsectors/sets.gms
+++ b/modules/37_industry/subsectors/sets.gms
@@ -175,5 +175,5 @@ fe_tax_sub_sbi(fe_tax_sub37) = YES;
 !! cal_ppf_industry_dyn37(ppfen_industry_dyn37)  = YES;
 !! cal_ppf_industry_dyn37(ppfkap_industry_dyn37) = YES;
 
-*** EOR ./modules/37_industry_four_sectors/sets.gms
+*** EOF ./modules/37_industry_four_sectors/sets.gms
 

--- a/modules/80_optimization/nash/solve.gms
+++ b/modules/80_optimization/nash/solve.gms
@@ -27,7 +27,8 @@ loop(all_regi,
 ***      -------------------------------------------------------------------
 
 if (execError > 0,
-abort "at least one execution error occured, possibly in the loop";
+  execute_unload "abort.gdx";
+  abort "at least one execution error occured, possibly in the loop";
 );
 
 solve hybrid using nlp maximizing vm_welfareGlob;
@@ -103,3 +104,4 @@ $endif.solprint
 p80_repy_iteration(all_regi,solveinfo80,iteration) = p80_repy(all_regi,solveinfo80);
 
 *** EOF ./modules/80_optimization/nash/solve.gms
+

--- a/modules/80_optimization/negishi/preloop.gms
+++ b/modules/80_optimization/negishi/preloop.gms
@@ -28,7 +28,8 @@ OPTION decimals =3;
 
 *AJS* Sanity check on Negishi weights: if not larger than 1E-3, smaller than 0.4, do not sum up to one -> abort
 if( ( smin(regi,pm_w(regi)) lt 1E-3 ) or ( smax(regi,pm_w(regi)) gt 0.4 ) or (abs(sum(regi,pm_w(regi)) - 1 ) gt 0.01 ) ,
-    abort "The Negishi weights look shabby, I won't start a run from those. Please choose a better gdx.";
+  execute_unload "abort.gdx";
+  abort "The Negishi weights look shabby, I won't start a run from those. Please choose a better gdx.";
 );
 
 
@@ -37,3 +38,4 @@ loop(regi,
     p80_nw("1",regi) = pm_w(regi);
 );
 *** EOF ./modules/80_optimization/negishi/preloop.gms
+


### PR DESCRIPTION
- there are several instances all over the code base where model solving
  is aborted due to some internal error arising
- writing all model data to a .gdx file prior to aborting enables users
  to inspect the error, even if insufficient put statements where
  sprinkled throughout the code