### PR TITLE
Move cesParamter set definition to module

### DIFF
--- a/core/sets.gms
+++ b/core/sets.gms
@@ -1902,17 +1902,6 @@ Sets
   //
   fe_tax_subEs(all_in,all_esty) "correspondence between tax and subsidy input data resolution and model sectoral resolution. For FE which takes the pathway III to the CES "
   //
-  cesParameter   "parameters of the CES functions and for calibration"
-  /
-    quantity   "quantity of CES function input/output"
-    price      "price of CES function input/output"
-    eff        "baseyear efficiency of CES function input/output"
-    effgr      "multiplicative efficiency growth of CES function input/output"
-    rho        "CES function elasticity parameter rho = 1 - (1 / sigma)"
-    xi         "baseyear income share of CES function input/output"
-    offset_quantity "quantity offset for the CES tree if the quantity is null"
-    compl_coef    "coefficients for the perfectly complementary factors"
-  /
 
 
 ***-------------------------------------------------------------------------------

--- a/modules/29_CES_parameters/calibrate/sets.gms
+++ b/modules/29_CES_parameters/calibrate/sets.gms
@@ -7,56 +7,86 @@
 *** SOF ./modules/29_CES_parameters/calibrate/sets.gms
 
 Sets
-  regi_dyn29(all_regi)   "dynamic region set for compatibility with testOneRegi"
-  ces_29(all_in,all_in)   "calibration CES tree structure"
-  ces2_29(all_in,all_in)   "calibration CES tree structure"
-  ces_29_load(all_in,all_in) "ces from input.gdx"
-  regi_29_load(all_regi)    "regional resolution from input.gdx"
-  ipf_29(all_in)   "calibration intermediate production factors"
-  ppf_29(all_in)   "primary production factors to calibrate for"
-  in_29(all_in)    "calibration production factors"
-  ue_29(all_in) "useful energy variables"
-  ue_fe_kap_29(all_in) "useful energy items which are the direct output of one FE and one Kap, and which is calibrated to. The CES efficiencies need specific treatment"
-  putty_compute_in(all_in)  "factors inside putty which should be computed from non-putty values"
-  in_beyond_calib_29(all_in)  "all factors which are outside of the calibration, including the ones which are ppf_29"
-  in_beyond_calib_29_excludeRoot(all_in) "all factors which are outside of the calibration, excluding the ones which are ppf_29"
-  root_beyond_calib_29(all_in) "all factors which operate the junction between the calibrated CES and the CES which is not calibrated"
-  ppf_beyondcalib_29(all_in)    "all factors which are not part of in_29"
-  ces_beyondcalib_29(all_in, all_in) "production relationships for the non calibrated CES"
-  ces2_beyondcalib_29(all_in, all_in) "production relationships for the non calibrated CES"
-  ipf_beyond_last(all_in) "intermediary factors which are just above the ppf_beyondcalib_29 level"
-  ipf_beyond_29(all_in)  "all ces intermediary levels whose inputs are in beyond_calib" 
-  ipf_beyond_29_excludeRoot(all_in)  "all ces intermediary levels whose inputs are in beyond_calib, excluding the roots" 
-  te_29_report(all_te)  "set of technologies to report on"
-  / hydro, ngcc, ngt, pc, apCarDit,dot, apCarPet, apCarElt, gaschp, wind, tnrs, gastr, refliq,biotr,coaltr/
-  t_29(ttot)     "time steps considered in the calibration"!! created in order to avoid xi negative in the latest periods. Should not be necessary with post-2100 reasonable FE pathways
+
+cesParameter   "parameters of the CES functions and for calibration"
+/
+  quantity          "quantity of CES function input/output"
+  price             "price of CES function input/output"
+  eff               "baseyear efficiency of CES function input/output"
+  effgr             "multiplicative efficiency growth of CES function input/output"
+  rho               "CES function elasticity parameter rho = 1 - (1 / sigma)"
+  xi                "baseyear income share of CES function input/output"
+  offset_quantity   "quantity offset for the CES tree if the quantity is null"
+  compl_coef        "coefficients for the perfectly complementary factors"
+/
+
+regi_dyn29(all_regi)   "dynamic region set for compatibility with testOneRegi"
+ces_29(all_in,all_in)   "calibration CES tree structure"
+ces2_29(all_in,all_in)   "calibration CES tree structure"
+ces_29_load(all_in,all_in) "ces from input.gdx"
+regi_29_load(all_regi)    "regional resolution from input.gdx"
+ipf_29(all_in)   "calibration intermediate production factors"
+ppf_29(all_in)   "primary production factors to calibrate for"
+in_29(all_in)    "calibration production factors"
+ue_29(all_in) "useful energy variables"
+ue_fe_kap_29(all_in) "useful energy items which are the direct output of one FE and one Kap, and which is calibrated to. The CES efficiencies need specific treatment"
+putty_compute_in(all_in)  "factors inside putty which should be computed from non-putty values"
+in_beyond_calib_29(all_in)  "all factors which are outside of the calibration, including the ones which are ppf_29"
+in_beyond_calib_29_excludeRoot(all_in) "all factors which are outside of the calibration, excluding the ones which are ppf_29"
+root_beyond_calib_29(all_in) "all factors which operate the junction between the calibrated CES and the CES which is not calibrated"
+ppf_beyondcalib_29(all_in)    "all factors which are not part of in_29"
+ces_beyondcalib_29(all_in, all_in) "production relationships for the non calibrated CES"
+ces2_beyondcalib_29(all_in, all_in) "production relationships for the non calibrated CES"
+ipf_beyond_last(all_in) "intermediary factors which are just above the ppf_beyondcalib_29 level"
+ipf_beyond_29(all_in)  "all ces intermediary levels whose inputs are in beyond_calib" 
+ipf_beyond_29_excludeRoot(all_in)  "all ces intermediary levels whose inputs are in beyond_calib, excluding the roots" 
+
+te_29_report(all_te)  "set of technologies to report on"
+/
+  hydro
+  ngcc
+  ngt
+  pc
+  apCarDit
+  dot
+  apCarPet
+  apCarElt
+  gaschp
+  wind
+  tnrs
+  gastr
+  refliq
+  biotr
+  coaltr
+/
+
+*created in order to avoid xi negative in the latest periods. Should not be necessary with post-2100 reasonable FE pathways
+t_29(ttot)     "time steps considered in the calibration"
   t_29hist(ttot) "historical periods from 2005 on. Used for setting the efficiencies of FE if calibrated at the UE level"
   t_29hist_last(ttot) "last historical period"
   t_29scen(ttot) "non historical periods in t_29"
   t_29_last(ttot) "last period of the calibration"
 
-  pf_eff_target_dyn29(all_in)    "production factors with efficiency target"
-  /   /
-  pf_quan_target_dyn29(all_in)   "production factors with quantity target"
-  /   /
+pf_eff_target_dyn29(all_in)    "production factors with efficiency target"    / /
+pf_quan_target_dyn29(all_in)   "production factors with quantity target"      / /
   
-  capUnitType  "Type of technological data: for investments or for the standing capital"
-  /
-    cap   "estimate for the standing capital (with some depreciation)"
-    inv   "estimate for new investments (without depreciation)" 
-  / 
+capUnitType  "Type of technological data: for investments or for the standing capital"
+/
+  cap   "estimate for the standing capital (with some depreciation)"
+  inv   "estimate for new investments (without depreciation)" 
+/ 
   
-  index_Nr "index to differentiate data points with identical characteristics"
-  /
-    0 * 62
-  /
+index_Nr "index to differentiate data points with identical characteristics"
+/
+  0 * 62
+/
 
-  eff_scale_par   "parameters for scaling certain efficiencies during calibration"
-  /
-    level
-    midperiod
-    width
-  /
+eff_scale_par   "parameters for scaling certain efficiencies during calibration"
+/
+  level
+  midperiod
+  width
+/
 ;
 
 alias(cesOut2cesIn_below,cesOut2cesIn_below2);

--- a/modules/29_CES_parameters/load/sets.gms
+++ b/modules/29_CES_parameters/load/sets.gms
@@ -6,14 +6,27 @@
 *** |  Contact: remind@pik-potsdam.de
 *** SOF ./modules/29_CES_parameters/load/sets.gms
 
-Set 
-  regi_dyn29(all_regi)   "dynamic region set for compatibility with testOneRegi"
+Sets
 
-  eff_scale_par   "parameters for scaling certain efficiencies during calibration"
-  /
-    level
-    midperiod
-    width
-  /
+cesParameter   "parameters of the CES functions and for calibration"
+/
+  quantity          "quantity of CES function input/output"
+  price             "price of CES function input/output"
+  eff               "baseyear efficiency of CES function input/output"
+  effgr             "multiplicative efficiency growth of CES function input/output"
+  rho               "CES function elasticity parameter rho = 1 - (1 / sigma)"
+  xi                "baseyear income share of CES function input/output"
+  offset_quantity   "quantity offset for the CES tree if the quantity is null"
+  compl_coef        "coefficients for the perfectly complementary factors"
+/
+
+regi_dyn29(all_regi)   "dynamic region set for compatibility with testOneRegi"
+
+eff_scale_par   "parameters for scaling certain efficiencies during calibration"
+/
+  level
+  midperiod
+  width
+/
 ;
 *** EOF ./modules/29_CES_parameters/load/sets.gms


### PR DESCRIPTION
This is in line with the general attempt of moving code from the core to modules.

This leads however to duplication of the code.. Still worth it? I think so, since having a module called CES_parameters without it being the location of the definition of those same parameters seems weird to me ;)