### PR TITLE
fix cm_secondary_steel_bound default setting ("scenario" instead of "none")

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -283,21 +283,21 @@ cfg$gms$cm_co2_tax_growth         <- 1.05           # def <- 1.05
 cfg$gms$c_macscen                 <- 1              # def <- 1
 cfg$gms$cm_CO2TaxSectorMarkup     <- "off"          # def <- "off"
 
-cfg$gms$cm_nucscen                  <-  2         #  def  <-  2
-cfg$gms$cm_ccapturescen             <-  1         #  def  <-  1
-cfg$gms$c_bioliqscen                <-  1         #  def  <-  1
-cfg$gms$c_bioh2scen                 <-  1         #  def  <-  1
-cfg$gms$c_shGreenH2                 <-  0         #  def  <-  0
-cfg$gms$c_shBioTrans                <-  1         #  def  <-  1
-cfg$gms$cm_shSynTrans               <-  0         #  def  <-  0
-cfg$gms$cm_shSynGas                 <-  0         #  def  <-  0
-cfg$gms$cm_IndCCSscen               <-  1         #  def  <-  1
-cfg$gms$cm_optimisticMAC            <-  0         #  def  <-  0
-cfg$gms$cm_CCS_cement               <-  1         #  def  <-  1
-cfg$gms$cm_CCS_chemicals            <-  1         #  def  <-  1
-cfg$gms$cm_CCS_steel                <-  1         #  def  <-  1
-cfg$gms$cm_secondary_steel_bound    <-  "none"    #  def  <-  "scenario"
-cfg$gms$c_solscen                   <-  1         #  def  <-  1
+cfg$gms$cm_nucscen                <-  2           #  def  <-  2
+cfg$gms$cm_ccapturescen           <-  1           #  def  <-  1
+cfg$gms$c_bioliqscen              <-  1           #  def  <-  1
+cfg$gms$c_bioh2scen               <-  1           #  def  <-  1
+cfg$gms$c_shGreenH2               <-  0           #  def  <-  0
+cfg$gms$c_shBioTrans              <-  1           #  def  <-  1
+cfg$gms$cm_shSynTrans             <-  0           #  def  <-  0
+cfg$gms$cm_shSynGas               <-  0           #  def  <-  0
+cfg$gms$cm_IndCCSscen             <-  1           #  def  <-  1
+cfg$gms$cm_optimisticMAC          <-  0           #  def  <-  0
+cfg$gms$cm_CCS_cement             <-  1           #  def  <-  1
+cfg$gms$cm_CCS_chemicals          <-  1           #  def  <-  1
+cfg$gms$cm_CCS_steel              <-  1           #  def  <-  1
+cfg$gms$cm_secondary_steel_bound  <-  "scenario"  #  def  <-  "scenario"
+cfg$gms$c_solscen                 <-  1           #  def  <-  1
 
 cfg$gms$c_regi_earlyreti_rate  <- "GLO 0.09, EUR_regi 0.15" # def <- GLO 0.09, EUR_regi 0.15
 cfg$gms$c_tech_earlyreti_rate  <- "GLO.(biodiesel 0.14, bioeths 0.14), EUR_regi.(biodiesel 0.15, bioeths 0.15), USA_regi.pc 0.13, REF_regi.pc 0.13, CHA_regi.pc 0.13" # def <- GLO.(biodiesel 0.14, bioeths 0.14), EUR.(biodiesel 0.15, bioeths 0.15), USA_regi.pc 0.13, REF_regi.pc 0.13, CHA_regi.pc 0.13, DEU.(tnrs 0.2)


### PR DESCRIPTION
- required to have a valid upper bound for secondary steel production in
  policy runs