### PR TITLE
Specify solely the root output folder to be ignored by git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,9 @@
 # Ignore everything in "input" folders
 input/
 !modules/29_CES_parameters/load/input
-# Ignore everything in "output" folders
-output/
+
+# Ignore everything in root "output" folder
+/output/
 
 # Ignore everything in "doc" folders, except for 3 specific files
 doc/


### PR DESCRIPTION
This is aimed at the script/output/ folder. With the .gitignore file as it is now, the scripts/output/ folder is ignored. However, since the the files in that folder were tracked by git before the .gitgnore file was refactored to its current version, they weren't in fact ignored. The problem arrises, when adding new files to the folder. These files are well and truly ignored. This commit fixes that.