### PR TITLE
Refactor CES markup cost implementation and extent it to industry subsectors 

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -411,12 +411,12 @@ cfg$gms$cm_H2targets <- 0 # def 0, off
 cfg$gms$cm_PriceDurSlope_elh2 <- 20 # def 20
 cfg$gms$cm_FlexTaxFeedback <- 0 # def 0, off
 
-cfg$gms$cm_build_H2costAddH2Inv <- 0.2  # Buildings def 6.5$/kg = 0.2 $/Kwh
+cfg$gms$cm_build_H2costAddH2Inv <- 0.2  # Buildings def 0.2 $/Kwh (6.5$/kg)
 cfg$gms$cm_build_costDecayStart <- 0.05 # Buildings def 5%
 cfg$gms$cm_build_H2costDecayEnd <- 0.1  # Buildings def 10%
 cfg$gms$cm_build_AdjCostActive  <- 0    # def 0 (off)
 
-cfg$gms$cm_indst_H2costAddH2Inv <- 0.1  # Industry def 6.5$/kg = 0.2 $/Kwh
+cfg$gms$cm_indst_H2costAddH2Inv <- 0.1  # Industry def 0.1 $/Kwh (3.2$/kg)
 cfg$gms$cm_indst_costDecayStart <- 0.05 # Industry def 5%
 cfg$gms$cm_indst_H2costDecayEnd <- 0.1  # Industry def 10%
 

--- a/core/declarations.gms
+++ b/core/declarations.gms
@@ -369,6 +369,10 @@ vm_emiCdrAll(ttot,all_regi)                          "all CDR emissions"
 *** ES layer variables
 vm_demFeForEs(ttot,all_regi,all_enty,all_esty,all_teEs)     "Final energy which will be used in the ES layer."
 v_prodEs(ttot,all_regi,all_enty,all_esty,all_teEs)          "Energy services (unit determined by conversion factor pm_fe2es)."
+
+*** CES markup to represent end-use technology cost
+vm_costCESMkup(ttot,all_regi,all_in)                                   "CES markup cost to represent demand-side technology cost of end-use transformation [trUSD/TWa]"
+
 ;
 ***----------------------------------------------------------------------------------------
 ***                                   EQUATIONS

--- a/core/equations.gms
+++ b/core/equations.gms
@@ -29,16 +29,24 @@ q_costFu(t,regi)..
 q_costInv(t,regi)..
   v_costInv(t,regi)
   =e=
+*** investment cost of conversion technologies
   sum(en2en(enty,enty2,te),
     v_costInvTeDir(t,regi,te) + v_costInvTeAdj(t,regi,te)$teAdj(te)
   )
   +
-  sum((te,sector),
-    vm_costAddTeInv(t,regi,te,sector)
-  )
-  +
+*** investment cost of non-conversion technologies (storage, grid etc.)
   sum(teNoTransform,
     v_costInvTeDir(t,regi,teNoTransform) + v_costInvTeAdj(t,regi,teNoTransform)$teAdj(teNoTransform)
+  )
+*** additional transmission and distribution cost (increases hydrogen cost at low hydrogen penetration levels when hydrogen infrastructure is not yet developed) 
+  +
+  sum(sector2te_addTDCost(sector,te),
+    vm_costAddTeInv(t,regi,te,sector)
+  )
+*** end-use technology cost placed on CES nodes to represent demand-side investment cost:
+  +
+  sum(in$(ppfen_CESMkup(in)),
+    vm_costCESMkup(t,regi,in)
   )
 ;
 

--- a/core/sets.gms
+++ b/core/sets.gms
@@ -2706,6 +2706,18 @@ $ENDIF.WindOff
         storcsp,gridspv,gridwind,gridcsp,h2curt) . 1
 /
 
+
+sector2te_addTDCost(emi_sectors,all_te) "mapping of sectors to t&d technologies to which sector-specific t&d cost should be added"
+/
+        indst.tdh2s
+        build.tdh2s
+/
+
+ppfen_CESMkup(all_in)                   "production factors of CES function to which CES markup cost can be applied"
+/     
+/
+
+
 opTimeYr2te(all_te,opTimeYr)        "mapping for technologies to yearly lifetime - is filled automatically in generisdata.inc from the lifetime values in generisdata_tech.prn"
 tsu2opTimeYr(ttot, opTimeYr)     "mapping for opTimeYr to the used time ttot - will be filled automatically in generisdata.inc"
 

--- a/modules/36_buildings/services_putty/not_used.txt
+++ b/modules/36_buildings/services_putty/not_used.txt
@@ -14,3 +14,5 @@ pm_tau_fe_sub,input,questionnaire
 sm_TWa_2_MWh,input,questionnaire
 cm_CESMkup_build,input,questionnaire
 vm_costCESMkup,input,questionnaire
+sm_trillion_2_non,input,questionnaire
+sm_TWa_2_kWh,input,questionnaire

--- a/modules/36_buildings/services_putty/not_used.txt
+++ b/modules/36_buildings/services_putty/not_used.txt
@@ -13,3 +13,4 @@ pm_tau_fe_tax,input,questionnaire
 pm_tau_fe_sub,input,questionnaire
 sm_TWa_2_MWh,input,questionnaire
 cm_CESMkup_build,input,questionnaire
+vm_costCESMkup,input,questionnaire

--- a/modules/36_buildings/services_with_capital/not_used.txt
+++ b/modules/36_buildings/services_with_capital/not_used.txt
@@ -19,3 +19,5 @@ qm_balFe,input,questionnaire
 sm_TWa_2_MWh,input,questionnaire
 cm_CESMkup_build,input,questionnaire
 vm_costCESMkup,input,questionnaire
+sm_trillion_2_non,input,questionnaire
+sm_TWa_2_kWh,input,questionnaire

--- a/modules/36_buildings/services_with_capital/not_used.txt
+++ b/modules/36_buildings/services_with_capital/not_used.txt
@@ -18,3 +18,4 @@ pm_shfe_lo,parameter,not needed
 qm_balFe,input,questionnaire
 sm_TWa_2_MWh,input,questionnaire
 cm_CESMkup_build,input,questionnaire
+vm_costCESMkup,input,questionnaire

--- a/modules/36_buildings/simple/declarations.gms
+++ b/modules/36_buildings/simple/declarations.gms
@@ -35,7 +35,6 @@ Positive Variables
   v36_Elshare(ttot,all_regi)      "electricity share in FE buildings"
   v36_costAddH2LowPen(ttot,all_regi) "low penetration H2 mark up component"
   v36_costAddTeInvH2(ttot,all_regi,all_te)         "Additional hydrogen phase-in cost at low H2 penetration levels [trUSD]"
-  v36_costCESMkup(ttot,all_regi,all_te)            "CES markup cost [trUSD]"
 ;
 
 Equations
@@ -46,7 +45,7 @@ Equations
   q36_costAddH2LowPen(ttot,all_regi) "additional buildings hydrogen annual investment costs under low technology diffusion"
   q36_auxCostAddTeInv(ttot,all_regi) "auxiliar logistic function exponent calculation for additional hydrogen low penetration cost"  
   q36_costAddH2PhaseIn(ttot,all_regi) "calculation of additional industry hydrogen t&d cost at low penetration levels of hydrogen in buildings" 
-  q36_costCESmarkup(ttot,all_regi,all_te) "calculation of additional CES markup cost to represent demand-side transformation cost, for example, investment cost of heat pumps"
+  q36_costCESmarkup(ttot,all_regi,all_in) "calculation of additional CES markup cost to represent demand-side technology cost of end-use transformation, for example, cost of heat pumps etc."
   q36_costAddTeInv(ttot,all_regi,all_te)  "summation of sector-specific demand-side cost"
 ;
 

--- a/modules/36_buildings/simple/declarations.gms
+++ b/modules/36_buildings/simple/declarations.gms
@@ -7,7 +7,7 @@
 *** SOF ./modules/36_buildings/simple/declarations.gms
 
 scalars
-  s36_costAddH2Inv   "additional h2 distribution costs for low diffusion levels (default value: 6.5$/kg = 0.2$/Kwh)"
+  s36_costAddH2Inv   "additional h2 distribution costs for low diffusion levels [$/Kwh]"
   s36_costDecayStart "simplified logistic function end of full value (ex. 5%  -> between 0 and 5% the function will have the value 1). [%]"
   s36_costDecayEnd   "simplified logistic function start of null value (ex. 10% -> after 10% the function will have the value 0). [%]"
 ;

--- a/modules/36_buildings/simple/declarations.gms
+++ b/modules/36_buildings/simple/declarations.gms
@@ -7,7 +7,7 @@
 *** SOF ./modules/36_buildings/simple/declarations.gms
 
 scalars
-  s36_costAddH2Inv   "additional h2 distribution costs for low diffusion levels [$/Kwh]"
+  s36_costAddH2Inv   "additional h2 distribution costs for low diffusion levels [$/kWh]"
   s36_costDecayStart "simplified logistic function end of full value (ex. 5%  -> between 0 and 5% the function will have the value 1). [%]"
   s36_costDecayEnd   "simplified logistic function start of null value (ex. 10% -> after 10% the function will have the value 0). [%]"
 ;

--- a/modules/36_buildings/simple/equations.gms
+++ b/modules/36_buildings/simple/equations.gms
@@ -45,7 +45,9 @@ q36_costAddH2PhaseIn(t,regi)..
 q36_costAddH2LowPen(t,regi)..
   v36_costAddH2LowPen(t,regi)
   =e=
-  1 / (1 + 3**v36_costExponent(t,regi)) * s36_costAddH2Inv * 8.76
+  1 / (1 + 3**v36_costExponent(t,regi)) 
+  * s36_costAddH2Inv 
+  * sm_TWa_2_kWh / sm_trillion_2_non
 ;
 
 

--- a/modules/36_buildings/simple/equations.gms
+++ b/modules/36_buildings/simple/equations.gms
@@ -20,12 +20,12 @@ q36_demFeBuild(ttot,regi,entyFe,emiMkt)$((ttot.val ge cm_startyear) AND (entyFe2
 ;
 
 ***---------------------------------------------------------------------------
-*'  Calculate sector-specific demand-side cost: hydrogen phase-in cost + CES markup cost 
+*'  Calculate sector-specific additional t&d cost (here only cost of hydrogen t&d at low hydrogen penetration levels when grid is not yet developed)
 ***---------------------------------------------------------------------------
-q36_costAddTeInv(t,regi,te)$(tdTeMarkup36(te) OR sameAs(te,"tdh2s"))..
+q36_costAddTeInv(t,regi,te)$(sameAs(te,"tdh2s"))..
   vm_costAddTeInv(t,regi,te,"build")
   =e=
-  v36_costAddTeInvH2(t,regi,te) + v36_costCESMkup(t,regi,te)
+  v36_costAddTeInvH2(t,regi,te)
 ;
 
 ***---------------------------------------------------------------------------
@@ -71,15 +71,11 @@ q36_H2Share(t,regi)..
 ***---------------------------------------------------------------------------
 *'  CES markup cost to represent sector-specific demand-side transformation cost in buildings
 ***---------------------------------------------------------------------------
-q36_costCESmarkup(t,regi,te)$(tdTeMarkup36(te))..
-  v36_costCESMkup(t,regi,te)
+q36_costCESmarkup(t,regi,in)$(ppfen_CESMkup_dyn36(in))..
+  vm_costCESMkup(t,regi,in)
   =e=
-  sum(in$(tdTe2In36(te,in)),
-  p36_CESMkup(t,regi,in)*(vm_cesIO(t,regi,in) + pm_cesdata(t,regi,in,"offset_quantity")))
+  p36_CESMkup(t,regi,in)*(vm_cesIO(t,regi,in) + pm_cesdata(t,regi,in,"offset_quantity"))
 ;
-
-
-
 
 
 *** calculate district heat share in FE buildings

--- a/modules/36_buildings/simple/sets.gms
+++ b/modules/36_buildings/simple/sets.gms
@@ -80,6 +80,13 @@ tdTe2In36(all_te,all_in) "mapping of td technologies to CES nodes for CES markup
   tdels.feelhpb
   tdhes.feheb
   /
+
+ppfen_CESMkup_dyn36(all_in)                   "buildings production factors of CES function to which CES markup cost can be applied"
+/
+  feelhpb
+  feheb
+/
+
 ;
 
 cal_ppf_buildings_dyn36(ppfen_buildings_dyn36) = YES;
@@ -92,4 +99,6 @@ ppfEn(ppfen_buildings_dyn36)      = YES;
 cesOut2cesIn(ces_buildings_dyn36) = YES;
 fe2ppfEn(fe2ppfEn36)              = YES;
 fe_tax_sub_sbi(fe_tax_sub36) = YES;
+ppfen_CESMkup(ppfen_CESMkup_dyn36) = YES;
+
 *** EOF ./modules/36_buildings/simple/sets.gms

--- a/modules/37_industry/fixed_shares/declarations.gms
+++ b/modules/37_industry/fixed_shares/declarations.gms
@@ -8,7 +8,7 @@
 
 
 scalars
-  s37_costAddH2Inv   "additional h2 distribution costs for low diffusion levels. [3.25$/kg = 0.1$/kWh]"
+  s37_costAddH2Inv   "additional h2 distribution costs for low diffusion levels. [$/kWh]"
   s37_costDecayStart "simplified logistic function end of full value   (ex. 5%  -> between 0 and 5% the simplified logistic function will have the value 1). [%]" 
   s37_costDecayEnd   "simplified logistic function start of null value (ex. 10% -> between 10% and 100% the simplified logistic function will have the value 0). [%]"
 ;

--- a/modules/37_industry/fixed_shares/declarations.gms
+++ b/modules/37_industry/fixed_shares/declarations.gms
@@ -49,7 +49,6 @@ Positive Variables
   v37_expSlack(ttot,all_regi)                      "slack variable to avoid overflow on too high logistic function exponent"
   v37_H2share(ttot,all_regi)                       "H2 share in gases"
   v37_costAddTeInvH2(ttot,all_regi,all_te)         "Additional hydrogen phase-in cost at low H2 penetration levels [trUSD]"
-  v37_costCESMkup(ttot,all_regi,all_te)            "CES markup cost [trUSD]"
 ;
 
 Equations
@@ -62,7 +61,7 @@ Equations
   q37_H2Share(ttot,all_regi)                        "H2 share in gases"
   q37_auxCostAddTeInv(ttot,all_regi)                "auxiliar logistic function exponent calculation for additional hydrogen low penetration cost" 
   q37_costAddH2PhaseIn(ttot,all_regi)               "calculation of additional industry hydrogen t&d cost at low penetration levels of hydrogen in industry"  
-  q37_costCESmarkup(ttot,all_regi,all_te)           "calculation of additional CES markup cost to represent demand-side transformation cost, for example, investment cost of electrification"
+  q37_costCESmarkup(ttot,all_regi,all_in)           "calculation of additional CES markup cost to represent demand-side technology cost of end-use transformation, for example, cost of heat pumps etc."
   q37_costAddTeInv(ttot,all_regi,all_te)            "summation of sector-specific demand-side cost"
 ;
 

--- a/modules/37_industry/fixed_shares/equations.gms
+++ b/modules/37_industry/fixed_shares/equations.gms
@@ -137,12 +137,12 @@ q37_IndCCSCost(ttot,regi,emiInd37)$( ttot.val ge cm_startyear ) ..
 ;
 
 ***---------------------------------------------------------------------------
-*'  Calculate sector-specific demand-side cost: hydrogen phase-in cost + CES markup cost 
+*'  Calculate sector-specific additional t&d cost (here only cost of hydrogen t&d at low hydrogen penetration levels when grid is not yet developed)
 ***---------------------------------------------------------------------------
-q37_costAddTeInv(t,regi,te)$(tdTeMarkup37(te) OR sameAs(te,"tdh2s"))..
+q37_costAddTeInv(t,regi,te)$(sameAs(te,"tdh2s"))..
   vm_costAddTeInv(t,regi,te,"indst")
   =e=
-  v37_costAddTeInvH2(t,regi,te) + v37_costCESMkup(t,regi,te)
+  v37_costAddTeInvH2(t,regi,te)
 ;
 
 
@@ -185,11 +185,10 @@ q37_H2Share(t,regi)..
 ***---------------------------------------------------------------------------
 *'  CES markup cost to represent sector-specific demand-side transformation cost in industry
 ***---------------------------------------------------------------------------
-q37_costCESmarkup(t,regi,te)$(tdTeMarkup37(te))..
-  v37_costCESMkup(t,regi,te)
+q37_costCESmarkup(t,regi,in)$(ppfen_CESMkup_dyn37(in))..
+  vm_costCESMkup(t,regi,in)
   =e=
-  sum(in$(tdTe2In37(te,in)),
-  p37_CESMkup(t,regi,in)*(vm_cesIO(t,regi,in) + pm_cesdata(t,regi,in,"offset_quantity")))
+  p37_CESMkup(t,regi,in)*(vm_cesIO(t,regi,in) + pm_cesdata(t,regi,in,"offset_quantity"))
 ;
 
 *** EOF ./modules/37_industry/fixed_shares/equations.gms

--- a/modules/37_industry/fixed_shares/equations.gms
+++ b/modules/37_industry/fixed_shares/equations.gms
@@ -152,14 +152,12 @@ q37_costAddTeInv(t,regi,te)$(sameAs(te,"tdh2s"))..
 q37_costAddH2PhaseIn(t,regi)..
   v37_costAddTeInvH2(t,regi,"tdh2s")
   =e=
-    ( 1 /(
-      1 + (3**v37_costExponent(t,regi))
-      )
-    ) * (
-      s37_costAddH2Inv * 8.76
-      * ( sum(emiMkt, vm_demFeSector(t,regi,"seh2","feh2s","indst",emiMkt)))
+    (1 / (1 + (3 ** v37_costExponent(t,regi)))) 
+  * ( s37_costAddH2Inv 
+    * sm_TWa_2_kWh / sm_trillion_2_non
+    * sum(emiMkt, vm_demFeSector(t,regi,"seh2","feh2s","indst",emiMkt))
     )
-    + (v37_expSlack(t,regi)*1e-8)
+  + (v37_expSlack(t,regi) * 1e-8)
 ;
 
 

--- a/modules/37_industry/fixed_shares/sets.gms
+++ b/modules/37_industry/fixed_shares/sets.gms
@@ -134,17 +134,21 @@ tdTe2In37(all_te,all_in) "mapping of td technologies to CES nodes for CES markup
   /   /
   ppfKap_industry_dyn37(all_in)   "energy efficiency capital of industry"
   /   /
+
+
+
+ppfen_CESMkup_dyn37(all_in)                   "industry production factors of CES function to which CES markup cost can be applied"
+/
+  feeli
+/
 ;
-
-
-
-
 *** add module specific sets and mappings to the global sets and mappings
 in(in_industry_dyn37)              = YES;
 ppfEn(ppfen_industry_dyn37)        = YES;
 cesOut2cesIn(ces_industry_dyn37)   = YES;
 fe2ppfEn(fe2ppfEn37)               = YES;
 fe_tax_sub_sbi(fe_tax_sub37)       = YES;
+ppfen_CESMkup(ppfen_CESMkup_dyn37) = YES;
 
 *** EOF ./modules/37_industry/fixed_shares/sets.gms
 

--- a/modules/37_industry/subsectors/datainput.gms
+++ b/modules/37_industry/subsectors/datainput.gms
@@ -186,5 +186,18 @@ pm_ue_eff_target("ue_steel_primary")    = 0.0015;
 pm_ue_eff_target("ue_steel_secondary")  = 0.0015;
 pm_ue_eff_target("ue_otherInd")         = 0.008;
 
+
+
+*** FS: CES markup cost industry
+*** default values of CES markup
+p37_CESMkup(t,regi,in) = 0;
+
+*** overwrite or extent CES markup cost if specified by switch
+$ifThen.CESMkup not "%cm_CESMkup_ind%" == "standard" 
+  p37_CESMkup(t,regi,in)$(p37_CESMkup_input(in)) = p37_CESMkup_input(in);
+$endIf.CESMkup
+
+display p37_CESMkup;
+
 *** EOF ./modules/37_industry/subsectors/datainput.gms
 

--- a/modules/37_industry/subsectors/declarations.gms
+++ b/modules/37_industry/subsectors/declarations.gms
@@ -20,6 +20,8 @@ Parameters
 
   pm_ue_eff_target(all_in)   "energy efficiency target trajectories [% p.a.]"
 
+  p37_CESMkup(ttot,all_regi,all_in)  "CES markup cost parameter [trUSD/CES input]"
+
 *** output parameters only for reporting
   o37_emiInd(ttot,all_regi,all_enty,secInd37,all_enty)                    "industry CCS emissions [GtC/a]"
   o37_cementProcessEmissions(ttot,all_regi,all_enty)                      "cement process emissions [GtC/a]"
@@ -27,6 +29,12 @@ Parameters
   o37_shIndFE(ttot,all_regi,all_enty,secInd37)                            "share of FE carrier in total FE per industry subsector"
   o37_demFeIndSub(ttot,all_regi,all_enty,all_enty,secInd37,all_emiMkt)    "FE demand per industry subsector"
 ;
+
+$ifThen.CESMkup not "%cm_CESMkup_ind%" == "standard" 
+Parameter
+	p37_CESMkup_input(all_in)  "markup cost parameter read in from config for CES levels in industry to influence demand-side cost and efficiencies in CES tree [trUSD/CES input]" / %cm_CESMkup_ind% /
+;
+$endIf.CESMkup
 
 Positive Variables
   vm_macBaseInd(ttot,all_regi,all_enty,secInd37)   "industry CCS baseline emissions [GtC/a]"
@@ -44,6 +52,7 @@ Equations
   q37_cementCCS(ttot,all_regi)                            "link cement fuel and process abatement"
   q37_IndCCSCost                                          "Calculate industry CCS costs"
   q37_demFeIndst(ttot,all_regi,all_enty,all_emiMkt)       "industry final energy demand (per emission market)"
+  q37_costCESmarkup(ttot,all_regi,all_in)                 "calculation of additional CES markup cost to represent demand-side technology cost of end-use transformation, for example, cost of heat pumps etc."
 ;
 
 *** EOF ./modules/37_industry/subsectors/declarations.gms

--- a/modules/37_industry/subsectors/equations.gms
+++ b/modules/37_industry/subsectors/equations.gms
@@ -113,5 +113,15 @@ q37_IndCCSCost(ttot,regi,emiInd37)$( ttot.val ge cm_startyear ) ..
     )
 ;
 
+
+***---------------------------------------------------------------------------
+*'  CES markup cost to represent sector-specific demand-side transformation cost in industry
+***---------------------------------------------------------------------------
+q37_costCESmarkup(t,regi,in)$(ppfen_CESMkup_dyn37(in))..
+  vm_costCESMkup(t,regi,in)
+  =e=
+  p37_CESMkup(t,regi,in)*(vm_cesIO(t,regi,in) + pm_cesdata(t,regi,in,"offset_quantity"))
+;
+
 *** EOF ./modules/37_industry/subsectors/equations.gms
 

--- a/modules/37_industry/subsectors/not_used.txt
+++ b/modules/37_industry/subsectors/not_used.txt
@@ -19,3 +19,5 @@ pm_shfe_lo,parameter,not needed
 pm_shfe_up,parameter,not needed
 cm_ARIADNE_FeShareBounds,input,questionnaire
 
+sm_trillion_2_non,input,questionnaire
+sm_TWa_2_kWh,input,questionnaire

--- a/modules/37_industry/subsectors/not_used.txt
+++ b/modules/37_industry/subsectors/not_used.txt
@@ -9,7 +9,6 @@ pm_ttot_val,input,questionnaire
 cm_optimisticMAC,input,questionnaire
 pm_macCostSwitch,input,questionnaire
 sm_MtCH4_2_TWa,input,questionnaire
-vm_demFeSector,input,questionnaire
 vm_costAddTeInv,input,questionnaire
 cm_indst_H2costAddH2Inv,input,questionnaire
 cm_indst_costDecayStart,input,questionnaire
@@ -19,4 +18,4 @@ pm_shGasLiq_fe_up,parameter,not needed
 pm_shfe_lo,parameter,not needed
 pm_shfe_up,parameter,not needed
 cm_ARIADNE_FeShareBounds,input,questionnaire
-cm_CESMkup_ind,input,questionnaire
+

--- a/modules/37_industry/subsectors/sets.gms
+++ b/modules/37_industry/subsectors/sets.gms
@@ -255,6 +255,15 @@ Sets
     ue_steel_primary   . en_steel_primary
     ue_steel_secondary . feel_steel_secondary
   /
+
+ppfen_CESMkup_dyn37(all_in)                   "industry production factors of CES function to which CES markup cost can be applied"
+  /
+    feelhth_chemicals
+    feelwlth_chemicals
+    feel_steel_secondary
+    feelwlth_otherInd
+    feelhth_otherInd
+  /
 ;
 
 *** ---------------------------------------------------------------------------


### PR DESCRIPTION
Changes:
* refactor CES markup cost implementation to work with different CES structures in buildings and industry
* extent implementation to industry subsectors realization

Background: 
The CES markup cost serves to have some representation of the cost of end-use technologies in buildings and industry (for example cost of heat pumps, electric arc furnaces etc.). The cost are placed on the bottom-level in ``vm_cesIO`` and can be controled via the switches ``cm_CESMkup_ind`` and ``cm_CESMkup_build``. 

By default, there is currently a markup only on heat pump electricity in buildings (``feelhpb``), district heat (``feheb``) and electricity in fixed_shares industry (``feeli``). In the future, we could extent this to ppfen in industry subsectors like ``feelwlth_otherInd`` or others to represent some end-use transformation cost. In specific policy scenarios, these markup cost might also be lowered to represent policy subsidies in certain sectors/for certain technologies. So currently, nothing changes but I might get back to you on this topic about where/how markups make sense. 