### PR TITLE
change lifetime of ships to 99, not 999

### DIFF
--- a/core/input/generisdata_trade.prn
+++ b/core/input/generisdata_trade.prn
@@ -24,5 +24,5 @@ omf                        0.01                      3.3                        
 omf_d                         0                        0                        0                       0                     0
 omv                           0                        0                        0                       0                     0
 omv_d                         0                        0                      2.3                       0                   2.3
-lifetime                     35                       35                      999                      35                   999
+lifetime                     35                       35                       99                      35                    99
 *** EOF ./core/input/generisdata_trade.prn


### PR DESCRIPTION
Fix the following error:
```
**** PUT ERROR FOR FILE diagnosis_opTimeYr2te AT LINE 21973: ITEM DOES NOT FIT - LOOK for ****
```