### PR TITLE
delete invisible control character in config/default.cfg

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -1,4 +1,4 @@
-﻿# |  (C) 2006-2020 Potsdam Institute for Climate Impact Research (PIK)
+# |  (C) 2006-2020 Potsdam Institute for Climate Impact Research (PIK)
 # |  authors, and contributors see CITATION.cff file. This file is part
 # |  of REMIND and licensed under AGPL-3.0-or-later. Under Section 7 of
 # |  AGPL-3.0, you are granted additional permissions described in the


### PR DESCRIPTION
was introduced by myself in https://github.com/remindmodel/remind/pull/535/commits/39666b1082ca61aab61c6f8bd9813be57559468a