### PR TITLE
Shift VRE integration cost start year from 2015 to 2020; enable dispatching down of pe2se via switch

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -387,6 +387,9 @@ cfg$gms$cm_implicitFE        <- "off"    # def = off
 cfg$gms$cm_implFETarget      <- "2030.EUR_regi 1.26921" # def = "2030.EUR_regi 1.26921"
 cfg$gms$cm_implFEExoTax      <- "off"    # def <- "off" 
 cfg$gms$cm_vehiclesSubsidies      <- "off"    # def <- "off" 
+cfg$gms$cm_dispatchSetyDown       <- "off"    # def <- "off"
+cfg$gms$cm_dispatchSeelDown       <- "off"    # def <- "off"
+
 
 # Calibration Switches
 cfg$gms$c_CES_calibration_iterations         <-  10       # def <- 10  number of calibration iterations

--- a/main.gms
+++ b/main.gms
@@ -465,6 +465,9 @@ $setGlobal cm_ESD_post2055Increase  2 !! def = 2
 $setGlobal cm_emiMktEScoop  off    !! def = off	
 $setGlobal cm_emiMktES2020price  30 !! def = 30
 $setGlobal cm_emiMktES2050	 off   !! def = off	
+$setGlobal cm_dispatchSetyDown       off   !! def = off  The amount that te producing any sety can dispatch less (in percent)
+$setGlobal cm_dispatchSeelDown       off   !! def = off  The amount that te producing seel can dispatch less (in percent) (overrides cm_dispatchSetyDown for te producing seel)
+
 $setGlobal cm_NucRegiPol	 off   !! def = off		
 $setGlobal cm_CoalRegiPol	 off   !! def = off		
 $setGlobal cm_proNucRegiPol	 off   !! def = off

--- a/main.gms
+++ b/main.gms
@@ -465,7 +465,7 @@ $setGlobal cm_ESD_post2055Increase  2 !! def = 2
 $setGlobal cm_emiMktEScoop  off    !! def = off	
 $setGlobal cm_emiMktES2020price  30 !! def = 30
 $setGlobal cm_emiMktES2050	 off   !! def = off	
-$setGlobal cm_dispatchSetyDown       off   !! def = off  The amount that te producing any sety can dispatch less (in percent)
+$setGlobal cm_dispatchSetyDown       off   !! def = off  The amount that te producing any sety can dispatch less (in percent) - so setting "20" in a cm_dispatchSetyDown column in scenario_config will allow the model to reduce the output of this te by 20% 
 $setGlobal cm_dispatchSeelDown       off   !! def = off  The amount that te producing seel can dispatch less (in percent) (overrides cm_dispatchSetyDown for te producing seel)
 
 $setGlobal cm_NucRegiPol	 off   !! def = off		

--- a/modules/32_power/IntC/bounds.gms
+++ b/modules/32_power/IntC/bounds.gms
@@ -11,6 +11,19 @@
 *** Fix capacity factors to the standard value from data
 vm_capFac.fx(t,regi,te) = pm_cf(t,regi,te);
 
+$IFTHEN.dispatchSetyDown not "%cm_dispatchSetyDown%" == "off"
+  loop(pe2se(enty,enty2,te),
+    vm_capFac.lo(t,regi,te) = ( 1 - %cm_dispatchSetyDown% / 100 ) * pm_cf(t,regi,te);
+  );
+$ENDIF.dispatchSetyDown
+
+$IFTHEN.dispatchSeelDown not "%cm_dispatchSeelDown%" == "off"
+  loop(pe2se(enty,enty2,te)$sameas(enty2,"seel"),  
+    vm_capFac.lo(t,regi,te) = ( 1 - %cm_dispatchSeelDown% / 100 ) * pm_cf(t,regi,te);  
+  );
+$ENDIF.dispatchSeelDown
+
+
 *** FS: for historically limited biomass production scenario (cm_bioprod_histlim >= 0)
 *** to avoid infeasibilities with vintage biomass capacities
 *** allow bio techs to reduce capacity factor

--- a/modules/32_power/IntC/declarations.gms
+++ b/modules/32_power/IntC/declarations.gms
@@ -14,6 +14,8 @@ parameters
     f32_storageCap(char, all_te)                    "multiplicative factor between dummy seel<-->h2 technologies and storXXX technologies"
     p32_storageCap(all_te,char)                     "multiplicative factor between dummy seel<-->h2 technologies and storXXX technologies"
     p32_PriceDurSlope(all_regi,all_te)              "slope of price duration curve used for calculation of electricity price for flexible technologies, determines how fast electricity price declines at lower capacity factors"
+    o32_dispatchDownPe2se(ttot,all_regi,all_te)           "output parameter to check by how much a pe2se te reduced its output below the normal, in % of the normal output."
+
 ;
 
 scalars

--- a/modules/32_power/IntC/equations.gms
+++ b/modules/32_power/IntC/equations.gms
@@ -49,7 +49,7 @@ q32_usableSeTe(t,regi,entySe,te)$(sameas(entySe,"seel") AND teVRE(te))..
 ***---------------------------------------------------------------------------
 *** Definition of capacity constraints for storage:
 ***---------------------------------------------------------------------------
-q32_limitCapTeStor(t,regi,teStor)$( t.val ge 2015 ) ..
+q32_limitCapTeStor(t,regi,teStor)$( t.val ge 2020 ) ..
     ( 0.5$( cm_VRE_supply_assumptions eq 1 )
     + 1$(   cm_VRE_supply_assumptions ne 1 )
     )
@@ -99,7 +99,7 @@ q32_limitCapTeChp(t,regi)..
 ***---------------------------------------------------------------------------
 *** Calculation of necessary grid installations for centralized renewables:
 ***---------------------------------------------------------------------------
-q32_limitCapTeGrid(t,regi)$( t.val ge 2015 ) .. 
+q32_limitCapTeGrid(t,regi)$( t.val ge 2020 ) .. 
     vm_cap(t,regi,"gridwind",'1')      !! Technology is now parameterized to yield marginal costs of ~3.5$/MWh VRE electricity
     / p32_grid_factor(regi)        		!! It is assumed that large regions require higher grid investment 
     =g=
@@ -134,7 +134,7 @@ q32_shStor(t,regi,teVRE)$(t.val ge 2015)..
 	)
 ;
 
-q32_storloss(t,regi,teVRE)$(t.val ge 2015)..
+q32_storloss(t,regi,teVRE)$(t.val ge 2020)..
 	v32_storloss(t,regi,teVRE)
 	=e=
 	v32_shStor(t,regi,teVRE) / 93    !! corrects for the 7%-shift in v32_shStor: at 100% the value is correct again

--- a/modules/32_power/IntC/postsolve.gms
+++ b/modules/32_power/IntC/postsolve.gms
@@ -10,5 +10,16 @@
 pm_SEPrice(ttot,regi,entySE)$(abs (qm_budget.m(ttot,regi)) gt sm_eps AND sameas(entySE,"seel")) = 
        q32_balSe.m(ttot,regi,entySE) / qm_budget.m(ttot,regi);
 
+loop(t,
+  loop(regi,
+    loop(pe2se(enty,enty2,te),
+      if ( ( vm_capFac.l(t,regi,te) < (0.999 * vm_capFac.up(t,regi,te) ) ),
+        o32_dispatchDownPe2se(t,regi,te) = round ( 100 * (vm_capFac.up(t,regi,te) - vm_capFac.l(t,regi,te) ) / (vm_capFac.up(t,regi,te) + 1e-10) );
+      );
+    );
+  );
+);
+
+
 *** EOF ./modules/32_power/IntC/postsolve.gms
 


### PR DESCRIPTION
1. Starting the grid/storage costs in 2015 led to weird power sector results in EU countries (the model couldn't scale up grid quickly enough to be in line with the 2015 values and therefore added gas and coal power plants just to reduce the VRE share that resulted from the VRE capacity build-up that was enforced via capacity fixings). Therefore, the start year was shifted to 2020, which leads to much smoother pathways of grid/storage scaleup. 

2. Using the two switches cm_dispatchSetyDown and cm_dispatchSeelDown one can now allow the model to dispatch down the output from pe2se technologies by the percentage value given to this switch. sety applies to all pe2se te, seel only the ones producing power.  
The parameter o32_dispatchDownPe2se shows which te were dispatched down by how many % in the last iteration. 