### PR TITLE
allow to differentiate path_gdx_ref and path_gdx_refpolicycost

### DIFF
--- a/scripts/output/single/LCOEPlot.R
+++ b/scripts/output/single/LCOEPlot.R
@@ -12,7 +12,7 @@ library(lusweave)
 
 
 ############################# BASIC CONFIGURATION #############################
-gdx_name     <- "fulldata.gdx"        # name of the gdx  
+gdx_name     <- "fulldata.gdx"        # name of the gdx
 
 if(!exists("source_include")) {
   #Define arguments that can be read from command line

--- a/scripts/output/single/convergenceCheck.R
+++ b/scripts/output/single/convergenceCheck.R
@@ -10,7 +10,7 @@ library(gms)
 library(lucode2)
 library(methods)
 ############################# BASIC CONFIGURATION #############################
-gdx_name     <- "fulldata.gdx"        # name of the gdx  
+gdx_name     <- "fulldata.gdx"        # name of the gdx
 
 if(!exists("source_include")) {
   #Define arguments that can be read from command line

--- a/scripts/output/single/rds_report.R
+++ b/scripts/output/single/rds_report.R
@@ -19,8 +19,8 @@ if(!exists("source_include")) {
 }
 
 load(paste0(outputdir, "/config.Rdata"))
-gdx	     <- file.path(outputdir,"fulldata.gdx")
-gdx_ref  <- file.path(outputdir,"input_ref.gdx")
+gdx      <- file.path(outputdir,"fulldata.gdx")
+gdx_ref  <- file.path(outputdir,"input_refpolicycost.gdx")
 if(!file.exists(gdx_ref)) gdx_ref <- NULL
 rds <- paste0(outputdir, "/report.rds")
 runstatistics <- paste0(outputdir,"/runstatistics.rda")

--- a/scripts/output/single/reportCEScalib.R
+++ b/scripts/output/single/reportCEScalib.R
@@ -17,8 +17,8 @@ require(colorspace)
 require(gdx)
 require(grid)
 
-gdx_name     <- "fulldata.gdx"        # name of the gdx  
-gdx_ref_name <- "input_ref.gdx"       # name of the reference gdx (for policy cost calculation)
+gdx_name     <- "fulldata.gdx"             # name of the gdx
+gdx_ref_name <- "input_refpolicycost.gdx"  # name of the reference gdx (for policy cost calculation)
 
 if(!exists("source_include")) {
   #Define arguments that can be read from command line

--- a/scripts/output/single/reportCEScalib.R
+++ b/scripts/output/single/reportCEScalib.R
@@ -18,16 +18,13 @@ require(gdx)
 require(grid)
 
 gdx_name     <- "fulldata.gdx"             # name of the gdx
-gdx_ref_name <- "input_refpolicycost.gdx"  # name of the reference gdx (for policy cost calculation)
 
 if(!exists("source_include")) {
   #Define arguments that can be read from command line
    outputdir <- "output/R17IH_SSP2_postIIASA-26_2016-12-23_16.03.23"     # path to the output folder
-   readArgs("outputdir","gdx_name","gdx_ref_name")
+   readArgs("outputdir","gdx_name")
 } 
 gdx      <- file.path(outputdir,gdx_name)
-gdx_ref  <- file.path(outputdir,gdx_ref_name)
-if(!file.exists(gdx_ref)) { gdx_ref <- NULL }
 scenario <- getScenNames(outputdir)
 
 #---------------------------------------------------------------------------

--- a/scripts/output/single/reporting.R
+++ b/scripts/output/single/reporting.R
@@ -11,8 +11,8 @@ library(lucode2)
 library(gms)
 library(methods)
 ############################# BASIC CONFIGURATION #############################
-gdx_name     <- "fulldata.gdx"        # name of the gdx  
-gdx_ref_name <- "input_ref.gdx"       # name of the reference gdx (for policy cost calculation)
+gdx_name     <- "fulldata.gdx"             # name of the gdx
+gdx_ref_name <- "input_refpolicycost.gdx"  # name of the reference gdx (for policy cost calculation)
  
 
 if(!exists("source_include")) {

--- a/scripts/output/single/reporting_MOFEX.R
+++ b/scripts/output/single/reporting_MOFEX.R
@@ -15,8 +15,8 @@ library(rlang)
 library(luscale)
 
 ############################# BASIC CONFIGURATION #############################
-gdx_name     <- "fulldata.gdx"        # name of the gdx  
-gdx_ref_name <- "input_ref.gdx"       # name of the reference gdx (for policy cost calculation)
+gdx_name     <- "fulldata.gdx"             # name of the gdx
+gdx_ref_name <- "input_refpolicycost.gdx"  # name of the reference gdx (for policy cost calculation)
  
 
 if(!exists("source_include")) {

--- a/scripts/start/prepare_and_run.R
+++ b/scripts/start/prepare_and_run.R
@@ -907,7 +907,7 @@ run <- function(start_subsequent_runs = TRUE) {
 
     # fulldatapath may be written into gdx paths of subsequent runs
     fulldatapath <- paste0(cfg_main$remind_folder,"/",cfg_main$results_folder,"/fulldata.gdx")
-    possible_pathes_to_gdx <- c("input.gdx", "input_ref.gdx", "input_bau.gdx", "input_carbonprice.gdx")
+    possible_pathes_to_gdx <- c("input.gdx", "input_ref.gdx", "input_refpolicycost.gdx", "input_bau.gdx", "input_carbonprice.gdx")
 
     # Loop possible subsequent runs, saving path to fulldata.gdx of current run (== cfg_main$title) to their cfg files
 

--- a/standalone/MOFEX/scripts/reporting_MOFEX.R
+++ b/standalone/MOFEX/scripts/reporting_MOFEX.R
@@ -15,8 +15,8 @@ library(rlang)
 library(luscale)
 
 ############################# BASIC CONFIGURATION #############################
-gdx_name     <- "fulldata.gdx"        # name of the gdx  
-gdx_ref_name <- "input_ref.gdx"       # name of the reference gdx (for policy cost calculation)
+gdx_name     <- "fulldata.gdx"             # name of the gdx
+gdx_ref_name <- "input_refpolicycost.gdx"  # name of the reference gdx (for policy cost calculation)
  
 
 if(!exists("source_include")) {

--- a/start.R
+++ b/start.R
@@ -167,10 +167,11 @@ configure_cfg <- function(icfg, iscen, iscenarios, isettings) {
     }
 
     # Define path where the GDXs will be taken from
-    gdxlist <- c(input.gdx             = isettings[iscen, "path_gdx"],
-                 input_ref.gdx         = isettings[iscen, "path_gdx_ref"],
-                 input_bau.gdx         = isettings[iscen, "path_gdx_bau"],
-                 input_carbonprice.gdx = isettings[iscen, "path_gdx_carbonprice"]
+    gdxlist <- c(input.gdx               = isettings[iscen, "path_gdx"],
+                 input_ref.gdx           = isettings[iscen, "path_gdx_ref"],
+                 input_refpolicycost.gdx = isettings[iscen, "path_gdx_refpolicycost"],
+                 input_bau.gdx           = isettings[iscen, "path_gdx_bau"],
+                 input_carbonprice.gdx   = isettings[iscen, "path_gdx_carbonprice"]
                  )
 
     # add gdxlist to list of files2export
@@ -235,7 +236,11 @@ if ('--restart' %in% argv) {
     settings <- read.csv2(config.file, stringsAsFactors = FALSE, row.names = 1, comment.char = "#", na.strings = "")
 
     # Add empty path_gdx_... columns if they are missing
-    path_gdx_list <- c("path_gdx", "path_gdx_ref", "path_gdx_bau", "path_gdx_carbonprice")
+    path_gdx_list <- c("path_gdx", "path_gdx_ref", "path_gdx_refpolicycost", "path_gdx_bau", "path_gdx_carbonprice")
+    if ("path_gdx_ref" %in% names(settings) && ! "path_gdx_refpolicycost" %in% names(settings)) {
+      settings$path_gdx_refpolicycost <- settings$path_gdx_ref
+      message("No column path_gdx_refpolicycost for policy cost comparison found, using path_gdx_ref instead.")
+    }
     settings[, path_gdx_list[! path_gdx_list %in% names(settings)]] <- NA
     
     # state if columns are unknown and probably will be ignored, and stop for some outdated parameters.

--- a/tutorials/3_RunningBundleOfRuns.md
+++ b/tutorials/3_RunningBundleOfRuns.md
@@ -41,8 +41,10 @@ Example with comments and different ways to specify subsequent runs.
 The columns to implement subsequent runs are usually found at the end, starting with `path_gdx`:
 
 * `path_gdx` allows to specify initial conditions for the run, overwriting the usual initial conditions taken from the calibration files found in [`./config/gdx-files/`](../config/gdx-files/files). If it points to an unconverged run, this can be used to restart runs, similar to `Rscript start.R --restart`.
-* `path_gdx_ref` points to the run used for all `t < cm_startyear`, which can be used for example for delayed transition scenarios, and which is also used as a comparison for the policy cost calculation.
 * `path_gdx_bau` points to the run used as business as usual (BAU) scenario, for example for runs using [`45_carbonprice/NDC`](../modules/45_carbonprice/NDC), where some countries specify emission as percentage reduction compared to BAU.
+* `path_gdx_carbonprice` can be used to use a carbon tax path from an earlier run with realization [`45_carbonprice/exogenous`](../modules/45_carbonprice/exogenous).
+* `path_gdx_ref` points to the run used for all `t < cm_startyear`, which can be used for example for delayed transition scenarios.
+* `path_gdx_refpolicycost` points to the run that is used as a comparison for the policy cost calculation. If no such column exists, `path_gdx_ref` is used instead.
 
 These three columns starting with `path…` can point to either finished runs or other rows of the current model execution:
 * provide a path to an existing `gdx` file such as `./output/SSP2-Base_2021-12-24_19.30.00/fulldata.gdx`. For subfolders of `./output/`, writing the folder name `SSP2-Base_2021-12-24_19.30.00` is sufficient.


### PR DESCRIPTION
For the scenario config, a new column name `path_gdx_refpolicycost` is introduced following the debate in https://github.com/remindmodel/development_issues/issues/10:

- `path_gdx_ref` is used as before for fixing until `cm_startyear`,
- `path_gdx_refpolicycost` is used as a baseline for policy cost calculation.

If no column `path_gdx_refpolicycost` is specified, `path_gdx_ref` is used as before, so this PR should not alter the working of any existing scenario config file.

`path_gdx_refpolicycost` is integrated in the determination of subsequent runs, so subsequent runs will wait until the run for comparison of policy cost is finished, although technically the `fulldata.gdx` is only required in the output generation at the end of the subsequent run. If this slows down the process, you can leave the `path_gdx_refpolicycost` cell empty and do the policy cost calculation manually after all runs are finished, or you can add a `_` after the run name in the cell to use an older, already finished run.