### PR TITLE
improve logging in output.R, harmonize order of slurm and output script choice

### DIFF
--- a/scripts/output/comparison/policyCosts.R
+++ b/scripts/output/comparison/policyCosts.R
@@ -135,7 +135,7 @@ write_new_reporting <- function(mif_path,
   my_data <- magclass::add_dimension(my_data,dim=3.1,add = "model",nm = "REMIND")
   my_data <- magclass::add_dimension(my_data,dim=3.1,add = "scenario",nm = scen_name)
   
-  magclass::write.report(my_data, file = new_mif_path, ndigit = 7, skipempty = FALSE)
+  magclass::write.report(my_data, file = new_mif_path, ndigit = 7)
   
   return(new_mif_path)
 }


### PR DESCRIPTION
- It was a bit confusing that single output first asks for slurm, then folders, then output type, and comparison asked for output type, then folders, then slurm. Is harmonized now to the setting of comparison which I find more logical.
- improve logging for output generation: If no output is written, doesn't state anymore that is was finished. If output was send to slurm, tells you output generation has started, not is finished.
- specify how runs must be entered for policyCosts
- as discussed with Johannes, skip empty entries in mif-file for policyCosts reporting to skip the variables that are always N/A , just like for normal reporting,

The diff looks as if I changed a lot, but this is mainly changing the number of spaces at the line beginning.