### PR TITLE
update scripts to future proof against R 4.0.0+ updates

### DIFF
--- a/scripts/start/prepare_and_run.R
+++ b/scripts/start/prepare_and_run.R
@@ -8,7 +8,7 @@ library(lucode, quietly = TRUE,warn.conflicts =FALSE)
 library(dplyr, quietly = TRUE,warn.conflicts =FALSE)
 require(gdx)
 
-################################################################################################## 
+##################################################################################################
 #                             function: getReportData                                            #
 ##################################################################################################
 
@@ -27,7 +27,7 @@ getReportData <- function(path_to_report,inputpath_mag="magpie",inputpath_acc="c
     out["JPN",is.na(out["JPN",,]),] <- 0
     dimnames(out)[[3]] <- NULL #Delete variable name to prevent it from being written into output file
     write.magpie(out[notGLO,,],paste0("./modules/30_biomass/",inputpath_mag,"/input/p30_pebiolc_pricemag_coupling.csv"),file_type="csvr")
-  }  
+  }
   .bioenergy_costs <- function(mag){
     notGLO <- getRegions(mag)[!(getRegions(mag)=="GLO")]
     if ("Production Cost|Agriculture|Biomass|Energy Crops (million US$2005/yr)" %in% getNames(mag)) {
@@ -40,7 +40,7 @@ getReportData <- function(path_to_report,inputpath_mag="magpie",inputpath_acc="c
     out["JPN",is.na(out["JPN",,]),] <- 0
     dimnames(out)[[3]] <- NULL
     write.magpie(out[notGLO,,],paste0("./modules/30_biomass/",inputpath_mag,"/input/p30_pebiolc_costsmag.csv"),file_type="csvr")
-  }  
+  }
   .bioenergy_production <- function(mag){
     notGLO <- getRegions(mag)[!(getRegions(mag)=="GLO")]
     if("Demand|Bioenergy|2nd generation|++|Bioenergy crops (EJ/yr)" %in% getNames(mag)) {
@@ -54,9 +54,9 @@ getReportData <- function(path_to_report,inputpath_mag="magpie",inputpath_acc="c
     out["JPN",is.na(out["JPN",,]),] <- 0
     dimnames(out)[[3]] <- NULL
     write.magpie(out[notGLO,,],paste0("./modules/30_biomass/",inputpath_mag,"/input/p30_pebiolc_demandmag_coupling.csv"),file_type="csvr")
-  }  
+  }
   .emissions_mac <- function(mag) {
-    # define three columns of dataframe: 
+    # define three columns of dataframe:
     #   emirem (remind emission names)
     #   emimag (magpie emission names)
     #   factor_mag2rem (factor for converting magpie to remind emissions)
@@ -124,13 +124,13 @@ getReportData <- function(path_to_report,inputpath_mag="magpie",inputpath_acc="c
         #}
         out<-mbind(out,tmp)
     }
-    
+
     # Write REMIND input file
     notGLO   <- getRegions(mag)[!(getRegions(mag)=="GLO")]
     filename <- paste0("./core/input/f_macBaseMagpie_coupling.cs4r")
     write.magpie(out[notGLO],filename)
     write(paste0("*** EOF ",filename," ***"),file=filename,append=TRUE)
-  }	
+  }
   .agriculture_costs <- function(mag){
     notGLO <- getRegions(mag)[!(getRegions(mag)=="GLO")]
     out <- mag[,,"Costs|MainSolve w/o GHG Emissions (million US$05/yr)"]/1000/1000 # with transformation factor from 10E6 US$2005 to 10E12 US$2005
@@ -145,7 +145,7 @@ getReportData <- function(path_to_report,inputpath_mag="magpie",inputpath_acc="c
     dimnames(out)[[3]] <- NULL
     write.magpie(out[notGLO,,],paste0("./modules/26_agCosts/",inputpath_acc,"/input/trade_bal_reg.rem.csv"),file_type="csvr")
   }
-  
+
   rep <- read.report(path_to_report,as.list=FALSE)
   if (length(getNames(rep,dim="scenario"))!=1) stop("getReportData: MAgPIE data contains more or less than 1 scenario.")
   rep <- collapseNames(rep) # get rid of scenrio and model dimension if they exist
@@ -160,14 +160,14 @@ getReportData <- function(path_to_report,inputpath_mag="magpie",inputpath_acc="c
   #.agriculture_tradebal(mag)
 }
 
-################################################################################################## 
+##################################################################################################
 #                             function: prepare                                                  #
 ##################################################################################################
 
 prepare <- function() {
 
   timePrepareStart <- Sys.time()
-  
+
   # Load libraries
   require(lucode, quietly = TRUE,warn.conflicts =FALSE)
   require(magclass, quietly = TRUE,warn.conflicts =FALSE)
@@ -175,7 +175,7 @@ prepare <- function() {
   require(remind, quietly = TRUE,warn.conflicts =FALSE)
   require(moinput)
   require(mrvalidation)
-  
+
   .copy.fromlist <- function(filelist,destfolder) {
     if(is.null(names(filelist))) names(filelist) <- rep("",length(filelist))
     for(i in 1:length(filelist)) {
@@ -186,7 +186,7 @@ prepare <- function() {
       }
 	  }
   }
- 
+
   # Display git information
   cat("\n===== git info =====\nLatest commit: ")
   cat(try(system("git show -s --format='%h %ci %cn'", intern=TRUE), silent=TRUE),"\nChanges since then: ")
@@ -198,32 +198,32 @@ prepare <- function() {
 
 
   load("config.Rdata")
-  
+
   # Store results folder of current scenario
   on.exit(setwd(cfg$results_folder))
-  
+
   # change to REMIND main folder
   setwd(cfg$remind_folder)
-  
+
   # Check configuration for consistency
   cfg <- check_config(cfg, reference_file="config/default.cfg", settings_config = "config/settings_config.csv")
-  
+
   # Check for compatibility with subsidizeLearning
   if ( (cfg$gms$optimization != 'nash') & (cfg$gms$subsidizeLearning == 'globallyOptimal') ) {
     cat("Only optimization='nash' is compatible with subsudizeLearning='globallyOptimal'. Switching subsidizeLearning to 'off' now. \n")
     cfg$gms$subsidizeLearning = 'off'
   }
-  
+
   # reportCEScalib only works with the calibrate module
   if ( cfg$gms$CES_parameters != "calibrate" ) cfg$output <- setdiff(cfg$output,"reportCEScalib")
-  
+
   #AJS quit if title is too long - GAMS can't handle that
   if( nchar(cfg$title) > 75 | grepl("\\.",cfg$title) ) {
       stop("This title is too long or the name contains dots - GAMS would not tolerate this, and quit working at a point where you least expect it. Stopping now. ")
   }
 
   # adjust GDPpcScen based on GDPscen
-  cfg$gms$c_GDPpcScen <- gsub("gdp_","",cfg$gms$cm_GDPscen) 
+  cfg$gms$c_GDPpcScen <- gsub("gdp_","",cfg$gms$cm_GDPscen)
 
   # Is the run performed on the cluster?
   on_cluster    <- file.exists('/p')
@@ -239,30 +239,30 @@ prepare <- function() {
   # Make sure all MAGICC files have LF line endings, so Fortran won't crash
   if (on_cluster)
     system("find ./core/magicc/ -type f | xargs dos2unix -q")
-  
+
   ################## M O D E L   L O C K ###################################
   # Lock the directory for other instances of the start scritps
   lock_id <- model_lock(timeout1 = 1, oncluster=on_cluster)
-  on.exit(model_unlock(lock_id, oncluster=on_cluster))  
+  on.exit(model_unlock(lock_id, oncluster=on_cluster))
   ################## M O D E L   L O C K ###################################
 
   ###########################################################
   ### PROCESSING INPUT DATA ###################### START ####
   ###########################################################
-   
-  # update input files based on previous runs if applicable 
+
+  # update input files based on previous runs if applicable
   # ATTENTION: modifying gms files
   if(!is.null(cfg$gms$carbonprice) && (cfg$gms$carbonprice == "NDC2018")){
     source("scripts/input/prepare_NDC2018.R")
     prepare_NDC2018(as.character(cfg$files2export$start["input_bau.gdx"]))
-  } 
+  }
   ## the following is outcommented because by now it has to be done by hand ( currently only one gdx is handed to the next run, so it is impossible to fix to one run and use the tax from another run)
   ## Update CO2 tax information for exogenous carbon price runs with the same CO2 price as a previous run
   #if(!is.null(cfg$gms$carbonprice) && (cfg$gms$carbonprice == "ExogSameAsPrevious")){
   #  source("scripts/input/create_ExogSameAsPrevious_CO2price_file.R")
   #  create_ExogSameAsPrevious_CO2price_file(as.character(cfg$files2export$start["input_ref.gdx"]))
-  #}  
-  
+  #}
+
   # select demand pathway for transportation: options are conv (conventional demand pathway) and wise (wiseways, limited demand)
   if(cfg$gms$transport == "edge_esm"){
     if(grepl("Wise", cfg$gms$cm_EDGEtr_scen)){
@@ -282,18 +282,18 @@ prepare <- function() {
                                          "Kap_", cfg$gms$capitalMarket, "-",
                                          ifelse(cfg$gms$transport == "edge_esm", paste0( "demTrsp_", demTrsp, "-"), ""),
                                          "Reg_", substr(regionscode(cfg$regionmapping),1,10))
-  
+
   # write name of corresponding CES file to datainput.gms
   replace_in_file(file    = "./modules/29_CES_parameters/load/datainput.gms",
                   content = paste0('$include "./modules/29_CES_parameters/load/input/',cfg$gms$cm_CES_configuration,'.inc"'),
                   subject = "CES INPUT")
- 
+
   # If a path to a MAgPIE report is supplied use it as REMIND intput (used for REMIND-MAgPIE coupling)
   # ATTENTION: modifying gms files
   if (!is.null(cfg$pathToMagpieReport)) {
     getReportData(path_to_report = cfg$pathToMagpieReport,inputpath_mag=cfg$gms$biomass,inputpath_acc=cfg$gms$agCosts)
   }
-  
+
   # Update module paths in GAMS code
   update_modules_embedding()
 
@@ -305,10 +305,10 @@ prepare <- function() {
   # run main.gms if not further specified
   if(is.null(cfg$model)) cfg$model <- "main.gms"
   manipulateConfig(cfg$model, cfg$gms)
-  
+
   ######## declare functions for updating information ####
   update_info <- function(regionscode,revision) {
-    
+
     subject <- 'VERSION INFO'
     content <- c('',
       paste('Regionscode:',regionscode),
@@ -317,9 +317,9 @@ prepare <- function() {
       '',
       paste('Last modification (input data):',date()),
       '')
-    replace_in_file(cfg$model,paste('*',content),subject)  
+    replace_in_file(cfg$model,paste('*',content),subject)
   }
-   
+
   update_sets <- function(map) {
      .tmp <- function(x,prefix="", suffix1="", suffix2=" /", collapse=",", n=10) {
       content <- NULL
@@ -338,7 +338,7 @@ prepare <- function() {
     content <- c(modification_warning,'','sets')
     # write iso set with nice formatting (10 countries per line)
     tmp <- lapply(split(map$CountryCode, ceiling(seq_along(map$CountryCode)/10)),paste,collapse=",")
-    regions <- levels(map$RegionCode)
+    regions <- unique(map$RegionCode)
     content <- c(content, '',paste('   all_regi "all regions" /',paste(regions,collapse=','),'/',sep=''),'')
     # Creating sets for H12 subregions
     subsets <- toolRegionSubsets(map=cfg$regionmapping)
@@ -356,20 +356,20 @@ prepare <- function() {
 	  content <- c(content,'   iso "list of iso countries" /')
     content <- c(content, .tmp(map$CountryCode, suffix1=",", suffix2=" /"),'')
     content <- c(content,'   regi2iso(all_regi,iso) "mapping regions to iso countries"','      /')
-    for(i in levels(map$RegionCode)) {
+    for(i in unique(map$RegionCode)) {
       content <- c(content, .tmp(map$CountryCode[map$RegionCode==i], prefix=paste0(i," . ("), suffix1=")", suffix2=")"))
     }
-    content <- c(content,'      /') 
+    content <- c(content,'      /')
     content <- c(content, 'iso_regi "all iso countries and EU and greater China region" /  EUR,CHA,')
     content <- c(content, .tmp(map$CountryCode, suffix1=",", suffix2=" /"),'')
     content <- c(content,'   map_iso_regi(iso_regi,all_regi) "mapping from iso countries to regions that represent country" ','         /')
-    for(i in regions[regions %in% c("EUR","CHA",levels(map$CountryCode))]) {
+    for(i in regions[regions %in% c("EUR","CHA",unique(map$CountryCode))]) {
       content <- c(content, .tmp(i, prefix=paste0(i," . "), suffix1="", suffix2=""))
     }
-    content <- c(content,'      /',';') 
+    content <- c(content,'      /',';')
     replace_in_file('core/sets.gms',content,"SETS",comment="***")
   }
-  
+
   ############ download and distribute input data ########
   # check wheather the regional resolution and input data revision are outdated and update data if needed
   if(file.exists("input/source_files.log")) {
@@ -378,7 +378,7 @@ prepare <- function() {
       input_old <- "no_data"
   }
   input_new <- paste0("rev",cfg$revision,"_", regionscode(cfg$regionmapping),"_", tolower(cfg$model_name),".tgz")
-    
+
   if(!setequal(input_new, input_old) | cfg$force_download) {
       cat("Your input data are outdated or in a different regional resolution. New data are downloaded and distributed. \n")
       download_distribute(files        = input_new,
@@ -386,15 +386,15 @@ prepare <- function() {
                           modelfolder  = ".",
                           debug        = FALSE)
   }
-  
+
   ############ update information ########################
   # update_info, which regional resolution and input data revision in cfg$model
   update_info(regionscode(cfg$regionmapping),cfg$revision)
   # update_sets, which is updating the region-depending sets in core/sets.gms
   #-- load new mapping information
-  map <- read.csv(cfg$regionmapping,sep=";")  
+  map <- read.csv(cfg$regionmapping,sep=";")
   update_sets(map)
-  
+
   ########################################################
   ### PROCESSING INPUT DATA ###################### END ###
   ########################################################
@@ -413,10 +413,10 @@ prepare <- function() {
   content <- c(content,'      /',';')
   replace_in_file('core/sets.gms',content,"MODULES",comment="***")
   ### ADD MODULE INFO IN SETS  ############# END #########
-      
+
   # choose which conopt files to copy
   cfg$files2export$start <- sub("conopt3",cfg$gms$cm_conoptv,cfg$files2export$start)
-  
+
   # Copy important files into output_folder (before REMIND execution)
   .copy.fromlist(cfg$files2export$start,cfg$results_folder)
 
@@ -426,7 +426,7 @@ prepare <- function() {
   # Merge GAMS files
   cat("Creating full.gms\n")
   singleGAMSfile(mainfile=cfg$model,output = path(cfg$results_folder, "full.gms"))
-  
+
   # Collect run statistics (will be saved to central database in submit.R)
   lucode::runstatistics(file = paste0(cfg$results_folder,"/runstatistics.rda"),
                         user = Sys.info()[["user"]],
@@ -443,72 +443,72 @@ prepare <- function() {
   # and remove "setwd(cfg$results_folder)" from on.exit, becaue we change to it in the next line
   on.exit()
   ################## M O D E L   U N L O C K ###################################
-  
+
   setwd(cfg$results_folder)
 
-  # Function to create the levs.gms, fixings.gms, and margs.gms files, used in 
+  # Function to create the levs.gms, fixings.gms, and margs.gms files, used in
   # delay scenarios.
   create_fixing_files <- function(cfg, input_ref_file = "input_ref.gdx") {
-    
+
     # Start the clock.
     begin <- Sys.time()
-    
-    # Extract data from input_ref.gdx file and store in levs_margs_ref.gms. 
-    system(paste("gdxdump", 
-                 input_ref_file, 
-                 "Format=gamsbas Delim=comma FilterDef=N Output=levs_margs_ref.gms", 
+
+    # Extract data from input_ref.gdx file and store in levs_margs_ref.gms.
+    system(paste("gdxdump",
+                 input_ref_file,
+                 "Format=gamsbas Delim=comma FilterDef=N Output=levs_margs_ref.gms",
                  sep = " "))
-    
+
     # Read data from levs_margs_ref.gms.
     ref_gdx_data <- suppressWarnings(readLines("levs_margs_ref.gms"))
-    
+
     # Create fixing files.
     cat("\n")
     create_standard_fixings(cfg, ref_gdx_data)
-    
+
     # Stop the clock.
     cat("Time it took to create the fixing files: ")
     manipulate_runtime <- Sys.time()-begin
     print(manipulate_runtime)
     cat("\n")
-    
-    
+
+
     # Delete file.
     file.remove("levs_margs_ref.gms")
-    
+
   }
 
 
-  # Function to create the levs.gms, fixings.gms, and margs.gms files, used in 
+  # Function to create the levs.gms, fixings.gms, and margs.gms files, used in
   # the standard (i.e. the non-macro stand-alone) delay scenarios.
   create_standard_fixings <- function(cfg, ref_gdx_data) {
-    
-    # Declare empty lists to hold the strings for the 'manipulateFile' functions. 
+
+    # Declare empty lists to hold the strings for the 'manipulateFile' functions.
     full_manipulateThis <- NULL
     levs_manipulateThis <- NULL
     fixings_manipulateThis <- NULL
     margs_manipulateThis <- NULL
 
     str_years <- c()
-    no_years  <- (cfg$gms$cm_startyear - 2005) / 5  
-    
+    no_years  <- (cfg$gms$cm_startyear - 2005) / 5
+
     # Write level values to file
     levs <- c()
     for (i in 1:no_years) {
       str_years[i] <- paste("L \\('", 2000 + i * 5, sep = "")
       levs         <- c(levs, grep(str_years[i], ref_gdx_data, value = TRUE))
     }
-    
+
     writeLines(levs, "levs.gms")
-    
+
     # Replace fixing.gms with level values
     file.copy("levs.gms", "fixings.gms", overwrite = TRUE)
 
     fixings_manipulateThis <- c(fixings_manipulateThis, list(c(".L ", ".FX ")))
-    #cb q_co2eq is only "static" equation to be active before cm_startyear, as multigasscen could be different from a scenario to another that is fixed on the first  
+    #cb q_co2eq is only "static" equation to be active before cm_startyear, as multigasscen could be different from a scenario to another that is fixed on the first
     #cb therefore, vm_co2eq cannot be fixed, otherwise infeasibilities would result. vm_co2eq.M is meaningless, is never used in the code (a manipulateFile delete line command would be even better)
     #  manipulateFile("fixings.gms", list(c("vm_co2eq.FX ", "vm_co2eq.M ")))
-    
+
     # Write marginal values to file
     margs <- c()
     str_years    <- c()
@@ -520,43 +520,43 @@ prepare <- function() {
      # temporary fix so that you can use older gdx for fixings - will become obsolete in the future and can be deleted once the next variable name change is done
     margs_manipulateThis <- c(margs_manipulateThis, list(c("q_taxrev","q21_taxrev")))
     # fixing for SPA runs based on ModPol input data
-    margs_manipulateThis <- c(margs_manipulateThis, 
+    margs_manipulateThis <- c(margs_manipulateThis,
                               list(c("q41_emitrade_restr_mp.M", "!!q41_emitrade_restr_mp.M")),
-                              list(c("q41_emitrade_restr_mp2.M", "!!q41_emitrade_restr_mp2.M"))) 
-    
-    #AJS this symbol is not known and crashes the run - is it depreciated? TODO 
-    levs_manipulateThis <- c(levs_manipulateThis, 
+                              list(c("q41_emitrade_restr_mp2.M", "!!q41_emitrade_restr_mp2.M")))
+
+    #AJS this symbol is not known and crashes the run - is it depreciated? TODO
+    levs_manipulateThis <- c(levs_manipulateThis,
                              list(c("vm_pebiolc_price_base.L", "!!vm_pebiolc_price_base.L")))
-    
+
     #AJS filter out nash marginals in negishi case, as they would lead to a crash when trying to fix on them:
     if(cfg$gms$optimization == 'negishi'){
       margs_manipulateThis <- c(margs_manipulateThis, list(c("q80_costAdjNash.M", "!!q80_costAdjNash.M")))
     }
     if(cfg$gms$subsidizeLearning == 'off'){
-      levs_manipulateThis <- c(levs_manipulateThis, 
+      levs_manipulateThis <- c(levs_manipulateThis,
                                list(c("v22_costSubsidizeLearningForeign.L",
                                       "!!v22_costSubsidizeLearningForeign.L")))
-      margs_manipulateThis <- c(margs_manipulateThis, 
+      margs_manipulateThis <- c(margs_manipulateThis,
                                 list(c("q22_costSubsidizeLearning.M", "!!q22_costSubsidizeLearning.M")),
                                 list(c("v22_costSubsidizeLearningForeign.M",
                                        "!!v22_costSubsidizeLearningForeign.M")),
                                 list(c("q22_costSubsidizeLearningForeign.M",
                                        "!!q22_costSubsidizeLearningForeign.M")))
-      fixings_manipulateThis <- c(fixings_manipulateThis, 
+      fixings_manipulateThis <- c(fixings_manipulateThis,
                                   list(c("v22_costSubsidizeLearningForeign.FX",
                                          "!!v22_costSubsidizeLearningForeign.FX")))
-      
+
     }
-    
+
     #JH filter out negishi marginals in nash case, as they would lead to a crash when trying to fix on them:
     if(cfg$gms$optimization == 'nash'){
-      margs_manipulateThis <- c(margs_manipulateThis, 
+      margs_manipulateThis <- c(margs_manipulateThis,
                                 list(c("q80_balTrade.M", "!!q80_balTrade.M")),
                                 list(c("q80_budget_helper.M", "!!q80_budget_helper.M")))
     }
-    #RP filter out module 40 techpol fixings 
+    #RP filter out module 40 techpol fixings
     if(cfg$gms$techpol == 'none'){
-      margs_manipulateThis <- c(margs_manipulateThis, 
+      margs_manipulateThis <- c(margs_manipulateThis,
                                 list(c("q40_NewRenBound.M", "!!q40_NewRenBound.M")),
                                 list(c("q40_CoalBound.M", "!!q40_CoalBound.M")),
                                 list(c("q40_LowCarbonBound.M", "!!q40_LowCarbonBound.M")),
@@ -574,16 +574,16 @@ prepare <- function() {
                                 list(c("q40_BioFuelBound.M", "!!q40_BioFuelBound.M")))
 
     }
-    
+
     if(cfg$gms$techpol == 'NPi2018'){
-      margs_manipulateThis <- c(margs_manipulateThis, 
+      margs_manipulateThis <- c(margs_manipulateThis,
                                 list(c("q40_El_RenShare.M", "!!q40_El_RenShare.M")),
                                 list(c("q40_CoalBound.M", "!!q40_CoalBound.M")))
     }
-    
-    # Include fixings (levels) and marginals in full.gms at predefined position 
+
+    # Include fixings (levels) and marginals in full.gms at predefined position
     # in core/loop.gms.
-    full_manipulateThis <- c(full_manipulateThis, 
+    full_manipulateThis <- c(full_manipulateThis,
                              list(c("cb20150605readinpositionforlevelfile",
                                     paste("first offlisting inclusion of levs.gms so that level value can be accessed",
                                           "$offlisting",
@@ -596,14 +596,14 @@ prepare <- function() {
                                                                "$include \"fixings.gms\";",
                                                                "$include \"margs.gms\";",
                                                                "$onlisting", sep = "\n"))))
-    
-    
-    # Perform actual manipulation on levs.gms, fixings.gms, and margs.gms in 
+
+
+    # Perform actual manipulation on levs.gms, fixings.gms, and margs.gms in
     # single, respective, parses of the texts.
     manipulateFile("levs.gms", levs_manipulateThis)
     manipulateFile("fixings.gms", fixings_manipulateThis)
     manipulateFile("margs.gms", margs_manipulateThis)
-    
+
     # Perform actual manipulation on full.gms, in single parse of the text.
     manipulateFile("full.gms", full_manipulateThis)
   }
@@ -619,30 +619,30 @@ prepare <- function() {
   if (  cfg$gms$cm_startyear > 2005  & (!file.exists("levs.gms.gz") | !file.exists("levs.gms"))) {
     create_fixing_files(cfg = cfg, input_ref_file = "input_ref.gdx")
   }
-  
+
   timePrepareEnd <- Sys.time()
   # Save run statistics to local file
   cat("Saving timePrepareStart and timePrepareEnd to runstatistics.rda\n")
   lucode::runstatistics(file           = paste0("runstatistics.rda"),
                       timePrepareStart = timePrepareStart,
                       timePrepareEnd   = timePrepareEnd)
-  
+
   # on.exit sets working directory to results folder
-  
+
 } # end of function "prepare"
 
-################################################################################################## 
+##################################################################################################
 #                                function: run                                                   #
 ##################################################################################################
 
 run <- function(start_subsequent_runs = TRUE) {
-  
+
   load("config.Rdata")
   on.exit(setwd(cfg$results_folder))
-  
+
   # Save start time
   timeGAMSStart <- Sys.time()
-  
+
   # De-compress finxing files if they have already been zipped (only valid if run is restarted)
   if (cfg$gms$cm_startyear > 2005) {
       if (file.exists("levs.gms.gz")) {
@@ -661,7 +661,7 @@ run <- function(start_subsequent_runs = TRUE) {
   # Call GAMS
   if (cfg$gms$CES_parameters == "load") {
 
-    system(paste0(cfg$gamsv, " full.gms -errmsg=1 -a=", cfg$action, 
+    system(paste0(cfg$gamsv, " full.gms -errmsg=1 -a=", cfg$action,
                   " -ps=0 -pw=185 -pc=2 -gdxcompress=1 -logoption=", cfg$logoption))
 
   } else if (cfg$gms$CES_parameters == "calibrate") {
@@ -677,34 +677,34 @@ run <- function(start_subsequent_runs = TRUE) {
       cat("CES calibration iteration: ", cal_itr, "\n")
 
       # Update calibration iteration in GAMS file
-      system(paste0("sed -i 's/^\\(\\$setglobal c_CES_calibration_iteration ", 
+      system(paste0("sed -i 's/^\\(\\$setglobal c_CES_calibration_iteration ",
                     "\\).*/\\1", cal_itr, "/' full.gms"))
 
-      system(paste0(cfg$gamsv, " full.gms -errmsg=1 -a=", cfg$action, 
+      system(paste0(cfg$gamsv, " full.gms -errmsg=1 -a=", cfg$action,
                     " -ps=0 -pw=185 -pc=2 -gdxcompress=1 -logoption=", cfg$logoption))
 
       # If GAMS found a solution
       if (   file.exists("fulldata.gdx")
           && file.info("fulldata.gdx")$mtime > fulldata_m_time) {
-        
+
         #create the file to be used in the load mode
         getLoadFile <- function(){
-          
+
           file_name = paste0(cfg$gms$cm_CES_configuration,"_ITERATION_",cal_itr,".inc")
           ces_in = system("gdxdump fulldata.gdx symb=in NoHeader Format=CSV", intern = TRUE) %>% gsub("\"","",.) #" This comment is just to obtain correct syntax highlighting
           expr_ces_in = paste0("(",paste(ces_in, collapse = "|") ,")")
 
-          
-          tmp = system("gdxdump fulldata.gdx symb=pm_cesdata", intern = TRUE)[-(1:2)] %>% 
+
+          tmp = system("gdxdump fulldata.gdx symb=pm_cesdata", intern = TRUE)[-(1:2)] %>%
             grep("(quantity|price|eff|effgr|xi|rho|offset_quantity|compl_coef)", x = ., value = TRUE)
           tmp = tmp %>% grep(expr_ces_in,x = ., value = T)
-          
+
           tmp %>%
             sub("'([^']*)'.'([^']*)'.'([^']*)'.'([^']*)' (.*)[ ,][ /];?",
                 "pm_cesdata(\"\\1\",\"\\2\",\"\\3\",\"\\4\") = \\5;", x = .) %>%
             write(file_name)
-          
-          
+
+
           pm_cesdata_putty = system("gdxdump fulldata.gdx symb=pm_cesdata_putty", intern = TRUE)
           if (length(pm_cesdata_putty) == 2){
             tmp_putty =  gsub("^Parameter *([A-z_(,)])+cesParameters\\).*$",'\\1"quantity")  =   0;',  pm_cesdata_putty[2])
@@ -717,14 +717,14 @@ run <- function(start_subsequent_runs = TRUE) {
             sub("'([^']*)'.'([^']*)'.'([^']*)'.'([^']*)' (.*)[ ,][ /];?",
                 "pm_cesdata_putty(\"\\1\",\"\\2\",\"\\3\",\"\\4\") = \\5;", x = .)%>% write(file_name,append =T)
         }
-        
+
         getLoadFile()
 
         # Store all the interesting output
         file.copy("full.lst", sprintf("full_%02i.lst", cal_itr), overwrite = TRUE)
         file.copy("full.log", sprintf("full_%02i.log", cal_itr), overwrite = TRUE)
         file.copy("fulldata.gdx", "input.gdx", overwrite = TRUE)
-        file.copy("fulldata.gdx", sprintf("input_%02i.gdx", cal_itr), 
+        file.copy("fulldata.gdx", sprintf("input_%02i.gdx", cal_itr),
                   overwrite = TRUE)
 
         # Update file modification time
@@ -741,7 +741,7 @@ run <- function(start_subsequent_runs = TRUE) {
   # Calculate run time statistics
   timeGAMSEnd  <- Sys.time()
   gams_runtime <- timeGAMSEnd - timeGAMSStart
-  timeOutputStart <- Sys.time() 
+  timeOutputStart <- Sys.time()
 
   # If REMIND actually did run
   if (cfg$action == "ce" && cfg$gms$c_skip_output != "on") {
@@ -769,7 +769,7 @@ run <- function(start_subsequent_runs = TRUE) {
                         submit     = cfg$runstatistics)
 
   # Compress files with the fixing-information
-  if (cfg$gms$cm_startyear > 2005) 
+  if (cfg$gms$cm_startyear > 2005)
     system("gzip -f levs.gms margs.gms fixings.gms")
 
   # go up to the main folder, where the cfg files for subsequent runs are stored and the output scripts are executed from
@@ -779,8 +779,8 @@ run <- function(start_subsequent_runs = TRUE) {
   if (start_subsequent_runs) {
     # Note: step 1. and 2. below write to the same .RData file but are usually executed by different runs.
     # Step 1. is usually only executed by BASE runs, step 2 by every run that preceeds another run.
-    
-    # 1. Save the path to the fulldata.gdx of the current run to the cfg files 
+
+    # 1. Save the path to the fulldata.gdx of the current run to the cfg files
     # of the runs that use it as 'input_bau.gdx'
 
     # Use the name to check whether it is a coupled run (TRUE if the name ends with "-rem-xx")
@@ -792,7 +792,7 @@ run <- function(start_subsequent_runs = TRUE) {
       source("scripts/start/submit.R")
       # Save the current cfg settings into a different data object, so that they are not overwritten
       cfg_main <- cfg
-      
+
       for(run in seq(1,length(cfg_main$RunsUsingTHISgdxAsBAU))){
         # for each of the runs that use this gdx as bau, read in the cfg, ...
         cat("Writing the path for input_bau.gdx to ",paste0(cfg_main$RunsUsingTHISgdxAsBAU[run],".RData"),"\n")
@@ -805,8 +805,8 @@ run <- function(start_subsequent_runs = TRUE) {
       cfg <- cfg_main
     }
 
-    # 2. Save the path to the fulldata.gdx of the current run to the cfg files 
-    # of the subsequent runs that use it as 'input_ref.gdx' and start these runs 
+    # 2. Save the path to the fulldata.gdx of the current run to the cfg files
+    # of the subsequent runs that use it as 'input_ref.gdx' and start these runs
 
     no_subsequent_runs <- identical(cfg$subsequentruns,character(0)) | identical(cfg$subsequentruns,NULL) | coupled_run
 
@@ -816,7 +816,7 @@ run <- function(start_subsequent_runs = TRUE) {
       # Save the current cfg settings into a different data object, so that they are not overwritten
       cfg_main <- cfg
       source("scripts/start/submit.R")
-      
+
       for(run in seq(1,length(cfg_main$subsequentruns))){
         # for each of the subsequent runs, read in the cfg, ...
         cat("Writing the path for input_ref.gdx to ",paste0(cfg_main$subsequentruns[run],".RData"),"\n")
@@ -824,8 +824,8 @@ run <- function(start_subsequent_runs = TRUE) {
         # ...change the path_gdx_ref field of the subsequent run to the fulldata gdx of the current (preceding) run ...
         cfg$files2export$start['input_ref.gdx'] <- paste0(cfg_main$remind_folder,"/",cfg_main$results_folder,"/fulldata.gdx")
         save(cfg, file = paste0(cfg_main$subsequentruns[run],".RData"))
-        
-        # Subsequent runs will be started in submit.R using the RData files written above 
+
+        # Subsequent runs will be started in submit.R using the RData files written above
         # after the current run has finished.
         cat("Starting subsequent run ",cfg_main$subsequentruns[run],"\n")
         submit(cfg)
@@ -835,7 +835,7 @@ run <- function(start_subsequent_runs = TRUE) {
     }
 
     # 3. Create script file that can be used later to restart the subsequent runs manually.
-    # In case there are no subsequent runs (or it's coupled runs), the file contains only 
+    # In case there are no subsequent runs (or it's coupled runs), the file contains only
     # a small message.
 
     subseq_start_file  <- paste0(cfg$results_folder,"/start_subsequentruns_manually.R")
@@ -858,22 +858,22 @@ run <- function(start_subsequent_runs = TRUE) {
     }
   }
   #=================== END - Subsequent runs ========================
-  
+
   # Copy important files into output_folder (after REMIND execution)
   for (file in cfg$files2export$end)
     file.copy(file, cfg$results_folder, overwrite = TRUE)
 
-  # Set source_include so that loaded scripts know they are included as 
+  # Set source_include so that loaded scripts know they are included as
   # source (instead of being executed from the command line)
   source_include <- TRUE
-   
+
   # Postprocessing / Output Generation
   output    <- cfg$output
   outputdir <- cfg$results_folder
   sys.source("output.R",envir=new.env())
   # get runtime for output
   timeOutputEnd <- Sys.time()
-  
+
   # Save run statistics to local file
   cat("Saving timeGAMSStart, timeGAMSEnd, timeOutputStart and timeOutputStart to runstatistics.rda\n")
   lucode::runstatistics(file           = paste0(cfg$results_folder, "/runstatistics.rda"),
@@ -881,14 +881,14 @@ run <- function(start_subsequent_runs = TRUE) {
                        timeGAMSEnd     = timeGAMSEnd,
                        timeOutputStart = timeOutputStart,
                        timeOutputEnd   = timeOutputEnd)
-  
+
   return(cfg$results_folder)
   # on.exit sets working directory back to results folder
-  
+
 } # end of function "run"
 
 
-################################################################################################## 
+##################################################################################################
 #                                    script                                                      #
 ##################################################################################################
 
@@ -896,12 +896,12 @@ run <- function(start_subsequent_runs = TRUE) {
 # copied to by submit(cfg)
 
 if (!file.exists("full.gms")) {
-  # If no "full.gms" exists, the script assumes that REMIND did not run before and 
+  # If no "full.gms" exists, the script assumes that REMIND did not run before and
   # prepares all inputs before starting the run.
   prepare()
   start_subsequent_runs <- TRUE
 } else {
-  # If "full.gms" exists, the script assumes that a full.gms has been generated before and you want 
+  # If "full.gms" exists, the script assumes that a full.gms has been generated before and you want
   # to restart REMIND in the same folder using the gdx that it eventually previously produced.
   if(file.exists("fulldata.gdx")) file.copy("fulldata.gdx", "input.gdx", overwrite = TRUE)
   start_subsequent_runs <- FALSE

--- a/start_bundle_coupled.R
+++ b/start_bundle_coupled.R
@@ -18,17 +18,17 @@ path_magpie <- "/p/projects/piam/runs/coupled-magpie/"
 path_settings_coupled <- paste0(path_remind,"config/scenario_config_coupled_SSPSDP.csv")
 path_settings_remind  <- paste0(path_remind,"config/scenario_config_SSPSDP.csv")
 
-# You can put a prefix in front of the names of your runs, this will turn e.g. "SSP2-Base" into "prefix_SSP2-Base". 
+# You can put a prefix in front of the names of your runs, this will turn e.g. "SSP2-Base" into "prefix_SSP2-Base".
 # This allows storing results of multiple coupled runs (which have the same scenario names) in the same MAgPIE and REMIND output folders.
 prefix_runname <- "C_"
-  
-# If there are existing runs you would like to take the gdxes (REMIND) or reportings (REMIND or MAgPIE) from, provide the path here and the name prefix below. 
-# Note: the scenario names of the old runs have to be identical to the runs that are to be started. If they differ please provide the names of the old scenarios in the 
+
+# If there are existing runs you would like to take the gdxes (REMIND) or reportings (REMIND or MAgPIE) from, provide the path here and the name prefix below.
+# Note: the scenario names of the old runs have to be identical to the runs that are to be started. If they differ please provide the names of the old scenarios in the
 # file that you specified on path_settings_coupled (scenario_config_coupled_xxx.csv).
 path_remind_oldruns <- paste0(path_remind,"output/")
 path_magpie_oldruns <- paste0(path_magpie,"output/")
 
-# If you want the script to find gdxs or reports of older runs as starting point for new runs please 
+# If you want the script to find gdxs or reports of older runs as starting point for new runs please
 # provide the prefix of the old run names so the script can find them.
 prefix_oldruns <-  "C_"
 
@@ -96,22 +96,22 @@ if (!identical(common,character(0))) {
 ####################################################
 for(scen in common){
   cat(paste0("\n################################\nPreparing run ",scen,"\n"))
-  
+
   runname      <- paste0(prefix_runname,scen)            # name of the run that is used for the folder names
   path_report  <- NULL                                   # sets the path to the report REMIND is started with in the first loop
   LU_pricing   <- scenarios_coupled[scen, "LU_pricing"]  # set the GHG prices to zero up to and including the year specified here
   qos          <- scenarios_coupled[scen, "qos"]         # set the SLURM quality of service (priority/short/medium/...)
   if(is.null(qos)) qos <- "short"                        # if qos could not be found in scenarios_coupled use short
-  
+
   start_iter <- 1 # iteration to start the coupling with
-  
+
   # look whether there is already a REMIND run (check for old name if provided)
   if (!is.na(scenarios_coupled[scen, "oldrun"])) {
     needle <- scenarios_coupled[scen, "oldrun"]
   } else {
     needle <- scen
   }
-	
+
   # Check for existing REMIND and MAgPIE runs and whether iteration can be continued from those (at least one REMIND iteration has to exist!)
   suche <- paste0(path_remind_oldruns,prefix_oldruns,needle,"-rem-*/fulldata.gdx")
   already_rem <- Sys.glob(suche)
@@ -128,7 +128,7 @@ for(scen in common){
       # continue counting only if remind is started in the same directoy the gdxes are taken from
       iter_rem <- as.integer(sub(".*rem-(\\d.*)/.*","\\1",already_rem))
     }
-      
+
     # is there already a MAgPIE run with this name?
     suche <- paste0(path_magpie_oldruns,prefix_oldruns,needle,"-mag-*/report.mif")
     already_mag <- Sys.glob(suche)
@@ -157,12 +157,12 @@ for(scen in common){
 
   cat(paste0("Set start iteration to: ",start_iter,"\n"))
 
-	# If a gdx is provided in scenario_config_coupled.csv use it instead of any previously found 
+	# If a gdx is provided in scenario_config_coupled.csv use it instead of any previously found
   if (!is.na(scenarios_coupled[scen, "path_gdx"])) {
     settings_remind[scen, "path_gdx"] <- scenarios_coupled[scen, "path_gdx"]
     cat("Using gdx specified in\n  ",path_settings_coupled,"\n  ",settings_remind[scen, "path_gdx"],"\n")
   }
-  
+
   # If provided replace the path to the MAgPIE report found automatically with path given in scenario_config_coupled.csv
   if (!is.na(scenarios_coupled[scen, "path_report"])) {
     path_report  <- scenarios_coupled[scen, "path_report"] # sets the path to the report REMIND is started with in the first loop
@@ -172,7 +172,7 @@ for(scen in common){
   source(paste0(path_remind,"config/default.cfg")) # retrieve REMIND settings
   cfg_rem <- cfg
   rm(cfg)
-  
+
   source(paste0(path_magpie,"config/default.cfg")) # retrieve MAgPIE settings
   cfg_mag <- cfg
   rm(cfg)
@@ -182,7 +182,7 @@ for(scen in common){
   cfg_mag <- check_config(cfg_mag, reference_file=paste0(path_magpie,"config/default.cfg"),modulepath = paste0(path_magpie,"modules/"))
 
   # How to provide the exogenous TC to MAgPIE:
-  # Running MAgPIE with exogenous TC requires a path with exogenous TC. Using exo_indc_MAR17 the path is chosen via c13_tau_scen. 
+  # Running MAgPIE with exogenous TC requires a path with exogenous TC. Using exo_indc_MAR17 the path is chosen via c13_tau_scen.
   # Using exo_JUN13 the path is given in the file modules/13_tc/exo_JUN13/input/tau_scenario.csv
   # This file can be generated (prior to all runs that use exogenous TC) using the following lines of code:
   #  require(magpie) # for tau function
@@ -222,25 +222,25 @@ for(scen in common){
 
   # Add non-gms-switches manually
   if( "regionmapping" %in% names(settings_remind)){
-    cfg_rem$regionmapping <- settings_remind[scen,"regionmapping"] 
+    cfg_rem$regionmapping <- settings_remind[scen,"regionmapping"]
   }
-  
+
   # Edit default.cfg settings according to the SSP scenarios only for elements in 'scenarios' that exist in the cfg
   for (switchname in intersect(names(cfg_rem$gms),names(settings_remind))){
     cfg_rem$gms[[switchname]] <- settings_remind[scen,switchname]
   }
-  
+
   # If provided replace gdx paths given in scenario_config_SSP with paths given in scenario_config_coupled
   if (!is.na(scenarios_coupled[scen, "path_gdx_bau"])) {
 	  settings_remind[scen, "path_gdx_bau"] <- scenarios_coupled[scen, "path_gdx_bau"]
 	  cat("Replacing gdx_bau information with those specified in\n  ",path_settings_coupled,"\n  ",settings_remind[scen, "path_gdx_bau"],"\n")
   }
-  
+
   if (!is.na(scenarios_coupled[scen, "path_gdx_ref"])) {
 	  settings_remind[scen, "path_gdx_ref"] <- scenarios_coupled[scen, "path_gdx_ref"]
 	  cat("Replacing gdx_ref information with those specified in\n  ",path_settings_coupled,"\n  ",settings_remind[scen, "path_gdx_ref"],"\n")
   }
- 
+
   # Create list of previously defined paths to gdxs
   gdxlist <- c(input.gdx     = settings_remind[scen, "path_gdx"], # eventually this was updated if older runs exists in this folder (see above)
                input_ref.gdx = settings_remind[scen, "path_gdx_ref"],
@@ -248,21 +248,21 @@ for(scen in common){
 
   # Remove potential elements that contain ".gdx" and append gdxlist
   cfg_rem$files2export$start <- .setgdxcopy(".gdx",cfg_rem$files2export$start,gdxlist)
-  
+
   # add information on subsequent runs to start after the current run is finished
   # take rownames (which is the runname) of that row, that has the current scenario in its gdx_ref
   cfg_rem$subsequentruns <- intersect(rownames(settings_remind[settings_remind$path_gdx_ref == scen & !is.na(settings_remind$path_gdx_ref),]),common)
-     
+
   # immediately start run if it has a real gdx file (not a runname) given (last four letters are ".gdx") in path_gdx_ref or where this field is empty (NA)
-  start_now <- (substr(settings_remind[scen,"path_gdx_ref"], nchar(settings_remind[scen,"path_gdx_ref"])-3, nchar(settings_remind[scen,"path_gdx_ref"])) == ".gdx" 
+  start_now <- (substr(settings_remind[scen,"path_gdx_ref"], nchar(settings_remind[scen,"path_gdx_ref"])-3, nchar(settings_remind[scen,"path_gdx_ref"])) == ".gdx"
                | is.na(settings_remind[scen,"path_gdx_ref"]))
-               
+
   if (!start_now) {
       # if no real file is given but a reference to another scenario (that has to run first) create path for input_ref and input_bau
       # using the scenario names given in the columns path_gdx_ref and path_gdx_ref in the REMIND standalone scenario config
       cfg_rem$files2export$start['input_ref.gdx'] <- paste0(path_remind,"output/",prefix_runname,settings_remind[scen,"path_gdx_ref"],"-rem-",max_iterations,"/fulldata.gdx")
       cfg_rem$files2export$start['input_bau.gdx'] <- paste0(path_remind,"output/",prefix_runname,settings_remind[scen,"path_gdx_bau"],"-rem-",max_iterations,"/fulldata.gdx")
-      
+
       # If the preceding run has already finished (= their gdx files exist) start the current run immediately.
       # This might be the case e.g. if you started the baseline and NDC runs in a first batch and now want to start the subsequent policy runs by hand after the baselines have finished
       if (file.exists(cfg_rem$files2export$start['input_ref.gdx']) & file.exists(cfg_rem$files2export$start['input_bau.gdx'])) {
@@ -279,7 +279,7 @@ for(scen in common){
 
   # convert from logi to character so file.exists does not throw an error
   path_report <- as.character(path_report)
-  
+
   cat("\nSUMMARY\n")
   cat("runname     :",runname,"\n")
   cat("QOS         :",qos,"\n")
@@ -291,10 +291,10 @@ for(scen in common){
   cat("bau_gdx     : ",ifelse(file.exists(cfg_rem$files2export$start["input_bau.gdx"]),green,red), cfg_rem$files2export$start["input_bau.gdx"], NC, "\n",sep="")
   cat("path_report : ",ifelse(file.exists(path_report),green,red), path_report, NC, "\n",sep="")
   cat("LU_pricing  :",LU_pricing,"\n")
- 
+
   if (cfg_rem$gms$optimization == "nash" && cfg_rem$gms$cm_nash_mode == "parallel") {
     # for nash: set the number of CPUs per node to number of regions + 1
-    nr_of_regions <- length(levels(read.csv2(cfg_rem$regionmapping)$RegionCode)) + 1 
+    nr_of_regions <- length(unique(read.csv2(cfg_rem$regionmapping)$RegionCode)) + 1
   } else {
     # for negishi: use only one CPU
     nr_of_regions <- 1


### PR DESCRIPTION
  - https://stat.ethz.ch/pipermail/r-announce/2020/000653.html
    > R now uses a stringsAsFactors = FALSE default, and hence by
    > default no longer converts strings to factors in calls to
    > data.frame() and read.table().

  - this breaks all instances of levels() being used on data.frames
    read using read.csv()

  - switching to unique() solves this

  - unique() used on factors (R < 4.0.0, currently on the cluster) still
    returns the same values as levels(), but as a factor, which does not
    cause problems (but is a little ugly in interactive use)