### PR TITLE
specify unit for gams_runtime

### DIFF
--- a/scripts/start/prepare_and_run.R
+++ b/scripts/start/prepare_and_run.R
@@ -852,7 +852,7 @@ run <- function(start_subsequent_runs = TRUE) {
   # to facilitate debugging, look which files were created.
   message("Model summary:")
   # Print REMIND runtime
-  message("  gams_runtime is ", gams_runtime, "")
+  message("  gams_runtime is ", round(gams_runtime,1), " ", units(gams_runtime), ".")
   if (! file.exists("full.gms")) {
     message("! full.gms does not exist, so the REMIND GAMS code was not generated.")
   } else {


### PR DESCRIPTION
was lost because `print(gams_runtime)` yields `Time difference of 2.334527 hours`, while `message(gams_runtime)` prints only `2.33452730721898`. Now, a rounded value plus the unit is given.