### PR TITLE
adapt 45_carbonprice/NDC to new filenames from mrremind, 

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -22,7 +22,7 @@ cfg$title <- "default"
 cfg$regionmapping <- "config/regionmappingH12.csv"
 
 #### Current input data revision (<mainrevision>.<subrevision>) ####
-cfg$inputRevision <- 6.28
+cfg$inputRevision <- 6.281
 
 #### Current CES parameter and GDX revision (commit hash) ####
 cfg$CESandGDXversion <- "9836fcbd137352a3c808283ed5b7104cb57b1f9e"

--- a/main.gms
+++ b/main.gms
@@ -83,9 +83,9 @@
 * 
 * Regionscode: 62eff8f7
 * 
-* Input data revision: 6.28
+* Input data revision: 6.281
 * 
-* Last modification (input data): Mon Jan 31 16:27:44 2022
+* Last modification (input data): Tue Feb 08 16:54:00 2022
 * 
 *###################### R SECTION END (VERSION INFO) ###########################
 

--- a/modules/45_carbonprice/NDC/datainput.gms
+++ b/modules/45_carbonprice/NDC/datainput.gms
@@ -17,95 +17,96 @@ pm_taxCO2eq("2015",regi)= 0;
 pm_taxCO2eq("2015",regi)$regi_group("EUR_regi",regi)= 5 * sm_DptCO2_2_TDpGtC;
 
 *** parameters for exponential increase after NDC targets
-Scalar p45_taxCO2eq_global2030 "startprice in 2030 (unit TDpGtC) of global CO2eq taxes towards which countries converge";
-p45_taxCO2eq_global2030 = 30 * sm_DptCO2_2_TDpGtC;
+Scalar p45_taxCO2eqGlobal2030 "startprice in 2030 (unit TDpGtC) of global CO2eq taxes towards which countries converge";
+p45_taxCO2eqGlobal2030 = 30 * sm_DptCO2_2_TDpGtC;
+Scalar p45_taxCO2eqYearlyIncrease "yearly multiplicative increase of co2 tax, write 3% as 1.03" /1.0125/;
 
-Scalar p45_taxCO2eq_convergence_year "year until which CO2eq taxes have converged globally" /2100/;
+Scalar p45_taxCO2eqConvergenceYear "year until which CO2eq taxes have converged globally" /2100/;
 *** set Years for CO2eq taxes to converge after 2030
 if(cm_NDC_divergentScenario = 0,
-    p45_taxCO2eq_convergence_year = 2100;
+    p45_taxCO2eqConvergenceYear = 2100;
 elseif cm_NDC_divergentScenario = 1,
-    p45_taxCO2eq_convergence_year = 2150;
+    p45_taxCO2eqConvergenceYear = 2150;
 elseif cm_NDC_divergentScenario = 2,
-    p45_taxCO2eq_convergence_year = 3000;
+    p45_taxCO2eqConvergenceYear = 3000;
 );
 
 *** load NDC data
-Table f45_factor_targetyear(ttot,all_regi,NDC_version,all_GDPscen) "Table for all NDC versions with multiplier for target year emissions vs 2005 emissions, as weighted average for all countries with quantifyable emissions under NDC in particular region"
+Table f45_factorTargetyear(ttot,all_regi,NDC_version,all_GDPscen) "Table for all NDC versions with multiplier for target year emissions vs 2005 emissions, as weighted average for all countries with quantifyable emissions under NDC in particular region"
 $offlisting
 $ondelim
-$include "./modules/45_carbonprice/NDC/input/f45_factor_targetyear.cs3r"
+$include "./modules/45_carbonprice/NDC/input/fm_factorTargetyear.cs3r"
 $offdelim
 $onlisting
 ;
 
-Parameter p45_factor_targetyear(ttot,all_regi) "Multiplier for target year emissions vs 2005 emissions, as weighted average for all countries with quantifyable emissions under NDC in particular region";
-p45_factor_targetyear(ttot,all_regi) = f45_factor_targetyear(ttot,all_regi,"%cm_NDC_version%","%cm_GDPscen%");
+Parameter p45_factorTargetyear(ttot,all_regi) "Multiplier for target year emissions vs 2005 emissions, as weighted average for all countries with quantifyable emissions under NDC in particular region";
+p45_factorTargetyear(ttot,all_regi) = f45_factorTargetyear(ttot,all_regi,"%cm_NDC_version%","%cm_GDPscen%");
 
-display p45_factor_targetyear;
+display p45_factorTargetyear;
 
-Table f45_2005share_target(ttot,all_regi,NDC_version,all_GDPscen) "Table for all NDC versions with 2005 GHG emission share of countries with quantifyable emissions under NDC in particular region, time dimension specifies alternative future target years"
+Table f45_2005shareTarget(ttot,all_regi,NDC_version,all_GDPscen) "Table for all NDC versions with 2005 GHG emission share of countries with quantifyable emissions under NDC in particular region, time dimension specifies alternative future target years"
 $offlisting
 $ondelim
-$include "./modules/45_carbonprice/NDC/input/f45_2005share_target.cs3r"
+$include "./modules/45_carbonprice/NDC/input/fm_2005shareTarget.cs3r"
 $offdelim
 $onlisting
 ;
 
-Parameter p45_2005share_target(ttot,all_regi) "2005 GHG emission share of countries with quantifyable emissions under NDC in particular region, time dimension specifies alternative future target years";
-p45_2005share_target(ttot,all_regi) = f45_2005share_target(ttot,all_regi,"%cm_NDC_version%","%cm_GDPscen%");
+Parameter p45_2005shareTarget(ttot,all_regi) "2005 GHG emission share of countries with quantifyable emissions under NDC in particular region, time dimension specifies alternative future target years";
+p45_2005shareTarget(ttot,all_regi) = f45_2005shareTarget(ttot,all_regi,"%cm_NDC_version%","%cm_GDPscen%");
 
-display p45_2005share_target;
+display p45_2005shareTarget;
 
-Table f45_hist_share(tall,all_regi,NDC_version) "Table for all NDC versions with GHG emissions share of countries with quantifyable 2030 target, time dimension specifies historic record"
+Table f45_histShare(tall,all_regi,NDC_version) "Table for all NDC versions with GHG emissions share of countries with quantifyable 2030 target, time dimension specifies historic record"
 $offlisting
 $ondelim
-$include "./modules/45_carbonprice/NDC/input/f45_hist_share.cs3r"
+$include "./modules/45_carbonprice/NDC/input/fm_histShare.cs3r"
 $offdelim
 $onlisting
 ;
 
-Parameter p45_hist_share(tall,all_regi) "GHG emissions share of countries with quantifyable 2030 target, time dimension specifies historic record";
-p45_hist_share(tall,all_regi) = f45_hist_share(tall,all_regi,"%cm_NDC_version%");
+Parameter p45_histShare(tall,all_regi) "GHG emissions share of countries with quantifyable 2030 target, time dimension specifies historic record";
+p45_histShare(tall,all_regi) = f45_histShare(tall,all_regi,"%cm_NDC_version%");
 
-display p45_hist_share;
+display p45_histShare;
 
 Parameter p45_BAU_reg_emi_wo_LU_bunkers(ttot,all_regi) "regional GHG emissions (without LU and bunkers) in BAU scenario"
   /
 $ondelim
-$include "./modules/45_carbonprice/NDC/input/p45_BAU_reg_emi_wo_LU_bunkers.cs4r"
+$include "./modules/45_carbonprice/NDC/input/pm_BAU_reg_emi_wo_LU_bunkers.cs4r"
 $offdelim
   /             ;
 
 *** parameters for selecting NDC years
-Scalar p45_ignore_NDC_before             "NDC targets before this years are ignored, for example to exclude 2030 targets" /2020/;
-Scalar p45_ignore_NDC_after              "NDC targets after  this years are ignored, for example to exclude 2050 net zero targets" /2030/;
-Scalar p45_min_ratio_of_coverage_to_max  "only targets whose coverage is this times p45_best_NDC_coverage are considered. Use 1 for only best." /1.0/;
-Scalar p45_use_single_year_close_to      "if 0: use all. If > 0: use only one single NDC target per country closest to this year (use 2030.4 to prefer 2030 over 2035 over 2025)" /2030.4/;
+Scalar p45_ignoreNDCbefore          "NDC targets before this years are ignored, for example to exclude 2030 targets" /2020/;
+Scalar p45_ignoreNDCafter           "NDC targets after  this years are ignored, for example to exclude 2050 net zero targets" /2030/;
+Scalar p45_minRatioOfCoverageToMax  "only targets whose coverage is this times p45_bestNDCcoverage are considered. Use 1 for only best." /1.0/;
+Scalar p45_useSingleYearCloseTo     "if 0: use all. If > 0: use only one single NDC target per country closest to this year (use 2030.4 to prefer 2030 over 2035 over 2025)" /2030.4/;
 
-Set p45_NDC_year_set(ttot,all_regi)               "YES for years whose NDC targets is used";
-Parameter p45_best_NDC_coverage(all_regi)         "highest coverage of NDC targets within region";
-Parameter p45_distance_to_optyear(ttot,all_regi)  "distance to p45_use_single_year_close_to to favor years in case of multiple equally good targets";
-Parameter p45_min_distance_to_optyear(all_regi)   "minimal distance to p45_use_single_year_close_to per region";
+Set p45_NDCyearSet(ttot,all_regi)              "YES for years whose NDC targets is used";
+Parameter p45_bestNDCcoverage(all_regi)        "highest coverage of NDC targets within region";
+Parameter p45_distanceToOptyear(ttot,all_regi) "distance to p45_useSingleYearCloseTo to favor years in case of multiple equally good targets";
+Parameter p45_minDistanceToOptyear(all_regi)   "minimal distance to p45_useSingleYearCloseTo per region";
 
-p45_best_NDC_coverage(regi) = smax(ttot$(ttot.val <= p45_ignore_NDC_after AND ttot.val >= p45_ignore_NDC_before), p45_2005share_target(ttot,regi));
-display p45_best_NDC_coverage;
+p45_bestNDCcoverage(regi) = smax(ttot$(ttot.val <= p45_ignoreNDCafter AND ttot.val >= p45_ignoreNDCbefore), p45_2005shareTarget(ttot,regi));
+display p45_bestNDCcoverage;
 
-p45_NDC_year_set(ttot,regi)$(ttot.val <= p45_ignore_NDC_after AND ttot.val >= p45_ignore_NDC_before) = p45_2005share_target(ttot,regi) >= p45_min_ratio_of_coverage_to_max * p45_best_NDC_coverage(regi);
+p45_NDCyearSet(ttot,regi)$(ttot.val <= p45_ignoreNDCafter AND ttot.val >= p45_ignoreNDCbefore) = p45_2005shareTarget(ttot,regi) >= p45_minRatioOfCoverageToMax * p45_bestNDCcoverage(regi);
 
-if(p45_use_single_year_close_to > 0,
-  p45_distance_to_optyear(p45_NDC_year_set(ttot,regi)) = abs(ttot.val - p45_use_single_year_close_to);
-  p45_min_distance_to_optyear(regi) = smin(ttot$(p45_NDC_year_set(ttot,regi)), p45_distance_to_optyear(ttot,regi));
-  p45_NDC_year_set(ttot,regi) = p45_distance_to_optyear(ttot,regi) = p45_min_distance_to_optyear(regi);
+if(p45_useSingleYearCloseTo > 0,
+  p45_distanceToOptyear(p45_NDCyearSet(ttot,regi)) = abs(ttot.val - p45_useSingleYearCloseTo);
+  p45_minDistanceToOptyear(regi) = smin(ttot$(p45_NDCyearSet(ttot,regi)), p45_distanceToOptyear(ttot,regi));
+  p45_NDCyearSet(ttot,regi) = p45_distanceToOptyear(ttot,regi) = p45_minDistanceToOptyear(regi);
 );
 
 *** first and last NDC year as a number
-Parameter p45_first_NDC_year(all_regi) "last year with NDC coverage within region";
-p45_first_NDC_year(regi) = smin( p45_NDC_year_set(ttot, regi), ttot.val );
-Parameter p45_last_NDC_year(all_regi)  "last year with NDC coverage within region";
-p45_last_NDC_year(regi)  = smax( p45_NDC_year_set(ttot, regi), ttot.val );
+Parameter p45_firstNDCyear(all_regi) "last year with NDC coverage within region";
+p45_firstNDCyear(regi) = smin( p45_NDCyearSet(ttot, regi), ttot.val );
+Parameter p45_lastNDCyear(all_regi)  "last year with NDC coverage within region";
+p45_lastNDCyear(regi)  = smax( p45_NDCyearSet(ttot, regi), ttot.val );
 
-display p45_NDC_year_set,p45_first_NDC_year,p45_last_NDC_year;
+display p45_NDCyearSet,p45_firstNDCyear,p45_lastNDCyear;
 
 *** adjust reduction value for LAM based on the assumption that Brazilian reduction targets are only from landuse, see https://climateactiontracker.org/countries/brazil/
 *** the adjustment were calculated such that Brazil is assumed to maintain its 2015 non-landuse emissions, as follows:
@@ -117,7 +118,7 @@ display p45_NDC_year_set,p45_first_NDC_year,p45_last_NDC_year;
 *** 0.2 is a rounded value valid for all except 2018_uncond, because Brazil had no unconditional target then.
 
 if (not sameas("%cm_NDC_version%","2018_uncond"),
-    p45_factor_targetyear(ttot,regi)$(sameas(regi,"LAM") AND sameas(ttot,"2030")) = p45_factor_targetyear(ttot,regi) + 0.2;
+    p45_factorTargetyear(ttot,regi)$(sameas(regi,"LAM") AND sameas(ttot,"2030")) = p45_factorTargetyear(ttot,regi) + 0.2;
 );
 
 *** EOF ./modules/45_carbonprice/NDC/datainput.gms

--- a/modules/45_carbonprice/NDC/declarations.gms
+++ b/modules/45_carbonprice/NDC/declarations.gms
@@ -6,13 +6,17 @@
 *** |  Contact: remind@pik-potsdam.de
 *** SOF ./modules/45_carbonprice/NDC/declarations.gms
 
-Parameter p45_actual_co2eq_woLU_regi(ttot,all_regi)                "actual level of regional 2020/2025/2030 GHG emissions in previous iteration";
-Parameter p45_ref_co2eq_woLU_regi(ttot,all_regi)                   "regional NDC target level of GHG - with different temporal meanings depending on NDC target year";
-Parameter p45_factorRescaleCO2Tax(ttot,all_regi)                   "multiplicative factor to rescale CO2 taxes to achieve the climate targets";
-Parameter p45_factorRescaleCO2TaxTrack(iteration,ttot,all_regi)    "Track the changes of p45_factorRescaleCO2Tax over the iterations";
-Parameter p45_taxCO2eq_first_NDC_year(all_regi)                    "CO2eq tax in p45_first_NDC_year";
-Parameter p45_taxCO2eq_last_NDC_year(all_regi)                     "CO2eq tax in p45_last_NDC_year";
-Scalar    p45_adjust_exponent                                      "exponent in tax adjustment process";
+Parameter
+p45_CO2eqwoLU_actual(ttot,all_regi)                   "actual level of regional GHG emissions after previous iteration"
+p45_CO2eqwoLU_goal(ttot,all_regi)                     "regional NDC target level of GHG emissions"
+p45_factorRescaleCO2Tax(ttot,all_regi)                "multiplicative factor to rescale CO2 taxes to achieve the climate targets"
+p45_factorRescaleCO2Tax_iter(iteration,ttot,all_regi) "Track the changes of p45_factorRescaleCO2Tax over the iterations"
+p45_taxCO2eqFirstNDCyear(all_regi)                    "CO2eq tax in p45_firstNDCyear"
+p45_taxCO2eqLastNDCyear(all_regi)                     "CO2eq tax in p45_lastNDCyear"
+p45_vm_co2eq_iter(iteration,ttot,all_regi)            "Track the changes of vm_co2eq over the iterations"
+;
+
+Scalar    p45_adjustExponent                          "exponent in tax adjustment process";
 
 
 *** EOF ./modules/45_carbonprice/NDC/declarations.gms

--- a/modules/45_carbonprice/NDC/input/files
+++ b/modules/45_carbonprice/NDC/input/files
@@ -1,3 +1,3 @@
-f45_2005share_target.cs3r
-f45_factor_targetyear.cs3r
-f45_hist_share.cs3r
+fm_2005shareTarget.cs3r
+fm_factorTargetyear.cs3r
+fm_histShare.cs3r

--- a/modules/45_carbonprice/NDC/postsolve.gms
+++ b/modules/45_carbonprice/NDC/postsolve.gms
@@ -8,11 +8,11 @@
 
 if(cm_iterative_target_adj eq 3,
 
-    display pm_taxCO2eq;
+display pm_taxCO2eq;
 
 *#' @equations 
 *#' calculate emission variable to be used for NDC target: GHG emissions w/o land-use change and w/o transport bunker emissions, unit [Mt CO2eq/yr]
-p45_actual_co2eq_woLU_regi(p45_NDC_year_set(ttot,regi)) =
+p45_CO2eqwoLU_actual(p45_NDCyearSet(ttot,regi)) =
     vm_co2eq.l(ttot,regi) * sm_c_2_co2*1000
 *** add F-Gases
     + vm_emiFgas.L(ttot,regi,"emiFgasTotal")
@@ -23,26 +23,26 @@ p45_actual_co2eq_woLU_regi(p45_NDC_year_set(ttot,regi)) =
       ); 
 
 display vm_co2eq.l;
-display p45_actual_co2eq_woLU_regi;
-display p45_ref_co2eq_woLU_regi;
+display p45_CO2eqwoLU_actual;
+display p45_CO2eqwoLU_goal;
 
 *#' nash compatible convergence scheme: adjustment of co2 tax for next iteration based on deviation of emissions in this iteration (actual) from target emissions (ref)
 *#' maximum possible change between iterations decreases with increase of iteration number
 
-if(       iteration.val lt  8, p45_adjust_exponent = 4;
-   elseif iteration.val lt 15, p45_adjust_exponent = 3;
-   elseif iteration.val lt 23, p45_adjust_exponent = 2;
-   else                        p45_adjust_exponent = 1;
+if(       iteration.val lt  8, p45_adjustExponent = 4;
+   elseif iteration.val lt 15, p45_adjustExponent = 3;
+   elseif iteration.val lt 23, p45_adjustExponent = 2;
+   else                        p45_adjustExponent = 1;
 );
 
-p45_factorRescaleCO2Tax(p45_NDC_year_set(ttot,regi)) =
-  min((( max(0.1, (p45_actual_co2eq_woLU_regi(ttot,regi)+0.0001)/(p45_ref_co2eq_woLU_regi(ttot,regi)+0.0001) ) )**p45_adjust_exponent),max(2-iteration.val/15,1.01-iteration.val/10000));
+p45_factorRescaleCO2Tax(p45_NDCyearSet(ttot,regi)) =
+  min((( max(0.1, (p45_CO2eqwoLU_actual(ttot,regi)+0.0001)/(p45_CO2eqwoLU_goal(ttot,regi)+0.0001) ) )**p45_adjustExponent),max(2-iteration.val/15,1.01-iteration.val/10000));
 *** use max(0.1, ...) to make sure that negative emission values cause no problem, use +0.0001 such that net zero targets cause no problem
 
-pm_taxCO2eq(t,regi)$(t.val gt 2016 AND t.val ge cm_startyear AND t.val le p45_last_NDC_year(regi)) = max(1* sm_DptCO2_2_TDpGtC,pm_taxCO2eq(t,regi) * p45_factorRescaleCO2Tax(t,regi) );
-p45_factorRescaleCO2TaxTrack(iteration,ttot,regi) = p45_factorRescaleCO2Tax(ttot,regi);
+pm_taxCO2eq(t,regi)$(t.val gt 2016 AND t.val ge cm_startyear AND t.val le p45_lastNDCyear(regi)) = max(1* sm_DptCO2_2_TDpGtC,pm_taxCO2eq(t,regi) * p45_factorRescaleCO2Tax(t,regi) );
+p45_factorRescaleCO2Tax_iter(iteration,ttot,regi) = p45_factorRescaleCO2Tax(ttot,regi);
 
-display p45_factorRescaleCO2TaxTrack;
+display p45_factorRescaleCO2Tax_iter;
 
 *CB* special case SSA: maximum carbon price at 7.5$ in 2020, 30 in 2025, 45 in 2030, to reflect low energy productivity of region, and avoid high losses
 pm_taxCO2eq("2020",regi)$(sameas(regi,"SSA")) = min(pm_taxCO2eq("2020",regi)$(sameas(regi,"SSA")),7.5 * sm_DptCO2_2_TDpGtC);
@@ -50,23 +50,23 @@ pm_taxCO2eq("2025",regi)$(sameas(regi,"SSA")) = min(pm_taxCO2eq("2025",regi)$(sa
 pm_taxCO2eq("2030",regi)$(sameas(regi,"SSA")) = min(pm_taxCO2eq("2030",regi)$(sameas(regi,"SSA")),45 * sm_DptCO2_2_TDpGtC);
 
 *** calculate tax path until NDC target year - linear increase
-p45_taxCO2eq_first_NDC_year(regi) = smax(ttot$(ttot.val = p45_first_NDC_year(regi)), pm_taxCO2eq(ttot,regi));
-pm_taxCO2eq(ttot,regi)$(ttot.val > 2016 AND ttot.val < p45_first_NDC_year(regi)) = p45_taxCO2eq_first_NDC_year(regi)*(ttot.val-2015)/(p45_first_NDC_year(regi)-2015);
+p45_taxCO2eqFirstNDCyear(regi) = smax(ttot$(ttot.val = p45_firstNDCyear(regi)), pm_taxCO2eq(ttot,regi));
+pm_taxCO2eq(ttot,regi)$(ttot.val > 2016 AND ttot.val < p45_firstNDCyear(regi)) = p45_taxCO2eqFirstNDCyear(regi)*(ttot.val-2015)/(p45_firstNDCyear(regi)-2015);
 
 *** replace taxCO2eq between NDC targets such that taxCO2eq between goals does not decrease
-loop( p45_NDC_year_set(ttot2,regi) ,
-  pm_taxCO2eq(ttot,regi)$(ttot.val > ttot2.val AND not p45_NDC_year_set(ttot,regi)) = pm_taxCO2eq(ttot2,regi);
+loop( p45_NDCyearSet(ttot2,regi) ,
+  pm_taxCO2eq(ttot,regi)$(ttot.val > ttot2.val AND not p45_NDCyearSet(ttot,regi)) = pm_taxCO2eq(ttot2,regi);
 ) ;
 
-*** convergence scheme post NDC target year: exponential increase with 1.25% AND regional convergence until p45_taxCO2eq_convergence_year
-p45_taxCO2eq_last_NDC_year(regi) = smax(ttot$(ttot.val = p45_last_NDC_year(regi)), pm_taxCO2eq(ttot,regi));
+*** convergence scheme post NDC target year: exponential increase AND regional convergence until p45_taxCO2eqConvergenceYear
+p45_taxCO2eqLastNDCyear(regi) = smax(ttot$(ttot.val = p45_lastNDCyear(regi)), pm_taxCO2eq(ttot,regi));
 
-pm_taxCO2eq(ttot,regi)$(ttot.val gt p45_last_NDC_year(regi))
+pm_taxCO2eq(ttot,regi)$(ttot.val gt p45_lastNDCyear(regi))
    = (  !! regional, weight going from 1 in NDC target year to 0  in 2100
-        p45_taxCO2eq_last_NDC_year(regi) * 1.0125**(ttot.val-p45_last_NDC_year(regi)) * (max(p45_taxCO2eq_convergence_year,ttot.val) - ttot.val)
+        p45_taxCO2eqLastNDCyear(regi) * p45_taxCO2eqYearlyIncrease**(ttot.val-p45_lastNDCyear(regi)) * (max(p45_taxCO2eqConvergenceYear,ttot.val) - ttot.val)
         !! global, weight going from 0 in NDC target year to 1 in and after 2100
-      + p45_taxCO2eq_global2030          * 1.0125**(ttot.val-2030)                    * (min(ttot.val,p45_taxCO2eq_convergence_year) - p45_last_NDC_year(regi))
-      )/(p45_taxCO2eq_convergence_year - p45_last_NDC_year(regi));
+      + p45_taxCO2eqGlobal2030          * p45_taxCO2eqYearlyIncrease**(ttot.val-2030)                    * (min(ttot.val,p45_taxCO2eqConvergenceYear) - p45_lastNDCyear(regi))
+      )/(p45_taxCO2eqConvergenceYear - p45_lastNDCyear(regi));
 
 ***as a minimum, have linear price increase starting from 1$ in 2030
 pm_taxCO2eq(ttot,regi)$(ttot.val gt 2030) = max(pm_taxCO2eq(ttot,regi),1*sm_DptCO2_2_TDpGtC * (1+(ttot.val-2030)*9/7));
@@ -75,6 +75,8 @@ pm_taxCO2eq(ttot,regi)$(ttot.val gt 2030) = max(pm_taxCO2eq(ttot,regi),1*sm_DptC
 pm_taxCO2eq("2020",regi) = (3*pm_taxCO2eq("2015",regi)+pm_taxCO2eq("2025",regi))/4;
 
         display pm_taxCO2eq;
+
+p45_vm_co2eq_iter(iteration,p45_NDCyearSet(t,regi)) = vm_co2eq.l(t,regi);
 );
 
 *** EOF ./modules/45_carbonprice/NDC/postsolve.gms

--- a/modules/45_carbonprice/NDC/preloop.gms
+++ b/modules/45_carbonprice/NDC/preloop.gms
@@ -10,22 +10,22 @@
 pm_taxCO2eq("2020",regi)$(sameas(regi,"SSA")) = 15 * sm_DptCO2_2_TDpGtC;
 
 *** first calculate tax path until last NDC target year - linear increase
-pm_taxCO2eq(ttot,regi)$(ttot.val gt 2016 AND ttot.val le p45_last_NDC_year(regi)) = pm_taxCO2eq("2020",regi)*(ttot.val-2015)/5;
+pm_taxCO2eq(ttot,regi)$(ttot.val gt 2016 AND ttot.val le p45_lastNDCyear(regi)) = pm_taxCO2eq("2020",regi)*(ttot.val-2015)/5;
 
-*** convergence scheme after the last NDC target year: exponential increase with 1.25% AND regional convergence until p45_taxCO2eq_convergence_year
-p45_taxCO2eq_last_NDC_year(regi) = smax(ttot$(ttot.val = p45_last_NDC_year(regi)), pm_taxCO2eq(ttot,regi));
+*** convergence scheme after the last NDC target year: exponential increase with 1.25% AND regional convergence until p45_taxCO2eqConvergenceYear
+p45_taxCO2eqLastNDCyear(regi) = smax(ttot$(ttot.val = p45_lastNDCyear(regi)), pm_taxCO2eq(ttot,regi));
 
-pm_taxCO2eq(ttot,regi)$(ttot.val gt p45_last_NDC_year(regi))
+pm_taxCO2eq(ttot,regi)$(ttot.val gt p45_lastNDCyear(regi))
    = (  !! regional, weight going from 1 in last NDC target year to 0 in 2100
-        p45_taxCO2eq_last_NDC_year(regi) * 1.0125**(ttot.val-p45_last_NDC_year(regi)) * (max(p45_taxCO2eq_convergence_year,ttot.val) - ttot.val)
+        p45_taxCO2eqLastNDCyear(regi) * p45_taxCO2eqYearlyIncrease**(ttot.val-p45_lastNDCyear(regi)) * (max(p45_taxCO2eqConvergenceYear,ttot.val) - ttot.val)
         !! global, weight going from 0 in NDC target year to 1 in and after 2100
-      + p45_taxCO2eq_global2030          * 1.0125**(ttot.val-2030)                    * (min(p45_taxCO2eq_convergence_year,ttot.val) - p45_last_NDC_year(regi))
-      )/(p45_taxCO2eq_convergence_year - p45_last_NDC_year(regi));
+      + p45_taxCO2eqGlobal2030          * p45_taxCO2eqYearlyIncrease**(ttot.val-2030)                    * (min(p45_taxCO2eqConvergenceYear,ttot.val) - p45_lastNDCyear(regi))
+      )/(p45_taxCO2eqConvergenceYear - p45_lastNDCyear(regi));
 
 display pm_taxCO2eq;
 
 ***as a minimum, have linear price increase starting from 1$ in 2030
-pm_taxCO2eq(ttot,regi)$(ttot.val gt p45_last_NDC_year(regi)) = max(pm_taxCO2eq(ttot,regi),1*sm_DptCO2_2_TDpGtC * (1+(ttot.val-2030)*9/7));
+pm_taxCO2eq(ttot,regi)$(ttot.val gt p45_lastNDCyear(regi)) = max(pm_taxCO2eq(ttot,regi),1*sm_DptCO2_2_TDpGtC * (1+(ttot.val-2030)*9/7));
 
 *** new 2020 carbon price definition: weighted average of 2015 and 2025, with triple weight for 2015 (which is zero for all non-eu regions).
 pm_taxCO2eq("2020",regi) = (3*pm_taxCO2eq("2015",regi)+pm_taxCO2eq("2025",regi))/4;
@@ -36,9 +36,9 @@ display pm_taxCO2eq;
 *#'  calculate level of emission target that it should converge to, composed of:
 *#'  emission target relative to 2005 emissions (factor_targetyear) for part of region with NDC target
 *#'  baseline for the rest of the countries
-p45_ref_co2eq_woLU_regi(p45_NDC_year_set(ttot,regi)) = 
-          p45_2005share_target(ttot,regi)     * p45_BAU_reg_emi_wo_LU_bunkers("2005",regi) * p45_factor_targetyear(ttot,regi)    !! share with NDC target
-        + (1-p45_2005share_target(ttot,regi)) * p45_BAU_reg_emi_wo_LU_bunkers(ttot,regi);            !! baseline for share of countries without NDC target
+p45_CO2eqwoLU_goal(p45_NDCyearSet(ttot,regi)) =
+          p45_2005shareTarget(ttot,regi)     * p45_BAU_reg_emi_wo_LU_bunkers("2005",regi) * p45_factorTargetyear(ttot,regi)    !! share with NDC target
+        + (1-p45_2005shareTarget(ttot,regi)) * p45_BAU_reg_emi_wo_LU_bunkers(ttot,regi);            !! baseline for share of countries without NDC target
 
-display pm_taxCO2eq,p45_ref_co2eq_woLU_regi;
+display pm_taxCO2eq,p45_CO2eqwoLU_goal;
 *** EOF ./modules/45_carbonprice/NDC/preloop.gms

--- a/modules/45_carbonprice/NDC/realization.gms
+++ b/modules/45_carbonprice/NDC/realization.gms
@@ -13,10 +13,10 @@
 *' several countries include land-use emissions (e.g. Australia and US). See https://www4.unfccc.int/sites/NDCStaging/Pages/All.aspx. To be checked!
 
 *** Next update (2022):
-*** - Add NDC_2022.xlsx in /p/projects/rd3mod/inputdata/sources/UNFCCC_NDC/ on cluster, see README.txt in this folder
-*** - Set switch cm_NDC_version in /config/default.cfg to new year
-*** - add 2022_cond, 2022_uncond to set NDC_version in /core/sets.gms
-*** - Add new 2022 option in mrremind: calcEmiTarget, calcCapTarget, readUNFCCC_NDC
+*** - Add NDC_2023.xlsx in /p/projects/rd3mod/inputdata/sources/UNFCCC_NDC/ on cluster, see README.txt in this folder
+*** - Set switch cm_NDC_version in /config/default.cfg and /main.gms to new year
+*** - add 2023_cond, 2023_uncond to set NDC_version in /core/sets.gms
+*** - Add new 2023 option in mrremind: calcEmiTarget, calcCapTarget, readUNFCCC_NDC
 
 
 *####################### R SECTION START (PHASES) ##############################

--- a/modules/45_carbonprice/NPi2018/not_used.txt
+++ b/modules/45_carbonprice/NPi2018/not_used.txt
@@ -24,7 +24,6 @@ pm_gdp,input,questionnaire
 cm_CO2priceRegConvEndYr,input,questionnaire
 cm_peakBudgYr,input,questionnaire
 cm_taxCO2inc_after_peakBudgYr,input,questionnaire
-cm_NDC_version,input,questionnaire
 cm_NDC_divergentScenario,input,questionnaire
 vm_demFeSector,input,questionnaire
 pm_emifac,input,questionnaire

--- a/scripts/input/prepare_NDC.R
+++ b/scripts/input/prepare_NDC.R
@@ -28,14 +28,13 @@ prepare_NDC<-function(gdx, cfg){
   }
   regs <- setdiff(getRegions(emi),"GLO")
   if ("Emi|GHG|w/o Land-Use Change (Mt CO2eq/yr)" %in% getItems(emi,3.1)) {
-      p45_BAU_reg_emi_wo_LU_bunkers <- emi[regs,seq(2005,2050,5),"Emi|GHG|w/o Land-Use Change (Mt CO2eq/yr)"]
+      pm_BAU_reg_emi_wo_LU_bunkers <- emi[regs,seq(2005,2050,5),"Emi|GHG|w/o Land-Use Change (Mt CO2eq/yr)"]
   } else if ("Emi|Kyoto Gases excl Land-Use Change|w/o Bunkers (Mt CO2-equiv/yr)" %in% getItems(emi,3.1)) {
-      p45_BAU_reg_emi_wo_LU_bunkers <- emi[regs,seq(2005,2050,5),"Emi|Kyoto Gases excl Land-Use Change|w/o Bunkers (Mt CO2-equiv/yr)"]
+      pm_BAU_reg_emi_wo_LU_bunkers <- emi[regs,seq(2005,2050,5),"Emi|Kyoto Gases excl Land-Use Change|w/o Bunkers (Mt CO2-equiv/yr)"]
   } else {
      stop("No emissions variable found in the NDC script!") 
   }
 
-  getNames(p45_BAU_reg_emi_wo_LU_bunkers) <- NULL
-  write.magpie(p45_BAU_reg_emi_wo_LU_bunkers,"./modules/45_carbonprice/NDC/input/p45_BAU_reg_emi_wo_LU_bunkers.cs4r", comment="** description: Regional GHG emi (excl. LU and bunkers) in BAU scenario \n*** unit: Mt CO2eq/yr \n*** file created with scripts/input/prepare_NDC.R")
-
+  getNames(pm_BAU_reg_emi_wo_LU_bunkers) <- NULL
+  write.magpie(pm_BAU_reg_emi_wo_LU_bunkers, "./modules/45_carbonprice/NDC/input/pm_BAU_reg_emi_wo_LU_bunkers.cs4r", comment="** description: Regional GHG emi (excl. LU and bunkers) in BAU scenario \n*** unit: Mt CO2eq/yr \n*** file created with scripts/input/prepare_NDC.R")
 }

--- a/start.R
+++ b/start.R
@@ -132,7 +132,7 @@ configure_cfg <- function(icfg, iscen, iscenarios, isettings) {
     # for columns path_gdx…, check whether the cell is non-empty, and not the title of another run with start = 1
     # if not a full path ending with .gdx provided, search for most recent folder with that title
     if (any(iscen %in% isettings[iscen, path_gdx_list])) {
-      stop("Self-reference: ", scen , " refers to itself in a path_gdx... column.")
+      stop("Self-reference: ", iscen , " refers to itself in a path_gdx... column.")
     }
     for (path_to_gdx in path_gdx_list) {
       if (!is.na(isettings[iscen, path_to_gdx]) & ! isettings[iscen, path_to_gdx] %in% row.names(iscenarios)) {
@@ -256,8 +256,8 @@ if ('--restart' %in% argv) {
       message("start.R might simply ignore them. Please check if these switches are not deprecated.")
       message("This check was added Jan. 2022. If you find false positives, add them to knownColumnNames in start.R.\n")
       forbiddenColumnNames <- list(   # specify forbidden column name and what should be done with it
-        "c_budgetCO2" = "Rename to c_budgetCO2from2020, reduce emission budgets by 200Gt, see https://github.com/remindmodel/remind/pull/640",
-        "c_budgetCO2FFI" = "Rename to c_budgetCO2from2020FFI, reduce emission budgets by 200Gt, see https://github.com/remindmodel/remind/pull/640"
+        "c_budgetCO2" = "Rename to c_budgetCO2from2020, adapt emission budgets, see https://github.com/remindmodel/remind/pull/640",
+        "c_budgetCO2FFI" = "Rename to c_budgetCO2from2020FFI, adapt emission budgets, see https://github.com/remindmodel/remind/pull/640"
       )
       for (i in intersect(names(forbiddenColumnNames), unknownColumnNames)) {
         message("Column name ", i, " in ", config.file , " is outdated. ", forbiddenColumnNames[i])


### PR DESCRIPTION
adapt some variable names, increase input revision, correct error code in start.R after discussion in meeting.

This PR contains the changes to input data and the 45 module that were in PR #647 (add module 48_carbonpriceRegi) such that we have more time to discuss the 46/48 module issue there without blocking updates to the input data.

testOneRegi run with 45_carbonprice/NDC setting can be found at `/p/tmp/oliverr/remind-smallfix/output/h_ndc_bIT_2022-02-10_16.57.43/`: not yet completed but successfully started GAMS optimization