### PR TITLE
Add pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+    -   id: check-case-conflict
+    -   id: check-json
+    -   id: check-yaml
+    -   id: check-merge-conflict
+    -   id: fix-byte-order-marker
+# these two are useful as well, but very much not followed in remind ATM
+#    -   id: end-of-file-fixer
+#    -   id: trailing-whitespace


### PR DESCRIPTION
This adds a simple pre-commit configuration which can be used together with https://pre-commit.ci/ to automatically check via github actions that pull requests:
* don't add files which conflict on non-case-sensitive (windows) file systems
* don't contain invalid json files
* don't contain invalid yaml files
* don't contain unhandled merge conflicts
* don't contain a byte-order-marker (compare https://github.com/remindmodel/remind/issues/518)

Additionally, the pre-commit CI will actually add *automatic fixes* for byte-order-marker problems (just deleting the BOM), so that there is zero work hunting byte-order-markers ever again.

There are two additional fixes which are quite useful IMHO, but which remind doesn't follow at the moment:
* make sure every non-empty file ends with a line break (as the UNIX gods decreed)
* delete trailing whitespace

If you think these two checks are reasonable within remind, we can enable them easily.

This is my first PR for remind, I hope it follows convention :grimacing: 