### PR TITLE
Bugfix REMIND-MAgPIE coupling

### DIFF
--- a/scripts/start/prepare_and_run.R
+++ b/scripts/start/prepare_and_run.R
@@ -248,9 +248,9 @@ prepare <- function() {
     system("find ./core/magicc/ -type f | xargs dos2unix -q")
 
   ################## M O D E L   L O C K ###################################
-  # Lock the directory for other instances of the start scritps
-  lock_id <- model_lock(timeout1 = 1, oncluster=on_cluster)
-  on.exit(model_unlock(lock_id, oncluster=on_cluster))
+  # Lock the directory for other instances of the start scripts
+  lock_id <- model_lock(timeout1 = 1,check_interval = runif(1, 10, 60), oncluster=on_cluster)
+  on.exit(model_unlock(lock_id, oncluster=on_cluster),add=TRUE)
   ################## M O D E L   L O C K ###################################
 
   ###########################################################

--- a/start_bundle_coupled.R
+++ b/start_bundle_coupled.R
@@ -20,6 +20,7 @@ path_settings_remind  <- paste0(path_remind,"config/scenario_config_SSPSDP.csv")
 
 # You can put a prefix in front of the names of your runs, this will turn e.g. "SSP2-Base" into "prefix_SSP2-Base".
 # This allows storing results of multiple coupled runs (which have the same scenario names) in the same MAgPIE and REMIND output folders.
+# !Currently not working for prefixes different from "C_". "C_" is hard-coded elsewhere!
 prefix_runname <- "C_"
 
 # If there are existing runs you would like to take the gdxes (REMIND) or reportings (REMIND or MAgPIE) from, provide the path here and the name prefix below.
@@ -146,7 +147,7 @@ for(scen in common){
       # if only remind has finished an iteration -> start with magpie in this iteration using a REMIND report
       start_iter  <- iter_rem
       path_run    <- gsub("/fulldata.gdx","",already_rem)
-      path_report <- Sys.glob(paste0(path_run,"/REMIND_generic_*","withoutPlus.mif"))
+      path_report <- Sys.glob(paste0(path_run,"/REMIND_generic_*"))
       if (identical(path_report,character(0))) stop("There is a fulldata.gdx but no REMIND_generic_.mif in",path_run)
       cat("Found REMIND report here: ",path_report,"\n")
       cat("Continuing with MAgPIE in iteration ",start_iter,"\n")


### PR DESCRIPTION
This PR solves issues with coupled REMIND-MAgPIE runs.

- There seems to be a problem with the .lock file if several runs are waiting for preparation. I added a random check time for the .lock file between 10-60 seconds to avoid this problem
- "withoutPlus.mif" does not exist anymore