### PR TITLE
remove exception to reach China emi peak year

### DIFF
--- a/modules/45_carbonprice/NDC2018/postsolve.gms
+++ b/modules/45_carbonprice/NDC2018/postsolve.gms
@@ -79,8 +79,6 @@ pm_taxCO2eq(ttot,regi)$(ttot.val gt 2030) = (pm_taxCO2eq("2030",regi)*1.0125**(t
 pm_taxCO2eq(ttot,regi_2025target)$(ttot.val gt 2025) = (pm_taxCO2eq("2025",regi_2025target)*1.0125**(ttot.val-2025)*max(75-ttot.val+2025,0) + 30 * sm_DptCO2_2_TDpGtC * 1.0125**(ttot.val-2030)*min(ttot.val-2025,75))/75;
 *#'as a minimum, have linear price increase starting from 1$ in 2030
 pm_taxCO2eq(ttot,regi)$(ttot.val gt 2030) = max(pm_taxCO2eq(ttot,regi),1*sm_DptCO2_2_TDpGtC * (1+(ttot.val-2030)*9/7));
-*#' exception for China to meet the target of 2030 peak: linear increase starts already in 2025
-pm_taxCO2eq(ttot,regi)$(ttot.val gt 2025 AND (sameas(regi,"CHN") OR sameas(regi,"CHA"))) = max(pm_taxCO2eq(ttot,regi),1*sm_DptCO2_2_TDpGtC * (1+(ttot.val-2025)*9/7));
 
 *** new 2020 carbon price definition: weighted average of 2015 and 2025, with triple weight for 2015 (which is zero for all non-eu regions).
 pm_taxCO2eq("2020",regi) = (3*pm_taxCO2eq("2015",regi)+pm_taxCO2eq("2025",regi))/4;

--- a/modules/45_carbonprice/NDC2018/preloop.gms
+++ b/modules/45_carbonprice/NDC2018/preloop.gms
@@ -18,8 +18,6 @@ pm_taxCO2eq(ttot,regi)$(ttot.val gt 2030) = (pm_taxCO2eq("2030",regi)*1.0125**(t
 pm_taxCO2eq(ttot,regi_2025target)$(ttot.val gt 2025) = (pm_taxCO2eq("2025",regi_2025target)*1.0125**(ttot.val-2025)*max(75-ttot.val+2025,0) + 30 * sm_DptCO2_2_TDpGtC * 1.0125**(ttot.val-2030)*min(ttot.val-2025,75))/75;
 ***as a minimum, have linear price increase starting from 1$ in 2030
 pm_taxCO2eq(ttot,regi)$(ttot.val gt 2030) = max(pm_taxCO2eq(ttot,regi),1*sm_DptCO2_2_TDpGtC * (1+(ttot.val-2030)*9/7));
-*** exception for China to meet the target of 2030 peak: linear increase starts already in 2025
-pm_taxCO2eq(ttot,regi)$(ttot.val gt 2025 AND (sameas(regi,"CHN") OR sameas(regi,"CHA"))) = max(pm_taxCO2eq(ttot,regi),1*sm_DptCO2_2_TDpGtC * (1+(ttot.val-2025)*9/7));
 
 *** new 2020 carbon price definition: weighted average of 2015 and 2025, with triple weight for 2015 (which is zero for all non-eu regions).
 pm_taxCO2eq("2020",regi) = (3*pm_taxCO2eq("2015",regi)+pm_taxCO2eq("2025",regi))/4;


### PR DESCRIPTION
Removed two lines that enabled China to reach emissions peak in target year 2030. With new NDCs, this is not necessary anymore.