### PR TITLE
update all solve statements with execute_unload abort.gdx

### DIFF
--- a/modules/05_initialCap/on/preloop.gms
+++ b/modules/05_initialCap/on/preloop.gms
@@ -96,6 +96,11 @@ option limcol = 70;
 option limrow = 70;
 
 *** solve statement
+if (execError > 0,
+  execute_unload "abort.gdx";
+  abort "at least one execution error occured, abort.gdx written";
+);
+
 solve initialcap2 using cns;
 
 display v05_INIdemEn0.l, v05_INIcap0.l;
@@ -514,3 +519,4 @@ display pm_emifac;
 
 
 *** EOF ./modules/05_initialCap/on/preloop.gms
+

--- a/modules/29_CES_parameters/calibrate/preloop.gms
+++ b/modules/29_CES_parameters/calibrate/preloop.gms
@@ -456,6 +456,11 @@ q29_putty_obj
 q29_esubsConstraint
 /;
 
+if (execError > 0,
+  execute_unload "abort.gdx";
+  abort "at least one execution error occured, abort.gdx written";
+);
+
 solve putty_paths minimizing v29_putty_obj using nlp;
 
 if ( NOT (( putty_paths.solvestat eq 1  
@@ -599,6 +604,11 @@ if ( sm_tmp2 gt 0,
       );
   );
    
+  if (execError > 0,
+    execute_unload "abort.gdx";
+    abort "at least one execution error occured, abort.gdx written";
+  );
+
   solve putty_paths minimizing v29_putty_obj using nlp;
 
 
@@ -1076,6 +1086,11 @@ loop ((cesOut2cesIn(out,in),  t_29hist_last(t))$((pm_cesdata_sigma(t,out) eq -1)
                                                * p29_capitalUnitProjections(regi,in,"0") !! index = 0, is the typical technology
 
 );
+if (execError > 0,
+  execute_unload "abort.gdx";
+  abort "at least one execution error occured, abort.gdx written";
+);
+
 solve esubs minimizing v29_esub_err using nlp;
 
 if ( NOT ( esubs.solvestat eq 1  AND (esubs.modelstat eq 1 OR esubs.modelstat eq 2)),
@@ -1529,3 +1544,4 @@ if (%c_CES_calibration_iteration% eq 1, !! first CES calibration iteration
 
 $ONorder
 *** EOF ./modules/29_CES_parameters/calibrate/preloop.gms
+

--- a/modules/30_biomass/magpie_40/preloop.gms
+++ b/modules/30_biomass/magpie_40/preloop.gms
@@ -44,6 +44,11 @@ $ifthen %cm_MAgPIE_coupling% == "on"
 *** ============================================================
 
 ***------------ Step 2a: calculate bioenergy prices -------------
+if (execError > 0,
+  execute_unload "abort.gdx";
+  abort "at least one execution error occured, abort.gdx written";
+);
+
 solve model_biopresolve_p using cns; !!! nothing has to be optimized here, just pure calculation
 p30_pebiolc_price_emu_preloop(ttot,regi) = vm_pebiolc_price.l(ttot,regi); !!! save for shift factor calculation and reporting
 
@@ -53,6 +58,11 @@ v30_pricemult.lo(ttot,regi) = 0;
 v30_pricemult.up(ttot,regi) = inf;
 
 s30_switch_shiftcalc = 1; !!! activate equations for shift calculation
+if (execError > 0,
+  execute_unload "abort.gdx";
+  abort "at least one execution error occured, abort.gdx written";
+);
+
 Solve model_priceshift using nlp minimizing v30_shift_r2;
 *** Initialize shift factors
 p30_pebiolc_pricshift(t,regi) = 0;
@@ -64,6 +74,11 @@ v30_pricemult.fx(ttot,regi) = p30_pebiolc_pricmult(ttot,regi);
 v30_priceshift.fx(ttot,regi) = p30_pebiolc_pricshift(ttot,regi);
 
 *** Calculate shifted prices
+if (execError > 0,
+  execute_unload "abort.gdx";
+  abort "at least one execution error occured, abort.gdx written";
+);
+
 solve model_biopresolve_p using cns; !!! nothing has to be optimized here, just pure calculation
 p30_pebiolc_price_emu_preloop_shifted(ttot,regi) = vm_pebiolc_price.l(ttot,regi); !!! save for reporting
 
@@ -79,6 +94,11 @@ $endif
 *** The costs are calculated applying the regular cost equation. 
 *** This equation integrates the shifted (!) price supply curve over the demand.
 *** It requires the price shift factor to be calcualted before (see above).
+
+if (execError > 0,
+  execute_unload "abort.gdx";
+  abort "at least one execution error occured, abort.gdx written";
+);
 
 solve model_biopresolve_c using cns; !!! nothing has to be optimized here, just pure calculation
 
@@ -98,3 +118,4 @@ vm_fuExtr.l(ttot,regi,"pebiolc","1")  = p30_pebiolc_demandmag(ttot,regi);
 ***-------------------------------------------------------------
 
 *** EOF ./modules/30_biomass/magpie_4/preloop.gms
+

--- a/modules/36_buildings/services_putty/preloop.gms
+++ b/modules/36_buildings/services_putty/preloop.gms
@@ -22,6 +22,11 @@ q36_putty_obj
 
 
 
+if (execError > 0,
+  execute_unload "abort.gdx";
+  abort "at least one execution error occured, abort.gdx written";
+);
+
 solve putty_paths_floor minimizing v36_putty_obj using nlp;
 
 if ( NOT ( putty_paths_floor.solvestat eq 1  AND (putty_paths_floor.modelstat eq 1 OR putty_paths_floor.modelstat eq 2)),
@@ -50,6 +55,11 @@ q36_ueTech2Total
 q36_cap
 q36_vintage_obj
 /;
+
+if (execError > 0,
+  execute_unload "abort.gdx";
+  abort "at least one execution error occured, abort.gdx written";
+);
 
 solve vintage_36 minimizing v36_vintage_obj using nlp;
 

--- a/modules/36_buildings/services_putty/presolve.gms
+++ b/modules/36_buildings/services_putty/presolve.gms
@@ -230,6 +230,11 @@ option
 ;
 
 s36_logit = 1;
+if (execError > 0,
+  execute_unload "abort.gdx";
+  abort "at least one execution error occured, abort.gdx written";
+);
+
 solve logit_36 maximizing v36_shares_obj using nlp;
 s36_logit = 0;
 

--- a/modules/36_buildings/services_with_capital/preloop.gms
+++ b/modules/36_buildings/services_with_capital/preloop.gms
@@ -23,6 +23,11 @@ q36_cap
 q36_vintage_obj
 /;
 
+if (execError > 0,
+  execute_unload "abort.gdx";
+  abort "at least one execution error occured, abort.gdx written";
+);
+
 solve vintage_36 minimizing v36_vintage_obj using nlp;
 
 if ( NOT ( vintage_36.solvestat eq 1  AND (vintage_36.modelstat eq 1 OR vintage_36.modelstat eq 2)),
@@ -50,3 +55,4 @@ p36_kapPriceImplicit(t,regi_dyn36(regi),teEs) = p36_kapPrice(t,regi) + p36_impli
 );
 
 *** EOF ./modules/36_buildings/services_with_capital/preloop.gms
+

--- a/modules/36_buildings/services_with_capital/presolve.gms
+++ b/modules/36_buildings/services_with_capital/presolve.gms
@@ -226,6 +226,11 @@ option
 ;
 
 s36_logit = 1;
+if (execError > 0,
+  execute_unload "abort.gdx";
+  abort "at least one execution error occured, abort.gdx written";
+);
+
 solve logit_36 maximizing v36_shares_obj using nlp;
 s36_logit = 0;
 

--- a/modules/80_optimization/negishi/solve.gms
+++ b/modules/80_optimization/negishi/solve.gms
@@ -11,6 +11,11 @@ hybrid.optfile = s80_cnptfile;
 ***      -------------------------------------------------------------------
 ***                     SOLVE statement
 ***      -------------------------------------------------------------------
+if (execError > 0,
+  execute_unload "abort.gdx";
+  abort "at least one execution error occured, abort.gdx written";
+);
+
 solve hybrid using nlp maximizing vm_welfareGlob;
 o_modelstat = hybrid.modelstat;
 
@@ -41,3 +46,4 @@ $IFTHEN.cm_SlowConvergence %cm_SlowConvergence% == "on"
 $ENDIF.cm_SlowConvergence
 );
 *** EOF ./modules/80_optimization/negishi/solve.gms
+

--- a/modules/80_optimization/testOneRegi/solve.gms
+++ b/modules/80_optimization/testOneRegi/solve.gms
@@ -22,6 +22,11 @@ option
   solprint = on
 ;
 
+if (execError > 0,
+  execute_unload "abort.gdx";
+  abort "at least one execution error occured, abort.gdx written";
+);
+
 solve hybrid using nlp maximizing vm_welfareGlob;
 
 o_modelstat = hybrid.modelstat;
@@ -40,3 +45,4 @@ if((o_modelstat eq 2),
 ***Warning: All reported values from regions except regi_dyn80 are just dummies ! 
 regi(all_regi) = YES;
 *** EOF ./modules/80_optimization/testOneRegi/solve.gms
+


### PR DESCRIPTION
- should exec errors have occured, the solve statements aren't executed
  in any case
- writing out abort.gdx files speeds up debugging by having all data
  from the point before the failed solve available