### PR TITLE
update input data revision number to 6.00

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -22,7 +22,7 @@ cfg$title <- "default"
 cfg$regionmapping <- "config/regionmappingH12.csv"
 
 #### Current input data revision (<mainrevision>.<subrevision>) ####
-cfg$revision <- 5.999
+cfg$revision <- 6.00
 
 #### Current CES parameter and GDX revision (commit hash) ####
 cfg$CESandGDXversion <- "5776d7ba7a08276f3112d71abf123d54331e8381"


### PR DESCRIPTION
- eb32c77 uses new input data, but rev5.9999 failed on the `madrat` end
- note that REMIND currently still fails, due to #371, but I tested it using 
  ```
  tar -xf /p/projects/rd3mod/inputdata/output/rev5.99_62eff8f7_remind.tgz f_maxProdGradeRegiWind.cs3r
  mv f_maxProdGradeRegiWind.cs3r ./core/input/
  ```