### PR TITLE
add symlinks to MAGICC files

### DIFF
--- a/core/magicc/EDGAR_CH4_EMIS_LANDUSE.IN
+++ b/core/magicc/EDGAR_CH4_EMIS_LANDUSE.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/EDGAR_CH4_EMIS_LANDUSE.IN

--- a/core/magicc/EDGAR_NOX_EMIS_FOSSIL_IND.IN
+++ b/core/magicc/EDGAR_NOX_EMIS_FOSSIL_IND.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/EDGAR_NOX_EMIS_FOSSIL_IND.IN

--- a/core/magicc/EDGAR_NOX_EMIS_LANDUSE.IN
+++ b/core/magicc/EDGAR_NOX_EMIS_LANDUSE.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/EDGAR_NOX_EMIS_LANDUSE.IN

--- a/core/magicc/GISS_BCB_OT.IN
+++ b/core/magicc/GISS_BCB_OT.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/GISS_BCB_OT.IN

--- a/core/magicc/GISS_BCB_RF.IN
+++ b/core/magicc/GISS_BCB_RF.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/GISS_BCB_RF.IN

--- a/core/magicc/GISS_BCI_OT.IN
+++ b/core/magicc/GISS_BCI_OT.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/GISS_BCI_OT.IN

--- a/core/magicc/GISS_BCI_RF.IN
+++ b/core/magicc/GISS_BCI_RF.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/GISS_BCI_RF.IN

--- a/core/magicc/GISS_BCSNOW_RF.IN
+++ b/core/magicc/GISS_BCSNOW_RF.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/GISS_BCSNOW_RF.IN

--- a/core/magicc/GISS_LANDUSE_RF.IN
+++ b/core/magicc/GISS_LANDUSE_RF.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/GISS_LANDUSE_RF.IN

--- a/core/magicc/GISS_NOX_RF.IN
+++ b/core/magicc/GISS_NOX_RF.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/GISS_NOX_RF.IN

--- a/core/magicc/GISS_OCB_OT.IN
+++ b/core/magicc/GISS_OCB_OT.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/GISS_OCB_OT.IN

--- a/core/magicc/GISS_OCB_RF.IN
+++ b/core/magicc/GISS_OCB_RF.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/GISS_OCB_RF.IN

--- a/core/magicc/GISS_OCI_OT.IN
+++ b/core/magicc/GISS_OCI_OT.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/GISS_OCI_OT.IN

--- a/core/magicc/GISS_OCI_RF.IN
+++ b/core/magicc/GISS_OCI_RF.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/GISS_OCI_RF.IN

--- a/core/magicc/GISS_OCN_OT.IN
+++ b/core/magicc/GISS_OCN_OT.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/GISS_OCN_OT.IN

--- a/core/magicc/GISS_SOXI_OT.IN
+++ b/core/magicc/GISS_SOXI_OT.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/GISS_SOXI_OT.IN

--- a/core/magicc/GISS_SOXNB_OT.IN
+++ b/core/magicc/GISS_SOXNB_OT.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/GISS_SOXNB_OT.IN

--- a/core/magicc/GISS_SOX_RF.IN
+++ b/core/magicc/GISS_SOX_RF.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/GISS_SOX_RF.IN

--- a/core/magicc/GISS_SS_OT.IN
+++ b/core/magicc/GISS_SS_OT.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/GISS_SS_OT.IN

--- a/core/magicc/HISTEDGAR_CH4B_EMIS.IN
+++ b/core/magicc/HISTEDGAR_CH4B_EMIS.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTEDGAR_CH4B_EMIS.IN

--- a/core/magicc/HISTEDGAR_CH4I_EMIS.IN
+++ b/core/magicc/HISTEDGAR_CH4I_EMIS.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTEDGAR_CH4I_EMIS.IN

--- a/core/magicc/HISTEDGAR_N2OB_EMIS.IN
+++ b/core/magicc/HISTEDGAR_N2OB_EMIS.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTEDGAR_N2OB_EMIS.IN

--- a/core/magicc/HISTEDGAR_N2OI_EMIS.IN
+++ b/core/magicc/HISTEDGAR_N2OI_EMIS.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTEDGAR_N2OI_EMIS.IN

--- a/core/magicc/HISTRCP85_SOLAR_RF.IN
+++ b/core/magicc/HISTRCP85_SOLAR_RF.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP85_SOLAR_RF.IN

--- a/core/magicc/HISTRCP_BCB_EMIS.IN
+++ b/core/magicc/HISTRCP_BCB_EMIS.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_BCB_EMIS.IN

--- a/core/magicc/HISTRCP_BCI_EMIS.IN
+++ b/core/magicc/HISTRCP_BCI_EMIS.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_BCI_EMIS.IN

--- a/core/magicc/HISTRCP_C2F6_CONC.IN
+++ b/core/magicc/HISTRCP_C2F6_CONC.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_C2F6_CONC.IN

--- a/core/magicc/HISTRCP_C2F6_EMIS.IN
+++ b/core/magicc/HISTRCP_C2F6_EMIS.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_C2F6_EMIS.IN

--- a/core/magicc/HISTRCP_C6F14I_EMIS.IN
+++ b/core/magicc/HISTRCP_C6F14I_EMIS.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_C6F14I_EMIS.IN

--- a/core/magicc/HISTRCP_C6F14_CONC.IN
+++ b/core/magicc/HISTRCP_C6F14_CONC.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_C6F14_CONC.IN

--- a/core/magicc/HISTRCP_C6F14_EMIS.IN
+++ b/core/magicc/HISTRCP_C6F14_EMIS.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_C6F14_EMIS.IN

--- a/core/magicc/HISTRCP_CF4_CONC.IN
+++ b/core/magicc/HISTRCP_CF4_CONC.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_CF4_CONC.IN

--- a/core/magicc/HISTRCP_CF4_EMIS.IN
+++ b/core/magicc/HISTRCP_CF4_EMIS.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_CF4_EMIS.IN

--- a/core/magicc/HISTRCP_CH4B_EMIS.IN
+++ b/core/magicc/HISTRCP_CH4B_EMIS.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_CH4B_EMIS.IN

--- a/core/magicc/HISTRCP_CH4I_EMIS.IN
+++ b/core/magicc/HISTRCP_CH4I_EMIS.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_CH4I_EMIS.IN

--- a/core/magicc/HISTRCP_CH4_CONC.IN
+++ b/core/magicc/HISTRCP_CH4_CONC.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_CH4_CONC.IN

--- a/core/magicc/HISTRCP_CO2B_EMIS.IN
+++ b/core/magicc/HISTRCP_CO2B_EMIS.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_CO2B_EMIS.IN

--- a/core/magicc/HISTRCP_CO2I_EMIS.IN
+++ b/core/magicc/HISTRCP_CO2I_EMIS.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_CO2I_EMIS.IN

--- a/core/magicc/HISTRCP_CO2_CONC.IN
+++ b/core/magicc/HISTRCP_CO2_CONC.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_CO2_CONC.IN

--- a/core/magicc/HISTRCP_COB_EMIS.IN
+++ b/core/magicc/HISTRCP_COB_EMIS.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_COB_EMIS.IN

--- a/core/magicc/HISTRCP_COI_EMIS.IN
+++ b/core/magicc/HISTRCP_COI_EMIS.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_COI_EMIS.IN

--- a/core/magicc/HISTRCP_HFC125_CONC.IN
+++ b/core/magicc/HISTRCP_HFC125_CONC.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_HFC125_CONC.IN

--- a/core/magicc/HISTRCP_HFC125_EMIS.IN
+++ b/core/magicc/HISTRCP_HFC125_EMIS.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_HFC125_EMIS.IN

--- a/core/magicc/HISTRCP_HFC134a_CONC.IN
+++ b/core/magicc/HISTRCP_HFC134a_CONC.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_HFC134a_CONC.IN

--- a/core/magicc/HISTRCP_HFC134a_EMIS.IN
+++ b/core/magicc/HISTRCP_HFC134a_EMIS.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_HFC134a_EMIS.IN

--- a/core/magicc/HISTRCP_HFC143a_CONC.IN
+++ b/core/magicc/HISTRCP_HFC143a_CONC.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_HFC143a_CONC.IN

--- a/core/magicc/HISTRCP_HFC143a_EMIS.IN
+++ b/core/magicc/HISTRCP_HFC143a_EMIS.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_HFC143a_EMIS.IN

--- a/core/magicc/HISTRCP_HFC227EA_CONC.IN
+++ b/core/magicc/HISTRCP_HFC227EA_CONC.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_HFC227EA_CONC.IN

--- a/core/magicc/HISTRCP_HFC227EA_EMIS.IN
+++ b/core/magicc/HISTRCP_HFC227EA_EMIS.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_HFC227EA_EMIS.IN

--- a/core/magicc/HISTRCP_HFC23_CONC.IN
+++ b/core/magicc/HISTRCP_HFC23_CONC.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_HFC23_CONC.IN

--- a/core/magicc/HISTRCP_HFC23_EMIS.IN
+++ b/core/magicc/HISTRCP_HFC23_EMIS.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_HFC23_EMIS.IN

--- a/core/magicc/HISTRCP_HFC245ca_CONC.IN
+++ b/core/magicc/HISTRCP_HFC245ca_CONC.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_HFC245ca_CONC.IN

--- a/core/magicc/HISTRCP_HFC245fa_CONC.IN
+++ b/core/magicc/HISTRCP_HFC245fa_CONC.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_HFC245fa_CONC.IN

--- a/core/magicc/HISTRCP_HFC245fa_EMIS.IN
+++ b/core/magicc/HISTRCP_HFC245fa_EMIS.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_HFC245fa_EMIS.IN

--- a/core/magicc/HISTRCP_HFC32_CONC.IN
+++ b/core/magicc/HISTRCP_HFC32_CONC.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_HFC32_CONC.IN

--- a/core/magicc/HISTRCP_HFC32_EMIS.IN
+++ b/core/magicc/HISTRCP_HFC32_EMIS.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_HFC32_EMIS.IN

--- a/core/magicc/HISTRCP_HFC43-10_CONC.IN
+++ b/core/magicc/HISTRCP_HFC43-10_CONC.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_HFC43-10_CONC.IN

--- a/core/magicc/HISTRCP_N2OB_EMIS.IN
+++ b/core/magicc/HISTRCP_N2OB_EMIS.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_N2OB_EMIS.IN

--- a/core/magicc/HISTRCP_N2OI_EMIS.IN
+++ b/core/magicc/HISTRCP_N2OI_EMIS.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_N2OI_EMIS.IN

--- a/core/magicc/HISTRCP_N2O_CONC.IN
+++ b/core/magicc/HISTRCP_N2O_CONC.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_N2O_CONC.IN

--- a/core/magicc/HISTRCP_NH3B_EMIS.IN
+++ b/core/magicc/HISTRCP_NH3B_EMIS.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_NH3B_EMIS.IN

--- a/core/magicc/HISTRCP_NH3I_EMIS.IN
+++ b/core/magicc/HISTRCP_NH3I_EMIS.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_NH3I_EMIS.IN

--- a/core/magicc/HISTRCP_NMVOCB_EMIS.IN
+++ b/core/magicc/HISTRCP_NMVOCB_EMIS.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_NMVOCB_EMIS.IN

--- a/core/magicc/HISTRCP_NMVOCI_EMIS.IN
+++ b/core/magicc/HISTRCP_NMVOCI_EMIS.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_NMVOCI_EMIS.IN

--- a/core/magicc/HISTRCP_NOXB_EMIS.IN
+++ b/core/magicc/HISTRCP_NOXB_EMIS.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_NOXB_EMIS.IN

--- a/core/magicc/HISTRCP_NOXI_EMIS.IN
+++ b/core/magicc/HISTRCP_NOXI_EMIS.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_NOXI_EMIS.IN

--- a/core/magicc/HISTRCP_OCB_EMIS.IN
+++ b/core/magicc/HISTRCP_OCB_EMIS.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_OCB_EMIS.IN

--- a/core/magicc/HISTRCP_OCI_EMIS.IN
+++ b/core/magicc/HISTRCP_OCI_EMIS.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_OCI_EMIS.IN

--- a/core/magicc/HISTRCP_SF6_CONC.IN
+++ b/core/magicc/HISTRCP_SF6_CONC.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_SF6_CONC.IN

--- a/core/magicc/HISTRCP_SF6_EMIS.IN
+++ b/core/magicc/HISTRCP_SF6_EMIS.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_SF6_EMIS.IN

--- a/core/magicc/HISTRCP_SOLAR_RF.IN
+++ b/core/magicc/HISTRCP_SOLAR_RF.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_SOLAR_RF.IN

--- a/core/magicc/HISTRCP_SOXB_EMIS.IN
+++ b/core/magicc/HISTRCP_SOXB_EMIS.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_SOXB_EMIS.IN

--- a/core/magicc/HISTRCP_SOXI_EMIS.IN
+++ b/core/magicc/HISTRCP_SOXI_EMIS.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_SOXI_EMIS.IN

--- a/core/magicc/HISTRCP_VOLCANIC_RF.MON
+++ b/core/magicc/HISTRCP_VOLCANIC_RF.MON
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HISTRCP_VOLCANIC_RF.MON

--- a/core/magicc/HIST_SEALEVEL_CHURCHWHITE2006_RF.IN
+++ b/core/magicc/HIST_SEALEVEL_CHURCHWHITE2006_RF.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HIST_SEALEVEL_CHURCHWHITE2006_RF.IN

--- a/core/magicc/HIST_SOXN_EMIS.IN
+++ b/core/magicc/HIST_SOXN_EMIS.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HIST_SOXN_EMIS.IN

--- a/core/magicc/HIST_VOLCANIC_RF.MON
+++ b/core/magicc/HIST_VOLCANIC_RF.MON
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/HIST_VOLCANIC_RF.MON

--- a/core/magicc/MAGCFG_BULKPARAS.CFG
+++ b/core/magicc/MAGCFG_BULKPARAS.CFG
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/MAGCFG_BULKPARAS.CFG

--- a/core/magicc/MAGCFG_DEFAULTALL_62.CFG
+++ b/core/magicc/MAGCFG_DEFAULTALL_62.CFG
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/MAGCFG_DEFAULTALL_62.CFG

--- a/core/magicc/MAGCFG_DEFAULTALL_64.CFG
+++ b/core/magicc/MAGCFG_DEFAULTALL_64.CFG
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/MAGCFG_DEFAULTALL_64.CFG

--- a/core/magicc/MAGCFG_NMLYEARS.CFG
+++ b/core/magicc/MAGCFG_NMLYEARS.CFG
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/MAGCFG_NMLYEARS.CFG

--- a/core/magicc/MAGCFG_USER.CFG
+++ b/core/magicc/MAGCFG_USER.CFG
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/MAGCFG_USER.CFG

--- a/core/magicc/MAGCFG_USER_OLDDEFAULT.CFG
+++ b/core/magicc/MAGCFG_USER_OLDDEFAULT.CFG
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/MAGCFG_STORE/MAGCFG_USER_OLDDEFAULT.CFG

--- a/core/magicc/MAGCFG_USER_RCP26_10.CFG
+++ b/core/magicc/MAGCFG_USER_RCP26_10.CFG
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/MAGCFG_STORE/MAGCFG_USER_RCP26_10.CFG

--- a/core/magicc/MAGCFG_USER_RCP26_20.CFG
+++ b/core/magicc/MAGCFG_USER_RCP26_20.CFG
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/MAGCFG_STORE/MAGCFG_USER_RCP26_20.CFG

--- a/core/magicc/MAGCFG_USER_RCP26_25.CFG
+++ b/core/magicc/MAGCFG_USER_RCP26_25.CFG
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/MAGCFG_STORE/MAGCFG_USER_RCP26_25.CFG

--- a/core/magicc/MAGCFG_USER_RCP26_30.CFG
+++ b/core/magicc/MAGCFG_USER_RCP26_30.CFG
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/MAGCFG_STORE/MAGCFG_USER_RCP26_30.CFG

--- a/core/magicc/MAGCFG_USER_RCP26_40.CFG
+++ b/core/magicc/MAGCFG_USER_RCP26_40.CFG
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/MAGCFG_STORE/MAGCFG_USER_RCP26_40.CFG

--- a/core/magicc/MAGCFG_USER_RCP26_5.CFG
+++ b/core/magicc/MAGCFG_USER_RCP26_5.CFG
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/MAGCFG_STORE/MAGCFG_USER_RCP26_5.CFG

--- a/core/magicc/MAGCFG_USER_RCP26_50.CFG
+++ b/core/magicc/MAGCFG_USER_RCP26_50.CFG
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/MAGCFG_STORE/MAGCFG_USER_RCP26_50.CFG

--- a/core/magicc/MAGCFG_USER_RCP26_60.CFG
+++ b/core/magicc/MAGCFG_USER_RCP26_60.CFG
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/MAGCFG_STORE/MAGCFG_USER_RCP26_60.CFG

--- a/core/magicc/MAGCFG_USER_RCP26_70.CFG
+++ b/core/magicc/MAGCFG_USER_RCP26_70.CFG
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/MAGCFG_STORE/MAGCFG_USER_RCP26_70.CFG

--- a/core/magicc/MAGCFG_USER_RCP26_75.CFG
+++ b/core/magicc/MAGCFG_USER_RCP26_75.CFG
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/MAGCFG_STORE/MAGCFG_USER_RCP26_75.CFG

--- a/core/magicc/MAGCFG_USER_RCP26_80.CFG
+++ b/core/magicc/MAGCFG_USER_RCP26_80.CFG
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/MAGCFG_STORE/MAGCFG_USER_RCP26_80.CFG

--- a/core/magicc/MAGCFG_USER_RCP26_90.CFG
+++ b/core/magicc/MAGCFG_USER_RCP26_90.CFG
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/MAGCFG_STORE/MAGCFG_USER_RCP26_90.CFG

--- a/core/magicc/MAGCFG_USER_RCP26_95.CFG
+++ b/core/magicc/MAGCFG_USER_RCP26_95.CFG
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/MAGCFG_STORE/MAGCFG_USER_RCP26_95.CFG

--- a/core/magicc/MAGCFG_USER_TCRE_HIGH.CFG
+++ b/core/magicc/MAGCFG_USER_TCRE_HIGH.CFG
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/MAGCFG_STORE/MAGCFG_USER_TCRE_HIGH.CFG

--- a/core/magicc/MAGCFG_USER_TCRE_HIGHEST.CFG
+++ b/core/magicc/MAGCFG_USER_TCRE_HIGHEST.CFG
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/MAGCFG_STORE/MAGCFG_USER_TCRE_HIGHEST.CFG

--- a/core/magicc/MAGCFG_USER_TCRE_LOW.CFG
+++ b/core/magicc/MAGCFG_USER_TCRE_LOW.CFG
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/MAGCFG_STORE/MAGCFG_USER_TCRE_LOW.CFG

--- a/core/magicc/MAGCFG_USER_TCRE_LOWEST.CFG
+++ b/core/magicc/MAGCFG_USER_TCRE_LOWEST.CFG
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/MAGCFG_STORE/MAGCFG_USER_TCRE_LOWEST.CFG

--- a/core/magicc/MAGCFG_USER_TCRE_MEDIUM.CFG
+++ b/core/magicc/MAGCFG_USER_TCRE_MEDIUM.CFG
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/MAGCFG_STORE/MAGCFG_USER_TCRE_MEDIUM.CFG

--- a/core/magicc/MAGICC_reporting.awk
+++ b/core/magicc/MAGICC_reporting.awk
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/MAGICC_reporting.awk

--- a/core/magicc/MAGTUNE_BULKPARASET_TEMPORARY.CFG
+++ b/core/magicc/MAGTUNE_BULKPARASET_TEMPORARY.CFG
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/MAGTUNE_BULKPARASET_TEMPORARY.CFG

--- a/core/magicc/MAGTUNE_C4MIP_BERN.CFG
+++ b/core/magicc/MAGTUNE_C4MIP_BERN.CFG
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/MAGTUNE_C4MIP_BERN.CFG

--- a/core/magicc/MAGTUNE_FULLTUNE_MEDIUM_CMIP3_ECS3.CFG
+++ b/core/magicc/MAGTUNE_FULLTUNE_MEDIUM_CMIP3_ECS3.CFG
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/MAGTUNE_FULLTUNE_MEDIUM_CMIP3_ECS3.CFG

--- a/core/magicc/MAGTUNE_FULLTUNE_NCAR_CCSM3_0.CFG
+++ b/core/magicc/MAGTUNE_FULLTUNE_NCAR_CCSM3_0.CFG
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/MAGTUNE_FULLTUNE_NCAR_CCSM3_0.CFG

--- a/core/magicc/MAGTUNE_KRIEGLER_USERSETTINGS.CFG
+++ b/core/magicc/MAGTUNE_KRIEGLER_USERSETTINGS.CFG
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/MAGTUNE_KRIEGLER_USERSETTINGS.CFG

--- a/core/magicc/MAGTUNE_TUNING_CURRENT_ITERATION.CFG
+++ b/core/magicc/MAGTUNE_TUNING_CURRENT_ITERATION.CFG
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/MAGTUNE_TUNING_CURRENT_ITERATION.CFG

--- a/core/magicc/MAGTUNE_XTRAPARAS_THISRUN.CFG
+++ b/core/magicc/MAGTUNE_XTRAPARAS_THISRUN.CFG
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/MAGTUNE_XTRAPARAS_THISRUN.CFG

--- a/core/magicc/MIXED_NOXB_OT.IN
+++ b/core/magicc/MIXED_NOXB_OT.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/MIXED_NOXB_OT.IN

--- a/core/magicc/MIXED_NOXI_OT.IN
+++ b/core/magicc/MIXED_NOXI_OT.IN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/MIXED_NOXI_OT.IN

--- a/core/magicc/RCP3PD.SCEN
+++ b/core/magicc/RCP3PD.SCEN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/RCP3PD.SCEN

--- a/core/magicc/RCP45.SCEN
+++ b/core/magicc/RCP45.SCEN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/RCP45.SCEN

--- a/core/magicc/RCP6.SCEN
+++ b/core/magicc/RCP6.SCEN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/RCP6.SCEN

--- a/core/magicc/RCP6.inc
+++ b/core/magicc/RCP6.inc
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/RCP6.inc

--- a/core/magicc/RCP85.SCEN
+++ b/core/magicc/RCP85.SCEN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/RCP85.SCEN

--- a/core/magicc/RCPODS_WMO2006_Emissions_A1.prn
+++ b/core/magicc/RCPODS_WMO2006_Emissions_A1.prn
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/RCPODS_WMO2006_Emissions_A1.prn

--- a/core/magicc/RCPODS_WMO2006_Emissions_A1Baseline.prn
+++ b/core/magicc/RCPODS_WMO2006_Emissions_A1Baseline.prn
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/RCPODS_WMO2006_Emissions_A1Baseline.prn

--- a/core/magicc/RCPODS_WMO2006_Emissions_RCP3PD.prn
+++ b/core/magicc/RCPODS_WMO2006_Emissions_RCP3PD.prn
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/RCPODS_WMO2006_Emissions_RCP3PD.prn

--- a/core/magicc/RCPODS_WMO2006_Emissions_RCP45.prn
+++ b/core/magicc/RCPODS_WMO2006_Emissions_RCP45.prn
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/RCPODS_WMO2006_Emissions_RCP45.prn

--- a/core/magicc/RCPODS_WMO2006_Emissions_RCP45Kate
+++ b/core/magicc/RCPODS_WMO2006_Emissions_RCP45Kate
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/RCPODS_WMO2006_Emissions_RCP45Kate

--- a/core/magicc/RCPODS_WMO2006_Emissions_RCP45SCP45to3PD.prn
+++ b/core/magicc/RCPODS_WMO2006_Emissions_RCP45SCP45to3PD.prn
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/RCPODS_WMO2006_Emissions_RCP45SCP45to3PD.prn

--- a/core/magicc/RCPODS_WMO2006_Emissions_RCP45ZERO2010.prn
+++ b/core/magicc/RCPODS_WMO2006_Emissions_RCP45ZERO2010.prn
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/RCPODS_WMO2006_Emissions_RCP45ZERO2010.prn

--- a/core/magicc/RCPODS_WMO2006_Emissions_RCP6.prn
+++ b/core/magicc/RCPODS_WMO2006_Emissions_RCP6.prn
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/RCPODS_WMO2006_Emissions_RCP6.prn

--- a/core/magicc/RCPODS_WMO2006_Emissions_RCP6SCP6to45.prn
+++ b/core/magicc/RCPODS_WMO2006_Emissions_RCP6SCP6to45.prn
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/RCPODS_WMO2006_Emissions_RCP6SCP6to45.prn

--- a/core/magicc/RCPODS_WMO2006_Emissions_RCP85.prn
+++ b/core/magicc/RCPODS_WMO2006_Emissions_RCP85.prn
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/RCPODS_WMO2006_Emissions_RCP85.prn

--- a/core/magicc/RCPODS_WMO2006_MixingRatios_A1.prn
+++ b/core/magicc/RCPODS_WMO2006_MixingRatios_A1.prn
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/RCPODS_WMO2006_MixingRatios_A1.prn

--- a/core/magicc/RCPODS_WMO2006_MixingRatios_A1Baseline.prn
+++ b/core/magicc/RCPODS_WMO2006_MixingRatios_A1Baseline.prn
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/RCPODS_WMO2006_MixingRatios_A1Baseline.prn

--- a/core/magicc/SRESA1B.SCEN
+++ b/core/magicc/SRESA1B.SCEN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/SRESA1B.SCEN

--- a/core/magicc/SRESA1FI.SCEN
+++ b/core/magicc/SRESA1FI.SCEN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/SRESA1FI.SCEN

--- a/core/magicc/SRESA1T.SCEN
+++ b/core/magicc/SRESA1T.SCEN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/SRESA1T.SCEN

--- a/core/magicc/SRESA2.SCEN
+++ b/core/magicc/SRESA2.SCEN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/SRESA2.SCEN

--- a/core/magicc/SRESB1.SCEN
+++ b/core/magicc/SRESB1.SCEN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/SRESB1.SCEN

--- a/core/magicc/SRESB2.SCEN
+++ b/core/magicc/SRESB2.SCEN
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/SRESB2.SCEN

--- a/core/magicc/WMO2006_ODS_A1Baseline.prn
+++ b/core/magicc/WMO2006_ODS_A1Baseline.prn
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/WMO2006_ODS_A1Baseline.prn

--- a/core/magicc/addEmissionPulse.awk
+++ b/core/magicc/addEmissionPulse.awk
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/addEmissionPulse.awk

--- a/core/magicc/climate_reporting_template.txt
+++ b/core/magicc/climate_reporting_template.txt
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/climate_reporting_template.txt

--- a/core/magicc/magicc6
+++ b/core/magicc/magicc6
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/magicc6

--- a/core/magicc/mod_allcfgs.mod
+++ b/core/magicc/mod_allcfgs.mod
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/mod_allcfgs.mod

--- a/core/magicc/mod_areas.mod
+++ b/core/magicc/mod_areas.mod
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/mod_areas.mod

--- a/core/magicc/mod_bulkspecs.mod
+++ b/core/magicc/mod_bulkspecs.mod
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/mod_bulkspecs.mod

--- a/core/magicc/mod_carboncycle.mod
+++ b/core/magicc/mod_carboncycle.mod
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/mod_carboncycle.mod

--- a/core/magicc/mod_climatecore_and_ocean.mod
+++ b/core/magicc/mod_climatecore_and_ocean.mod
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/mod_climatecore_and_ocean.mod

--- a/core/magicc/mod_cloudstore.mod
+++ b/core/magicc/mod_cloudstore.mod
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/mod_cloudstore.mod

--- a/core/magicc/mod_datafilespecifications.mod
+++ b/core/magicc/mod_datafilespecifications.mod
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/mod_datafilespecifications.mod

--- a/core/magicc/mod_datastore.mod
+++ b/core/magicc/mod_datastore.mod
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/mod_datastore.mod

--- a/core/magicc/mod_halos.mod
+++ b/core/magicc/mod_halos.mod
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/mod_halos.mod

--- a/core/magicc/mod_methane.mod
+++ b/core/magicc/mod_methane.mod
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/mod_methane.mod

--- a/core/magicc/mod_n2o.mod
+++ b/core/magicc/mod_n2o.mod
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/mod_n2o.mod

--- a/core/magicc/mod_names.mod
+++ b/core/magicc/mod_names.mod
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/mod_names.mod

--- a/core/magicc/mod_oceancarboncycle.mod
+++ b/core/magicc/mod_oceancarboncycle.mod
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/mod_oceancarboncycle.mod

--- a/core/magicc/mod_outputoptions.mod
+++ b/core/magicc/mod_outputoptions.mod
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/mod_outputoptions.mod

--- a/core/magicc/mod_ozone.mod
+++ b/core/magicc/mod_ozone.mod
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/mod_ozone.mod

--- a/core/magicc/mod_permafrost.mod
+++ b/core/magicc/mod_permafrost.mod
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/mod_permafrost.mod

--- a/core/magicc/mod_radiative_forcing.mod
+++ b/core/magicc/mod_radiative_forcing.mod
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/mod_radiative_forcing.mod

--- a/core/magicc/mod_rawemissions.mod
+++ b/core/magicc/mod_rawemissions.mod
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/mod_rawemissions.mod

--- a/core/magicc/mod_sealevel.mod
+++ b/core/magicc/mod_sealevel.mod
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/mod_sealevel.mod

--- a/core/magicc/mod_sector.mod
+++ b/core/magicc/mod_sector.mod
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/mod_sector.mod

--- a/core/magicc/mod_years.mod
+++ b/core/magicc/mod_years.mod
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/mod_years.mod

--- a/core/magicc/out2csv.awk
+++ b/core/magicc/out2csv.awk
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/out2csv.awk

--- a/core/magicc/scen2inc.awk
+++ b/core/magicc/scen2inc.awk
@@ -1,0 +1,1 @@
+/home/pehl/swap/magicc/scen2inc.awk


### PR DESCRIPTION
I'm still of the opinion that we can just add the MAGICC files, since you also get them on their website, but here goes:

In order to have a REMIND with on less source of constant failure (#180), we can add symlinks to the `./core/magicc/` directory.  The symlinks only contain the information where the files are to be found ([e.g.](https://github.com/0UmfHxcvx5J7JoaOhFSs5mncnisTJJ6q/remind/blob/feature/symlink_magicc/core/magicc/EDGAR_CH4_EMIS_LANDUSE.IN)), but no actual data.  When the run is assembled by `./scripts/start/prepare_and_run.R`, the `./core/magicc/` directory [is copied](https://github.com/remindmodel/remind/blob/3e4fc335245fc37c4ed0572eb4aee960a8c29182/scripts/start/prepare_and_run.R#L403) using `file.copy()` [which copies the targets of the links, not the links](https://stat.ethz.ch/R-manual/R-devel/library/base/html/files.html): 
> On a POSIX filesystem the targets of symbolic links will be copied rather than the links themselves

so we end up with proper MAGICC in the output directory, without any actuall MAGICC in the repository.

If this is agreeable, pick a proper place for the MAGICC files, not my home directory ;)