### PR TITLE
Replaced dim with length on checks for cfg$RunsUsingTHISgdxAsInput

### DIFF
--- a/scripts/start/prepare_and_run.R
+++ b/scripts/start/prepare_and_run.R
@@ -857,8 +857,7 @@ run <- function(start_subsequent_runs = TRUE) {
   # Don't start subsequent runs form here if REMIND runs coupled. They are started in start_coupled.R instead.
   start_subsequent_runs <- !coupled_run
  
-  # if RunsUsingTHISgdxAsInput has at least one row
-  if (start_subsequent_runs & (dim(cfg$RunsUsingTHISgdxAsInput)[1] != 0)) {
+  if (start_subsequent_runs & (length(cfg$RunsUsingTHISgdxAsInput)[1] != 0)) {
   
     # Save the current cfg settings into a different data object, so that they are not overwritten
     cfg_main <- cfg

--- a/start.R
+++ b/start.R
@@ -281,12 +281,10 @@ if ('--restart' %in% argv) {
     }
   
     # print names of subsequent runs if there are any
-    # we have to check first is there is a cfg$RunsUsingTHISgdxAsInput, since there won't be if this is a default run 
-    if (!is.null(dim(cfg$RunsUsingTHISgdxAsInput))) { 
-    if (dim(cfg$RunsUsingTHISgdxAsInput)[1] != 0) { 
+    if (length(cfg$RunsUsingTHISgdxAsInput)[1] != 0) { 
       if (any(cfg$RunsUsingTHISgdxAsInput$path_gdx_ref == scen)) {
       cat("   Subsequent runs:",rownames(cfg$RunsUsingTHISgdxAsInput[cfg$RunsUsingTHISgdxAsInput$path_gdx_ref == scen,]),"\n")
-    }}}
+    }}
     
   }
 }


### PR DESCRIPTION
Some places used `dim(cfg$RunsUsingTHISgdxAsInput)` to check whether there were subsequent runs to be started. This caused some bugs in cases where only one run was being issued. For example, this is causing `default` runs to either not start or return a `FAILED` slurm status even when they are successful.

This replaces `dim` with `length`, which reacts more predictably on edge cases such as when `cfg$RunsUsingTHISgdxAsInput` doesn't exist or is `character(0)`.