### PR TITLE
synfuel update

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -284,6 +284,7 @@ cfg$gms$c_bioh2scen                <-  1       #  def  <-  1
 cfg$gms$c_shGreenH2                <-  0       #  def  <-  0
 cfg$gms$c_shBioTrans               <-  1       #  def  <-  1
 cfg$gms$cm_shSynTrans              <-  0       #  def  <-  0
+cfg$gms$cm_shSynGas                <-  0       #  def  <-  0
 cfg$gms$cm_IndCCSscen              <-  1       #  def  <-  1
 cfg$gms$cm_optimisticMAC           <-  0       #  def  <-  0
 cfg$gms$cm_CCS_cement              <-  1       #  def  <-  1

--- a/main.gms
+++ b/main.gms
@@ -231,7 +231,8 @@ c_bioliqscen          "bioenergy liquids technology choise"
 c_bioh2scen           "bioenergy hydrogen technology choice"
 c_shGreenH2           "lower bound on share of green hydrogen in all hydrogen by 2030"
 c_shBioTrans          "upper bound on share of bioliquids in transport from 2025 onwards"
-cm_shSynTrans         "lower bound on share of synthetic fuels in all transport fuels by 2035"
+cm_shSynTrans         "lower bound on share of synthetic fuels in all transport fuels by 2045"
+cm_shSynGas           "lower bound on share of synthetic gases by 2045"
 cm_IndCCSscen        "CCS for Industry"
 cm_optimisticMAC     "assume optimistic Industry MAC from AR5 Ch. 10?"
 cm_CCS_cement        "CCS for cement sub-sector"
@@ -329,6 +330,7 @@ c_bioh2scen      = 1;        !! def = 1
 c_shGreenH2      = 0;        !! def = 0
 c_shBioTrans     = 1;        !! def = 1
 cm_shSynTrans    = 0;        !! def = 0
+cm_shSynGas      = 0;        !! def = 0
 c_solscen        = 1;        !! def = 1
 
 cm_IndCCSscen          = 1;        !! def = 1

--- a/modules/39_CCU/off/not_used.txt
+++ b/modules/39_CCU/off/not_used.txt
@@ -6,6 +6,7 @@
 # |  Contact: remind@pik-potsdam.de
 name,type,reason
 vm_prodSe,input,questionnaire
+vm_co2capture,input,questionnaire
 cm_shSynTrans,input,questionnaire
 pm_emifac,input,questionnaire
 fm_dataglob,input,questionnaire

--- a/modules/39_CCU/on/bounds.gms
+++ b/modules/39_CCU/on/bounds.gms
@@ -6,6 +6,8 @@
 *** |  Contact: remind@pik-potsdam.de
 *** SOF ./modules/39_CCU/on/bounds.gms
 
+*** constrain solution space for CO2 capture
+vm_co2capture.up(t,regi,"cco2","ico2","ccsinje","1") = 50;
 
 *** FS: overwrite bounds of se2se technologies in core/bounds.gms and set synfuel lower bounds only from 2035 on
 *** (they are only there in case the solver misses to see the technologies)

--- a/modules/39_CCU/on/bounds.gms
+++ b/modules/39_CCU/on/bounds.gms
@@ -6,19 +6,32 @@
 *** |  Contact: remind@pik-potsdam.de
 *** SOF ./modules/39_CCU/on/bounds.gms
 
-*** -------------------------------------------------------------------------------------------------------------
-***LP* Narrowing down the solution space for vm_co2capture for CCU
-*** -------------------------------------------------------------------------------------------------------------
-vm_co2capture.fx(t,regi,"cco2","ico2","ccsinje","1") = 0;
-vm_co2capture.up(t,regi,"cco2","ico2","ccsinje","1") = 50;
+
+*** FS: overwrite bounds of se2se technologies in core/bounds.gms and set synfuel lower bounds only from 2035 on
+*** (they are only there in case the solver misses to see the technologies)
+vm_cap.lo(t,regi,te_ccu39,"1")=0;
+vm_cap.lo(t,regi,te_ccu39,"1")$(t.val gt 2031)=1e-7;
+
+*** FS: switch off CCU in baseline runs (as CO2 capture technologies teCCS are also switched off)
+if(cm_emiscen = 1,
+  vm_cap.fx(t,regi,te_ccu39,rlf) = 0;
+);
+
 
 ***----------------------------------------------------------------------------
 *** lower bound on share of synthetic fuels in all transport fuels by 2035
 ***----------------------------------------------------------------------------
 
-v39_shSynTrans.lo(t,regi)$(t.val eq 2025) = cm_shSynTrans / 4;
-v39_shSynTrans.lo(t,regi)$(t.val eq 2030) = cm_shSynTrans / 2;
-v39_shSynTrans.lo(t,regi)$(t.val gt 2030) = cm_shSynTrans;
+v39_shSynTrans.lo(t,regi)$(t.val ge 2030) = cm_shSynTrans / 4;
+v39_shSynTrans.lo(t,regi)$(t.val ge 2040) = cm_shSynTrans / 2;
+v39_shSynTrans.lo(t,regi)$(t.val ge 2045) = cm_shSynTrans;
 
+***----------------------------------------------------------------------------
+*** force synthetic gas in as a share of total gases
+***----------------------------------------------------------------------------
+
+v39_shSynGas.lo(t,regi)$(t.val ge 2030) = cm_shSynGas / 4;
+v39_shSynGas.lo(t,regi)$(t.val ge 2040) = cm_shSynGas / 2;
+v39_shSynGas.lo(t,regi)$(t.val ge 2045) = cm_shSynGas;
 
 *** EOF ./modules/39_CCU/39_CCU.gms

--- a/modules/39_CCU/on/declarations.gms
+++ b/modules/39_CCU/on/declarations.gms
@@ -12,12 +12,14 @@ p39_co2_dem(ttot,all_regi,all_enty,all_enty,all_te)					"CO2 demand of CCU techn
 
 positive variables
 vm_co2CCUshort(ttot,all_regi,all_enty,all_enty,all_te,rlf)           "CO2 captured in CCU te that have a persistence for co2 storage shorter than 5 years. Unit GtC/a"
-v39_shSynTrans(ttot,all_regi)                                        "Share of synthetic liquids in all fossil liquids. Value between 0 and 1."
+v39_shSynTrans(ttot,all_regi)                                        "Share of synthetic liquids in all SE liquids. Value between 0 and 1."
+v39_shSynGas(ttot,all_regi)                                          "Share of synthetic gas in all SE gases. Value between 0 and 1."
 ;
 
 equations
 q39_emiCCU(ttot,all_regi,all_te)                                        "calculate CCU emissions"
-q39_shSynTrans(ttot,all_regi)                                           "Define share of synthetic liquids in all fossil liquids."
+q39_shSynTrans(ttot,all_regi)                                           "Define share of synthetic liquids in all SE liquids."
+q39_shSynGas(ttot,all_regi)                                             "Define share of of synthetic gas in all SE gases."
 ;
 
 *** EOF ./modules/39_CCU/on/declarations.gms

--- a/modules/39_CCU/on/equations.gms
+++ b/modules/39_CCU/on/equations.gms
@@ -40,7 +40,7 @@ q39_shSynGas(t,regi)..
 	+ sum(se2se(entySe,entySe2,te)$seAgg2se("all_sega",entySe2), vm_prodSe(t,regi,entySe,entySe2,te))
     ) * v39_shSynGas(t,regi)
     =e=
-    vm_prodSe(t,regi,"seh2","segabio","h22ch4")
+    vm_prodSe(t,regi,"seh2","segafos","h22ch4")
 ;
 
 

--- a/modules/39_CCU/on/equations.gms
+++ b/modules/39_CCU/on/equations.gms
@@ -33,5 +33,15 @@ q39_shSynTrans(t,regi)..
     vm_prodSe(t,regi,"seh2","seliqfos","MeOH")
 ;
 
+*** share of synthetic gas in all SE gases
+q39_shSynGas(t,regi)..
+    (
+	sum(pe2se(entyPe,entySe,te)$seAgg2se("all_sega",entySe), vm_prodSe(t,regi,entyPe,entySe,te))
+	+ sum(se2se(entySe,entySe2,te)$seAgg2se("all_sega",entySe2), vm_prodSe(t,regi,entySe,entySe2,te))
+    ) * v39_shSynGas(t,regi)
+    =e=
+    vm_prodSe(t,regi,"seh2","segabio","h22ch4")
+;
+
 
 *** EOF ./modules/39_CCU/on/equations.gms

--- a/modules/39_CCU/on/not_used.txt
+++ b/modules/39_CCU/on/not_used.txt
@@ -5,10 +5,5 @@
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
 name,type,reason
-vm_prodSe,input,questionnaire
-cm_shSynTrans,input,questionnaire
-pm_emifac,input,questionnaire
-fm_dataglob,input,questionnaire
-vm_cap,input,questionnaire
-cm_emiscen,input,questionnaire
-cm_shSynGas,input,questionnaire
+
+


### PR DESCRIPTION
This fixes synfuels to zero in baseline runs and moves the minmial lower bounds of synfuel technologies to after 2030 (avoids infeasibilities in certain cases). Also, a switch to force in synthetic gas was added in analogy to the one for synthetic liquids. These switches now force in synfuels starting in 2035 (more realistic than from 2025 onwards after discussion with industry guy from Sunfire). 