### PR TITLE
Rescale FE input data for 2005 capacity calibration and enable historic biomass share constraint for buildings and industry again

### DIFF
--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -1512,7 +1512,7 @@ sm_globalBudget_dev = 1;
 s_histBioShareTolerance = 0.02;
 *** temporary: until subsectors historical FE mix checked -> high tolerance for industry subsectors to make it run 
 $ifthen.subsectors "%industry%" == "subsectors"   !! industry
-s_histBioShareTolerance = 0.3;
+s_histBioShareTolerance = 0.02;
 $endif.subsectors
 
 

--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -1507,14 +1507,4 @@ $endif.subsectors
 *** initialize global target deviation scalar
 sm_globalBudget_dev = 1;
 
-*** define tolerance level by how much biomass share needs to comply with 2005 historical values
-*** low tolerance for fixed_shares, there is works
-s_histBioShareTolerance = 0.02;
-*** temporary: until subsectors historical FE mix checked -> high tolerance for industry subsectors to make it run 
-$ifthen.subsectors "%industry%" == "subsectors"   !! industry
-s_histBioShareTolerance = 0.02;
-$endif.subsectors
-
-
-
 *** EOF ./core/datainput.gms

--- a/core/declarations.gms
+++ b/core/declarations.gms
@@ -552,7 +552,6 @@ sm_globalBudget_dev                                   "actual level of global cu
 
 sm_eps                                                "small number: 1e-9 "  /1e-9/
 
-s_histBioShareTolerance                               "tolerance range of percentage points by how much the biomass share in solids, liquids and gases in industry and buildings can deviate from the historical value in 2005"
 ***----------------------------------------------------------------------------------------
 ***----------------------------------------------trade module------------------------------
 ;

--- a/core/equations.gms
+++ b/core/equations.gms
@@ -987,7 +987,7 @@ q_limitCapFeH2BI(t,regi,sector)$(SAMEAS(sector,"build") OR SAMEAS(sector,"indst"
 ***---------------------------------------------------------------------------
 
 q_shbiofe_up(t,regi,entyFe,sector,emiMkt)$((sameas(entyFE,"fegas") or sameas(entyFE,"fehos") or sameas(entyFE,"fesos")) and entyFe2Sector(entyFe,sector) and sector2emiMkt(sector,emiMkt) and (t.val le 2015))..
-  (pm_secBioShare(t,regi,entyFe,sector) + s_histBioShareTolerance)
+  (pm_secBioShare(t,regi,entyFe,sector) + 0.02)
   *
   sum((entySe,te)$se2fe(entySe,entyFe,te), vm_demFeSector(t,regi,entySe,entyFe,sector,emiMkt))
   =g=
@@ -995,7 +995,7 @@ q_shbiofe_up(t,regi,entyFe,sector,emiMkt)$((sameas(entyFE,"fegas") or sameas(ent
 ;
 
 q_shbiofe_lo(t,regi,entyFe,sector,emiMkt)$((sameas(entyFE,"fegas") or sameas(entyFE,"fehos") or sameas(entyFE,"fesos")) and entyFe2Sector(entyFe,sector) and sector2emiMkt(sector,emiMkt) and (t.val le 2015))..
-  (pm_secBioShare(t,regi,entyFe,sector) - s_histBioShareTolerance)
+  (pm_secBioShare(t,regi,entyFe,sector) - 0.02)
   *
   sum((entySe,te)$se2fe(entySe,entyFe,te), vm_demFeSector(t,regi,entySe,entyFe,sector,emiMkt))
   =l=

--- a/modules/04_PE_FE_parameters/iea2014/datainput.gms
+++ b/modules/04_PE_FE_parameters/iea2014/datainput.gms
@@ -24,11 +24,110 @@ $offdelim
 /
 ;
 
+
+
+
 *** making sure f04_IO_output is compatible with pm_fedemand values in 2005  
 *** this will become irrelevant to the model once the input data routines can be fixed so that pm_fedemand is again the same as f04_IO_output
 *** these lines should be removed once this is fixed at mrremind side.
-f04_IO_output("2005",regi,"sesobio","fesob","tdbiosob") = f04_IO_output("2005",regi,"sesobio","fesob","tdbiosob") * (pm_fedemand("2005",regi,"fesob"))/(f04_IO_output("2005",regi,"sesobio","fesob","tdbiosob")+f04_IO_output("2005",regi,"sesofos","fesob","tdfossob"));
-f04_IO_output("2005",regi,"sesofos","fesob","tdfossob") = f04_IO_output("2005",regi,"sesofos","fesob","tdfossob") * (pm_fedemand("2005",regi,"fesob"))/(f04_IO_output("2005",regi,"sesobio","fesob","tdbiosob")+f04_IO_output("2005",regi,"sesofos","fesob","tdfossob"));
+
+
+*** save original input data
+p04_IO_output_beforeFix(t,regi,all_enty,all_enty2,all_te) = f04_IO_output(t,regi,all_enty,all_enty2,all_te);
+
+p04_IO_output_beforeFix_Total(t,regi,"fesob") = p04_IO_output_beforeFix(t,regi,"sesobio","fesob","tdbiosob")
+                                                  + p04_IO_output_beforeFix(t,regi,"sesofos","fesob","tdfossob");
+
+p04_IO_output_beforeFix_Total(t,regi,"fehob") = p04_IO_output_beforeFix(t,regi,"seliqbio","fehob","tdbiohob")
+                                                  + p04_IO_output_beforeFix(t,regi,"seliqfos","fehob","tdfoshob");
+
+*** adjust buildings solids
+f04_IO_output("2005",regi,"sesobio","fesob","tdbiosob")$(p04_IO_output_beforeFix_Total("2005",regi,"fesob")) = p04_IO_output_beforeFix("2005",regi,"sesobio","fesob","tdbiosob") * pm_fedemand("2005",regi,"fesob")/p04_IO_output_beforeFix_Total("2005",regi,"fesob");
+f04_IO_output("2005",regi,"sesofos","fesob","tdfossob")$(p04_IO_output_beforeFix_Total("2005",regi,"fesob")) = p04_IO_output_beforeFix("2005",regi,"sesofos","fesob","tdfossob") * pm_fedemand("2005",regi,"fesob")/p04_IO_output_beforeFix_Total("2005",regi,"fesob");
+
+*** adjust buildings liquids
+f04_IO_output("2005",regi,"seliqbio","fehob","tdbiohob")$(p04_IO_output_beforeFix_Total("2005",regi,"fehob")) = p04_IO_output_beforeFix("2005",regi,"seliqbio","fehob","tdbiohob") * pm_fedemand("2005",regi,"fehob")/p04_IO_output_beforeFix_Total("2005",regi,"fehob");
+f04_IO_output("2005",regi,"seliqfos","fehob","tdfoshob")$(p04_IO_output_beforeFix_Total("2005",regi,"fehob")) = p04_IO_output_beforeFix("2005",regi,"seliqfos","fehob","tdfoshob") * pm_fedemand("2005",regi,"fehob")/p04_IO_output_beforeFix_Total("2005",regi,"fehob");
+
+
+
+$ifthen.subsectors "%industry%" == "subsectors"   !! industry
+
+*** industry solids
+p04_IO_output_beforeFix_Total(t,regi,"fesoi") = p04_IO_output_beforeFix(t,regi,"sesobio","fesoi","tdbiosoi")
+                                                  + p04_IO_output_beforeFix(t,regi,"sesofos","fesoi","tdfossoi");
+
+
+f04_IO_output("2005",regi,"sesobio","fesoi","tdbiosoi")$(p04_IO_output_beforeFix_Total("2005",regi,"fesoi")) = p04_IO_output_beforeFix("2005",regi,"sesobio","fesoi","tdbiosoi")  
+                                                            *  ( pm_fedemand("2005",regi,"feso_otherInd")
+                                                               + pm_fedemand("2005",regi,"feso_cement")
+                                                               + pm_fedemand("2005",regi,"feso_steel")
+                                                               + pm_fedemand("2005",regi,"feso_chemicals"))
+                                                            /  p04_IO_output_beforeFix_Total("2005",regi,"fesoi");
+
+
+f04_IO_output("2005",regi,"sesofos","fesoi","tdfossoi")$(p04_IO_output_beforeFix_Total("2005",regi,"fesoi")) = p04_IO_output_beforeFix("2005",regi,"sesofos","fesoi","tdfossoi")  
+                                                            *  ( pm_fedemand("2005",regi,"feso_otherInd")
+                                                               + pm_fedemand("2005",regi,"feso_cement")
+                                                               + pm_fedemand("2005",regi,"feso_steel")
+                                                               + pm_fedemand("2005",regi,"feso_chemicals"))
+                                                            /  p04_IO_output_beforeFix_Total("2005",regi,"fesoi");
+
+*** industry liquids
+p04_IO_output_beforeFix_Total(t,regi,"fehoi") = p04_IO_output_beforeFix(t,regi,"seliqbio","fehoi","tdbiohoi")
+                                                  + p04_IO_output_beforeFix(t,regi,"seliqfos","fehoi","tdfoshoi");
+
+
+f04_IO_output("2005",regi,"seliqbio","fehoi","tdbiohoi")$(p04_IO_output_beforeFix_Total("2005",regi,"fehoi")) = p04_IO_output_beforeFix("2005",regi,"seliqbio","fehoi","tdbiohoi")  
+                                                            *  ( pm_fedemand("2005",regi,"feli_otherInd")
+                                                               + pm_fedemand("2005",regi,"feli_cement")
+                                                               + pm_fedemand("2005",regi,"feli_steel")
+                                                               + pm_fedemand("2005",regi,"feli_chemicals"))
+                                                            /  p04_IO_output_beforeFix_Total("2005",regi,"fehoi");
+
+
+f04_IO_output("2005",regi,"seliqfos","fehoi","tdfoshoi")$(p04_IO_output_beforeFix_Total("2005",regi,"fehoi")) = p04_IO_output_beforeFix("2005",regi,"seliqfos","fehoi","tdfoshoi")  
+                                                            *  ( pm_fedemand("2005",regi,"feli_otherInd")
+                                                               + pm_fedemand("2005",regi,"feli_cement")
+                                                               + pm_fedemand("2005",regi,"feli_steel")
+                                                               + pm_fedemand("2005",regi,"feli_chemicals"))
+                                                            /  p04_IO_output_beforeFix_Total("2005",regi,"fehoi");
+
+*** industry gases
+p04_IO_output_beforeFix_Total(t,regi,"fegai") = p04_IO_output_beforeFix(t,regi,"segabio","fegai","tdbiogai")
+                                                  + p04_IO_output_beforeFix(t,regi,"segafos","fegai","tdfosgai");
+
+
+f04_IO_output("2005",regi,"segabio","fegai","tdbiogai")$(p04_IO_output_beforeFix_Total("2005",regi,"fegai")) = p04_IO_output_beforeFix("2005",regi,"segabio","fegai","tdbiogai")  
+                                                            *  ( pm_fedemand("2005",regi,"fega_otherInd")
+                                                               + pm_fedemand("2005",regi,"fega_cement")
+                                                               + pm_fedemand("2005",regi,"fega_steel")
+                                                               + pm_fedemand("2005",regi,"fega_chemicals"))
+                                                            /  p04_IO_output_beforeFix_Total("2005",regi,"fegai");
+
+
+f04_IO_output("2005",regi,"segafos","fegai","tdfosgai")$(p04_IO_output_beforeFix_Total("2005",regi,"fegai")) = p04_IO_output_beforeFix("2005",regi,"segafos","fegai","tdfosgai")  
+                                                            *  ( pm_fedemand("2005",regi,"fega_otherInd")
+                                                               + pm_fedemand("2005",regi,"fega_cement")
+                                                               + pm_fedemand("2005",regi,"fega_steel")
+                                                               + pm_fedemand("2005",regi,"fega_chemicals"))
+                                                            /  p04_IO_output_beforeFix_Total("2005",regi,"fegai");
+
+
+
+*** industry heat
+p04_IO_output_beforeFix_Total(t,regi,"fehei") = p04_IO_output_beforeFix(t,regi,"sehe","fehei","tdhei")
+                                                  + p04_IO_output_beforeFix(t,regi,"sehe","fehei","tdhei");
+
+
+f04_IO_output("2005",regi,"sehe","fehei","tdhei")$(p04_IO_output_beforeFix_Total("2005",regi,"fehei")) = p04_IO_output_beforeFix("2005",regi,"sehe","fehei","tdhei")  
+                                                            *  ( pm_fedemand("2005",regi,"fehe_otherInd")
+                                                              )
+                                                            /  p04_IO_output_beforeFix_Total("2005",regi,"fehei");
+
+$endif.subsectors
+
+*** end adjustment of f04_IO_output to pm_fedemand values
 
 *** convert data from EJ to TWa
 f04_IO_input(ttot,regi,all_enty,all_enty2,all_te) = f04_IO_input(ttot,regi,all_enty,all_enty2,all_te) * sm_EJ_2_TWa;

--- a/modules/04_PE_FE_parameters/iea2014/datainput.gms
+++ b/modules/04_PE_FE_parameters/iea2014/datainput.gms
@@ -116,8 +116,7 @@ f04_IO_output("2005",regi,"segafos","fegai","tdfosgai")$(p04_IO_output_beforeFix
 
 
 *** industry heat
-p04_IO_output_beforeFix_Total(t,regi,"fehei") = p04_IO_output_beforeFix(t,regi,"sehe","fehei","tdhei")
-                                                  + p04_IO_output_beforeFix(t,regi,"sehe","fehei","tdhei");
+p04_IO_output_beforeFix_Total(t,regi,"fehei") = p04_IO_output_beforeFix(t,regi,"sehe","fehei","tdhei");
 
 
 f04_IO_output("2005",regi,"sehe","fehei","tdhei")$(p04_IO_output_beforeFix_Total("2005",regi,"fehei")) = p04_IO_output_beforeFix("2005",regi,"sehe","fehei","tdhei")  

--- a/modules/04_PE_FE_parameters/iea2014/declarations.gms
+++ b/modules/04_PE_FE_parameters/iea2014/declarations.gms
@@ -17,4 +17,8 @@ p04_shOilGasEx(all_regi, all_enty)                              "share of oil an
 p04_fuExtr(all_regi, all_enty)                                  "regional fuel extraction for the base year calibration"
 pm_histfegrowth(all_regi,all_enty)                              "average growth rate of fe use from 1995 to 2005"
 p04_prodCoupleGlob(all_enty,all_enty,all_te,all_enty)           "global couple products"
+
+
+p04_IO_output_beforeFix(ttot,all_regi,all_enty,all_enty,all_te)        "Energy output based on IEA data as read in from input data before correction from FE trajectories"
+p04_IO_output_beforeFix_Total(ttot,all_regi,all_enty)                         "Energy output based on IEA data as read in from input data before correction from FE trajectories summed over SE"
 ;


### PR DESCRIPTION
This PR addresses the [historic biomass vs. fossil split issue](https://github.com/remindmodel/development_issues/issues/37) and provides a quick fix for the input data inconsistency between the 2005 calibration and the CES calibration FE trajectories. 
 
* rescaling of ``f04_IO_output`` 2005 FE data used for the 2005 se2fe capacity calibration of REMIND to be in line with the FE data provided by ``pm_fedemand`` for the CES calibration, this is a quick fix; the long-term solution should be to make both input data in line in mrremind. It mainly affects solids/liquids/gases in buildings and industry. 

* activate the ``q_shbiofe_lo`` and ``q_shbiofe_up`` constraints again under industry subsectors to constrain biomass shares to historic levels

You find a comparison PDF here: ``/p/tmp/schreyer/Modeling/REMIND_H12/NewDev/compScen-2021-12-08_17.25.03-H12`` (default_2 is the "fixed" version). 