### PR TITLE
shift technology cost convergence to 2070 and increase coal power plant convergence target costs from 1260 to 2000$(2015)/kW

### DIFF
--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -953,12 +953,12 @@ $if %c_techcosts% == "REG"      );
 $if %c_techcosts% == "REG"    );
 
 ***linear convergence of investment costs from 2025 on for non-learning technologies,
-***so that in 2050 all regions again have the technology cost data that is given in generisdata.prn
-$if %cm_techcosts% == "REG"   loop(ttot$(ttot.val ge 2020 AND ttot.val le 2050),
+***so that in 2070 all regions again have the technology cost data that is given in generisdata.prn
+$if %cm_techcosts% == "REG"   loop(ttot$(ttot.val ge 2020 AND ttot.val le 2070),
 $if %cm_techcosts% == "REG"     pm_inco0_t(ttot,regi,teNoLearn(te)) = ((pm_ttot_val(ttot)-2020)*fm_dataglob("inco0",te)
-$if %cm_techcosts% == "REG"                                            + (2050-pm_ttot_val(ttot))*pm_inco0_t("2020",regi,te))/30;
+$if %cm_techcosts% == "REG"                                            + (2070-pm_ttot_val(ttot))*pm_inco0_t("2020",regi,te))/50;
 $if %cm_techcosts% == "REG"   );
-$if %cm_techcosts% == "REG"   loop(ttot$(ttot.val gt 2050),
+$if %cm_techcosts% == "REG"   loop(ttot$(ttot.val gt 2070),
 $if %cm_techcosts% == "REG"   pm_inco0_t(ttot,regi,teNoLearn(te)) = fm_dataglob("inco0",te);
 $if %cm_techcosts% == "REG"   );
 

--- a/core/input/generisdata_flexibility.prn
+++ b/core/input/generisdata_flexibility.prn
@@ -6,9 +6,9 @@ fm_dataglob("flexibility","ngccc")  = 0.85;
 fm_dataglob("flexibility","ngt")    = 6;
 fm_dataglob("flexibility","h2turb") = 6;
 fm_dataglob("flexibility","dot")    = 6;
-fm_dataglob("flexibility","igcc")   = 0.8;
+fm_dataglob("flexibility","igcc")   = 0.85;
 fm_dataglob("flexibility","igccc")  = 0.7;
-fm_dataglob("flexibility","pc")     = 0.85;
+fm_dataglob("flexibility","pc")     = 0.90;
 $ifthen setGlobal cm_ccsfosall
 fm_dataglob("flexibility","pcc")    = 0.7;
 fm_dataglob("flexibility","pco")    = 0.7;

--- a/core/input/generisdata_tech.prn
+++ b/core/input/generisdata_tech.prn
@@ -34,7 +34,7 @@ lifetime              40
 
 +                  igcc       igccc          pc       coalchp      coalhp      coaltr     coalgas   coalftrec  coalftcrec      coalh2     coalh2c
 tech_stat             1          2                                                                        1           3           1           2 
-inco0               1760        2800        1280        2500         550         120        1440        1740        1820        1510        1720
+inco0               2300        2900        2000        2500         550         120        1440        1740        1820        1510        1720
 constrTme             4          5            4           4           2           1           4           4           4           4           4
 mix0                                                                                                    0.00        0.00        0.30        0.00
 eta                 0.42        0.33        0.41        0.38        0.75        0.95        0.60        0.40        0.40        0.59        0.57
@@ -45,7 +45,7 @@ lifetime              40          40          40          40          40        
 $ifthen setGlobal cm_ccsfosall
 +                  pcc         pco
 tech_stat           2           2
-inco0              2900        2600  
+inco0              3200        2900  
 constrTme           5            5 
 mix0                   
 eta                0.36        0.37     

--- a/core/input/generisdata_tech_SSP1.prn
+++ b/core/input/generisdata_tech_SSP1.prn
@@ -34,7 +34,7 @@ lifetime              40
 
 +                  igcc       igccc          pc       coalchp      coalhp      coaltr     coalgas   coalftrec  coalftcrec      coalh2     coalh2c
 tech_stat             1          2                                                                        1           3           1           2 
-inco0               1760        3640        1280        2500         550         120        1440        1740        2370        1510        2240
+inco0               2300        3770        2000        2500         550         120        1440        1740        2370        1510        2240
 constrTme             4          5            4           4           2           1           4           4           4           4           4
 mix0                                                                                                    0.00        0.00        0.30        0.00
 eta                 0.42        0.33        0.41        0.38        0.75        0.95        0.60        0.40        0.40        0.59        0.57
@@ -45,7 +45,7 @@ lifetime              40          40          40          40          40        
 $ifthen setGlobal cm_ccsfosall
 +                  pcc         pco
 tech_stat           2           2
-inco0              3770        3380  
+inco0              4160        3770  
 constrTme           5            5 
 mix0                   
 eta                0.36        0.37     

--- a/core/input/generisdata_tech_SSP5.prn
+++ b/core/input/generisdata_tech_SSP5.prn
@@ -34,7 +34,7 @@ lifetime              40
 
 +                  igcc       igccc          pc       coalchp      coalhp      coaltr     coalgas   coalftrec  coalftcrec      coalh2     coalh2c
 tech_stat             1          2                                                                        1           3           1           2 
-inco0               2200        3070        1600        2500         550         120        1440        1580        1650        1510        1720
+inco0               2300        3180        2000        2500         550         120        1440        1580        1650        1510        1720
 constrTme             4          5            4           4           2           1           4           4           4           4           4
 mix0                                                                0.31        0.35        0.05        0.00        0.00        0.30        0.00
 eta                 0.42        0.33        0.41        0.38        0.75        0.95        0.60        0.40        0.40        0.59        0.57
@@ -45,7 +45,7 @@ lifetime              40          40          40          40          40        
 $ifthen setGlobal cm_ccsfosall
 +                  pcc         pco
 tech_stat           2           2
-inco0              3190        2850  
+inco0              3520        3180  
 constrTme           5            5 
 mix0                   
 eta                0.36        0.37     


### PR DESCRIPTION
Reason: coal power plant investment costs were reduced during the Jan/2019 validation of REMIND below the value found in literature. Current cost estimates in developed countries are in the range of 2000-3600$/kW, so the old implementation meant substantial cost reductions, which are not expected in literature. To prevent a very fast increase of costs in developing countries, the convergence point was shifted to 2070.