### PR TITLE
add lower bound on feso/feli/fega in chemicals FE input for feedstocks

### DIFF
--- a/modules/37_industry/subsectors/datainput.gms
+++ b/modules/37_industry/subsectors/datainput.gms
@@ -199,5 +199,13 @@ $endIf.CESMkup
 
 display p37_CESMkup;
 
+Parameter p37_chemicals_feedstock_share(ttot,all_regi)   "minimum share of feso/feli/fega in total chemicals FE input [0-1]"
+  /
+$ondelim
+$include "./modules/37_industry/subsectors/input/p37_chemicals_feedstock_share.cs4r";
+$offdelim
+  /
+;
+
 *** EOF ./modules/37_industry/subsectors/datainput.gms
 

--- a/modules/37_industry/subsectors/declarations.gms
+++ b/modules/37_industry/subsectors/declarations.gms
@@ -22,6 +22,7 @@ Parameters
   pm_IndstCO2Captured(ttot,all_regi,all_enty,all_enty,secInd37,all_emiMkt) "Captured CO2 in industry by energy carrier, subsector and emissions market"
 
   p37_CESMkup(ttot,all_regi,all_in)  "CES markup cost parameter [trUSD/CES input]"
+  p37_chemicals_feedstock_share(ttot,all_regi)   "minimum share of feso/feli/fega in total chemicals FE input [0-1]"
 
 *** output parameters only for reporting
   o37_emiInd(ttot,all_regi,all_enty,secInd37,all_enty)                    "industry CCS emissions [GtC/a]"
@@ -55,6 +56,7 @@ Equations
   q37_IndCCSCost                                          "Calculate industry CCS costs"
   q37_demFeIndst(ttot,all_regi,all_enty,all_emiMkt)       "industry final energy demand (per emission market)"
   q37_costCESmarkup(ttot,all_regi,all_in)                 "calculation of additional CES markup cost to represent demand-side technology cost of end-use transformation, for example, cost of heat pumps etc."
+  q37_chemicals_feedstocks_limit(ttot,all_regi)           "lower bound on feso/feli/fega in chemicals FE input for feedstocks"
 ;
 
 *** EOF ./modules/37_industry/subsectors/declarations.gms

--- a/modules/37_industry/subsectors/equations.gms
+++ b/modules/37_industry/subsectors/equations.gms
@@ -124,5 +124,13 @@ q37_costCESmarkup(t,regi,in)$(ppfen_CESMkup_dyn37(in))..
   * (vm_cesIO(t,regi,in) + pm_cesdata(t,regi,in,"offset_quantity"))
 ;
 
+* lower bound on feso/feli/fega in chemicals FE input for feedstocks
+q37_chemicals_feedstocks_limit(t,regi)$( t.val ge cm_startyear ) .. 
+  sum(in_chemicals_feedstocks37(in), vm_cesIO(t,regi,in))
+  =g=
+    sum(ces_eff_target_dyn37("ue_chemicals",in), vm_cesIO(t,regi,in))
+  * p37_chemicals_feedstock_share(t,regi)
+;
+
 *** EOF ./modules/37_industry/subsectors/equations.gms
 

--- a/modules/37_industry/subsectors/input/files
+++ b/modules/37_industry/subsectors/input/files
@@ -1,2 +1,3 @@
 p37_cesIO_up_steel_secondary.cs4r
 p37_clinker-to-cement-ratio.cs3r
+p37_chemicals_feedstock_share.cs4r

--- a/modules/37_industry/subsectors/sets.gms
+++ b/modules/37_industry/subsectors/sets.gms
@@ -141,6 +141,13 @@ Sets
                       feh2_otherInd, fehe_otherInd, feelhth_otherInd)
   /  
 
+  in_chemicals_feedstocks37(all_in)   "chemicals FE that can provide feedstocks"
+  /
+    feso_chemicals
+    feli_chemicals
+    fega_chemicals
+  /
+
   ces_eff_target_dyn37(all_in,all_in)   "limits to specific total energy use"
   /
     ue_cement . (feso_cement, feli_cement, fega_cement, feh2_cement, 


### PR DESCRIPTION
- set lower bound for solids/liquids/gases share in chemicals total FE consumption
- starting at historic values, converging towards global average (65 %), see https://github.com/pik-piam/mrremind/pull/124
- awaiting further implementation of emission handling, see https://github.com/remindmodel/development_issues/issues/48