### PR TITLE
output.R regex fix

### DIFF
--- a/output.R
+++ b/output.R
@@ -199,7 +199,7 @@ if (comp == TRUE) {
   }
 
   # ask for filename_prefix, if one of the modules that use it is selected
-  modules_using_filename_prefix <- c("compareScenarios")
+  modules_using_filename_prefix <- c("compareScenarios", "compareScenarios2")
   if (!exists("filename_prefix")) {
     if (any(modules_using_filename_prefix %in% output)) {
       filename_prefix <- choose_filename_prefix(modules = intersect(modules_using_filename_prefix, output))
@@ -209,7 +209,7 @@ if (comp == TRUE) {
   }
 
   # choose the slurm options. If you use command line arguments, use slurmConfig=priority or standby
-  modules_using_slurmConfig <- c("compareScenarios")
+  modules_using_slurmConfig <- c("compareScenarios", "compareScenarios2")
   if (!exists("slurmConfig") && any(modules_using_slurmConfig %in% output)) {
     slurmConfig <- choose_slurmConfig_priority_standby()
   }
@@ -223,7 +223,7 @@ if (comp == TRUE) {
   # included as source (instead of a load from command line)
   source_include <- TRUE
 
-  # Execute output scripts over all choosen folders
+  # Execute output scripts over all chosen folders
   for (rout in output) {
     name <- paste(rout, ".R", sep = "")
     if (file.exists(paste("scripts/output/comparison/", name, sep = ""))) {

--- a/output.R
+++ b/output.R
@@ -60,7 +60,7 @@ choose_folder <- function(folder, title = "Please choose a folder") {
   # Detect all output folders containing fulldata.gdx
   # For coupled runs please use the outcommented text block below
 
-  dirs <- sub("/fulldata.gdx", "", sub("./output/", "", Sys.glob(file.path(folder, "*", "fulldata.gdx"))))
+  dirs <- sub("/fulldata\\.gdx$", "", sub("^\\./output/", "", Sys.glob(file.path(folder, "*", "fulldata.gdx"))))
 
   # DK: The following outcommented lines are specially made for listing results of coupled runs
   # runs <- findCoupledruns(folder)

--- a/scripts/output/comparison/compareScenarios2.R
+++ b/scripts/output/comparison/compareScenarios2.R
@@ -82,13 +82,14 @@ start_comp <- function(outputdirs,
     )
   cat("Starting ", jobname, "\n")
   on_cluster <- file.exists("/p/projects/")
+  script <- "scripts/utils/run_compareScenarios2.R"
   clcom <- paste0(
-    "sbatch --qos=standby",
+    "sbatch ", slurmConfig,
     " --job-name=", jobname,
     " --output=", jobname, ".out",
     " --error=", jobname, ".err",
     " --mail-type=END --time=200 --mem-per-cpu=8000",
-    " --wrap=\"Rscript scripts/utils/run_compareScenarios2.R",
+    " --wrap=\"Rscript ", script,
     " outputdirs=", paste(outputdirs, collapse = ","),
     " shortTerm=", shortTerm,
     " outfilename=", jobname,
@@ -100,7 +101,6 @@ start_comp <- function(outputdirs,
   } else {
     outfilename <- jobname
     tmp.env <- new.env()
-    script <- "scripts/utils/run_compareScenarios2.R"
     tmp.error <- try(sys.source(script, envir = tmp.env))
     if (!is.null(tmp.error))
       warning("Script ", script, " was stopped by an error and not executed properly!")

--- a/scripts/output/comparison/compareScenarios2.R
+++ b/scripts/output/comparison/compareScenarios2.R
@@ -1,0 +1,140 @@
+# |  (C) 2006-2022 Potsdam Institute for Climate Impact Research (PIK)
+# |  authors, and contributors see CITATION.cff file. This file is part
+# |  of REMIND and licensed under AGPL-3.0-or-later. Under Section 7 of
+# |  AGPL-3.0, you are granted additional permissions described in the
+# |  REMIND License Exception, version 1.0 (see LICENSE file).
+# |  Contact: remind@pik-potsdam.de
+# ---- Define set of runs that will be compared ----
+
+if (exists("outputdirs")) {
+  # This is the case if this script was called via Rscript output.R
+  listofruns <- list(list(
+    period = "both",
+    set = format(Sys.time(), "%Y-%m-%d_%H.%M.%S"),
+    dirs = outputdirs))
+} else {
+  # This is the case if this script was called directly via Rscript
+  listofruns <- list(
+    list(
+      period = "both",
+      set = "cpl-Base",
+      dirs = c("C_SDP-Base-rem-5","C_SSP1-Base-rem-5","C_SSP2-Base-rem-5","C_SSP5-Base-rem-5")),
+    list(
+      period = "both",
+      set = "cpl-PkBudg900",
+      dirs = c("C_SDP-PkBudg900-rem-5","C_SSP1-PkBudg900-rem-5","C_SSP2-PkBudg900-rem-5","C_SSP5-PkBudg900-rem-5")),
+    list(
+      period = "both",
+      set = "cpl-PkBudg1100",
+      dirs = c("C_SDP-PkBudg1100-rem-5","C_SSP1-PkBudg1100-rem-5","C_SSP2-PkBudg1100-rem-5","C_SSP5-PkBudg1100-rem-5")),
+    list(
+      period = "both",
+      set = "cpl-PkBudg1300",
+      dirs = c("C_SDP-PkBudg1300-rem-5","C_SSP1-PkBudg1300-rem-5","C_SSP2-PkBudg1300-rem-5","C_SSP5-PkBudg1300-rem-5")),
+    list(
+      period = "both",
+      set = "cpl-NPi",
+      dirs = c("C_SDP-NPi-rem-5","C_SSP1-NPi-rem-5","C_SSP2-NPi-rem-5","C_SSP5-NPi-rem-5")),
+    list(
+      period = "both",
+      set = "cpl-SDP",
+      dirs = c("C_SDP-Base-rem-5","C_SDP-NPi-rem-5","C_SDP-PkBudg1300-rem-5","C_SDP-PkBudg1100-rem-5","C_SDP-PkBudg1000-rem-5")),
+    list(
+      period = "both",
+      set = "cpl-SSP1",
+      dirs = c("C_SSP1-Base-rem-5","C_SSP1-NPi-rem-5","C_SSP1-PkBudg1300-rem-5","C_SSP1-PkBudg1100-rem-5","C_SSP1-PkBudg900-rem-5")),
+    list(
+      period = "both",
+      set = "cpl-SSP2",
+      dirs = c("C_SSP2-Base-rem-5","C_SSP2-NPi-rem-5","C_SSP2-PkBudg1300-rem-5","C_SSP2-PkBudg1100-rem-5","C_SSP2-PkBudg900-rem-5","C_SSP2-NDC-rem-5")),
+    list(
+      period = "both",
+      set = "cpl-SSP5",
+      dirs = c("C_SSP5-Base-rem-5","C_SSP5-NPi-rem-5","C_SSP5-PkBudg1300-rem-5","C_SSP5-PkBudg1100-rem-5","C_SSP5-PkBudg900-rem-5")))
+}
+
+# remove the NULL element
+listofruns <- listofruns[!sapply(listofruns, is.null)]
+
+# if no path in "dirs" starts with "output/" insert it at the beginning
+# this is the case if listofruns was created in the lower case above !exists("outputdirs"), i.e. if this script was not called via Rscript output.R
+for (i in 1:length(listofruns)) {
+  if (!any(grepl("output/", listofruns[[i]]$dirs))) {
+    listofruns[[i]]$dirs <- paste0("output/", listofruns[[i]]$dirs)
+  }
+}
+
+# ---- Start compareScenarios either on the cluster or locally ----
+
+start_comp <- function(outputdirs,
+                       shortTerm,
+                       outfilename,
+                       regionList,
+                       mainReg) {
+  if (!exists("slurmConfig")) {
+    slurmConfig <- "--qos=standby"
+  }
+  jobname <- paste0(
+      "cs2",
+      ifelse(outfilename == "", "", "-"),
+      outfilename,
+      ifelse(shortTerm, "-shortTerm", "")
+    )
+  cat("Starting ", jobname, "\n")
+  on_cluster <- file.exists("/p/projects/")
+  clcom <- paste0(
+    "sbatch --qos=standby",
+    " --job-name=", jobname,
+    " --output=", jobname, ".out",
+    " --error=", jobname, ".err",
+    " --mail-type=END --time=200 --mem-per-cpu=8000",
+    " --wrap=\"Rscript scripts/utils/run_compareScenarios2.R",
+    " outputdirs=", paste(outputdirs, collapse = ","),
+    " shortTerm=", shortTerm,
+    " outfilename=", jobname,
+    " regionList=", paste(regionList, collapse = ","),
+    " mainRegName=", mainReg, "\"")
+  cat(clcom, "\n")
+  if (on_cluster) {
+    system(clcom)
+  } else {
+    outfilename <- jobname
+    tmp.env <- new.env()
+    script <- "scripts/utils/run_compareScenarios2.R"
+    tmp.error <- try(sys.source(script, envir = tmp.env))
+    if (!is.null(tmp.error))
+      warning("Script ", script, " was stopped by an error and not executed properly!")
+    rm(tmp.env)
+  }
+}
+
+# ---- For each list entry call start script that starts compareScenarios ----
+regionSubsetList <- remind2::toolRegionSubsets(file.path(listofruns[[1]]$dirs, "fulldata.gdx"))
+# ADD EU-27 region aggregation if possible
+if ("EUR" %in% names(regionSubsetList)) {
+  regionSubsetList <- c(regionSubsetList, list(
+    "EU27" = c("ENC", "EWN", "ECS", "ESC", "ECE", "FRA", "DEU", "ESW"))) # EU27 (without Ireland)
+}
+
+for (r in listofruns) {
+  # Create multiple pdf files for H12 and subregions of H12
+  for (reg in c("H12", names(regionSubsetList))) {
+    if (exists("filename_prefix")) {
+      fileName <- paste0(filename_prefix, ifelse(filename_prefix == "", "", "-"), r$set, "-", reg)
+    } else {
+      fileName <- paste0(r$set, "-", reg)
+    }
+    if (reg == "H12")
+      regionList <- c("World","LAM","OAS","SSA","EUR","NEU","MEA","REF","CAZ","CHA","IND","JPN","USA")
+    else
+      regionList <- c(reg, regionSubsetList[[reg]])
+    if (reg == "H12")
+      mainRegName <- "World"
+    else
+      mainRegName <- reg
+    if (r$period == "short" | r$period == "both")
+      start_comp(outputdirs=r$dirs, shortTerm=TRUE, outfilename=fileName, regionList=regionList, mainReg=mainRegName)
+    if (r$period == "long" | r$period == "both")
+      start_comp(outputdirs=r$dirs, shortTerm=FALSE, outfilename=fileName, regionList=regionList, mainReg=mainRegName)
+  }
+}

--- a/scripts/utils/run_compareScenarios2.R
+++ b/scripts/utils/run_compareScenarios2.R
@@ -1,0 +1,70 @@
+# |  (C) 2006-2020 Potsdam Institute for Climate Impact Research (PIK)
+# |  authors, and contributors see CITATION.cff file. This file is part
+# |  of REMIND and licensed under AGPL-3.0-or-later. Under Section 7 of
+# |  AGPL-3.0, you are granted additional permissions described in the
+# |  REMIND License Exception, version 1.0 (see LICENSE file).
+# |  Contact: remind@pik-potsdam.de
+library(lucode2) # getScenNames
+library(remind2)
+
+if (!exists("source_include")) {
+  readArgs("outputdirs")
+  readArgs("shortTerm")
+  readArgs("outfilename")
+  readArgs("regionList")
+  readArgs("mainRegName")
+}
+
+run_compareScenarios2 <- function(outputdirs, shortTerm, outfilename, regionList, mainRegName) {
+
+  scenNames <- getScenNames(outputdirs)
+  # Add '../' in front of the paths as compareScenarios2() will be run in individual temporary subfolders (see below).
+  mif_path  <- file.path("..", outputdirs, paste("REMIND_generic_", scenNames, ".mif", sep = ""))
+  hist_path <- file.path("..", outputdirs[1], "historical.mif")
+
+  # Create temporary folder. This is necessary because each compareScenarios2 creates a folder names 'figure'.
+  # If multiple compareScenarios2 run in parallel they would interfere with the others' figure folder.
+  # So we create a temporary subfolder in which each compareScenarios2 creates its own figure folder.
+  system(paste0("mkdir ", outfilename))
+  outfilename <- normalizePath(outfilename) # Make path absolute.
+  wd <- getwd()
+
+  setwd(outfilename)
+  # remove temporary folder
+  on.exit(system(paste0("mv ", outfilename, ".pdf ..")))
+  on.exit(setwd(wd), add = TRUE)
+  on.exit(system(paste0("rm -rf ", outfilename)), add = TRUE)
+
+  # Make paths absolute.
+  mif_path <- normalizePath(mif_path)
+  hist_path <- normalizePath(hist_path)
+
+  splt <- strsplit(outfilename, "/", fixed=TRUE)[[1]]
+  outputFile <- splt[length(splt)]
+  outputDir <- paste(splt[-length(splt)], collapse="/")
+
+  if (!shortTerm) {
+    try(compareScenarios2(
+      mifScen = mif_path,
+      mifHist = hist_path,
+      outputDir = outputDir,
+      outputFile = outputFile,
+      outputFormat = "PDF",
+      reg = regionList,
+      mainReg = mainRegName))
+  } else {
+    try(compareScenarios2(
+      mifScen = mif_path,
+      mifHist = hist_path,
+      outputDir = outputDir,
+      outputFile = outputFile,
+      outputFormat = "PDF",
+      reg = regionList,
+      mainReg = mainRegName,
+      yearsScen = seq(2005, 2050, 5),
+      yearsHist = c(seq(1990, 2020, 1), seq(2025, 2050, 5)),
+      yearsBarPlot = c(2010, 2030, 2050)))
+  }
+}
+
+run_compareScenarios2(outputdirs, shortTerm, outfilename, regionList, mainRegName)


### PR DESCRIPTION
The first argument of `sub()` is a regex-pattern, in which the `.` is a wildcard. If I understand the intention of the modified line of code correctly, it should only the symbol `.` should be matched and the matches should occur at the beginning and end of the strings respectively. The regex-pattern is modified to achieve this.