### PR TITLE
Limit rows and columns print-out in preloop models

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -558,7 +558,7 @@ cfg$gms$cm_VRE_supply_assumptions <- 0 # 0 - default, 1 - optimistic, 2 - sombre
 #-----------------------------------------------------------------------------
 cfg$gms$cm_SlowConvergence     <- "off"   # def = off
 cfg$gms$cm_nash_mode           <- "parallel" # def = parallel ; Choices: parallel, serial, debug.
-cfg$gms$cm_debug_preloop <- "on" # to debug preloop models
+cfg$gms$cm_debug_preloop <- "off" # to debug preloop models
 cfg$gms$cm_OILRETIRE           <- "on"   # def = on
 
 cfg$gms$cm_INCONV_PENALTY       <- "on"    # def = on

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -558,6 +558,7 @@ cfg$gms$cm_VRE_supply_assumptions <- 0 # 0 - default, 1 - optimistic, 2 - sombre
 #-----------------------------------------------------------------------------
 cfg$gms$cm_SlowConvergence     <- "off"   # def = off
 cfg$gms$cm_nash_mode           <- "parallel" # def = parallel ; Choices: parallel, serial, debug.
+cfg$gms$cm_debug_preloop <- "on" # to debug preloop models
 cfg$gms$cm_OILRETIRE           <- "on"   # def = on
 
 cfg$gms$cm_INCONV_PENALTY       <- "on"    # def = on

--- a/core/preloop.gms
+++ b/core/preloop.gms
@@ -147,5 +147,12 @@ p_agriEmiPhaseOut(t)$(t.val ge 2040) = 1;
 p_macBaseMagpie(t,regi,enty)$(sameas(regi,"DEU") AND (emiMac2sector(enty,"agriculture","process","ch4") OR emiMac2sector(enty,"agriculture","process","n2o")))
   = (1-p_agriEmiPhaseOut(t)*c_BaselineAgriEmiRedDEU)*p_macBaseMagpie(t,regi,enty);
 
+$IFTHEN.out "%cm_debug_preloop%" == "on" 
+option limrow = 70;
+option limcol = 70;
+$ELSE.out
+option limrow = 0;
+option limcol = 0;
+$ENDIF.out
 
 *** EOF ./core/preloop.gms

--- a/main.gms
+++ b/main.gms
@@ -581,6 +581,7 @@ cm_deuCDRmax = -1; !! def = -1
 *--------------------flags------------------------------------------------------------
 $SETGLOBAL cm_SlowConvergence  off        !! def = off
 $setGlobal cm_nash_mode  parallel      !! def = parallel
+$setGLobal cm_debug_preloop off !! def = off
 $setGlobal c_EARLYRETIRE       on         !! def = on
 $setGlobal cm_OILRETIRE  on        !! def = on
 $setglobal cm_INCONV_PENALTY  on         !! def = on

--- a/modules/05_initialCap/on/preloop.gms
+++ b/modules/05_initialCap/on/preloop.gms
@@ -92,9 +92,6 @@ display pm_data;
 *** model definition
 model initialcap2 / q05_eedemini, q05_ccapini /;
 
-option limcol = 70;
-option limrow = 70;
-
 *** solve statement
 if (execError > 0,
   execute_unload "abort.gdx";


### PR DESCRIPTION
so one does not get INFES printed from these models in debug mode

