### PR TITLE
fix shebangs in R scripts and update insertheader() to preserve them

### DIFF
--- a/output.R
+++ b/output.R
@@ -1,3 +1,4 @@
+#!/usr/bin/env Rscript
 # |  (C) 2006-2020 Potsdam Institute for Climate Impact Research (PIK)
 # |  authors, and contributors see CITATION.cff file. This file is part
 # |  of REMIND and licensed under AGPL-3.0-or-later. Under Section 7 of

--- a/scripts/insertheader/insertheader.R
+++ b/scripts/insertheader/insertheader.R
@@ -17,7 +17,7 @@ insertheader <- function(maindir=".",
                                       ".spam",".xlsx",".xls", ".sh","files",".md",".RData", ".jpg",
                                       ".png",".cff", ".rds", ".aux", ".log", ".out", ".pdf",
                                       ".tex", ".htm", ".css", ".bib", ".ref", ".mif", ".gmif", ".gdx",
-                                      ".lst", ".git-id", ".csv", ".gcsv", ".Rdata", ".prn", ".cmd", ".put", 
+                                      ".lst", ".git-id", ".csv", ".gcsv", ".Rdata", ".prn", ".cmd", ".put",
                                       ".IN", ".awk", ".MON", ".CFG", ".mod", ".SCEN", ".inc"),
                          comments=c(".R"="#", ".Rmd"="#",".gms"="***",".cfg"="#",".csv"="*",".cs2"="*",
                                     ".cs3r"="*",".cs4r"="*",".sh"="#",".txt"="#"),
@@ -85,7 +85,7 @@ insertheader <- function(maindir=".",
 
     # insert header after line 0
     withcomment <- paste(co,key,header)
-    f <- append(f,withcomment,after = 0)
+    f <- append(f,withcomment,after = ifelse(!length(tmp), 0, tmp[1] - 1))
     writefile <- TRUE
     done <- c(done,file)
 

--- a/start.R
+++ b/start.R
@@ -1,10 +1,10 @@
+#!/usr/bin/env Rscript
 # |  (C) 2006-2020 Potsdam Institute for Climate Impact Research (PIK)
 # |  authors, and contributors see CITATION.cff file. This file is part
 # |  of REMIND and licensed under AGPL-3.0-or-later. Under Section 7 of
 # |  AGPL-3.0, you are granted additional permissions described in the
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
-#!/usr/bin/env Rscript
 library(lucode)
 
 #' Usage:


### PR DESCRIPTION
- shebangs https://en.wikipedia.org/wiki/Shebang_(Unix) are used to
  inform the shell about the interpreter to be used to run a script, and
  they have to be on the first line of the file

- by putting the header always in the first line, insertheader()
  destroyed the shebangs of certain R scripts, reducing usability

- insertheader() now replaces existing headers at their current
  position, while adding new ones to the first line