### PR TITLE
Remove EDGE-T scenario description file

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -647,7 +647,6 @@ cfg$files2export$start <- c("config/conopt3.opt",
                             "modules/11_aerosols/exoGAINS/input/emi_gains.cs4r",
                             "modules/11_aerosols/exoGAINS/input/mappingGAINSmixedtoREMIND17activities.csv",
                             "modules/11_aerosols/exoGAINS/input/mappingGAINStoREMINDsectors.csv",
-                            "modules/35_transport/edge_esm/input/EDGEscenario_description.csv",
                             "modules/35_transport/edge_esm/input/mapping_CESnodes_EDGE.csv",
                             "modules/35_transport/edge_esm/input/mapping_EDGE_REMIND_transport_categories.csv")
 


### PR DESCRIPTION
from list of files-to-be-copied in default config.