### PR TITLE
Add emission factors for fegat.

### DIFF
--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -1335,6 +1335,7 @@ p_ef_dem(regi,"fedie") = 69.3;
 p_ef_dem(regi,"fehos") = 69.3;
 p_ef_dem(regi,"fepet") = 68.5;
 p_ef_dem(regi,"fegas") = 50.3;
+p_ef_dem(regi,"fegat") = 50.3;
 p_ef_dem(regi,"fesos") = 90.5;
 
 $ifthen.altFeEmiFac not "%cm_altFeEmiFac%" == "off"


### PR DESCRIPTION
Adds the missing CO2 emission factor for gases used in transportation (`fegat`). `fegat` is only used in the `edge_esm` realization of transport. There is not much used there, but from time to time the missing emissions bump up.

For simplicity, I used the same value as the one used for gases in buildings.