### PR TITLE
switch cm_OILRETIRE on by default

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -375,7 +375,7 @@ cfg$gms$cm_EDGEtr_scen       <- "ConvCase"     # def <- "ConvCase". For calibrat
 #-----------------------------------------------------------------------------
 cfg$gms$cm_SlowConvergence     <- "off"   # def = off
 cfg$gms$cm_nash_mode           <- "parallel" # def = parallel ; Choices: parallel, serial, debug.
-cfg$gms$cm_OILRETIRE           <- "off"   # def = off
+cfg$gms$cm_OILRETIRE           <- "on"   # def = on
 
 cfg$gms$cm_INCONV_PENALTY       <- "on"    # def = on
 cfg$gms$cm_so2_out_of_opt      <- "on"    # def = on      ask Jessi


### PR DESCRIPTION
This switches oil retirement option "on" by default. It is to make sure that default policy runs see this option, which makes quite a difference for residual 2050 emissions in stringent scenarios. @robertpietzcker @nicobauer agreed. 