### PR TITLE
Add Mix to EDGE-T scenarios in REMIND set definitions

### DIFF
--- a/modules/29_CES_parameters/calibrate/datainput.gms
+++ b/modules/29_CES_parameters/calibrate/datainput.gms
@@ -244,11 +244,11 @@ $offdelim
 
 
 $ifthen "%cm_calibration_FE%" == "low"
-  pm_fedemand(t,regi,"%cm_GDPscen%",in_dyn35)$(t.val ge 2006) = p29_fedemand_trasp(t,regi,"gdp_SSP2","ConvCaseWise",in_dyn35);
+  pm_fedemand(t,regi,"%cm_GDPscen%",in_dyn35)$(t.val ge 2006) = p29_fedemand_trasp(t,regi,"gdp_SSP2","MixWise",in_dyn35);
 $elseif "%cm_calibration_FE%" == "medium"
-  pm_fedemand(t,regi,"%cm_GDPscen%",in_dyn35)$(t.val ge 2006) = p29_fedemand_trasp(t,regi,"gdp_SSP2","ConvCase",in_dyn35);
+  pm_fedemand(t,regi,"%cm_GDPscen%",in_dyn35)$(t.val ge 2006) = p29_fedemand_trasp(t,regi,"gdp_SSP2","Mix",in_dyn35);
 $elseif "%cm_calibration_FE%" == "high"
-  pm_fedemand(t,regi,"%cm_GDPscen%",in_dyn35)$(t.val ge 2006) = p29_fedemand_trasp(t,regi,"gdp_SSP2","ConvCase",in_dyn35);
+  pm_fedemand(t,regi,"%cm_GDPscen%",in_dyn35)$(t.val ge 2006) = p29_fedemand_trasp(t,regi,"gdp_SSP2","Mix",in_dyn35);
 $endif
 
 Parameter

--- a/modules/35_transport/complex/datainput.gms
+++ b/modules/35_transport/complex/datainput.gms
@@ -64,7 +64,7 @@ $offdelim
 /
 ;
 
-p35_bunkers_fe(ttot,regi) = sm_EJ_2_TWa * p35_bunkers_fedemand(ttot,regi,"gdp_SSP2","ConvCase");
+p35_bunkers_fe(ttot,regi) = sm_EJ_2_TWa * p35_bunkers_fedemand(ttot,regi,"gdp_SSP2","Mix");
 
 display p35_bunkers_fe;
 

--- a/modules/35_transport/complex/sets.gms
+++ b/modules/35_transport/complex/sets.gms
@@ -144,6 +144,8 @@ ElecEra
 ElecEraWise
 HydrHype
 HydrHypeWise
+Mix
+MixWise
 /
 ;
 

--- a/modules/35_transport/edge_esm/sets.gms
+++ b/modules/35_transport/edge_esm/sets.gms
@@ -124,6 +124,8 @@ ElecEra
 ElecEraWise
 HydrHype
 HydrHypeWise
+Mix
+MixWise
 /
 
 EDGE_scenario(EDGE_scenario_all) "Selected EDGE-T scenario"


### PR DESCRIPTION
... and fix some places where the combination "SSP2" and "ConvCase" was used explicitly to load EDGE-T demand trajectories for complex.