### PR TITLE
Add H2 and electricity HTH trajectories for industry and introduce markup cost for H2 and electricity HTH

### DIFF
--- a/modules/29_CES_parameters/calibrate/datainput.gms
+++ b/modules/29_CES_parameters/calibrate/datainput.gms
@@ -383,6 +383,11 @@ loop (pf_quantity_shares_37(in,in2),
   * (t.val - 2020) 
   + pm_cesdata("2020",regi,in,"quantity");
 
+
+*** set CES offset quantity to remove FE demand from H2 an feelhth in baseline
+  pm_cesdata(t,regi_dyn29(regi),in,"offset_quantity") 
+  = -pm_cesdata(t,regi,in,"quantity");
+
 );
 
 *** Assume fehe_otherInd at 0.1% of fega_otherInd for regions with zero 

--- a/modules/29_CES_parameters/calibrate/datainput.gms
+++ b/modules/29_CES_parameters/calibrate/datainput.gms
@@ -365,10 +365,24 @@ $endif.edgesm
 pm_cesdata(t,regi,ppfKap,"quantity") = p29_capitalQuantity(t,regi,ppfKap);
 
 $ifthen.subsectors "%industry%" == "subsectors"
-*** Assume H2 and feelhth demand at 0.1% of gases and feelwlth demand
+*** Assume H2 and feelhth demand at 10% of gases and feelwlth demand from 2050
+*** linear phase-in between 2025 and 2050
 loop (pf_quantity_shares_37(in,in2),
-  pm_cesdata(t,regi_dyn29(regi),in,"quantity")
-  = 1e-4 * pm_cesdata(t,regi,in2,"quantity");
+
+*** 10% from 2050
+  pm_cesdata(t,regi_dyn29(regi),in,"quantity")$(t.val ge 2050) 
+  = 0.1 * pm_cesdata(t,regi,in2,"quantity");
+*** 0.1% before 2025
+  pm_cesdata(t,regi_dyn29(regi),in,"quantity")$(t.val lt 2025) 
+  = 0.001 * pm_cesdata(t,regi,in2,"quantity");
+*** linear phase-in 2025-2050
+  pm_cesdata(t,regi_dyn29(regi),in,"quantity")$(t.val ge 2025 AND t.val lt 2050) 
+  = (pm_cesdata("2050",regi,in,"quantity") 
+  - pm_cesdata("2020",regi,in,"quantity")) 
+  / (2050-2020)
+  * (t.val - 2020) 
+  + pm_cesdata("2020",regi,in,"quantity");
+
 );
 
 *** Assume fehe_otherInd at 0.1% of fega_otherInd for regions with zero 

--- a/modules/36_buildings/simple/equations.gms
+++ b/modules/36_buildings/simple/equations.gms
@@ -73,7 +73,7 @@ q36_H2Share(t,regi)..
 ***---------------------------------------------------------------------------
 *'  CES markup cost to represent sector-specific demand-side transformation cost in buildings
 ***---------------------------------------------------------------------------
-q36_costCESmarkup(t,regi,in)$(ppfen_CESMkup_dyn36(in))..
+q36_costCESmarkup(t,regi,in)$(ppfen_buildings_dyn36(in))..
   vm_costCESMkup(t,regi,in)
   =e=
   p36_CESMkup(t,regi,in)*(vm_cesIO(t,regi,in) + pm_cesdata(t,regi,in,"offset_quantity"))

--- a/modules/36_buildings/simple/sets.gms
+++ b/modules/36_buildings/simple/sets.gms
@@ -69,24 +69,6 @@ Sets
  ue_dyn36(all_in)  "useful energy items"
  //
 
- tdTeMarkup36(all_te)   "td technologies to which CES markup cost should be attributed to as investment cost"
-  /
-  tdels
-  tdhes
-  /
-
-tdTe2In36(all_te,all_in) "mapping of td technologies to CES nodes for CES markup cost"
-  /
-  tdels.feelhpb
-  tdhes.feheb
-  /
-
-ppfen_CESMkup_dyn36(all_in)                   "buildings production factors of CES function to which CES markup cost can be applied"
-/
-  feelhpb
-  feheb
-/
-
 ;
 
 cal_ppf_buildings_dyn36(ppfen_buildings_dyn36) = YES;
@@ -99,6 +81,6 @@ ppfEn(ppfen_buildings_dyn36)      = YES;
 cesOut2cesIn(ces_buildings_dyn36) = YES;
 fe2ppfEn(fe2ppfEn36)              = YES;
 fe_tax_sub_sbi(fe_tax_sub36) = YES;
-ppfen_CESMkup(ppfen_CESMkup_dyn36) = YES;
+ppfen_CESMkup(ppfen_buildings_dyn36) = YES;
 
 *** EOF ./modules/36_buildings/simple/sets.gms

--- a/modules/37_industry/subsectors/datainput.gms
+++ b/modules/37_industry/subsectors/datainput.gms
@@ -187,7 +187,7 @@ pm_ue_eff_target("ue_otherInd")         = 0.008;
 *** default values of CES markup
 p37_CESMkup(t,regi,in) = 0;
 
-
+$ontext
 *** place markup cost of 200 USD/MWh(el) on electricity high-temperature heat and electricity steel nodes
 *** to represent demand-side cost of electrification and reach higher subsitution rates
 p37_CESMkup(t,regi,"feelhth_chemicals") = 200* sm_TWa_2_MWh * 1e-12;
@@ -201,7 +201,7 @@ p37_CESMkup(t,regi,"feh2_chemicals") = 100* sm_TWa_2_MWh * 1e-12;
 p37_CESMkup(t,regi,"feh2_otherInd") = 100* sm_TWa_2_MWh * 1e-12;
 p37_CESMkup(t,regi,"feh2_steel") = 100* sm_TWa_2_MWh * 1e-12;
 p37_CESMkup(t,regi,"feh2_cement") = 100* sm_TWa_2_MWh * 1e-12;
-
+$offtext
 
 *** overwrite or extent CES markup cost if specified by switch
 $ifThen.CESMkup not "%cm_CESMkup_ind%" == "standard" 

--- a/modules/37_industry/subsectors/datainput.gms
+++ b/modules/37_industry/subsectors/datainput.gms
@@ -187,6 +187,22 @@ pm_ue_eff_target("ue_otherInd")         = 0.008;
 *** default values of CES markup
 p37_CESMkup(t,regi,in) = 0;
 
+
+*** place markup cost of 200 USD/MWh(el) on electricity high-temperature heat and electricity steel nodes
+*** to represent demand-side cost of electrification and reach higher subsitution rates
+p37_CESMkup(t,regi,"feelhth_chemicals") = 200* sm_TWa_2_MWh * 1e-12;
+p37_CESMkup(t,regi,"feelhth_otherInd") = 200* sm_TWa_2_MWh * 1e-12;
+p37_CESMkup(t,regi,"feel_steel_secondary") = 200* sm_TWa_2_MWh * 1e-12;
+p37_CESMkup(t,regi,"feel_steel_primary") = 200* sm_TWa_2_MWh * 1e-12;
+
+*** place markup cost of 100 USD/MWh(H2) on H2 nodes
+*** to represent demand-side cost of hydrogen usage and reach higher subsitution rates
+p37_CESMkup(t,regi,"feh2_chemicals") = 100* sm_TWa_2_MWh * 1e-12;
+p37_CESMkup(t,regi,"feh2_otherInd") = 100* sm_TWa_2_MWh * 1e-12;
+p37_CESMkup(t,regi,"feh2_steel") = 100* sm_TWa_2_MWh * 1e-12;
+p37_CESMkup(t,regi,"feh2_cement") = 100* sm_TWa_2_MWh * 1e-12;
+
+
 *** overwrite or extent CES markup cost if specified by switch
 $ifThen.CESMkup not "%cm_CESMkup_ind%" == "standard" 
   p37_CESMkup(t,regi,in)$(p37_CESMkup_input(in)) = p37_CESMkup_input(in);

--- a/modules/37_industry/subsectors/equations.gms
+++ b/modules/37_industry/subsectors/equations.gms
@@ -117,7 +117,7 @@ q37_IndCCSCost(ttot,regi,emiInd37)$( ttot.val ge cm_startyear ) ..
 ***---------------------------------------------------------------------------
 *'  CES markup cost to represent sector-specific demand-side transformation cost in industry
 ***---------------------------------------------------------------------------
-q37_costCESmarkup(t,regi,in)$(ppfen_CESMkup_dyn37(in))..
+q37_costCESmarkup(t,regi,in)$(ppfen_industry_dyn37(in))..
   vm_costCESMkup(t,regi,in)
   =e=
     p37_CESMkup(t,regi,in) 

--- a/modules/37_industry/subsectors/sets.gms
+++ b/modules/37_industry/subsectors/sets.gms
@@ -294,19 +294,6 @@ entyFeCC37(all_enty)  "FE carriers in industry which can be used for CO2 capture
     fehos
     fegas
   /
-
-
-ppfen_CESMkup_dyn37(all_in)                   "industry production factors of CES function to which CES markup cost can be applied"
-  /
-    feelwlth_chemicals
-    feelhth_chemicals
-    feel_cement
-    feelwlth_otherInd
-    feelhth_otherInd
-    feel_steel_secondary
-    feel_steel_primary
-    feh2_steel
-  /
 ;
 
 *** ---------------------------------------------------------------------------
@@ -324,7 +311,8 @@ fe2ppfen(fe2ppfen37)                        = YES;
 fe_tax_sub_sbi(fe_tax_sub37)                = YES;
 pf_eff_target_dyn37(ppfen_industry_dyn37)   = YES;
 pf_quan_target_dyn37(ppfkap_industry_dyn37) = YES;
-ppfen_CESMkup(ppfen_CESMkup_dyn37)          = YES;
+
+ppfen_CESMkup(ppfen_industry_dyn37) = YES;
 
 $ifthen.calibrate "%CES_parameters%" == "calibrate"   !! CES_parameters
 pf_eff_target_dyn29(pf_eff_target_dyn37)    = YES;


### PR DESCRIPTION
This
* adds small amounts of H2 and HTH electricity in industry sectors for baseline trajectories 
* introduces markup cost on CES nodes of H2 and electricity HTH in industry sector to represent demand-side cost of electrification/H2 technologies

For results and discussion, see this [issue](https://github.com/remindmodel/development_issues/issues/95). 

To be discussed further. 
