### PR TITLE
rhdf5 no longer needed

### DIFF
--- a/tutorials/1_GettingREMIND.md
+++ b/tutorials/1_GettingREMIND.md
@@ -49,7 +49,6 @@ pkgs <- c("curl",
           "mrremind",
           "remind2",
           "remulator",
-          "rhdf5",
           "shinyresults")
 install.packages(pkgs)
 ```


### PR DESCRIPTION
`magpie4` no longer depends on `moinput` so `rhdf5` from BioConductor is no longer needed. Closes #76 