### PR TITLE
 improving near-term realism of expansion of renewables and natural gas power generation

### DIFF
--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -764,6 +764,9 @@ loop(ttot$(ttot.val ge 2005),
 *** ==> 1TW power plant ~ 650 million LDV
   
   p_adj_coeff(ttot,regi,te)                = 0.2;
+  p_adj_coeff(ttot,regi,"pc")              = 0.5;
+  p_adj_coeff(ttot,regi,"ngcc")            = 0.5;
+  p_adj_coeff(ttot,regi,"igcc")            = 0.5;
   p_adj_coeff(ttot,regi,"coaltr")          = 0.1;
   p_adj_coeff(ttot,regi,"tnrs")            = 1.0;
   p_adj_coeff(ttot,regi,"hydro")           = 1.0;
@@ -772,15 +775,15 @@ loop(ttot$(ttot.val ge 2005),
   p_adj_coeff(ttot,regi,"gasftcrec")       = 0.8;
   p_adj_coeff(ttot,regi,"coalftrec")       = 0.6;
   p_adj_coeff(ttot,regi,"coalftcrec")      = 0.8;
-  p_adj_coeff(ttot,regi,"spv")             = 0.1;
-  p_adj_coeff(ttot,regi,"wind")            = 0.1;
+  p_adj_coeff(ttot,regi,"spv")             = 0.08;
+  p_adj_coeff(ttot,regi,"wind")            = 0.08;
   p_adj_coeff(ttot,regi,"dac")             = 0.8;
   p_adj_coeff(ttot,regi,'apCarH2T')        = 1.0;
   p_adj_coeff(ttot,regi,'apCarElT')        = 1.0;
   p_adj_coeff(ttot,regi,'apCarDiT')        = 1.0;
   p_adj_coeff(ttot,regi,'apCarDiEffT')     = 2.0;
   p_adj_coeff(ttot,regi,'apCarDiEffH2T')   = 2.0;
-  p_adj_coeff(ttot,regi,teGrid)            = 1.0;
+  p_adj_coeff(ttot,regi,teGrid)            = 0.1;
   p_adj_coeff(ttot,regi,teStor)            = 0.05;
 );
 

--- a/core/declarations.gms
+++ b/core/declarations.gms
@@ -397,7 +397,7 @@ q_smoothphaseoutCapEarlyReti(ttot,all_regi,all_te)    "phase-out constraint for 
 q_limitBiotrmod(ttot,all_regi)                        "limit the total amount of modern biomass use for solids to the amount of coal use for solids "
 q_limitShOil(ttot,all_regi)                           "requires minimum share of liquids from oil in total liquids of 15%"
 q_PE_histCap(ttot,all_regi,all_enty,all_enty)         "model capacity must be equal or greater than historical capacity"
-q_PE_histCap_NGCC_2020_up(ttot,all_regi,all_enty,all_enty)
+q_PE_histCap_NGCC_2020_up(ttot,all_regi,all_enty,all_enty) "gas capacity can only increase by 50% maximum from 2015 to 2020, plus 10 GW to account for extra flexibility in regions with small 2015 capacity"
 
 *** ES layer equations
 q_transFe2Es(ttot,all_regi,all_enty,all_esty,all_teEs)    "Conversion from final energy to energy service"

--- a/core/declarations.gms
+++ b/core/declarations.gms
@@ -397,6 +397,8 @@ q_smoothphaseoutCapEarlyReti(ttot,all_regi,all_te)    "phase-out constraint for 
 q_limitBiotrmod(ttot,all_regi)                        "limit the total amount of modern biomass use for solids to the amount of coal use for solids "
 q_limitShOil(ttot,all_regi)                           "requires minimum share of liquids from oil in total liquids of 15%"
 q_PE_histCap(ttot,all_regi,all_enty,all_enty)         "model capacity must be equal or greater than historical capacity"
+q_PE_histCap_NGCC_2020_up(ttot,all_regi,all_enty,all_enty)
+
 *** ES layer equations
 q_transFe2Es(ttot,all_regi,all_enty,all_esty,all_teEs)    "Conversion from final energy to energy service"
 q_es2ppfen(ttot,all_regi,all_in)                          "Energy services are handed to the CES tree."

--- a/core/equations.gms
+++ b/core/equations.gms
@@ -822,6 +822,16 @@ q_PE_histCap(t,regi,entyPe,entySe)$(p_PE_histCap(t,regi,entyPe,entySe))..
 ;
 
 
+
+q_PE_histCap_NGCC_2020_up(t,regi,entyPe,entySe)$( (p_PE_histCap("2015",regi,entyPe,entySe) gt 0.02) AND sameas(entyPe,"pegas") AND sameas(entySe,"seel") AND sameas(t,"2020") )..
+    sum(te$pe2se(entyPe,entySe,te),
+      sum(te2rlf(te,rlf), vm_cap(t,regi,te,rlf))
+    )
+    =l=
+    1.5 * p_PE_histCap("2015",regi,entyPe,entySe) + 0.01
+;
+
+
 ***---------------------------------------------------------------------------
 *' Share of green hydrogen in all hydrogen.
 ***---------------------------------------------------------------------------


### PR DESCRIPTION
update adjustment costs to better reflect observed upscaling, and include additional equation for 2020 to limit natural gas ramp-up to observed levels

This PR contains changes that are relevant for release 2.1.3, and should be considered for updated runs with this release