### PR TITLE
update input cache: improved historical capfac

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -22,7 +22,7 @@ cfg$title <- "default"
 cfg$regionmapping <- "config/regionmappingH12.csv"
 
 #### Current input data revision (<mainrevision>.<subrevision>) ####
-cfg$revision <- 6.221
+cfg$revision <- 6.222
 
 #### Current CES parameter and GDX revision (commit hash) ####
 cfg$CESandGDXversion <- "bb8c8b606bd541440890368cf47d4323eb0fc519"


### PR DESCRIPTION
- make sure historical capfac is calculated using gen(t)*2/(cap(t) + cap(t-1)) for the "added capacity effect"

- capfac is averaged over 5 years correctly

- remove capfac=0 from average

- remove too small standing capacity from data point (<200MW) (so artefact won't skew future projection)
