### PR TITLE
Fix cs2 outdir

### DIFF
--- a/scripts/utils/run_compareScenarios2.R
+++ b/scripts/utils/run_compareScenarios2.R
@@ -26,10 +26,10 @@ run_compareScenarios2 <- function(outputdirs, shortTerm, outfilename, regionList
   # If multiple compareScenarios2 run in parallel they would interfere with the others' figure folder.
   # So we create a temporary subfolder in which each compareScenarios2 creates its own figure folder.
   system(paste0("mkdir ", outfilename))
-  outfilename <- normalizePath(outfilename) # Make path absolute.
+  outfilepath <- normalizePath(outfilename) # Make path absolute.
   wd <- getwd()
 
-  setwd(outfilename)
+  setwd(outfilepath)
   # remove temporary folder
   on.exit(system(paste0("mv ", outfilename, ".pdf ..")))
   on.exit(setwd(wd), add = TRUE)
@@ -39,16 +39,12 @@ run_compareScenarios2 <- function(outputdirs, shortTerm, outfilename, regionList
   mif_path <- normalizePath(mif_path)
   hist_path <- normalizePath(hist_path)
 
-  splt <- strsplit(outfilename, "/", fixed=TRUE)[[1]]
-  outputFile <- splt[length(splt)]
-  outputDir <- outfilename
-
   if (!shortTerm) {
     try(compareScenarios2(
       mifScen = mif_path,
       mifHist = hist_path,
-      outputDir = outputDir,
-      outputFile = outputFile,
+      outputDir = outfilepath,
+      outputFile = outfilename,
       outputFormat = "PDF",
       reg = regionList,
       mainReg = mainRegName))
@@ -56,8 +52,8 @@ run_compareScenarios2 <- function(outputdirs, shortTerm, outfilename, regionList
     try(compareScenarios2(
       mifScen = mif_path,
       mifHist = hist_path,
-      outputDir = outputDir,
-      outputFile = outputFile,
+      outputDir = outfilepath,
+      outputFile = outfilename,
       outputFormat = "PDF",
       reg = regionList,
       mainReg = mainRegName,

--- a/scripts/utils/run_compareScenarios2.R
+++ b/scripts/utils/run_compareScenarios2.R
@@ -41,7 +41,7 @@ run_compareScenarios2 <- function(outputdirs, shortTerm, outfilename, regionList
 
   splt <- strsplit(outfilename, "/", fixed=TRUE)[[1]]
   outputFile <- splt[length(splt)]
-  outputDir <- paste(splt[-length(splt)], collapse="/")
+  outputDir <- outfilename
 
   if (!shortTerm) {
     try(compareScenarios2(


### PR DESCRIPTION
Calling compareScenarios2 via `Rscript output.R` failed to created short term and long term versions of PDF. This was due to a conflict of running this as two processes in parallel and a bug in the script that calls `remind2::compareScenarios2()` which did not provide the correct output folder to the function.
The error is now corrected