### PR TITLE
Increase initial capex of electrolysis and add bounds to only build the technology from 2020 on

### DIFF
--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -545,4 +545,7 @@ v_shGasLiq_fe.lo(t,regi,sector)$pm_shGasLiq_fe_lo(t,regi,sector) = pm_shGasLiq_f
 *** FS: allow for H2 use in buildings only from 2030 onwards
 vm_demFeSector.up(t,regi,"seh2","feh2s","build",emiMkt)$(t.val le 2025)=0;
 
+*** FS: no electrolysis capacities before 2020
+vm_cap.up(t,regi,"elh2","1")$(t.val le 2015) = 0;
+
 *** EOF ./core/bounds.gms

--- a/core/input/generisdata_tech.prn
+++ b/core/input/generisdata_tech.prn
@@ -81,14 +81,14 @@ luse                                                                            
 
 +                  elh2         dot         dhp       h2turb      h2curt       h2turbVRE  elh2VRE      h22ch4      MeOH
 tech_stat            1                                    2                                               3          3  
-inco0               1600         480         360         600         700          0.1      0.1          700        800
+inco0               2500         480         360         600         700          0.1      0.1          700        800
 constrTme            2            2           1           2           2            1        1            2          2
 mix0                                                                                                                    
 eta                 0.73        0.30        0.80        0.40        0.62         0.40      0.73         0.8        0.7
 omf                 0.05        0.03        0.03        0.03        0.05         0.00      0.00         0.03       0.03
 omv                    3          12          12          24           0                                 3           12
 lifetime              30          25          25          30          30          30        30            30          30
-incolearn           1400
+incolearn           2000
 ccap0             0.0005 
 learn               0.15  
 

--- a/core/input/generisdata_tech_SSP1.prn
+++ b/core/input/generisdata_tech_SSP1.prn
@@ -79,14 +79,14 @@ luse                                                                            
 
 +                  elh2         dot         dhp       h2turb      h2curt       h2turbVRE  elh2VRE      h22ch4      MeOH
 tech_stat            1                                    2                                               3          3 
-inco0               1600         480         360         600         700          0.1      0.1          700        800
+inco0               2500         480         360         600         700          0.1      0.1          700        800
 constrTme            2            2           1           2           2            1        1            2          2
 mix0                                                                                                                    
 eta                 0.73        0.30        0.80        0.40        0.62         0.40      0.73         0.8        0.7
 omf                 0.05        0.03        0.03        0.03        0.05         0.00      0.00         0.03       0.03
 omv                    3          12          12          24           0                                 3           12
 lifetime              30          25          25          30          30          30        30           30          30
-incolearn           1500
+incolearn           2000
 ccap0             0.0005 
 learn               0.15
 

--- a/core/input/generisdata_tech_SSP5.prn
+++ b/core/input/generisdata_tech_SSP5.prn
@@ -79,14 +79,14 @@ luse                                                                            
 
 +                   elh2         dot         dhp      h2turb      h2curt    h2turbVRE   elh2VRE         h22ch4      MeOH
 tech_stat            1                                    2                                                 3          3
-inco0                1600         480         360         600         700          0.1       0.1          700        800
+inco0                2500         480         360         600         700          0.1       0.1          700        800
 constrTme              2           2           1           2           2            1         1            2          2
 mix0                                                                                                                    
 eta                 0.73        0.30        0.80        0.40        0.62         0.40      0.73          0.8        0.7
 omf                 0.05        0.03        0.03        0.03        0.05         0.00      0.00          0.03       0.03
 omv                    3          12          12          24           0                                  3           12
 lifetime              30          25          25          30          30           30         30          30          30
-incolearn           1200
+incolearn           2000
 ccap0             0.0005 
 learn               0.15
 


### PR DESCRIPTION
This PR

* increases the initial CAPEX of electrolysis to 2500 USD/KW(H2) (~ 1500 USD/kW(el) with initial efficiency) and adapts floor cost. The changes are in line with the literature analysis done by [Ueckerdt et al.](https://static-content.springer.com/esm/art%3A10.1038%2Fs41558-021-01032-7/MediaObjects/41558_2021_1032_MOESM1_ESM.pdf) (see Suppl. -> Figure S2). The changes were necessary a) because CAPEX are usually given in kW(el),whilekW(H2) is fed into REMIND and we decreased our initial efficiency and b) because now the average and not the cheapest electrolysis technology is chosen as reference. 

* adds bound to only build electrolysis from 2020 time step on which is in line with historic trends

Test runs can be found here:

``/p/tmp/schreyer/Modeling/REMIND_H12/NewDev/output/Base_elh2learn_2021-11-29_12.20.01``
``/p/tmp/schreyer/Modeling/REMIND_H12/NewDev/output/PkBudg1020_elh2learn_2021-11-29_16.19.32``

I compiled some results of these runs for CAPEX and electrolysis capacities here ``/p/tmp/schreyer/Modeling/REMIND_H12/NewDev/output/PkBudg1020_elh2learn_2021-11-29_16.19.32/CAPEX_TestRuns_2021_11_29.xlsx``