### PR TITLE
Revert of the Revert of the Revert for the transport UE unit patch

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -22,7 +22,7 @@ cfg$title <- "default"
 cfg$regionmapping <- "config/regionmappingH12.csv"
 
 #### Current input data revision (<mainrevision>.<subrevision>) ####
-cfg$revision <- 5.960
+cfg$revision <- 5.961
 
 #### Force the model to download new input data ####
 cfg$force_download <- FALSE

--- a/core/input/generisdata_tech.prn
+++ b/core/input/generisdata_tech.prn
@@ -154,7 +154,7 @@ lifetime              45          45          45
 +               apcarelt    aptrnelt     apcarh2t    apcarpet    apcardit  apcardiEfft  apcardiEffH2t
 inco0              24000       12000       33000        8400        2400      6500        12000
 mix0                0.00        1.00        0.00        1.00        1.00      0.00         0.00
-eta                 0.64        1.00        0.36        0.22        0.24      0.43         1.44
+eta                 3.00        1.00        2.50        1.00        1.00      1.80         6.00
 omf                 0.06        0.10        0.06        0.10        0.10      0.08         0.08
 omv                                                                                                                        
 lifetime              13          20          13          13          20        20           20

--- a/core/input/generisdata_tech_SSP1.prn
+++ b/core/input/generisdata_tech_SSP1.prn
@@ -154,7 +154,7 @@ lifetime              45          45          45
 +               apcarelt    aptrnelt     apcarh2t    apcarpet    apcardit  apcardiEfft  apcardiEffH2t
 inco0              24000       12000       33000        8400        2400      6500        12000
 mix0                0.00        1.00        0.00        1.00        1.00      0.00         0.00
-eta                 0.64        1.00        0.36        0.22        0.24      0.48         1.56
+eta                 3.00        1.00        2.50        1.00        1.00      2.00         6.50
 omf                 0.06        0.10        0.06        0.10        0.10      0.08         0.08
 omv                                                                                                                        
 lifetime              13          20          13          13          20        20           20

--- a/core/input/generisdata_tech_SSP5.prn
+++ b/core/input/generisdata_tech_SSP5.prn
@@ -155,7 +155,7 @@ lifetime              45          45          45
 +               apcarelt    aptrnelt     apcarh2t    apcarpet    apcardit  apcardiEfft  apcardiEffH2t
 inco0              25400       12000       33000        8400        2400      6500        12000
 mix0                0.00        1.00        0.00        1.00        1.00      0.00         0.00
-eta                 0.64        1.00        0.36        0.22        0.24      0.36         1.20
+eta                 3.00        1.00        2.50        1.00        1.00      1.50         5.00
 omf                 0.10        0.10        0.06        0.10        0.10      0.08         0.08
 omv                                                                                                                        
 lifetime              13          20          13          13          20        20           20


### PR DESCRIPTION
Restore the old UE coefficients for now. The patch for the new UE units will be tested in a dev branch first, since it turns out there are a couple of side effects regarding capacity costs.

It is also required to change the `pm_prodCouple` coefficients for coupled prod. freight transport.