### PR TITLE
update EU21 region calibration including new FE industry trajectories

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -25,7 +25,7 @@ cfg$regionmapping <- "config/regionmappingH12.csv"
 cfg$inputRevision <- 6.281
 
 #### Current CES parameter and GDX revision (commit hash) ####
-cfg$CESandGDXversion <- "9836fcbd137352a3c808283ed5b7104cb57b1f9e"
+cfg$CESandGDXversion <- "9834f4e4cc8caf7ede3cbe9876994b791e17a41a"
 
 #### Force the model to download new input data ####
 cfg$force_download <- FALSE


### PR DESCRIPTION
based on calibration run: ``/p/tmp/schreyer/Modeling/REMIND_H12/Current/output/EU21reg-SSP2EU_calibrate_2022-02-10_10.57.13``