### PR TITLE
fix regex in output.R

### DIFF
--- a/output.R
+++ b/output.R
@@ -60,7 +60,7 @@ choose_folder <- function(folder, title = "Please choose a folder") {
   # Detect all output folders containing fulldata.gdx
   # For coupled runs please use the outcommented text block below
 
-  dirs <- sub("/fulldata\\.gdx$", "", sub("^\\./output/", "", Sys.glob(file.path(folder, "*", "fulldata.gdx"))))
+  dirs <- basename(dirname(Sys.glob(file.path(folder, "*", "fulldata.gdx"))))
 
   # DK: The following outcommented lines are specially made for listing results of coupled runs
   # runs <- findCoupledruns(folder)

--- a/output.R
+++ b/output.R
@@ -60,7 +60,7 @@ choose_folder <- function(folder, title = "Please choose a folder") {
   # Detect all output folders containing fulldata.gdx
   # For coupled runs please use the outcommented text block below
 
-  dirs <- sub("/fulldata.gdx", "", sub("./output/", "", Sys.glob(file.path(folder, "*", "fulldata.gdx"))))
+  dirs <- sub("/fulldata\\.gdx$", "", sub("^\\./output/", "", Sys.glob(file.path(folder, "*", "fulldata.gdx"))))
 
   # DK: The following outcommented lines are specially made for listing results of coupled runs
   # runs <- findCoupledruns(folder)


### PR DESCRIPTION
The first argument of [`sub()`](https://github.com/remindmodel/remind/blob/49f1db07fd3a2b3167be7d229975212f3f5be4fe/output.R#L63) is a regex-pattern, in which the `.` is a wildcard. If I understand the intention of the modified line of code correctly, only the symbol `.` should be matched and the matches should occur at the beginning and end of the strings, respectively. The regex-patterns are modified to achieve this.