### PR TITLE
update industry/subsectors for dynamic minimum primary steel share

### DIFF
--- a/modules/37_industry/subsectors/datainput.gms
+++ b/modules/37_industry/subsectors/datainput.gms
@@ -199,5 +199,33 @@ $endIf.CESMkup
 
 display p37_CESMkup;
 
+loop (t,
+  sm_tmp
+  = max(0, min(1,
+      (t.val - s37_min_primary_steel_share_from) 
+    / (s37_min_primary_steel_share_by - s37_min_primary_steel_share_from)
+    ));
+
+  p37_min_primary_steel_share(t,regi)$( 
+                                     t.val le s37_min_primary_steel_share_from )
+    = pm_fedemand(t,regi,"%cm_GDPscen%","ue_steel_primary")
+    / sum(cesOut2cesIn(in,out)$( cesOut2cesIn2(in,"ue_steel_primary") ),
+        pm_fedemand(t,regi,"%cm_GDPscen%",out)
+      );
+
+  p37_min_primary_steel_share(t,regi)$(
+                                     t.val gt s37_min_primary_steel_share_from )
+  = ( (1 - sm_tmp)
+    * sum(t2$( t2.val eq s37_min_primary_steel_share_from ),
+        p37_min_primary_steel_share(t2,regi)
+      )
+    )
+  + ( sm_tmp
+    * s37_min_primary_steel_share_target
+    );
+);
+
+display "calculated p37_min_primary_steel_share", p37_min_primary_steel_share;
+
 *** EOF ./modules/37_industry/subsectors/datainput.gms
 

--- a/modules/37_industry/subsectors/declarations.gms
+++ b/modules/37_industry/subsectors/declarations.gms
@@ -7,29 +7,29 @@
 *** SOF ./modules/37_industry/subsectors/declarations.gms
 
 Scalar
-  s37_clinker_process_CO2   "CO2 emissions per unit of clinker production"
+  s37_clinker_process_CO2              "CO2 emissions per unit of clinker production"
+  s37_min_primary_steel_share_target   "minimum share of primary steel production"                     / 0.1  /
+  s37_min_primary_steel_share_by       "period in which s37_min_primary_steel_share must be reached"   / 2040 /
+  s37_min_primary_steel_share_from     "period from which s37_min_primary_steel_share is faded in"     / 2015 /
 ;
 
 Parameters
-  pm_abatparam_Ind(ttot,all_regi,all_enty,steps)         "industry CCS MAC curves [ratio @ US$2005]"
-  p37_energy_limit(all_in)                               "thermodynamic/technical limits of energy use [GJ/product]"
-  p37_fctEmi(all_enty)                                   "FE emission factors"
+  pm_abatparam_Ind(ttot,all_regi,all_enty,steps)                             "industry CCS MAC curves [ratio @ US$2005]"
+  p37_energy_limit(all_in)                                                   "thermodynamic/technical limits of energy use [GJ/product]"
+  p37_fctEmi(all_enty)                                                       "FE emission factors"
+  p37_clinker_cement_ratio(ttot,all_regi)                                    "clinker content per unit cement used"
+  pm_ue_eff_target(all_in)                                                   "energy efficiency target trajectories [% p.a.]"
+  pm_IndstCO2Captured(ttot,all_regi,all_enty,all_enty,secInd37,all_emiMkt)   "Captured CO2 in industry by energy carrier, subsector and emissions market"
+  p37_min_primary_steel_share(ttot,all_regi)                                 "minimum share of primary steel production [0-1]"
+  p37_CESMkup(ttot,all_regi,all_in)                                          "CES markup cost parameter [trUSD/CES input]"
 
-
-  p37_clinker_cement_ratio(ttot,all_regi)   "clinker content per unit cement used"
-
-  pm_ue_eff_target(all_in)   "energy efficiency target trajectories [% p.a.]"
-  pm_IndstCO2Captured(ttot,all_regi,all_enty,all_enty,secInd37,all_emiMkt) "Captured CO2 in industry by energy carrier, subsector and emissions market"
-
-  p37_CESMkup(ttot,all_regi,all_in)  "CES markup cost parameter [trUSD/CES input]"
-
-*** output parameters only for reporting
-  o37_emiInd(ttot,all_regi,all_enty,secInd37,all_enty)                    "industry CCS emissions [GtC/a]"
-  o37_cementProcessEmissions(ttot,all_regi,all_enty)                      "cement process emissions [GtC/a]"
-  o37_demFeIndTotEn(ttot,all_regi,all_enty,all_emiMkt)                               "total FE per energy carrier and emissions market in industry (sum over subsectors)"
-  o37_shIndFE(ttot,all_regi,all_enty,secInd37,all_emiMkt)                            "share of subsector in FE industry energy carriers and emissions markets"
-  o37_demFeIndSub(ttot,all_regi,all_enty,all_enty,secInd37,all_emiMkt)    "FE demand per industry subsector"
-  o37_demFeIndSub_SecCC(ttot,all_regi,secInd37)           "FE per subsector whose emissions can be captured, helper parameter for calculation of industry captured CO2"
+  !! output parameters only for reporting
+  o37_emiInd(ttot,all_regi,all_enty,secInd37,all_enty)                       "industry CCS emissions [GtC/a]"
+  o37_cementProcessEmissions(ttot,all_regi,all_enty)                         "cement process emissions [GtC/a]"
+  o37_demFeIndTotEn(ttot,all_regi,all_enty,all_emiMkt)                       "total FE per energy carrier and emissions market in industry (sum over subsectors)"
+  o37_shIndFE(ttot,all_regi,all_enty,secInd37,all_emiMkt)                    "share of subsector in FE industry energy carriers and emissions markets"
+  o37_demFeIndSub(ttot,all_regi,all_enty,all_enty,secInd37,all_emiMkt)       "FE demand per industry subsector"
+  o37_demFeIndSub_SecCC(ttot,all_regi,secInd37)                              "FE per subsector whose emissions can be captured, helper parameter for calculation of industry captured CO2"
 ;
 
 $ifThen.CESMkup not "%cm_CESMkup_ind%" == "standard" 

--- a/modules/37_industry/subsectors/equations.gms
+++ b/modules/37_industry/subsectors/equations.gms
@@ -32,9 +32,12 @@ q37_energy_limits(ttot,regi,industry_ue_calibration_target_dyn37(out))$(
 
 *** No more than 90% of steel from secondary production
 q37_limit_secondary_steel_share(ttot,regi)$( ttot.val ge cm_startyear ) .. 
-  9 * vm_cesIO(ttot,regi,"ue_steel_primary")
+    vm_cesIO(ttot,regi,"ue_steel_primary")
+  * p37_min_primary_steel_share(ttot,regi)
   =g=
-  vm_cesIO(ttot,regi,"ue_steel_secondary")
+  sum(cesOut2cesIn(out,in)$( cesOut2cesIn2(out,"ue_steel_primary") ),
+    vm_cesIO(ttot,regi,in)
+  )
 ;
 
 *' Compute gross industry emissions before CCS by multiplying sub-sector energy


### PR DESCRIPTION
- minimum share of primary steel in total steel production converges
  from historic (2015) values to 10 % until 2040
- share and temporal behaviour are controlled by
  - `s37_min_primary_steel_share_target` (0.1)
  - `s37_min_primary_steel_share_from` (2015)
  - `s37_min_primary_steel_share_by` (2040)