### PR TITLE
Revert changes for NDC versioning

### DIFF
--- a/modules/45_carbonprice/NDC2018/datainput.gms
+++ b/modules/45_carbonprice/NDC2018/datainput.gms
@@ -18,20 +18,14 @@ pm_taxCO2eq("2015",regi)$regi_group("EUR_regi",regi)= 5 * sm_DptCO2_2_TDpGtC;
 Parameter p45_factor_targetyear(ttot,all_regi,all_GDPscen) "Multiplier for target year emissions vs 2005 emissions, as weighted average for all countries with quantifyable emissions under NDC in particular region"
   /
 $ondelim
-$if "%cm_NDC_version%" == "2021_cond" $include "./modules/45_carbonprice/NDC2018/input/p45_factor_targetyear_NDC2021_cond.cs4r"
-$if "%cm_NDC_version%" == "2021_uncond" $include "./modules/45_carbonprice/NDC2018/input/p45_factor_targetyear_NDC2021_uncond.cs4r"
-$if "%cm_NDC_version%" == "2018_cond" $include "./modules/45_carbonprice/NDC2018/input/p45_factor_targetyear_NDC2018_cond.cs4r"
-$if "%cm_NDC_version%" == "2018_uncond" $include "./modules/45_carbonprice/NDC2018/input/p45_factor_targetyear_NDC2018_uncond.cs4r"
+$include "./modules/45_carbonprice/NDC2018/input/p45_factor_targetyear.cs4r"
 $offdelim
   /             ;
 
 Parameter p45_2005share_target(ttot,all_regi,all_GDPscen) "2005 GHG emission share of countries with quantifyable emissions under NDC in particular region, time dimension specifies alternative future target years"
   /
 $ondelim
-$if "%cm_NDC_version%" == "2021_cond" $include "./modules/45_carbonprice/NDC2018/input/p45_2005share_target_NDC2021_cond.cs4r"
-$if "%cm_NDC_version%" == "2021_uncond" $include "./modules/45_carbonprice/NDC2018/input/p45_2005share_target_NDC2021_uncond.cs4r"
-$if "%cm_NDC_version%" == "2018_cond" $include "./modules/45_carbonprice/NDC2018/input/p45_2005share_target_NDC2018_cond.cs4r"
-$if "%cm_NDC_version%" == "2018_uncond" $include "./modules/45_carbonprice/NDC2018/input/p45_2005share_target_NDC2018_uncond.cs4r"
+$include "./modules/45_carbonprice/NDC2018/input/p45_2005share_target.cs4r"
 $offdelim
   /             ;
 
@@ -39,10 +33,7 @@ $offdelim
 Parameter p45_hist_share(tall,all_regi) "GHG emissions share of countries with quantifyable 2030 target, time dimension specifies historic record"
   /
 $ondelim
-$if "%cm_NDC_version%" == "2021_cond" $include "./modules/45_carbonprice/NDC2018/input/p45_hist_share_NDC2021_cond.cs4r"
-$if "%cm_NDC_version%" == "2021_uncond" $include "./modules/45_carbonprice/NDC2018/input/p45_hist_share_NDC2021_uncond.cs4r"
-$if "%cm_NDC_version%" == "2018_cond" $include "./modules/45_carbonprice/NDC2018/input/p45_hist_share_NDC2018_cond.cs4r"
-$if "%cm_NDC_version%" == "2018_uncond" $include "./modules/45_carbonprice/NDC2018/input/p45_hist_share_NDC2018_uncond.cs4r"
+$include "./modules/45_carbonprice/NDC2018/input/p45_hist_share.cs4r"
 $offdelim
   /             ;
   

--- a/modules/45_carbonprice/NDC2018/input/files
+++ b/modules/45_carbonprice/NDC2018/input/files
@@ -1,12 +1,3 @@
-p45_2005share_target_NDC2021_cond.cs4r
-p45_2005share_target_NDC2021_uncond.cs4r
-p45_2005share_target_NDC2018_cond.cs4r
-p45_2005share_target_NDC2018_uncond.cs4r
-p45_factor_targetyear_NDC2021_cond.cs4r
-p45_factor_targetyear_NDC2021_uncond.cs4r
-p45_factor_targetyear_NDC2018_cond.cs4r
-p45_factor_targetyear_NDC2018_uncond.cs4r
-p45_hist_share_NDC2021_cond.cs4r
-p45_hist_share_NDC2021_uncond.cs4r
-p45_hist_share_NDC2018_cond.cs4r
-p45_hist_share_NDC2018_uncond.cs4r
+p45_2005share_target.cs4r
+p45_factor_targetyear.cs4r
+p45_hist_share.cs4r

--- a/modules/45_carbonprice/NDC2018/not_used.txt
+++ b/modules/45_carbonprice/NDC2018/not_used.txt
@@ -18,5 +18,6 @@ pm_shPPPMER,input,questionnaire
 pm_pop,input,questionnaire
 pm_gdp,input,questionnaire
 cm_CO2priceRegConvEndYr,input,questionnaire
+cm_NDC_version,input,questionnaire
 cm_peakBudgYr,input,questionnaire
 cm_taxCO2inc_after_peakBudgYr,input,questionnaire


### PR DESCRIPTION
Input data import depending on NDC version is reverted for now, the new switch `cm_NDC_version` kept for later use.