### PR TITLE
Added information to log if no output is generated, as for --testOneRegi

### DIFF
--- a/output.R
+++ b/output.R
@@ -274,6 +274,11 @@ if (comp == TRUE) {
     # Execute R scripts
     ###################################################################################
 
+    # output creation for --testOneRegi was switched off in start.R in this commit: https://github.com/remindmodel/remind/commit/5905d9dd814b4e4a62738d282bf1815e6029c965
+    if (is.na(output)) {
+      cat(paste("No output generation, as output was set to NA, as for example for --testOneRegi.\n"))
+    }
+
     for (rout in output) {
       name <- paste(rout, ".R", sep = "")
       if (file.exists(paste0("scripts/output/single/", name))) {


### PR DESCRIPTION
I was confused a while ago that with --testOneRegi the output generation did not work although the log stated otherwise. Therefore, I added information that --testOneRegi does not produce output to log.