### PR TITLE
add filename_prefix and slurmConfig to output.R with compareScenario

### DIFF
--- a/output.R
+++ b/output.R
@@ -138,7 +138,7 @@ choose_mode <- function(title = "Please choose the output mode") {
 }
 
 choose_slurmConfig_priority_standby <- function(title = "Please enter the slurm mode, uses priority if empty") {
-  slurm_options <- c("--qos=priority", "--qos=short", "--qos=standby")
+  slurm_options <- c("priority", "short", "standby")
   cat("\n\n", title, ":\n\n")
   cat(paste(seq_along(slurm_options), slurm_options, sep = ": "), sep = "\n")
   cat("\nNumber: ")
@@ -213,8 +213,10 @@ if (comp == TRUE) {
   if (!exists("slurmConfig") && any(modules_using_slurmConfig %in% output)) {
     slurmConfig <- choose_slurmConfig_priority_standby()
   }
-  if (slurmConfig %in% c("priority", "short", "standby")) {
-    slurmConfig <- paste0("--qos=", slurmConfig)
+  if (exists("slurmConfig")) {
+    if (slurmConfig %in% c("priority", "short", "standby")) {
+      slurmConfig <- paste0("--qos=", slurmConfig)
+    }
   }
 
   # Set value source_include so that loaded scripts know, that they are

--- a/output.R
+++ b/output.R
@@ -29,7 +29,7 @@ library(gms)
 if (!exists("source_include")) {
   # if this script is not being sourced by another script but called from the command line via Rscript read the command
   # line arguments and let the user choose the slurm options
-  readArgs("outputdir", "output", "comp", "remind_dir")
+  readArgs("outputdir", "output", "comp", "remind_dir", "filename_identifier")
 }
 
 # Setting relevant paths
@@ -137,6 +137,15 @@ choose_mode <- function(title = "Please choose the output mode") {
   return(comp)
 }
 
+choose_filename_identifier <- function(modules, title = "Please choose identifier for filenames, using A-Za-z0-9_-, or leave empty,") {
+  cat("\n\n", title, "for", paste(modules, collapse=", "), ":\n\n")
+  filename_identifier <- get_line()
+  if(grepl("[^A-Za-z0-9_-]", filename_identifier)) {
+    filename_identifier <- choose_filename_identifier(modules, title = paste("No, this contained special characters, try again.\n",title))
+  }
+  return(filename_identifier)
+}
+
 if (exists("source_include")) {
   comp <- FALSE
 } else if (!exists("comp")) {
@@ -171,6 +180,16 @@ if (comp == TRUE) {
     }
   } else {
     outputdirs <- outputdir
+  }
+
+  # ask for filename_identifier, if one of the modules that use it is selected
+  modules_using_filename_identifier = c("compareScenarios")
+  if (!exists("filename_identifier")) {
+    if (any(modules_using_filename_identifier %in% output)) {
+      filename_identifier <- choose_filename_identifier(modules = modules_using_filename_identifier[modules_using_filename_identifier %in% output])
+    } else {
+      filename_identifier <- ""
+    }
   }
 
   # Set value source_include so that loaded scripts know, that they are

--- a/output.R
+++ b/output.R
@@ -138,7 +138,7 @@ choose_mode <- function(title = "Please choose the output mode") {
 }
 
 choose_slurmConfig_priority_standby <- function(title = "Please enter the slurm mode, uses priority if empty") {
-  slurm_options <- c("--qos=priority", "--qos=standby")
+  slurm_options <- c("--qos=priority", "--qos=short", "--qos=standby")
   cat("\n\n", title, ":\n\n")
   cat(paste(seq_along(slurm_options), slurm_options, sep = ": "), sep = "\n")
   cat("\nNumber: ")
@@ -202,13 +202,8 @@ if (comp == TRUE) {
   modules_using_filename_prefix <- c("compareScenarios")
   if (!exists("filename_prefix")) {
     if (any(modules_using_filename_prefix %in% output)) {
-      filename_prefix <- choose_filename_prefix(modules = modules_using_filename_prefix[modules_using_filename_prefix %in% output])
+      filename_prefix <- choose_filename_prefix(modules = intersect(modules_using_filename_prefix, output))
     } else {
-      filename_prefix <- ""
-    }
-  } else {
-    # because readArgs cannot treat empty strings, `no prefix` is specified by `-`
-    if (filename_prefix == "-") {
       filename_prefix <- ""
     }
   }
@@ -218,7 +213,7 @@ if (comp == TRUE) {
   if (!exists("slurmConfig") && any(modules_using_slurmConfig %in% output)) {
     slurmConfig <- choose_slurmConfig_priority_standby()
   }
-  if (slurmConfig %in% c("priority", "standby")) {
+  if (slurmConfig %in% c("priority", "short", "standby")) {
     slurmConfig <- paste0("--qos=", slurmConfig)
   }
 

--- a/scripts/output/comparison/compareScenarios.R
+++ b/scripts/output/comparison/compareScenarios.R
@@ -75,16 +75,20 @@ if("EUR" %in% names(regionSubsetList)){
 for (r in listofruns) {
   # Create multiple pdf files for H12 and subregions of H12
   for (reg in c("H12",names(regionSubsetList))){
-    fileName <- paste0(r$set, "-" , reg)
-	if (reg=="H12")
-	  regionList <- c("GLO","LAM","OAS","SSA","EUR","NEU","MEA","REF","CAZ","CHA","IND","JPN","USA")
-	else
-	  regionList <- c(reg,regionSubsetList[[reg]])
-	if (reg=="H12")
-	  mainRegName <- c("GLO")
-	else
-	  mainRegName <- c(reg)
-	if (r$period == "short" | r$period == "both") start_comp(outputdirs = r$dirs, shortTerm = TRUE,  outfilename = fileName, regionList=regionList, mainReg=mainRegName)
-	if (r$period == "long"  | r$period == "both") start_comp(outputdirs = r$dirs, shortTerm = FALSE, outfilename = fileName, regionList=regionList, mainReg=mainRegName)
+    if (exists("filename_identifier")) {
+      fileName <- paste0(filename_identifier, ifelse(filename_identifier=="","","-") ,r$set, "-" , reg)
+    } else {
+      fileName <- paste0(r$set, "-" , reg)
+    }
+    if (reg=="H12")
+      regionList <- c("GLO","LAM","OAS","SSA","EUR","NEU","MEA","REF","CAZ","CHA","IND","JPN","USA")
+    else
+      regionList <- c(reg,regionSubsetList[[reg]])
+    if (reg=="H12")
+      mainRegName <- c("GLO")
+    else
+      mainRegName <- c(reg)
+    if (r$period == "short" | r$period == "both") start_comp(outputdirs = r$dirs, shortTerm = TRUE,  outfilename = fileName, regionList=regionList, mainReg=mainRegName)
+    if (r$period == "long"  | r$period == "both") start_comp(outputdirs = r$dirs, shortTerm = FALSE, outfilename = fileName, regionList=regionList, mainReg=mainRegName)
   }
 }

--- a/scripts/output/comparison/compareScenarios.R
+++ b/scripts/output/comparison/compareScenarios.R
@@ -45,10 +45,13 @@ for (i in 1:length(listofruns)) {
 # ---- Start compareScenarios either on the cluster or locally ----
 
 start_comp <- function(outputdirs,shortTerm,outfilename,regionList,mainReg) {
+  if(!exists("slurmConfig")) {
+    slurmConfig <- "--qos=standby"
+  }
   jobname <- paste0("compScen",ifelse(outfilename=="","","-"),outfilename,ifelse(shortTerm, "-shortTerm", ""))
   cat("Starting ",jobname,"\n")
   on_cluster <- file.exists("/p/projects/")
-  cat(paste0("sbatch --qos=standby --job-name=",jobname," --output=",jobname,".out --error=",jobname,".err --mail-type=END --time=200 --mem-per-cpu=8000 --wrap=\"Rscript scripts/utils/run_compareScenarios.R outputdirs=",paste(outputdirs,collapse=",")," shortTerm=",shortTerm," outfilename=",jobname," regionList=",paste(regionList,collapse=",")," mainRegName=",mainReg,"\""))
+  cat(paste0("sbatch ", slurmConfig, " --job-name=",jobname," --output=",jobname,".out --error=",jobname,".err --mail-type=END --time=200 --mem-per-cpu=8000 --wrap=\"Rscript scripts/utils/run_compareScenarios.R outputdirs=",paste(outputdirs,collapse=",")," shortTerm=",shortTerm," outfilename=",jobname," regionList=",paste(regionList,collapse=",")," mainRegName=",mainReg,"\""))
   if (on_cluster) {
     clcom <- paste0("sbatch --qos=standby --job-name=",jobname," --output=",jobname,".out --error=",jobname,".err --mail-type=END --time=200 --mem-per-cpu=8000 --wrap=\"Rscript scripts/utils/run_compareScenarios.R outputdirs=",paste(outputdirs,collapse=",")," shortTerm=",shortTerm," outfilename=",jobname," regionList=",paste(regionList,collapse=",")," mainRegName=",mainReg,"\"")
     system(clcom)
@@ -75,8 +78,8 @@ if("EUR" %in% names(regionSubsetList)){
 for (r in listofruns) {
   # Create multiple pdf files for H12 and subregions of H12
   for (reg in c("H12",names(regionSubsetList))){
-    if (exists("filename_identifier")) {
-      fileName <- paste0(filename_identifier, ifelse(filename_identifier=="","","-") ,r$set, "-" , reg)
+    if (exists("filename_prefix")) {
+      fileName <- paste0(filename_prefix, ifelse(filename_prefix=="","","-") ,r$set, "-" , reg)
     } else {
       fileName <- paste0(r$set, "-" , reg)
     }

--- a/tutorials/5_AnalysingModelOutputs.md
+++ b/tutorials/5_AnalysingModelOutputs.md
@@ -2,22 +2,22 @@ Analyzing REMIND model outputs
 ================
 Felix Scheyer (<felix.schreyer@pik-potsdam.de>), Isabelle Weindl (<weindl@pik-potsdam.de>), Lavinia Baumstark (<baumstark@pik-potsdam.de>)
 
--   [1. Introduction](#introduction)
--   [2. Model output files](#model-output-files)
--   [3. Loading and analyzing model output in R](#loading-and-analyzing-model-output-in-r)
-    - [3.1 Access Cluster](###Access-Cluster)
-    - [3.2 Load mif-file as Magpie Object](#load-mif-file-as-magpie-object)
-    - [3.3 Load mif file as quitte Object](#load-mif-file-as-quitte-object)
-    - [3.4 Load gdx file as magpie object](#load-gdx-file-as-magpie-object)
--   [4. Automated model validation](#automated-model-validation)
-    -   [4.1. Generation of validation pdfs](#generation-of-validation-pdfs)
-    -   [4.2 A Summary of Results](#summary-of-results)
-    -   [4.3 The Whole Range of Validation](#whole-range-of-validation)
--   [5. Interactive scenario analysis](#interactive-scenario-analysis)
-    -   [5.1. AppResults](#appResults)
--   [6. Model-internal R-scripts for output analysis](#model-internal-r-scripts-for-output-analysis)
-    -   [6.1. Execution of model-internal output scripts via the REMIND configuration file](#execution-of-model-internal-output-scripts-via-the-remind-configuration-file)
-    -   [6.2. Execution of model-internal output scripts in the command window](#execution-of-model-internal-output-scripts-in-the-command-window)
+-   [1. Introduction](#1-introduction)
+-   [2. Model output files](#2-model-output-files)
+-   [3. Loading and analyzing model output in R](#3-loading-and-analyzing-model-output-in-r)
+    - [3.1 Access the Cluster](#31-access-the-cluster)
+    - [3.2 Load mif-file as Magpie Object](#32-load-a-mif-file-as-a-magpie-object)
+    - [3.3 Load mif file as quitte Object](#33-load-a-mif-file-as-a-quitte-object)
+    - [3.4 Load gdx file as magpie object](#34-load-a-gdx-file-as-a-magpie-object)
+-   [4. Automated model validation](#4-automated-model-validation)
+    -   [4.1. Generation of validation pdfs](#41-generation-of-summary-and-validation-pdfs)
+    -   [4.2 A Summary of Results](#42-a-summary-of-results)
+    -   [4.3 The Whole Range of Validation](#43-the-whole-range-of-validation)
+-   [5. Interactive scenario analysis](#5-interactive-scenario-analysis)
+    -   [5.1. AppResults](#51-appresults)
+-   [6. Model-internal R-scripts for output analysis](#6-model-internal-r-scripts-for-output-analysis)
+    -   [6.1. Execution of model-internal output scripts via the REMIND configuration file](#61-execution-of-model-internal-output-scripts-via-the-remind-configuration-file)
+    -   [6.2. Execution of model-internal output scripts in the command window](#62-execution-of-model-internal-output-scripts-in-the-command-window)
 
 
 ## 1. Introduction
@@ -175,8 +175,15 @@ In both cases, you can choose from the list of available model scenarios, for wh
 
 Now, the selected scripts are executed. After completion, the results are written in the respective folder of the run (combination of **model title** name and the **current date** inside the **output** folder of the model).
 
-One recommended script for comparison of different scenarios is compareScenarios. How to create new plots is described in the tutorial 8_Advanced_AnalysingModelOutputs.Rmd. 
+One recommended script for comparison of different scenarios is `compareScenarios`. After you selected folder names, specified a `filename_prefix` and the priority on the cluster, it produces two large PDF in the `./remind/` folder, one `shortTerm` with a 2050 time horizon and one until 2100.
 
+You can also specify the parameters in the command line, for example starting a `compareScenario` run without any prefix as:
+
+```
+Rscript output.R comp=TRUE filename_prefix=- output=compareScenarios slurmConfig=priority
+```
+
+How to create new plots is described in the tutorial [8_Advanced_AnalysingModelOutputs.Rmd](./8_Advanced_AnalysingModelOutputs.Rmd).
 
 ## 7. Analysis of outputs with the remind package
 
@@ -196,4 +203,3 @@ library(remind2)
 ```
 
 You can click on the index and search for interesting functions. All functions used to generate the reporting start with "reporting*.R".
-

--- a/tutorials/5_AnalysingModelOutputs.md
+++ b/tutorials/5_AnalysingModelOutputs.md
@@ -179,8 +179,8 @@ One recommended script for comparison of different scenarios is `compareScenario
 
 You can also specify the parameters in the command line, for example starting a `compareScenario` run without any prefix as:
 
-```
-Rscript output.R comp=TRUE filename_prefix=- output=compareScenarios slurmConfig=priority
+``` bash
+Rscript output.R comp=TRUE filename_prefix= output=compareScenarios slurmConfig=priority
 ```
 
 How to create new plots is described in the tutorial [8_Advanced_AnalysingModelOutputs.Rmd](./8_Advanced_AnalysingModelOutputs.Rmd).


### PR DESCRIPTION
this adds the possibility to specify a filename_prefix and the slurmConfig (priority vs. standby) for the compareScenario run of output.R.

If compareScenario is selected, the script asks to enter a filename_prefix and checks whether it contains only letters, numbers, `-` or `_` to be safe. In any case, the filename of the final pdf then reads something like `compScen-whatever-2022-01-05_17.36.03-H12.pdf`. If left empty, everything should remain as it is. As I know that these scripts are called from many other scripts, my extension carefully checks whether `filename_prefix` exists to be sure not to break anything.

If compareScenario is selected, the scripts asks you to run it under slurmCondig priority or standby.

Alternatively, these information can be specified by running `Rscript output.R filename_prefix=whatever slurmConfig=priority`. If you require more specific slurm configs that contains blanks, write it as `slurmConfig="--qos=priority --further=data"`.

If further scripts in `scripts/output/comparison` want to use this, simply add it their names to `modules_using_filename_prefix` resp. `modules_using_slurmConfig` and use it. This is done to avoid annoying people that use other output scripts, as they aren't asked now to specify something that is not used later.