### PR TITLE
temporary fix of secondary steel constraint to avoid infes when primary steel is zero in calibration data

### DIFF
--- a/modules/37_industry/subsectors/equations.gms
+++ b/modules/37_industry/subsectors/equations.gms
@@ -31,7 +31,7 @@ q37_energy_limits(ttot,regi,industry_ue_calibration_target_dyn37(out))$(
 ;
 
 *** No more than 90% of steel from secondary production
-q37_limit_secondary_steel_share(ttot,regi)$( ttot.val ge cm_startyear ) .. 
+q37_limit_secondary_steel_share(ttot,regi)$( ttot.val ge cm_startyear AND (pm_fedemand(ttot,regi,"ue_steel_primary") ge 1e-4)) .. 
   9 * vm_cesIO(ttot,regi,"ue_steel_primary")
   =g=
   vm_cesIO(ttot,regi,"ue_steel_secondary")


### PR DESCRIPTION
Currently, infes is caused for REMIND-EU because ue_primary_steel is zero/very small in some years in NEN region (see e.g. here ``/p/tmp/schreyer/Modeling/REMIND_H12/Current/output/EU-SSP2EU_calibrate_2021-10-18_18.00.38``). This fix is done to avoid infeasibilities for small values in input data. Still to be checked why input data is zero in this case. 