### PR TITLE
Add elh2 to set with dynamic efficiency adjustments

### DIFF
--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -923,6 +923,7 @@ loop(te,
         teEtaIncr(te) = no;
         teEtaIncr(te) = yes$(f_dataetaglob('1900',te) > 0);
 );
+teEtaConst(te) = not teEtaIncr(te);
 display teEtaIncr;
 
 *** import regionalized CCS constraints:

--- a/core/sets.gms
+++ b/core/sets.gms
@@ -1279,6 +1279,7 @@ teEtaIncr(all_te)       "Technologies with time variable efficiency parameter et
   ngt
   bioigcc
   bioigccc
+  elh2
 /
 
 teEtaConst(all_te)      "Technologies with constant eta"


### PR DESCRIPTION
It turned out in recent ARIADNE runs that the efficiency of electrolyzers were not take over automatically from `generisdata_varying_eta.prn`, despite of a code snippet that looks like it is updating the corresponding set, `teEtaIncr`, [here](https://github.com/remindmodel/remind/blob/develop/core/datainput.gms#L919).
This is fixed by explicitly calculating the complementary set `teEtaConst` after updating `teEtaIncr`.

Secondly, `elh2` is explicitly added to the set of dynamic technologies.

