### PR TITLE
enable option to use --restart to also restart subsequent runs

### DIFF
--- a/scripts/start/prepare_and_run.R
+++ b/scripts/start/prepare_and_run.R
@@ -896,7 +896,7 @@ run <- function(start_subsequent_runs = TRUE) {
   # Use the name to check whether it is a coupled run (TRUE if the name ends with "-rem-xx")
   coupled_run <- grepl("-rem-[0-9]{1,2}$",cfg$title)
   # Don't start subsequent runs form here if REMIND runs coupled. They are started in start_coupled.R instead.
-  start_subsequent_runs <- start_subsequent_runs & !coupled_run
+  start_subsequent_runs <- (start_subsequent_runs | isTRUE(cfg$restart_subsequent_runs)) & !coupled_run
 
   if (start_subsequent_runs & (length(rownames(cfg$RunsUsingTHISgdxAsInput)) > 0)) {
     # track whether any subsequent run was actually started

--- a/start.R
+++ b/start.R
@@ -205,11 +205,15 @@ if(!exists("slurmConfig")) slurmConfig <- choose_slurmConfig()
 if ('--restart' %in% argv) {
   # choose results folder from list
   outputdirs <- choose_folder("./output","Please choose the runs to be restarted")
+  message("\nAlso restart subsequent runs? Enter Y, else leave empty:")
+  restart_subsequent_runs <- get_line() %in% c("Y", "y")
   for (outputdir in outputdirs) {
-    cat("Restarting",outputdir,"\n")
+    message("Restarting ", outputdir)
     load(paste0("output/",outputdir,"/config.Rdata")) # read config.Rdata from results folder
+    cfg$restart_subsequent_runs <- restart_subsequent_runs
     cfg$slurmConfig <- combine_slurmConfig(cfg$slurmConfig,slurmConfig) # update the slurmConfig setting to what the user just chose
     cfg$results_folder <- paste0("output/",outputdir) # overwrite results_folder in cfg with name of the folder the user wants to restart, because user might have renamed the folder before restarting
+    save(cfg,file=paste0("output/",outputdir,"/config.Rdata"))
     submit(cfg, restart = TRUE)
     #cat(paste0("output/",outputdir,"/config.Rdata"),"\n")
   }

--- a/tutorials/3_RunningBundleOfRuns.md
+++ b/tutorials/3_RunningBundleOfRuns.md
@@ -57,12 +57,13 @@ Everything in the row after a `#` is interpreted as comment. Best use it as firs
 Further notes:
 --------------
 
-The cells need not contain only a single value, but for example module realization [`47_regipol/regiCarbonPrice`](../modules/47_regipol/regiCarbonPrice) allows to specify in the parameter `cm_regiCO2target` to enter comma separated values `2020.2050.USA.year.netGHG 1, 2020.2050.EUR.year.netGHG 1` to specify emission goals for multiple regions.
+* To check the functioning of the `scenario_config*.csv`, edit [`default.cfg`](./config/default.cfg) and set `cfg$gms$optimization` to `testOneRegi` which runs one iteration in one region for each run.
 
-To compare a `scenario_config*.csv` file to the current default configuration, you can run `Rscript -e "remind2::colorScenConf()"` in your remind directory and select the file you are interested in. [`colorScenConf()`](https://github.com/pik-piam/remind2/blob/master/R/colorScenConf.R) produces a file ending with `_colorful.xlsx` in the same directory and provides you with information how to interpret the colors within.
+* The cells need not contain only a single value, but for example module realization [`47_regipol/regiCarbonPrice`](../modules/47_regipol/regiCarbonPrice) allows to specify in the parameter `cm_regiCO2target` to enter comma separated values `2020.2050.USA.year.netGHG 1, 2020.2050.EUR.year.netGHG 1` to specify emission goals for multiple regions.
 
-To compare two `scenario_config*.csv` files, for example after a change, these commands are useful:
-``` bash
-git diffmif scenario_config_1.csv scenario_config_2.csv
-git diff --word-diff=color --word-diff-regex=. --no-index scenario_config_1.csv scenario_config_2.csv
-```
+* To compare a `scenario_config*.csv` file to the current default configuration, you can run `Rscript -e "remind2::colorScenConf()"` in your remind directory and select the file you are interested in. [`colorScenConf()`](https://github.com/pik-piam/remind2/blob/master/R/colorScenConf.R) produces a file ending with `_colorful.xlsx` in the same directory and provides you with information how to interpret the colors within.
+
+* To compare two `scenario_config*.csv` files, for example after a change, these commands are useful:
+
+        git diffmif scenario_config_1.csv scenario_config_2.csv
+        git diff --word-diff=color --word-diff-regex=. --no-index scenario_config_1.csv scenario_config_2.csv


### PR DESCRIPTION
This PR enables an option to use --restart to also restart subsequent runs.

- Running `Rscript start.R --restart`, it asks you whether you also want to restart the subsequent runs of the run you want to restart.
- `start.R` stores this in `cfg$restart_subsequent_runs` and saves this to `config.Rdata` in all the selected run folders.
- Note that I also write the new `cfg$results_folder` and `cfg$slurmConfig` into this file, although I'm not sure whether this is correct – the fact that this was missing is probably a bug if indeed (as suggested in the comment) the folder was moved, because `prepare_and_run.R` uses `cfg$results_folder` in several occasions, then using the wrong folder. Probably was never a problem because hardly anyone moves folders and restarts run, I guess. But please check carefully if that is correct. 
- `prepare_and_run.R` normally sets `start_subsequent_runs` to FALSE for restarted runs. But if `isTRUE(cfg$restart_subsequent_runs))` is satisfied, it starts them nevertheless. As `isTRUE(cfg$whatever)` is `FALSE` if `whatever` does not exist, this check should be safe.

A related issue was opened by @giannou: [Subsequent runs not starting #174](https://github.com/remindmodel/remind/issues/174).
But I haven't fully understood what automatically preempted run means. @LaviniaBaumstark there states: "There is an option to run a few scripts before a run is preempted." Basically you just need to set `cfg$restart_subsequent_runs` to `TRUE` in `config.Rdata` in these scripts, wherever they are.

Tested: `/p/tmp/oliverr/remind-smallfix/output/SSP2-Base_2022-02-25_13.16.32` was restarted and successfully started a subsequent run.

(also added some hint on using testOneRegi to tutorial 3)