### PR TITLE
EDGE-T: reduced internal feedback, adapted to edgeTrpLib latest version.

### DIFF
--- a/scripts/iterative/EDGE_transport.R
+++ b/scripts/iterative/EDGE_transport.R
@@ -297,7 +297,7 @@ num_veh_stations = calc_num_vehicles_stations(
 saveRDS(num_veh_stations$learntechdem, datapath("demand_learn.RDS"))  ## in million veh
 saveRDS(num_veh_stations$alltechdem, datapath("demand_totalLDV.RDS")) ## in million veh
 ## save the demand for next iteration renaming the column
-setnames(ES_demand, old ="demand", new = "demandpr")                  ## in million km
+setnames(ES_demand, old ="demand", new = "demandpr")                  ## in million passenger-km
 saveRDS(ES_demand, datapath("demand_previousiter.RDS"))
 
 


### PR DESCRIPTION
This PR contains:

- learning OFF by default.
- stations feedback removed, according to the changes we included in the libraries.
- small cosmetics (e.g. loads `mrremind` not deprecated `moinput`)