### PR TITLE
DAC FE to use any fehes,feh2s,feels,fegas and see Industry FE tax

### DIFF
--- a/core/sets.gms
+++ b/core/sets.gms
@@ -1834,6 +1834,8 @@ entyFe2Sector(all_enty,emi_sectors) "final energy (stationary and transportation
 		feelt.trans
 		feels.cdr
 		fehes.cdr
+                fegas.cdr
+                feh2s.cdr
 /
 
 ppfEn2Sector(all_in,emi_sectors) "primary energy production factors mapping to sectors"
@@ -1853,6 +1855,10 @@ ppfEn2Sector(all_in,emi_sectors) "primary energy production factors mapping to s
 		ueHDVt.trans
 		ueLDVt.trans
 		ueelTt.trans
+                feeli.cdr
+                fehei.cdr
+                feh2i.cdr
+                fegai.cdr
 /
 
 all_emiMkt         "emission markets"

--- a/modules/21_tax/on/equations.gms
+++ b/modules/21_tax/on/equations.gms
@@ -116,7 +116,7 @@ v21_taxrevFEtrans(t,regi)
 q21_taxrevFEBuildInd(t,regi)$(t.val ge max(2010,cm_startyear))..
   v21_taxrevFEBuildInd(t,regi) 
   =e= 
-  sum(sector$(SAMEAS(sector,"build") OR SAMEAS(sector,"indst")),
+  sum(sector$(SAMEAS(sector,"build") OR SAMEAS(sector,"indst") OR SAMEAS(sector,"cdr")),
     sum(ppfen$ppfEn2Sector(ppfen,sector),
       (pm_tau_fe_tax_bit_st(t,regi,ppfen) + pm_tau_fe_sub_bit_st(t,regi,ppfen))
       *

--- a/modules/21_tax/on/postsolve.gms
+++ b/modules/21_tax/on/postsolve.gms
@@ -29,7 +29,7 @@ p21_taxrevFEtrans0(ttot,regi) = SUM(feForUe(enty),
                                     )+
 				SUM(feForEs(enty), (p21_tau_fe_tax_transport(ttot,regi,feForEs) + p21_tau_fe_sub_transport(ttot,regi,feForEs) ) * SUM(se2fe(enty2,enty,te), vm_prodFe.l(ttot,regi,enty2,enty,te))
 				);
-p21_taxrevFEBuildInd0(ttot,regi) = sum(sector$(SAMEAS(sector,"build") OR SAMEAS(sector,"indst")),
+p21_taxrevFEBuildInd0(ttot,regi) = sum(sector$(SAMEAS(sector,"build") OR SAMEAS(sector,"indst") OR SAMEAS(sector,"cdr")),
     sum(ppfen$ppfEn2Sector(ppfen,sector),
       (pm_tau_fe_tax_bit_st(ttot,regi,ppfen) + pm_tau_fe_sub_bit_st(ttot,regi,ppfen))
       *

--- a/modules/21_tax/on/presolve.gms
+++ b/modules/21_tax/on/presolve.gms
@@ -28,7 +28,7 @@ p21_taxrevFEtrans0(ttot,regi) = SUM(feForUe(enty),
                                       )+
 				      SUM(feForEs(enty), (p21_tau_fe_tax_transport(ttot,regi,feForEs) + p21_tau_fe_sub_transport(ttot,regi,feForEs) ) * SUM(se2fe(enty2,enty,te), vm_prodFe.l(ttot,regi,enty2,enty,te))
 				    );
-p21_taxrevFEBuildInd0(ttot,regi) = sum(sector$(SAMEAS(sector,"build") OR SAMEAS(sector,"indst")),
+p21_taxrevFEBuildInd0(ttot,regi) = sum(sector$(SAMEAS(sector,"build") OR SAMEAS(sector,"indst") OR SAMEAS(sector,"cdr")),
     sum(ppfen$ppfEn2Sector(ppfen,sector),
       (pm_tau_fe_tax_bit_st(ttot,regi,ppfen) + pm_tau_fe_sub_bit_st(ttot,regi,ppfen))
       *

--- a/modules/33_CDR/DAC/datainput.gms
+++ b/modules/33_CDR/DAC/datainput.gms
@@ -5,13 +5,13 @@
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
 !! Beutler et al. 2019 (Climeworks)
-p33_dac_fedem("feels") = 5.28;
-p33_dac_fedem("fehes") = 21.12;
-!!previously used fe demands
-!!p33_dac_fedem("feels") = 7.33;    
-!!p33_dac_fedem("fegas") = 36.667;
-!!p33_dac_fedem("feh2s") = 36.667;
-
+!!fe demand electricity for ventilation
+p33_dac_fedem_el("feels") = 5.28;
+!!fe demand heat for material recovery
+p33_dac_fedem_heat("fehes") = 21.12;
+p33_dac_fedem_heat("fegas") = 21.12;
+p33_dac_fedem_heat("feh2s") = 21.12;
+p33_dac_fedem_heat("feels") = 21.12;
 *** FS: INNOPATHS sensitivity on DAC efficiency
 $if not "%cm_INNOPATHS_DAC_eff%" == "off" parameter p33_dac_fedem_fac(entyFeStat) / %cm_INNOPATHS_DAC_eff% /;
 $if not "%cm_INNOPATHS_DAC_eff%" == "off" p33_dac_fedem(entyFeStat) = p33_dac_fedem(entyFeStat) * p33_dac_fedem_fac(entyFeStat);

--- a/modules/33_CDR/DAC/declarations.gms
+++ b/modules/33_CDR/DAC/declarations.gms
@@ -6,8 +6,9 @@
 *** |  Contact: remind@pik-potsdam.de
 *** SOF ./modules/33_CDR/DAC/declarations.gms
 parameters
-*JeS* GJ/tCO2 = EJ/Gt CO2 = 44/12 EJ/Gt C. Numbers from Report from Micah Broehm.
-p33_dac_fedem(all_enty)           "specific heat and electricity demand for direct air capture [EJ per Gt of C captured]"
+*AnM* kWh/tCO2 = 1/278 * GJ/tCO2 = 1/278 * EJ/Gt CO2 = 1/278 * 44/12 EJ/Gt C. Numbers from Beutler et al. 2019 (Climeworks)
+p33_dac_fedem_el(all_enty)           "specific electricity demand for direct air capture [EJ per Gt of C captured] - ventilation"
+p33_dac_fedem_heat(all_enty)         "specific heat demand for direct air capture [EJ per Gt of C captured] - absorption material recovery"
 ;
 
 variables
@@ -19,12 +20,17 @@ v33_emiEW(ttot,all_regi)        "negative CO2 emission from EW [GtC / a] - fixed
 positive variables
 v33_grindrock_onfield(ttot,all_regi,rlf,rlf)         "amount of ground rock spread on fields in each timestep [Gt]"
 v33_grindrock_onfield_tot(ttot,all_regi,rlf,rlf)     "total amount of ground rock on fields [Gt]"
+v33_DacFEdemand_el(ttot,all_regi,all_enty)          "DAC FE electricity demand [TWa]"
+v33_DacFEdemand_heat(ttot,all_regi,all_enty)        "DAC FE heat demand [TWa]"
 ;
 
 equations
-q33_otherFEdemand(ttot,all_regi,all_enty)             "calculates final energy demand from no transformation technologies (e.g. enhanced weathering)"
+q33_DacFEdemand_heat(ttot,all_regi,all_enty)        "calculates DAC FE demand for heat"
+q33_DacFEdemand_el(ttot,all_regi,all_enty)          "calculates DAC FE demand for electricity"
+q33_otherFEdemand(ttot,all_regi,all_enty)           "calculates final energy demand from no transformation technologies (e.g. enhanced weathering)"
 q33_capconst_dac(ttot,all_regi)                     "calculates amount of carbon captured"
 q33_ccsbal(ttot,all_regi,all_enty,all_enty,all_te)  "calculates CCS emissions from CDR technologies"
+q33_H2bio_lim(ttot,all_regi,all_te)                 "limits H2 from bioenergy to FE - otherFEdemand, i.e. no H2 from bioenergy for DAC"
 q33_emicdrregi(ttot,all_regi)                       "calculates the (negative) emissions due to CDR technologies"
 q33_demFeCDR(ttot,all_regi,all_enty)                "CDR demand balance for final energy"
 ;

--- a/modules/33_CDR/DAC/equations.gms
+++ b/modules/33_CDR/DAC/equations.gms
@@ -16,12 +16,14 @@ q33_demFeCDR(t,regi,entyFe)$(entyFe2Sector(entyFe,"cdr")) ..
 ;
 
 ***---------------------------------------------------------------------------
-*'  Calculation of (negative) CO2 emissions from direct air capture. 
+*'  Calculation of (negative) CO2 emissions from direct air capture. The first part of the equation describes emissions captured from the ambient air, 
+*'  the second part calculates the CO2 captured from the gas used for heat production assuming 90% capture rate.
 ***---------------------------------------------------------------------------
 q33_capconst_dac(t,regi)..
 	v33_emiDAC(t,regi)
 	=e=
 	- sum(teNoTransform2rlf_dyn33(te,rlf2), vm_capFac(t,regi,"dac") * vm_cap(t,regi,"dac",rlf2))
+	-  (1 / pm_eta_conv(t,regi,"gash2c")) * fm_dataemiglob("pegas","seh2","gash2c","cco2") * vm_otherFEdemand(t,regi,"fegas")
 	;
 
 ***---------------------------------------------------------------------------
@@ -33,12 +35,36 @@ q33_emicdrregi(t,regi)..
 	v33_emiDAC(t,regi);
 	
 ***---------------------------------------------------------------------------
-*'  Calculation of energy demand of direct air capture. DAC demands feels and fehes
+*'  Calculation of electricity demand for ventilation of direct air capture.
+***---------------------------------------------------------------------------
+q33_DacFEdemand_el(t,regi,entyFe)..
+    v33_DacFEdemand_el(t,regi,entyFe)
+    =e=
+	- vm_emiCdr(t,regi,"co2") * sm_EJ_2_TWa *p33_dac_fedem_el(entyFe)
+    ;
+
+***---------------------------------------------------------------------------
+*'  Calculation of heat demand of direct air capture. Heat can be provided as heat or by electricity, gas or H2; 
+*'  For example, vm_otherFEdemand(t,regi,"fegas") is calculated as the total energy demand for heat from fegas minus what is already covered by other carriers (i.e. heat, h2 or elec) 
+***---------------------------------------------------------------------------
+q33_DacFEdemand_heat(t,regi,entyFe)..
+    v33_DacFEdemand_heat(t,regi,entyFe)
+    =e=
+    - vm_emiCdr(t,regi,"co2") * sm_EJ_2_TWa * p33_dac_fedem_heat(entyFe)
+    - v33_DacFEdemand_heat(t,regi,"feh2s")$((sameas(entyFe,"fegas"))OR(sameas(entyFe,"fehes"))OR(sameas(entyFe,"feels"))) 
+	- v33_DacFEdemand_heat(t,regi,"fegas")$((sameas(entyFe,"feh2s"))OR(sameas(entyFe,"fehes"))OR(sameas(entyFe,"feels")))
+	- v33_DacFEdemand_heat(t,regi,"feels")$((sameas(entyFe,"feh2s"))OR(sameas(entyFe,"fehes"))OR(sameas(entyFe,"fegas")))
+	- v33_DacFEdemand_heat(t,regi,"fehes")$((sameas(entyFe,"feh2s"))OR(sameas(entyFe,"fegas"))OR(sameas(entyFe,"feels")))
+    ;
+
+
+***---------------------------------------------------------------------------
+*'  Calculation of total energy demand of direct air capture. 
 ***---------------------------------------------------------------------------
 q33_otherFEdemand(t,regi,entyFe)..
     vm_otherFEdemand(t,regi,entyFe)
     =e=
-    - vm_emiCdr(t,regi,"co2") * sm_EJ_2_TWa * p33_dac_fedem(entyFe)
+	v33_DacFEdemand_el(t,regi,entyFe) + v33_DacFEdemand_heat(t,regi,entyFe)
     ;
 
 ***---------------------------------------------------------------------------
@@ -50,4 +76,13 @@ q33_ccsbal(t,regi,ccs2te(ccsCo2(enty),enty2,te))..
 	-vm_emiCdr(t,regi,"co2")
 	;
 
+***---------------------------------------------------------------------------
+*'  Limit the amount of H2 from biomass to the demand without DAC.
+***---------------------------------------------------------------------------
+q33_H2bio_lim(t,regi,te)..	         
+	vm_prodSE(t,regi,"pebiolc","seh2",te)$pe2se("pebiolc","seh2",te)
+	=l=
+    vm_prodFe(t,regi,"seh2","feh2s","tdh2s") - vm_otherFEdemand(t,regi,"feh2s")
+	;
+	
 *** EOF ./modules/33_CDR/DAC/equations.gms

--- a/modules/33_CDR/all/datainput.gms
+++ b/modules/33_CDR/all/datainput.gms
@@ -6,12 +6,13 @@
 *** |  Contact: remind@pik-potsdam.de
 *** SOF ./modules/33_CDR/all/datainput.gms
 !! Beutler et al. 2019 (Climeworks)
-p33_dac_fedem("feels") = 5.28;
-p33_dac_fedem("fehes") = 21.12;
-!!previously used fe demands
-!!p33_dac_fedem("feels") = 7.33;    
-!!p33_dac_fedem("fegas") = 36.667;
-!!p33_dac_fedem("feh2s") = 36.667;
+!!fe demand electricity for ventilation
+p33_dac_fedem_el("feels") = 5.28;
+!!fe demand heat for material recovery
+p33_dac_fedem_heat("fehes") = 21.12;
+p33_dac_fedem_heat("fegas") = 21.12;
+p33_dac_fedem_heat("feh2s") = 21.12;
+p33_dac_fedem_heat("feels") = 21.12;
 
 *** enhanced weatering data
 table f33_maxProdGradeRegiWeathering(all_regi,rlf)                                      "regional maximum potentials for enhanced weathering in Gt of grinded stone/a for different grades"

--- a/modules/33_CDR/all/declarations.gms
+++ b/modules/33_CDR/all/declarations.gms
@@ -18,13 +18,16 @@ s33_step                    "size of bins in v33_grindrock_onfield [Gt stone]"
 parameters
 p33_transport_costs(all_regi,rlf,rlf)    "transport costs [T$/Gt stone]"
 p33_co2_rem_rate(rlf)                    "carbon removal rate [fraction of annual reduction of total carbon removal potential], multiplied with grade factor"
-p33_dac_fedem(all_enty)                  "specific heat and electricity demand for direct air capture [EJ per Gt of C captured]"
+p33_dac_fedem_el(all_enty)           "specific electricity demand for direct air capture [EJ per Gt of C captured] - ventilation"
+p33_dac_fedem_heat(all_enty)         "specific heat demand for direct air capture [EJ per Gt of C captured] - absorption material recovery"
 p33_LimRock(all_regi)                    "regional share of EW limit [fraction], calculated ex ante for a maximal annual amount of 8 Gt rock in D:\projects\CEMICS\paper_technical\supply_curve_transport_remind_regions.m"
 ;
 
 positive variables
 v33_grindrock_onfield(ttot,all_regi,rlf,rlf)      "amount of ground rock spread on fields in each timestep [Gt]"
 v33_grindrock_onfield_tot(ttot,all_regi,rlf,rlf)  "total amount of ground rock on fields [Gt]"
+v33_DacFEdemand_el(ttot,all_regi,all_enty)          "DAC FE electricity demand [TWa]"
+v33_DacFEdemand_heat(ttot,all_regi,all_enty)        "DAC FE heat demand [TWa]"
 ;
 
 variables
@@ -36,6 +39,8 @@ v33_emiEW(ttot,all_regi)                                "negative CO2 emission f
 equations
 q33_demFeCDR(ttot,all_regi,all_enty)                "CDR demand balance for final energy"
 q33_otherFEdemand(ttot,all_regi,all_enty)           "calculates final energy demand from no transformation technologies (e.g. enhanced weathering)"
+q33_DacFEdemand_heat(ttot,all_regi,all_enty)        "calculates DAC FE demand for heat"
+q33_DacFEdemand_el(ttot,all_regi,all_enty)          "calculates DAC FE demand for electricity"
 q33_capconst_grindrock(ttot,all_regi)               "calculates amount of ground rock spred on fields"
 q33_grindrock_onfield_tot(ttot,all_regi,rlf,rlf)    "total amount of ground rock on fields"
 q33_omcosts(ttot,all_regi)                          "calculates O&M costs for spreading ground rocks on fields"
@@ -45,6 +50,7 @@ q33_LimEmiEW(ttot,all_regi)                         "limits EW to a maximal annu
 q33_capconst_dac(ttot,all_regi)                     "calculates amount of carbon captured by DAC"
 q33_emicdrregi(ttot,all_regi)                       "calculates the (negative) emissions due to CDR technologies"
 q33_ccsbal(ttot,all_regi,all_enty,all_enty,all_te)  "calculates CCS emissions from CDR technologies"
+q33_H2bio_lim(ttot,all_regi,all_te)                 "limits H2 from bioenergy to FE - otherFEdemand, i.e. no H2 from bioenergy for DAC"
 ;
 
 *** EOF ./modules/33_CDR/all/declarations.gms

--- a/modules/33_CDR/all/equations.gms
+++ b/modules/33_CDR/all/equations.gms
@@ -48,12 +48,14 @@ q33_emiEW(t,regi)..
 	;	
 
 ***---------------------------------------------------------------------------
-*'  Calculation of (negative) CO2 emissions from direct air capture. 
+*'  Calculation of (negative) CO2 emissions from direct air capture. The first part of the equation describes emissions captured from the ambient air, 
+*'  the second part calculates the CO2 captured from the gas used for heat production assuming 90% capture rate.
 ***---------------------------------------------------------------------------
 q33_capconst_dac(t,regi)..
 	v33_emiDAC(t,regi)
 	=e=
 	-sum(teNoTransform2rlf_dyn33(te,rlf2), vm_capFac(t,regi,"dac") * vm_cap(t,regi,"dac",rlf2))
+	-  (1 / pm_eta_conv(t,regi,"gash2c")) * fm_dataemiglob("pegas","seh2","gash2c","cco2") * vm_otherFEdemand(t,regi,"fegas")	
 	;
 
 ***---------------------------------------------------------------------------
@@ -64,6 +66,30 @@ q33_emicdrregi(t,regi)..
 	=e=
 	v33_emiEW(t,regi) + v33_emiDAC(t,regi)
 	;
+
+
+***---------------------------------------------------------------------------
+*'  Calculation of electricity demand for ventilation of direct air capture.
+***---------------------------------------------------------------------------
+q33_DacFEdemand_el(t,regi,entyFe)..
+    v33_DacFEdemand_el(t,regi,entyFe)
+    =e=
+	- vm_emiCdr(t,regi,"co2") * sm_EJ_2_TWa *p33_dac_fedem_el(entyFe)
+    ;
+
+***---------------------------------------------------------------------------
+*'  Calculation of heat demand of direct air capture. Heat can be provided as heat or by electricity, gas or H2; 
+*'  For example, vm_otherFEdemand(t,regi,"fegas") is calculated as the total energy demand for heat from fegas minus what is already covered by other carriers (i.e. heat, h2 or elec) 
+***---------------------------------------------------------------------------
+q33_DacFEdemand_heat(t,regi,entyFe)..
+    v33_DacFEdemand_heat(t,regi,entyFe)
+    =e=
+    - vm_emiCdr(t,regi,"co2") * sm_EJ_2_TWa * p33_dac_fedem_heat(entyFe)
+    - v33_DacFEdemand_heat(t,regi,"feh2s")$((sameas(entyFe,"fegas"))OR(sameas(entyFe,"fehes"))OR(sameas(entyFe,"feels"))) 
+	- v33_DacFEdemand_heat(t,regi,"fegas")$((sameas(entyFe,"feh2s"))OR(sameas(entyFe,"fehes"))OR(sameas(entyFe,"feels")))
+	- v33_DacFEdemand_heat(t,regi,"feels")$((sameas(entyFe,"feh2s"))OR(sameas(entyFe,"fehes"))OR(sameas(entyFe,"fegas")))
+	- v33_DacFEdemand_heat(t,regi,"fehes")$((sameas(entyFe,"feh2s"))OR(sameas(entyFe,"fegas"))OR(sameas(entyFe,"feels")))
+    ;
 
 ***---------------------------------------------------------------------------
 *'  Calculation of energy demand of DAC and EW. 
@@ -76,7 +102,7 @@ q33_otherFEdemand(t,regi,entyFe)..
 	=e=
 	sum(rlf, s33_rockgrind_fedem$(sameas(entyFe,"feels")) * sm_EJ_2_TWa * sum(rlf2,v33_grindrock_onfield(t,regi,rlf,rlf2)))
    + sum(rlf, s33_rockfield_fedem$(sameas(entyFe,"fedie")) * sm_EJ_2_TWa * sum(rlf2,v33_grindrock_onfield(t,regi,rlf,rlf2)))
-   - v33_emiDAC(t,regi) * sm_EJ_2_TWa * p33_dac_fedem(entyFe)
+   + v33_DacFEdemand_el(t,regi,entyFe) + v33_DacFEdemand_heat(t,regi,entyFe)
 	;	
 	
 
@@ -120,5 +146,13 @@ q33_LimEmiEW(t,regi)..
                 )
         =l=
         cm_LimRock*p33_LimRock(regi);
-		
+
+***---------------------------------------------------------------------------
+*'  Limit the amount of H2 from biomass to the demand without DAC.
+***---------------------------------------------------------------------------
+q33_H2bio_lim(t,regi,te)..	         
+	vm_prodSE(t,regi,"pebiolc","seh2",te)$pe2se("pebiolc","seh2",te)
+	=l=
+    vm_prodFe(t,regi,"seh2","feh2s","tdh2s") - vm_otherFEdemand(t,regi,"feh2s")
+	;		
 *** EOF ./modules/33_CDR/all/equations.gms

--- a/modules/33_CDR/off/not_used.txt
+++ b/modules/33_CDR/off/not_used.txt
@@ -10,6 +10,9 @@ pm_ts, parameter,???
 cm_startyear, switch, ???
 sm_eps,scalar,???
 cm_gs_ew,switch,???
+fm_dataemiglob,parameter,???
+pm_eta_conv,parameter,???
+vm_prodFe,variable,???
 vm_capFac,variable,???
 pm_pop,input,questionnaire
 cm_LimRock,input,questionnaire

--- a/modules/33_CDR/weathering/not_used.txt
+++ b/modules/33_CDR/weathering/not_used.txt
@@ -8,3 +8,6 @@ name, type, reason
 sm_eps,scalar,???
 cm_ccapturescen,input,questionnaire
 cm_emiscen,input,questionnaire
+fm_dataemiglob,parameter,???
+pm_eta_conv,parameter,???
+vm_prodFe,variable,???


### PR DESCRIPTION
Heat for DAC material recovery will now be supplied by a mix of fehes, feh2s, fegas and/or feels.
DAC FE demands are now included in Industry FE taxes.
Results can be studied here:
/p/tmp/amerfort/remind/compScen-2021-04-01_16.26.49-H12.pdf