### PR TITLE
Revert the revert :) Revert "Merge pull request #246 from Loisel/reve…

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -22,7 +22,7 @@ cfg$title <- "default"
 cfg$regionmapping <- "config/regionmappingH12.csv"
 
 #### Current input data revision (<mainrevision>.<subrevision>) ####
-cfg$revision <- 5.958
+cfg$revision <- 5.959
 
 #### Force the model to download new input data ####
 cfg$force_download <- FALSE

--- a/core/input/generisdata_tech.prn
+++ b/core/input/generisdata_tech.prn
@@ -154,7 +154,7 @@ lifetime              45          45          45
 +               apcarelt    aptrnelt     apcarh2t    apcarpet    apcardit  apcardiEfft  apcardiEffH2t
 inco0              24000       12000       33000        8400        2400      6500        12000
 mix0                0.00        1.00        0.00        1.00        1.00      0.00         0.00
-eta                 3.00        1.00        2.50        1.00        1.00      1.80         6.00
+eta                 0.64        1.00        0.36        0.22        0.24      0.43         1.44
 omf                 0.06        0.10        0.06        0.10        0.10      0.08         0.08
 omv                                                                                                                        
 lifetime              13          20          13          13          20        20           20

--- a/core/input/generisdata_tech_SSP1.prn
+++ b/core/input/generisdata_tech_SSP1.prn
@@ -154,7 +154,7 @@ lifetime              45          45          45
 +               apcarelt    aptrnelt     apcarh2t    apcarpet    apcardit  apcardiEfft  apcardiEffH2t
 inco0              24000       12000       33000        8400        2400      6500        12000
 mix0                0.00        1.00        0.00        1.00        1.00      0.00         0.00
-eta                 3.00        1.00        2.50        1.00        1.00      2.00         6.50
+eta                 0.64        1.00        0.36        0.22        0.24      0.48         1.56
 omf                 0.06        0.10        0.06        0.10        0.10      0.08         0.08
 omv                                                                                                                        
 lifetime              13          20          13          13          20        20           20

--- a/core/input/generisdata_tech_SSP5.prn
+++ b/core/input/generisdata_tech_SSP5.prn
@@ -155,7 +155,7 @@ lifetime              45          45          45
 +               apcarelt    aptrnelt     apcarh2t    apcarpet    apcardit  apcardiEfft  apcardiEffH2t
 inco0              25400       12000       33000        8400        2400      6500        12000
 mix0                0.00        1.00        0.00        1.00        1.00      0.00         0.00
-eta                 3.00        1.00        2.50        1.00        1.00      1.50         5.00
+eta                 0.64        1.00        0.36        0.22        0.24      0.36         1.20
 omf                 0.10        0.10        0.06        0.10        0.10      0.08         0.08
 omv                                                                                                                        
 lifetime              13          20          13          13          20        20           20


### PR DESCRIPTION
…rt_ldv_fix"

This reverts commit 3e4fc335245fc37c4ed0572eb4aee960a8c29182, reversing
changes made to fdb42f81f34e8d1a4116a118fa0b3d4258833335.

The text from the original PR:

Update efficiencies for LDV and HDV technologies so that these technologies now produce motive energy instead of fossil-fuel equivalents.

The tank-to-wheel efficiencies are obtained from the carculator
project, see

 Cox, B., Bauer, C., Mendoza Beltran, A., van Vuuren, D. P., & Mutel, C. (2020). Life cycle environmental and cost comparison of current and future passenger cars under different energy scenarios. Applied Energy2.

Sacchi, R., Bauer, C., Cox, B., & Mutel, C. (2020). carculator: an open-source tool for prospective environmental and economic life cycle assessment of vehicles. When, Where and How can battery-electric vehicles help reduce greenhouse gas emissions? Renewable and Sustainable Energy Reviews, submitted (in review). https://www.psi.ch/en/media/57994/download

For the combined technologies apcardiEfft and apcardieEffH2t I kept
Roberts efficiency multipliers for simplicity, although they deviate
slightly from the PSI values.

**Note**: With rev 5.959 of the inputdata the correct inputfiles should be in place and a calibration can be started.