### PR TITLE
Bunkers calculation based on EDGE-T data for complex transport realization

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -22,7 +22,7 @@ cfg$title <- "default"
 cfg$regionmapping <- "config/regionmappingH12.csv"
 
 #### Current input data revision (<mainrevision>.<subrevision>) ####
-cfg$revision <- 5.961
+cfg$revision <- 5.962
 
 #### Force the model to download new input data ####
 cfg$force_download <- FALSE

--- a/modules/35_transport/complex/datainput.gms
+++ b/modules/35_transport/complex/datainput.gms
@@ -55,23 +55,17 @@ display p35_passLDV_ES_efficiency;
 display p35_freight_ES_efficiency;
 
 
-*CB* read-in of bunker share in non-LDV transport, i.e. fedie. Based on regional linear regional aggregation, but limited to 50% (binding in EU, OAS, RUS)
-Parameter  pm_bunker_share_in_nonldv_fe(tall,all_regi)       "share of bunkers in non-LDV transport, i.e. fedie"
+*** bunker share in non-LDV transport
+Parameter  p35_bunker_share(tall,all_regi,all_GDPscen,EDGE_scenario_all)       "share of bunkers in non-LDV transport"
 /
 $ondelim
 $include "./modules/35_transport/complex/input/pm_bunker_share_in_nonldv_fe.cs4r"
 $offdelim
 /
 ;
-display pm_bunker_share_in_nonldv_fe;
-*** limit share to maximum 55%
-loop(regi,
-     loop(t,
-         if( pm_bunker_share_in_nonldv_fe(t,regi) > 0.55,
-             pm_bunker_share_in_nonldv_fe(t,regi) = 0.55;
-         ); 
-     ); 
-);
+
+pm_bunker_share_in_nonldv_fe(ttot,regi) = p35_bunker_share(ttot,regi,"%cm_GDPscen%","%cm_EDGEtr_scen%");
+
 display pm_bunker_share_in_nonldv_fe;
 
 

--- a/modules/35_transport/complex/declarations.gms
+++ b/modules/35_transport/complex/declarations.gms
@@ -27,6 +27,7 @@ p35_harmonizing_year        "Year when full harmonization of shares and efficien
 p35_share_seliq_t(ttot,all_regi)                               "share of liquids used for transport sector (fedie + fepet). Unit 0..1"
 p35_share_seh2_t(ttot,all_regi)                                "share of hydrogen used for transport sector  (feh2t). Unit 0..1"
 p35_share_seel_t(ttot,all_regi)                                "Share of electricity used for transport sector (feelt). Unit 0..1"
+pm_bunker_share_in_nonldv_fe(tall,all_regi)                    "Share of bunkers in non-LDV transport - fedie"
 ;
 
 *** EOF ./modules/35_transport/complex/declarations.gms

--- a/modules/35_transport/complex/sets.gms
+++ b/modules/35_transport/complex/sets.gms
@@ -108,6 +108,16 @@ char35 "characteristics of transport technologies"
   Eff_Pass_LDV
   Eff_Freight
 /
+
+EDGE_scenario_all    "EDGE-T scenarios, used to get the bunkers share on total liquids demand."
+/
+ConvCase
+ConvCaseWise
+ElecEra
+ElecEraWise
+HydrHype
+HydrHypeWise
+/
 ;
 
 ***-----------------------------------------------------------


### PR DESCRIPTION
This PR contains:

- the updated calculation of bunker shares on total `fedie` FE demand based on `EDGE-T` values from `mrremind`.

- a cache update, to allow for the new bunker shares data to be processed by REMIND.