### PR TITLE
Shift handling the `fegat` issue to the complex module

### DIFF
--- a/core/sets.gms
+++ b/core/sets.gms
@@ -855,6 +855,7 @@ $endif.altFeEmiFac
 ***######################## R SECTION START (MODULES) ###############################
 *** THIS CODE IS CREATED AUTOMATICALLY, DO NOT MODIFY THESE LINES DIRECTLY
 *** ANY DIRECT MODIFICATION WILL BE LOST AFTER NEXT MODEL START
+*** CHANGES CAN BE DONE USING THE RESPECTIVE LINES IN scripts/start_functions.R
 
 sets
 
@@ -894,7 +895,7 @@ sets
        codePerformance
        /
 
-      module2realisation(modules,*) "mapping of modules and active realisations" /
+module2realisation(modules,*) "mapping of modules and active realisations" /
        macro . %macro%
        welfare . %welfare%
        PE_FE_parameters . %PE_FE_parameters%
@@ -1713,6 +1714,7 @@ entyFe(all_enty)      "final energy types."
         fedie        "FE diesel transport"
         feh2t        "FE hydrogen transport"
 	feelt        "FE electricity for transport"
+        fegat        "FE gases for transport"
 /
 
 esty(all_esty)      "energy service types. Have to be added by modules."
@@ -1737,6 +1739,7 @@ entyFeTrans(all_enty) "final energy types from transport sector"
         fedie        "FE diesel transport"
         feh2t        "FE hydrogen transport"
 	feelt        "FE electricity for transport"
+        fegat        "FE gases for transport"
 /
 
 feForCes(all_enty)   "limit q_balFeForCes to entyFe in fe2ppfEn"
@@ -1927,6 +1930,7 @@ entyFe2Sector(all_enty,emi_sectors) "final energy (stationary and transportation
 		fedie.trans
 		feh2t.trans
 		feelt.trans
+                fegat.trans
 		feels.cdr
 		fehes.cdr
                 fegas.cdr

--- a/core/sets.gms
+++ b/core/sets.gms
@@ -2386,6 +2386,9 @@ se2fe(all_enty,all_enty,all_te)   "map secondary energy to end-use energy using 
         segabio.fegas.tdbiogas
         segafos.fegas.tdfosgas
         segasyn.fegas.tdsyngas
+        segabio.fegat.tdbiogat
+        segafos.fegat.tdfosgat
+        segasyn.fegat.tdsyngat
         seliqbio.fehos.tdbiohos
         seliqfos.fehos.tdfoshos
         seliqsyn.fehos.tdsynhos
@@ -2550,6 +2553,8 @@ $endif
         seliqfos.fedie.tdfosdie.oc
         seliqbio.fepet.tdbiopet.oc
         seliqfos.fepet.tdfospet.oc
+        segabio.fegat.tdbiogat.ch4
+        segafos.fegat.tdfosgat.ch4
 
         segafos.fegas.tdfosgas.co2
         seliqfos.fehos.tdfoshos.co2

--- a/modules/35_transport/complex/sets.gms
+++ b/modules/35_transport/complex/sets.gms
@@ -70,6 +70,20 @@ notIn_entyFe2Sector_dyn35(all_enty,emi_sectors)   "mapping final energy to trans
     fegat.trans
 /
 
+*** nat. gas is not used in complex, that's why these elements have to be defined here and not in core
+notIn_se2fe_dyn35(all_enty,all_enty,all_te) "gas techs for transport not used in complex"
+/
+segabio.fegat.tdbiogat
+segafos.fegat.tdfosgat
+segasyn.fegat.tdsyngat
+/
+
+notIn_emi2te_dyn35(all_enty,all_enty,all_te,all_enty) "remove emission pathways: CH4 from nat. gas"
+/
+segabio.fegat.tdbiogat.ch4
+segafos.fegat.tdfosgat.ch4
+/
+
 
 transType_35  "transport type"
 /
@@ -137,10 +151,6 @@ HydrHypeWise
 ***                  module specific mappings
 ***------------------------------------------------------------
 sets
-se2fe_dyn35(all_enty,all_enty,all_te)   "map secondary energy to end-use energy using a technology - transport module additions"
-/
-   seel.feelt.tdelt
-/
 
 fe2ue_dyn35(all_enty,all_enty,all_te)    "map FE carriers to ES via appliances"
 /
@@ -192,7 +202,6 @@ sets
 te(te_dyn35)             = YES;
 teAdj(adjte_dyn35)       = YES;
 teLearn(learnte_dyn35)   = YES;
-se2fe(se2fe_dyn35)       = YES;
 fe2ue(fe2ue_dyn35)       = YES;
 teFe2rlf(teFe2rlf_dyn35) = YES;
 
@@ -202,6 +211,8 @@ entyUe(entyUe_dyn35)            = YES;
 entyFeTrans(notIn_entyFeTrans_dyn35)  = NO;
 entyFe(notIn_entyFeTrans_dyn35)  = NO;
 entyFe2Sector(notIn_entyFe2Sector_dyn35) = NO;
+se2fe(notIn_se2fe_dyn35) = NO;
+emi2te(notIn_emi2te_dyn35) = NO;
 
 in(in_dyn35)             = YES;
 ppfEn(ppfen_dyn35)       = YES;

--- a/modules/35_transport/complex/sets.gms
+++ b/modules/35_transport/complex/sets.gms
@@ -60,10 +60,16 @@ enty_dyn35(all_enty)        "all types of quantities - transport module addition
     feelt
 /
 
-entyFeTrans_dyn35(all_enty)      "final energy types - transport module additions"
+notIn_entyFeTrans_dyn35(all_enty)      "final energy types - transport module additions"
 /
-    feelt
+    fegat
 /
+
+notIn_entyFe2Sector_dyn35(all_enty,emi_sectors)   "mapping final energy to transport sector"
+/
+    fegat.trans
+/
+
 
 transType_35  "transport type"
 /
@@ -191,8 +197,11 @@ fe2ue(fe2ue_dyn35)       = YES;
 teFe2rlf(teFe2rlf_dyn35) = YES;
 
 enty(enty_dyn35)                = YES;
-entyFeTrans(entyFeTrans_dyn35)  = YES;
 entyUe(entyUe_dyn35)            = YES;
+
+entyFeTrans(notIn_entyFeTrans_dyn35)  = NO;
+entyFe(notIn_entyFeTrans_dyn35)  = NO;
+entyFe2Sector(notIn_entyFe2Sector_dyn35) = NO;
 
 in(in_dyn35)             = YES;
 ppfEn(ppfen_dyn35)       = YES;

--- a/modules/35_transport/edge_esm/sets.gms
+++ b/modules/35_transport/edge_esm/sets.gms
@@ -140,16 +140,6 @@ segafos.fegat.tdfosgat
 segasyn.fegat.tdsyngat
 /
 
-enty_dyn35(all_enty) "nat. gas FE used for transport, see comment above"
-/
-fegat        "final energy gas transport"
-/
-
-entyFeTrans_dyn35(all_enty) "nat. gas FE used for transport, see comment above"
-/
-fegat        "FE nat. gas transport"
-/
-
 fe_transport_liquids_dyn35(all_enty) "liquids used by the transport module"
 /
 fepet
@@ -161,12 +151,6 @@ emi2te_dyn35(all_enty,all_enty,all_te,all_enty) "add. emission pathways: CH4 fro
 segabio.fegat.tdbiogat.ch4
 segafos.fegat.tdfosgat.ch4
 /
-
-entyFe2Sector_dyn35(all_enty,emi_sectors)   "mapping final energy to transport sector"
-/
-    fegat.trans
-/
-;
 
 alias(teEs_dyn35,teEs_dyn35_2);
 teEs(teEs_dyn35)         = YES;
@@ -180,10 +164,7 @@ ppfEn(ppfen_dyn35)       = YES;
 
 *** compatibility set overwrites
 se2fe(se2fe_dyn35) = YES;
-enty(enty_dyn35) = YES;
-entyFeTrans(entyFeTrans_dyn35) = YES;
 emi2te(emi2te_dyn35) = YES;
-entyFe2Sector(entyFe2Sector_dyn35) = YES;
 
 cesOut2cesIn(ces_transport_dyn35)            = YES;
 

--- a/modules/35_transport/edge_esm/sets.gms
+++ b/modules/35_transport/edge_esm/sets.gms
@@ -137,6 +137,7 @@ fe_transport_liquids_dyn35(all_enty) "liquids used by the transport module"
 fepet
 fedie
 /
+;
 
 alias(teEs_dyn35,teEs_dyn35_2);
 teEs(teEs_dyn35)         = YES;

--- a/modules/35_transport/edge_esm/sets.gms
+++ b/modules/35_transport/edge_esm/sets.gms
@@ -132,24 +132,10 @@ EDGE_scenario(EDGE_scenario_all) "Selected EDGE-T scenario"
 FE_Transp_fety35(all_enty) "FEs used in the transport module"  / fepet, fedie, feh2t, feelt, fegat/
 FE_Elec_fety35(all_enty)   "FE electricity sets (should be moved to core/sets asap)"  / feels, feelt /
 
-*** nat. gas is not used in complex, that's why these elements have to be defined here and not in core
-se2fe_dyn35(all_enty,all_enty,all_te) "nat. gas techs for transport, missing in se2fe in core/sets"
-/
-segabio.fegat.tdbiogat
-segafos.fegat.tdfosgat
-segasyn.fegat.tdsyngat
-/
-
 fe_transport_liquids_dyn35(all_enty) "liquids used by the transport module"
 /
 fepet
 fedie
-/
-
-emi2te_dyn35(all_enty,all_enty,all_te,all_enty) "add. emission pathways: CH4 from nat. gas"
-/
-segabio.fegat.tdbiogat.ch4
-segafos.fegat.tdfosgat.ch4
 /
 
 alias(teEs_dyn35,teEs_dyn35_2);
@@ -161,10 +147,6 @@ esty(esty_dyn35)     = YES;
 fe2es(fe2es_dyn35)       = YES;
 es2ppfen(es2ppfen_dyn35) = YES;
 ppfEn(ppfen_dyn35)       = YES;
-
-*** compatibility set overwrites
-se2fe(se2fe_dyn35) = YES;
-emi2te(emi2te_dyn35) = YES;
 
 cesOut2cesIn(ces_transport_dyn35)            = YES;
 


### PR DESCRIPTION
The `complex` transportation realisation does not consider gases for transportation (`fegat`). This has been dealt with by adding `fegat` in the module realisation of `edge_esm`. Now we remove the corresponding items in `complex` and add the `fegat` entries to the default sets in `core/sets.gms`.