### PR TITLE
update industry/subsectors clinker-to-cement ratio to be region setting agnostic

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -22,7 +22,7 @@ cfg$title <- "default"
 cfg$regionmapping <- "config/regionmappingH12.csv"
 
 #### Current input data revision (<mainrevision>.<subrevision>) ####
-cfg$revision <- 5.99
+cfg$revision <- 5.999
 
 #### Current CES parameter revision (commit hash) ####
 cfg$CESversion <- "712e6bc3d8320d66bb80a088d476c90b45708116"

--- a/modules/37_industry/subsectors/datainput.gms
+++ b/modules/37_industry/subsectors/datainput.gms
@@ -109,28 +109,15 @@ $offdelim
 
 s37_clinker_process_CO2 = 0.5262;
 
-*** FIXME *** this needs to be in mrremind
-p37_clinker_cement_ratio("2005","CAZ") = 0.81;
-p37_clinker_cement_ratio("2005","CHA") = 0.58;
-p37_clinker_cement_ratio("2005","DEU") = 0.73;
-p37_clinker_cement_ratio("2005","ECE") = 0.73;
-p37_clinker_cement_ratio("2005","ECS") = 0.73;
-p37_clinker_cement_ratio("2005","ENC") = 0.73;
-p37_clinker_cement_ratio("2005","ESC") = 0.73;
-p37_clinker_cement_ratio("2005","ESW") = 0.73;
-p37_clinker_cement_ratio("2005","EWN") = 0.73;
-p37_clinker_cement_ratio("2005","FRA") = 0.73;
-p37_clinker_cement_ratio("2005","UKI") = 0.73;
-p37_clinker_cement_ratio("2005","IND") = 0.71;
-p37_clinker_cement_ratio("2005","JPN") = 0.80;
-p37_clinker_cement_ratio("2005","LAM") = 0.70;
-p37_clinker_cement_ratio("2005","MEA") = 0.81;
-p37_clinker_cement_ratio("2005","NEN") = 0.81;
-p37_clinker_cement_ratio("2005","NES") = 0.81;
-p37_clinker_cement_ratio("2005","OAS") = 0.80;
-p37_clinker_cement_ratio("2005","REF") = 0.80;
-p37_clinker_cement_ratio("2005","SSA") = 0.77;
-p37_clinker_cement_ratio("2005","USA") = 0.82;
+*** Clinker-to-cement ratio
+Parameter
+  p37_clinker_cement_ratio(ttot,all_regi)
+  /
+$ondelim
+$include "./modules/37_industry/subsectors/input/p37_clinker-to-cement-ratio.cs3r"
+$offdelim
+  /
+;
 
 *' Clinker-to-cement ratios converge to the lowest regional 2005 value by 2100.
 p37_clinker_cement_ratio(t,regi)

--- a/modules/37_industry/subsectors/datainput.gms
+++ b/modules/37_industry/subsectors/datainput.gms
@@ -111,7 +111,7 @@ s37_clinker_process_CO2 = 0.5262;
 
 *** Clinker-to-cement ratio
 Parameter
-  p37_clinker_cement_ratio(ttot,all_regi)
+  p37_clinker_cement_ratio(ttot,all_regi)   "clinker content per unit cement used"
   /
 $ondelim
 $include "./modules/37_industry/subsectors/input/p37_clinker-to-cement-ratio.cs3r"

--- a/modules/37_industry/subsectors/input/files.txt
+++ b/modules/37_industry/subsectors/input/files.txt
@@ -1,1 +1,2 @@
 p37_cesIO_up_steel_secondary.cs4r
+p37_clinker-to-cement-ratio.cs3r


### PR DESCRIPTION
- use file p37_clinker-to-cement-ratio.cs3r from mrremind >= 0.56.1