### PR TITLE
Fixed bug on starting default runs

### DIFF
--- a/start.R
+++ b/start.R
@@ -281,10 +281,12 @@ if ('--restart' %in% argv) {
     }
   
     # print names of subsequent runs if there are any
+    # we have to check first is there is a cfg$RunsUsingTHISgdxAsInput, since there won't be if this is a default run 
+    if (!is.null(dim(cfg$RunsUsingTHISgdxAsInput))) { 
     if (dim(cfg$RunsUsingTHISgdxAsInput)[1] != 0) { 
       if (any(cfg$RunsUsingTHISgdxAsInput$path_gdx_ref == scen)) {
       cat("   Subsequent runs:",rownames(cfg$RunsUsingTHISgdxAsInput[cfg$RunsUsingTHISgdxAsInput$path_gdx_ref == scen,]),"\n")
-    }}
+    }}}
     
   }
 }


### PR DESCRIPTION
This fixes a bug on `start.R` that was preventing default runs to start. The new exogenous carbon price implementation had a check for en entry in `cfg` that does not exist in the case of a default run. This adds a previous check to see if it exists first.