### PR TITLE
Update input data to rev 6.275

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -22,7 +22,7 @@ cfg$title <- "default"
 cfg$regionmapping <- "config/regionmappingH12.csv"
 
 #### Current input data revision (<mainrevision>.<subrevision>) ####
-cfg$inputRevision <- 6.273
+cfg$inputRevision <- 6.275
 
 #### Current CES parameter and GDX revision (commit hash) ####
 cfg$CESandGDXversion <- "3e7e897aa8575d6512c222eb3a47604fd2c68d13"


### PR DESCRIPTION
I was irritated that there are only 2 instead of the usual 4 files (regionmappings). Is it okay to only have `2b1450bc` and `62eff8f7`? Otherwise we should not merge this.