### PR TITLE
improve tutorials, enable more empty cells in scenario config

### DIFF
--- a/start.R
+++ b/start.R
@@ -100,33 +100,25 @@ configure_cfg <- function(icfg, iscen, iscenarios, isettings) {
 
     # Edit run title
     icfg$title <- iscen
-    cat("   Configuring cfg for", iscen,"\n")
+    message("   Configuring cfg for ", iscen)
 
-    # Edit main file of model
-    if( "model" %in% names(iscenarios)){
-      icfg$model <- iscenarios[iscen,"model"]
-    }
-
-    # Edit regional aggregation
-    if( "regionmapping" %in% names(iscenarios)){
-      icfg$regionmapping <- iscenarios[iscen,"regionmapping"]
-    }
-
-    # Edit input data revision
-    if( "inputRevision" %in% names(iscenarios)){
-      icfg$inputRevision <- iscenarios[iscen,"inputRevision"]
-    }
-
-    # Edit switches in default.cfg according to the values given in the scenarios table, if non-empty
-    for (switchname in intersect(names(icfg$gms), names(iscenarios))) {
+    # Edit main model file, region settings and input data revision based on scenarios table, if cell non-empty
+    for (switchname in intersect(c("model", "regionmapping", "inputRevision"), names(iscenarios))) {
       if ( !is.na(iscenarios[iscen,switchname] )) {
-        icfg$gms[[switchname]] <- iscenarios[iscen,switchname]
+        icfg[[switchname]] <- iscenarios[iscen, switchname]
       }
     }
 
     # Set reporting script
-    if( "output" %in% names(iscenarios)){
+    if ("output" %in% names(iscenarios) && !is.na(iscenarios[iscen,"output"])) {
       icfg$output <- gsub('c\\("|\\)|"','',strsplit(iscenarios[iscen,"output"],',')[[1]])
+    }
+
+    # Edit switches in default.cfg based on scenarios table, if cell non-empty
+    for (switchname in intersect(names(icfg$gms), names(iscenarios))) {
+      if ( !is.na(iscenarios[iscen,switchname] )) {
+        icfg$gms[[switchname]] <- iscenarios[iscen, switchname]
+      }
     }
 
     # for columns path_gdx…, check whether the cell is non-empty, and not the title of another run with start = 1

--- a/tutorials/3_RunningBundleOfRuns.md
+++ b/tutorials/3_RunningBundleOfRuns.md
@@ -1,7 +1,6 @@
 Running more than one REMIND scenario
 ================
-Oliver Richters
-10 January, 2022
+Oliver Richters, 10 January, 2022
 
 The folder **[config](../config)** in your REMIND folder contains a number of csv files that start with **scenario_config**. Those files are used to start a bundle of runs each with different configurations.
 
@@ -26,7 +25,7 @@ Those two columns are mandatory and usually placed at the beginning:
 * `start` is a boolean switch that lets you choose whether or not you would like to start this run once you submit this config file to the modeling routine. It often makes sense to keep some runs in the csv file to remember their configurations for the next time although you do not want to run them now and therefore switch them off. You do this by setting `start` to 0.
 
 Further columns are the configurations that you can choose for the specific runs.
-They may contain values for parameters such as `cm_rcp_scen` and module realizations such as `exponential` for [`./module/carbonprice/`](../modules/45_carbonprice). They overwrite the default defined and explained in [`./config/default.cfg`](../develop/config/default.cfg) by the respective cell value for each run. If you leave a cell empty or if no column exists for a setting, the default value is used.
+They may contain values for parameters such as `cm_rcp_scen` and module realizations such as `exponential` for [`./module/carbonprice/`](../modules/45_carbonprice). They overwrite the default defined and explained in [`./config/default.cfg`](../config/default.cfg) by the respective cell value for each run. If you leave a cell empty or if no column exists for a setting, the default value is used.
 
 An important feature of scenario_config files is the possibility to execute runs which build on each other.
 Examples are (1) using the base run for all time steps until `cm_startyear`, or (2) use it to compare the impact of certain policies to a situation without them.
@@ -58,7 +57,7 @@ Everything in the row after a `#` is interpreted as comment. Best use it as firs
 Further notes:
 --------------
 
-The cells need not contain only a single value, but for example module realization [`47_regipol/regiCarbonPrice`](../develop/modules/47_regipol/regiCarbonPrice) allows to specify in the parameter `cm_regiCO2target` to enter comma separated values `2020.2050.USA.year.netGHG 1, 2020.2050.EUR.year.netGHG 1` to specify emission goals for multiple regions.
+The cells need not contain only a single value, but for example module realization [`47_regipol/regiCarbonPrice`](../modules/47_regipol/regiCarbonPrice) allows to specify in the parameter `cm_regiCO2target` to enter comma separated values `2020.2050.USA.year.netGHG 1, 2020.2050.EUR.year.netGHG 1` to specify emission goals for multiple regions.
 
 To compare a `scenario_config*.csv` file to the current default configuration, you can run `Rscript -e "remind2::colorScenConf()"` in your remind directory and select the file you are interested in. [`colorScenConf()`](https://github.com/pik-piam/remind2/blob/master/R/colorScenConf.R) produces a file ending with `_colorful.xlsx` in the same directory and provides you with information how to interpret the colors within.
 

--- a/tutorials/6_Advanced_ChangeInputs.md
+++ b/tutorials/6_Advanced_ChangeInputs.md
@@ -3,7 +3,9 @@ Changing inputs in REMIND model
 Miško Stevanović (<stevanovic@pik-potsdam.de>), Lavinia Baumstark (<baumstark@pik-potsdam.de>)
 
 -   [Introduction](#introduction)
--   [Lokal Input Data](#lokal_input_data)
+-   [Local Input Data](#local-input-data)
+-   [Adding New Input Data](#adding-new-input-data)
+-   [How to Update Input Data](#how-to-update-input-data)
 
 Introduction
 ===============
@@ -22,7 +24,7 @@ the name of the needed input data is constructed. It is checked whether those in
 
 The prepared input data is a compressed tar archive file "`.tgz`", which can be opened with software such as [7-Zip](https://www.7-zip.org/), or in terminal by `tar` and `untar` commands. 
 
-Lokal Input Data
+Local Input Data
 ==================
 If you like to get the input data on your local machine you need to copy your ssh key (`/home/[your_cluster_user_name]/.ssh/id_dsa`) to your computer and adjust your local **.Rprofile** by adding the following line:
 ``` r
@@ -36,7 +38,7 @@ ssh-keygen -p
 ```
 It is recommended to first copy the existing key (e.g. id_dsa into id_dsa-local) and remove the passphrase of this copy and copy it to your machine.
 
-If you plan to run REMIND not with the default regional resolution you have to take care that REMIND starts from a gdx with the correct regional resolution. Either you can use one from an older run with the corresponding regional resolution or you can construct a new gdx with the correct regional resolution from a gdx in a different regional resolution by using the function gdx_rename from the package (gdx) (e.g. gdx_rename("input.gdx",set_name="all_regi",c(REF="RUS",CAZ="ROW",...,MEA="MEA",USA="USA"))).
+If you plan to run REMIND not with the default regional resolution you have to take care that REMIND starts from a gdx with the correct regional resolution. Either you can use one from an older run with the corresponding regional resolution or you can construct a new gdx with the correct regional resolution from a gdx in a different regional resolution by using the function `gdx_rename` from the package (gdx) (e.g. `gdx_rename("input.gdx",set_name="all_regi",c(REF="RUS",CAZ="ROW",...,MEA="MEA",USA="USA"))`).
 
 
 Adding New Input Data
@@ -49,7 +51,7 @@ How to Update Input Data
 
 
 1. Check for the current input data revision number in this cluster folder: `/p/projects/rd3mod/inputdata/cache`. Alternatively, run the helper tool `lastRev` (`/p/projects/rd3mod/tools/lastrev`) to get a list of the last five revX.XXX*_remind.tgz items in the default moinput output directory.
-2. Clone the repo `https://gitlab.pik-potsdam.de/REMIND/preprocessing-remind` to your tmp folder on the cluster and edit the `start.R` file by inserting the next revision number. If an old revision number is used, the input data will not be recalculated. Input data for a new regional resolution will be recalculated based on the existing cache information.
+2. Clone the repo [`https://gitlab.pik-potsdam.de/REMIND/preprocessing-remind`](https://gitlab.pik-potsdam.de/REMIND/preprocessing-remind) to your tmp folder on the cluster and edit its `start.R` file by inserting the next revision number. If an old revision number is used, the input data will not be recalculated. Input data for a new regional resolution will be recalculated based on the existing cache information.
 
 3. Start the script with 
 
@@ -59,6 +61,10 @@ sbatch slurm_start.sh
 
 The .log file lists the progress and potential errors. This process might take a while (currently >8 hours).
 
-4. If the process terminates without errors, do a test run with the new input data. To do this, clone the REMIND repo and update the data input version using your recently created data revision number in the `config/default.cfg` file and run one scenario (e.g. SSP2EU-Base). 
-5. If the test run completes without errors, update `cfg$revision` in `config/default.cfg` and push the change to the REMIND repo, so REMIND uses the new data by default.
+4. If the process terminates without errors, do a test run with the new input data. To do this, clone the REMIND repo and update the data input version `cfg$revision` in `config/default.cfg` using your recently created data revision number file and run one scenario (e.g. SSP2EU-Base).
+5. If the test run completes without errors, add the change in `config/default.cfg` and the update of the Input data revision in `main.gms` that was automatically performed by the REMIND run to a commit in your REMIND clone. This can be best done by using
+``` bash
+git add -p config/default.cfg main.gms
+````
+and then selecting the change in `default.cfg` and the first change to the input data in `main.gms` with `y`, and then ignoring possible other changes in `main.gms` with `d`. Create a pull request to push this change to the main REMIND repository, and REMIND will use the new data by default.
 


### PR DESCRIPTION
 - For scenario configs, allow that also the columns `model`, `output`, `regionMapping` and `inputData` may have empty cells and use the default
 - clarify a bit the very welcome tutorial by @fbenke-pik on input data update; fix links