### PR TITLE
Fix a catch that can occur if EDGE-T runs start after iteration 20.

### DIFF
--- a/scripts/iterative/EDGE_transport.R
+++ b/scripts/iterative/EDGE_transport.R
@@ -182,7 +182,7 @@ saveRDS(REMIND_prices, datapath(paste0("REMINDprices", iter, ".RDS")))
 
 if(average_prices){
 
-  if(max(unique(REMIND_prices$iternum)) >= 20 & max(unique(REMIND_prices$iternum)) <= 30){
+  if(max(unique(REMIND_prices$iternum)) >= 20 & max(unique(REMIND_prices$iternum)) <= 30 & file.exists(datapath(pfile))){
     old_prices <- readRDS(datapath(pfile))
     all_prices <- rbind(old_prices, REMIND_prices)
     setkeyv(all_prices, keys)


### PR DESCRIPTION
In this case, no old price file can be found, leading to a file-not-found error.