### PR TITLE
fix writing of intermediate gdxes

### DIFF
--- a/core/loop.gms
+++ b/core/loop.gms
@@ -162,16 +162,18 @@ if (o_modelstat le 2,
   !! retain gdxes of intermediate iterations by copying them using shell
   !! commands
   if (c_keep_iteration_gdxes eq 1,
-    put_utility "shell" / "printf '%03i\n'" iteration.val:0:0
-                          "| sed 's/\(.*\)/fulldata.gdx fulldata_\1.gdx/'"
-                          "| xargs -n 2 cp"
+    put_utility logfile, "shell" / 
+      "printf '%03i\n'" iteration.val:0:0
+      "| sed 's/\(.*\)/fulldata.gdx fulldata_\1.gdx/'"
+      "| xargs -n 2 cp"
   );
 else
   execute_unload 'non_optimal';
   if (c_keep_iteration_gdxes eq 1,
-    put_utility "shell" / "printf '%03i\n'" iteration.val:0:0
-                          "| sed 's/\(.*\)/non_optimal.gdx non_optimal_\1.gdx/'"
-                          "| xargs -n 2 cp"
+    put_utility logfile, "shell" / 
+      "printf '%03i\n'" iteration.val:0:0
+      "| sed 's/\(.*\)/non_optimal.gdx non_optimal_\1.gdx/'"
+      "| xargs -n 2 cp"
   );
 );
 

--- a/core/loop.gms
+++ b/core/loop.gms
@@ -163,17 +163,13 @@ if (o_modelstat le 2,
   !! commands
   if (c_keep_iteration_gdxes eq 1,
     put_utility logfile, "shell" / 
-      "printf '%03i\n'" iteration.val:0:0
-      "| sed 's/\(.*\)/fulldata.gdx fulldata_\1.gdx/'"
-      "| xargs -n 2 cp"
+      "cp fulldata.gdx fulldata_" iteration.val:0:0 ".gdx";
   );
 else
   execute_unload 'non_optimal';
   if (c_keep_iteration_gdxes eq 1,
     put_utility logfile, "shell" / 
-      "printf '%03i\n'" iteration.val:0:0
-      "| sed 's/\(.*\)/non_optimal.gdx non_optimal_\1.gdx/'"
-      "| xargs -n 2 cp"
+      "cp non_optimal.gdx non_optimal_" iteration.val:0:0 ".gdx";
   );
 );
 


### PR DESCRIPTION
- 29_CES_parameters/calibrate left a .pc = 5 configured file open which
  prevents put_utility from invoking features, therefore

- use put_utility with logfile, which we know is not .pc = 5, thus
  clearing the .pc attribute

- fix the renaming of gdxes, as GAMS does not seem to resolve single
  '%' anymore