### PR TITLE
add constraint to have equal shares of synfuels in biofuel+synfuel total per transport subsectors

### DIFF
--- a/core/sets.gms
+++ b/core/sets.gms
@@ -2295,8 +2295,8 @@ alias(esty,esty2);
 alias(rlf,rlf2);
 alias(regi,regi2,regi3);
 alias(steps,steps2);
-alias(all_emiMkt,emiMkt);
-alias(emi_sectors,sector);
+alias(all_emiMkt,emiMkt,emiMkt2);
+alias(emi_sectors,sector,sector2);
 alias(sector_types,type)
 
 ***-----------------------------------------------------------------------------

--- a/modules/39_CCU/off/not_used.txt
+++ b/modules/39_CCU/off/not_used.txt
@@ -4,3 +4,4 @@ cm_shSynTrans,input,questionnaire
 pm_emifac,input,questionnaire
 cm_emiscen,input,questionnaire
 cm_shSynGas,input,questionnaire
+vm_demFeSector,input,questionnaire

--- a/modules/39_CCU/on/declarations.gms
+++ b/modules/39_CCU/on/declarations.gms
@@ -20,6 +20,7 @@ equations
 q39_emiCCU(ttot,all_regi,all_te)                                        "calculate CCU emissions"
 q39_shSynTrans(ttot,all_regi)                                           "Define share of of synthetic liquids in all SE liquids."
 q39_shSynGas(ttot,all_regi)                                             "Define share of of synthetic gas in all SE gases."
+q39_EqualSecShare_BioSyn(ttot,all_regi,all_enty,emi_sectors,emiMkt)     "constraint on equal share of synfuels in biofuels+synfuels for sectors"
 ;
 
 *** EOF ./modules/39_CCU/on/declarations.gms

--- a/modules/39_CCU/on/equations.gms
+++ b/modules/39_CCU/on/equations.gms
@@ -43,5 +43,17 @@ q39_shSynGas(t,regi)..
     vm_prodSe(t,regi,"seh2","segasyn","h22ch4")
 ;
 
+*** impose same shares of synfuels in total biofuel+synfuel across all transport subsectors
+q39_EqualSecShare_BioSyn(t,regi,entyFe,sector,emiMkt)$(enty_BioSyn_39(entyFe,sector,emiMkt))..
+  vm_demFeSector(t,regi,"seliqsyn",entyFe,sector,emiMkt)
+  * sum(enty_BioSyn_39(entyFe2,sector2,emiMkt2),
+      ( vm_demFeSector(t,regi,"seliqsyn",entyFe2,sector2,emiMkt2)
+      + vm_demFeSector(t,regi,"seliqbio",entyFe2,sector2,emiMkt2)))
+  =e=
+  ( vm_demFeSector(t,regi,"seliqsyn",entyFe,sector,emiMkt)
+    + vm_demFeSector(t,regi,"seliqbio",entyFe,sector,emiMkt))
+  * sum(enty_BioSyn_39(entyFe2,sector2,emiMkt2), 
+      vm_demFeSector(t,regi,"seliqsyn",entyFe2,sector2,emiMkt2))
+;
 
 *** EOF ./modules/39_CCU/on/equations.gms

--- a/modules/39_CCU/on/sets.gms
+++ b/modules/39_CCU/on/sets.gms
@@ -23,6 +23,18 @@ te_ccu39(all_te)                            "CCU technologies"
 	MeOH									"conversion technology of secondary energy hydrogen to secondary energy liquids by the H2-Fischer-Tropsch route/Methanol route using captured CO2"
 /
 
+
+enty_BioSyn_39(all_enty,emi_sectors,emiMkt)	"FE, sector and emissions markets to which constraint on equal share of synfuels in biofuels+synfuels should be applied"
+/
+	fedie.trans.ETS
+	fedie.trans.ES
+	fedie.trans.other
+	fepet.trans.ETS
+	fepet.trans.ES
+	fepet.trans.other
+
+/
+
 ***-------------------------------------------------------------------------
 ***                  module specific mappings
 ***-------------------------------------------------------------------------


### PR DESCRIPTION
After a recent discussion with Robert, we said we would for now want to have equal shares of synfuels and biofuels per transport subsector (LDV, HDV, Bunkers) as there seems to be no real reason why we should put all biofuels into bunkers and all synfuels into trucks or vice versa which REMIND does quite arbitrarily at the moment. 

So this constraint, makes the synfuel share in carbon-neutral liquids (biofuel+synfuels) the same in ``fepet`` (LDV), ``fedie.ES`` (HDV), and ``fedie.other`` (Bunkers). 

We are planning to soon add reporting of that fuel distinction in the EDGE-T reporting based on the shares in ``vm_demFeSector``. 