### PR TITLE
remove reslim and iterlim bounds on CONOPT #265

### DIFF
--- a/core/loop.gms
+++ b/core/loop.gms
@@ -15,10 +15,6 @@ hybrid.optfile   = 1;
 hybrid.holdfixed = 1;
 hybrid.scaleopt  = 1;
 option savepoint = 0;
-option reslim    = 1.e+6;
-*AJS* limit maximum time for one nash region to two hours.
-$IFI %optimization% == 'nash' option reslim = 7200;
-option iterlim   = 1.e+6;
 option solprint  = off ;
 o_modelstat      = 100;
 


### PR DESCRIPTION
- limiting CONOPT to two hours runtime (reslim) may prevent finding
  a (first) solution for complicated runs, while not yielding any
  benfits for usage of cluster resources

- iterations limits on CONOPT are arbitrary as well, not improving
  cluster usage efficiency