### PR TITLE
provide config files in call to `compareScenarios2()` via output.R

### DIFF
--- a/scripts/utils/run_compareScenarios2.R
+++ b/scripts/utils/run_compareScenarios2.R
@@ -21,6 +21,8 @@ run_compareScenarios2 <- function(outputdirs, shortTerm, outfilename, regionList
   # Add '../' in front of the paths as compareScenarios2() will be run in individual temporary subfolders (see below).
   mif_path  <- file.path("..", outputdirs, paste("REMIND_generic_", scenNames, ".mif", sep = ""))
   hist_path <- file.path("..", outputdirs[1], "historical.mif")
+  scen_config_path  <- file.path("..", outputdirs, "config.Rdata")
+  default_config_path  <- file.path("..", "config", "default.cfg")
 
   # Create temporary folder. This is necessary because each compareScenarios2 creates a folder names 'figure'.
   # If multiple compareScenarios2 run in parallel they would interfere with the others' figure folder.
@@ -43,6 +45,8 @@ run_compareScenarios2 <- function(outputdirs, shortTerm, outfilename, regionList
     try(compareScenarios2(
       mifScen = mif_path,
       mifHist = hist_path,
+      cfgScen = scen_config_path,
+      cfgDefault = default_config_path,
       outputDir = outfilepath,
       outputFile = outfilename,
       outputFormat = "PDF",
@@ -52,6 +56,8 @@ run_compareScenarios2 <- function(outputdirs, shortTerm, outfilename, regionList
     try(compareScenarios2(
       mifScen = mif_path,
       mifHist = hist_path,
+      cfgScen = scen_config_path,
+      cfgDefault = default_config_path,
       outputDir = outfilepath,
       outputFile = outfilename,
       outputFormat = "PDF",


### PR DESCRIPTION
When calling `compareScenarios2()` via output.R, the function is now told the location of the config.Rdata files for each scenario and the path to `default.cfg`. This enables the new functionality implemented in #685 and https://github.com/pik-piam/remind2/pull/206