### PR TITLE
set SOF and EOF statements to actual filenames

### DIFF
--- a/modules/01_macro/singleSectorGr/realization.gms
+++ b/modules/01_macro/singleSectorGr/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/01_macro/singleSectorGr.gms
+*** SOF ./modules/01_macro/singleSectorGr/realization.gms
 
 *' @description The singleSectorGr realization corresponds to a neo-classical, single 
 *' sector growth model.
@@ -18,4 +18,4 @@ $Ifi "%phase%" == "preloop" $include "./modules/01_macro/singleSectorGr/preloop.
 $Ifi "%phase%" == "bounds" $include "./modules/01_macro/singleSectorGr/bounds.gms"
 $Ifi "%phase%" == "postsolve" $include "./modules/01_macro/singleSectorGr/postsolve.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/01_macro/singleSectorGr.gms
+*** EOF ./modules/01_macro/singleSectorGr/realization.gms

--- a/modules/02_welfare/utilitarian/realization.gms
+++ b/modules/02_welfare/utilitarian/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/02_welfare/realization.gms
+*** SOF ./modules/02_welfare/utilitarian/realization.gms
 
 *' @description
 *' The utilitarian realization loads the utilitarian aka. Benthamite social welfare function, in which social welfare is equal to the discounted intertemporal sum of utility, which itself is a function of per capita consumption.
@@ -15,4 +15,4 @@ $Ifi "%phase%" == "equations" $include "./modules/02_welfare/utilitarian/equatio
 $Ifi "%phase%" == "bounds" $include "./modules/02_welfare/utilitarian/bounds.gms"
 $Ifi "%phase%" == "postsolve" $include "./modules/02_welfare/utilitarian/postsolve.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/02_welfare/realization.gms
+*** EOF ./modules/02_welfare/utilitarian/realization.gms

--- a/modules/04_PE_FE_parameters/iea2014/datainput.gms
+++ b/modules/04_PE_FE_parameters/iea2014/datainput.gms
@@ -4,6 +4,8 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/04_PE_FE_parameters/iea2014/datainput.gms
+
 parameter f04_IO_input(tall,all_regi,all_enty,all_enty,all_te)        "Energy input based on IEA data"
 /
 $ondelim
@@ -423,3 +425,5 @@ loop(regi,
 );
 
 display pm_histfegrowth, pm_data;
+
+*** EOF ./modules/04_PE_FE_parameters/iea2014/datainput.gms

--- a/modules/04_PE_FE_parameters/iea2014/declarations.gms
+++ b/modules/04_PE_FE_parameters/iea2014/declarations.gms
@@ -4,6 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/04_PE_FE_parameters/iea2014/declarations.gms
 
 parameter
 pm_IO_input(all_regi,all_enty,all_enty,all_te)                 "Energy input based on IEA data"
@@ -22,3 +23,5 @@ p04_prodCoupleGlob(all_enty,all_enty,all_te,all_enty)           "global couple p
 p04_IO_output_beforeFix(ttot,all_regi,all_enty,all_enty,all_te)        "Energy output based on IEA data as read in from input data before correction from FE trajectories"
 p04_IO_output_beforeFix_Total(ttot,all_regi,all_enty)                         "Energy output based on IEA data as read in from input data before correction from FE trajectories summed over SE"
 ;
+
+*** EOF ./modules/04_PE_FE_parameters/iea2014/declarations.gms

--- a/modules/04_PE_FE_parameters/iea2014/realization.gms
+++ b/modules/04_PE_FE_parameters/iea2014/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-
+*** SOF ./modules/04_PE_FE_parameters/iea2014/realization.gms
 
 *' @description This realization used IEA data from 2014.
 *' The realization iea2014 serves to caliibrate the conversion efficiencies 
@@ -22,3 +22,5 @@ $Ifi "%phase%" == "sets" $include "./modules/04_PE_FE_parameters/iea2014/sets.gm
 $Ifi "%phase%" == "declarations" $include "./modules/04_PE_FE_parameters/iea2014/declarations.gms"
 $Ifi "%phase%" == "datainput" $include "./modules/04_PE_FE_parameters/iea2014/datainput.gms"
 *######################## R SECTION END (PHASES) ###############################
+
+*** EOF ./modules/04_PE_FE_parameters/iea2014/realization.gms

--- a/modules/04_PE_FE_parameters/iea2014/sets.gms
+++ b/modules/04_PE_FE_parameters/iea2014/sets.gms
@@ -4,6 +4,8 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/04_PE_FE_parameters/iea2014/sets.gms
+
 sets
 *** the mappings of the input data are for the CES-Structure (all_in) and in this module all_in is mapped to all_enty
 bi2s(all_enty,all_enty,all_te,all_te)   "match ESM fe for buildings and industry to stationary"
@@ -40,3 +42,5 @@ in2enty2(all_enty,all_enty,all_te,all_te)  "alias of in2enty"
 in2enty(all_enty,all_enty2,all_te,all_te2) = bi2s(all_enty,all_enty2,all_te,all_te2) + uet2fet(all_enty,all_enty2,all_te,all_te2);
 
 in2enty2(all_enty,all_enty2,all_te,all_te2) = in2enty(all_enty,all_enty2,all_te,all_te2);
+
+*** EOF ./modules/04_PE_FE_parameters/iea2014/sets.gms

--- a/modules/04_PE_FE_parameters/module.gms
+++ b/modules/04_PE_FE_parameters/module.gms
@@ -4,6 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/04_PE_FE_parameters/module.gms
 
 *' @title Calibration of PE and FE parameters
 *'
@@ -12,3 +13,5 @@
 *###################### R SECTION START (MODULETYPES) ##########################
 $Ifi "%PE_FE_parameters%" == "iea2014" $include "./modules/04_PE_FE_parameters/iea2014/realization.gms"
 *###################### R SECTION END (MODULETYPES) ############################
+
+*** EOF ./modules/04_PE_FE_parameters/module.gms

--- a/modules/05_initialCap/on/declarations.gms
+++ b/modules/05_initialCap/on/declarations.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/05_initialCap/on/declaration.gms
+*** SOF ./modules/05_initialCap/on/declarations.gms
 
 Parameter
   pm_cap0(all_regi,all_te)                           "standing capacity in 2005 as calculated by the initialization routine generisinical. Unit: TWa"
@@ -43,5 +43,5 @@ Scalars
   s05_aux_prod_remaining   "auxiliary calculation parameter for the capacities in different grades: production that still has to be distributed to a grade"
 ;
 
-*** EOF ./modules/05_initalCap/on/declaration.gms
+*** EOF ./modules/05_initialCap/on/declarations.gms
 

--- a/modules/05_initialCap/on/realization.gms
+++ b/modules/05_initialCap/on/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/05_initalCap/on/realization.gms
+*** SOF ./modules/05_initialCap/on/realization.gms
 
 *' @description This realisation computes the initial capital stocks using a 
 *' constrained non-linear model that ensures the production from capacities 
@@ -29,5 +29,5 @@ $Ifi "%phase%" == "declarations" $include "./modules/05_initialCap/on/declaratio
 $Ifi "%phase%" == "preloop" $include "./modules/05_initialCap/on/preloop.gms"
 *######################## R SECTION END (PHASES) ###############################
 
-*** EOF ./modules/05_initalCap/on/realization.gms
+*** EOF ./modules/05_initialCap/on/realization.gms
 

--- a/modules/11_aerosols/exoGAINS/realization.gms
+++ b/modules/11_aerosols/exoGAINS/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/11_aerosols/exoGAINS.gms
+*** SOF ./modules/11_aerosols/exoGAINS/realization.gms
 
 *' @description Bundle the air pollution emission results from different sources. We calculate the emissions for sectors that are available in the GAINS model with the interactively run script exoGAINSAirpollutants.R. Land related emissions are taken from MAGPIE. 
 
@@ -19,4 +19,4 @@ $Ifi "%phase%" == "equations" $include "./modules/11_aerosols/exoGAINS/equations
 $Ifi "%phase%" == "presolve" $include "./modules/11_aerosols/exoGAINS/presolve.gms"
 $Ifi "%phase%" == "postsolve" $include "./modules/11_aerosols/exoGAINS/postsolve.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/11_aerosols/exoGAINS.gms
+*** EOF ./modules/11_aerosols/exoGAINS/realization.gms

--- a/modules/11_aerosols/module.gms
+++ b/modules/11_aerosols/module.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/11_aerosols/11_aerosols.gms
+*** SOF ./modules/11_aerosols/module.gms
 
 *' @title aerosols
 *'
@@ -15,4 +15,4 @@
 *###################### R SECTION START (MODULETYPES) ##########################
 $Ifi "%aerosols%" == "exoGAINS" $include "./modules/11_aerosols/exoGAINS/realization.gms"
 *###################### R SECTION END (MODULETYPES) ############################
-*** EOF ./modules/11_aerosols/11_aerosols.gms
+*** EOF ./modules/11_aerosols/module.gms

--- a/modules/15_climate/box/realization.gms
+++ b/modules/15_climate/box/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/15_climate/box.gms
+*** SOF ./modules/15_climate/box/realization.gms
 
 *' @description 
 *' In this realization, concentration, forcing, and temperature values are calculated using a simple model that can be used within the optimization routine.
@@ -20,4 +20,4 @@ $Ifi "%phase%" == "presolve" $include "./modules/15_climate/box/presolve.gms"
 $Ifi "%phase%" == "postsolve" $include "./modules/15_climate/box/postsolve.gms"
 $Ifi "%phase%" == "output" $include "./modules/15_climate/box/output.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/15_climate/box.gms
+*** EOF ./modules/15_climate/box/realization.gms

--- a/modules/15_climate/magicc/realization.gms
+++ b/modules/15_climate/magicc/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/15_climate/magicc.gms
+*** SOF ./modules/15_climate/magicc/realization.gms
 
 *' @description 
 *' In this realization, concentration, forcing, and temperature values are calculated using a MAGICC6.4. 
@@ -16,4 +16,4 @@ $Ifi "%phase%" == "declarations" $include "./modules/15_climate/magicc/declarati
 $Ifi "%phase%" == "datainput" $include "./modules/15_climate/magicc/datainput.gms"
 $Ifi "%phase%" == "postsolve" $include "./modules/15_climate/magicc/postsolve.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/15_climate/magicc.gms
+*** EOF ./modules/15_climate/magicc/realization.gms

--- a/modules/15_climate/module.gms
+++ b/modules/15_climate/module.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/15_climate/15_climate.gms
+*** SOF ./modules/15_climate/module.gms
 
 *' @title climate
 *'
@@ -17,4 +17,4 @@ $Ifi "%climate%" == "box" $include "./modules/15_climate/box/realization.gms"
 $Ifi "%climate%" == "magicc" $include "./modules/15_climate/magicc/realization.gms"
 $Ifi "%climate%" == "off" $include "./modules/15_climate/off/realization.gms"
 *###################### R SECTION END (MODULETYPES) ############################
-*** EOF ./modules/15_climate/15_climate.gms
+*** EOF ./modules/15_climate/module.gms

--- a/modules/15_climate/off/realization.gms
+++ b/modules/15_climate/off/realization.gms
@@ -4,10 +4,10 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/15_climate/off.gms
+*** SOF ./modules/15_climate/off/realization.gms
 
 *####################### R SECTION START (PHASES) ##############################
 $Ifi "%phase%" == "declarations" $include "./modules/15_climate/off/declarations.gms"
 $Ifi "%phase%" == "datainput" $include "./modules/15_climate/off/datainput.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/15_climate/off.gms
+*** EOF ./modules/15_climate/off/realization.gms

--- a/modules/16_downscaleTemperature/CMIP5/datainput.gms
+++ b/modules/16_downscaleTemperature/CMIP5/datainput.gms
@@ -4,6 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/16_downscaleTemperature/CMIP5/datainput.gms
 
 pm_regionalTemperature(tall,regi)      = 0;
 pm_tempScaleGlob2Reg(tall,regi)        = 1;
@@ -68,5 +69,4 @@ loop(ttot$(ttot.val ge 2005) ,
 *** keep constant from 2090 on
 pm_tempScaleGlob2Reg(tall,regi)$(tall.val gt 2090) = pm_tempScaleGlob2Reg("2090",regi);
 
-
-
+*** EOF ./modules/16_downscaleTemperature/CMIP5/datainput.gms

--- a/modules/16_downscaleTemperature/CMIP5/declarations.gms
+++ b/modules/16_downscaleTemperature/CMIP5/declarations.gms
@@ -4,9 +4,13 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/16_downscaleTemperature/CMIP5/declarations.gms
+
 parameters
 pm_regionalTemperature(tall,all_regi) "regional temperature"
 pm_tempScaleGlob2Reg(tall,all_regi)   "scaling factor from global to regional temperature"
 p16_tempRegionalCMIP5(tall,all_regi)  "regional temperature"
 p16_tempGlobalCMIP5(tall)             "global temperature"
 ;
+
+*** EOF ./modules/16_downscaleTemperature/CMIP5/declarations.gms

--- a/modules/16_downscaleTemperature/CMIP5/postsolve.gms
+++ b/modules/16_downscaleTemperature/CMIP5/postsolve.gms
@@ -4,8 +4,11 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/16_downscaleTemperature/CMIP5/postsolve.gms
 
 ***update regional temperature based on GMT
 pm_regionalTemperature(tall,regi)$(tall.val ge 2005) =
   p16_tempRegionalCalibrate2005(regi)
   + pm_tempScaleGlob2Reg(tall,regi) * ( pm_globalMeanTemperature(tall) - pm_globalMeanTemperature("2005"));
+
+*** EOF ./modules/16_downscaleTemperature/CMIP5/postsolve.gms

--- a/modules/16_downscaleTemperature/CMIP5/realization.gms
+++ b/modules/16_downscaleTemperature/CMIP5/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/16_downscaleTemperature/CMIP5/CMIP5.gms
+*** SOF ./modules/16_downscaleTemperature/CMIP5/realization.gms
 
 *' @description This produces the downscaled regional temperatures based on the exogenous downscaling factors and the MAGICC global mean temperature path. 
 
@@ -15,4 +15,4 @@ $Ifi "%phase%" == "declarations" $include "./modules/16_downscaleTemperature/CMI
 $Ifi "%phase%" == "datainput" $include "./modules/16_downscaleTemperature/CMIP5/datainput.gms"
 $Ifi "%phase%" == "postsolve" $include "./modules/16_downscaleTemperature/CMIP5/postsolve.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/16_downscaleTemperature/CMIP5/CMIP5.gms
+*** EOF ./modules/16_downscaleTemperature/CMIP5/realization.gms

--- a/modules/16_downscaleTemperature/module.gms
+++ b/modules/16_downscaleTemperature/module.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/16_downscaleTemperature/16_downscaleTemperature.gms
+*** SOF ./modules/16_downscaleTemperature/module.gms
 
 *' @title downscaleTemperature
 *'
@@ -16,4 +16,4 @@
 $Ifi "%downscaleTemperature%" == "CMIP5" $include "./modules/16_downscaleTemperature/CMIP5/realization.gms"
 $Ifi "%downscaleTemperature%" == "off" $include "./modules/16_downscaleTemperature/off/realization.gms"
 *###################### R SECTION END (MODULETYPES) ############################
-*** EOF ./modules/16_downscaleTemperature/16_downscaleTemperature.gms
+*** EOF ./modules/16_downscaleTemperature/module.gms

--- a/modules/16_downscaleTemperature/off/realization.gms
+++ b/modules/16_downscaleTemperature/off/realization.gms
@@ -4,10 +4,10 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/16_downscaleTemperature/off.gms
+*** SOF ./modules/16_downscaleTemperature/off/realization.gms
 
 *' @description No temperature downscaling - default setting.
 
 *####################### R SECTION START (PHASES) ##############################
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/16_downscaleTemperature/off.gms
+*** EOF ./modules/16_downscaleTemperature/off/realization.gms

--- a/modules/20_growth/exogenous/realization.gms
+++ b/modules/20_growth/exogenous/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/20_growth/exogenous.gms
+*** SOF ./modules/20_growth/exogenous/realization.gms
 
 *' @description
 *' The exogenous growth realization makes no changes to the (macroeconomic) efficiency growth rate parameters.
@@ -19,4 +19,4 @@
 $Ifi "%phase%" == "declarations" $include "./modules/20_growth/exogenous/declarations.gms"
 $Ifi "%phase%" == "bounds" $include "./modules/20_growth/exogenous/bounds.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/20_growth/exogenous.gms
+*** EOF ./modules/20_growth/exogenous/realization.gms

--- a/modules/20_growth/module.gms
+++ b/modules/20_growth/module.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/20_growth/20_growth.gms
+*** SOF ./modules/20_growth/module.gms
 
 *' @title Growth
 *'
@@ -18,4 +18,4 @@
 $Ifi "%growth%" == "exogenous" $include "./modules/20_growth/exogenous/realization.gms"
 $Ifi "%growth%" == "spillover" $include "./modules/20_growth/spillover/realization.gms"
 *###################### R SECTION END (MODULETYPES) ############################
-*** EOF ./modules/20_growth/20_growth.gms
+*** EOF ./modules/20_growth/module.gms

--- a/modules/20_growth/spillover/realization.gms
+++ b/modules/20_growth/spillover/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/20_growth/spillover.gms
+*** SOF ./modules/20_growth/spillover/realization.gms
 
 *' @description
 *' This realization implies an endogenous growth path. It replaces and overwrites, respectively, the exogenous SSP GDP growth paths.
@@ -24,4 +24,4 @@ $Ifi "%phase%" == "equations" $include "./modules/20_growth/spillover/equations.
 $Ifi "%phase%" == "bounds" $include "./modules/20_growth/spillover/bounds.gms"
 $Ifi "%phase%" == "output" $include "./modules/20_growth/spillover/output.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/20_growth/spillover.gms
+*** EOF ./modules/20_growth/spillover/realization.gms

--- a/modules/21_tax/module.gms
+++ b/modules/21_tax/module.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/21_tax/21_tax.gms
+*** SOF ./modules/21_tax/module.gms
 
 *' @title Tax Module
 *'
@@ -14,4 +14,4 @@
 $Ifi "%tax%" == "off" $include "./modules/21_tax/off/realization.gms"
 $Ifi "%tax%" == "on" $include "./modules/21_tax/on/realization.gms"
 *###################### R SECTION END (MODULETYPES) ############################
-*** EOF ./modules/21_tax/21_tax.gms
+*** EOF ./modules/21_tax/module.gms

--- a/modules/21_tax/off/realization.gms
+++ b/modules/21_tax/off/realization.gms
@@ -4,9 +4,9 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/21_tax/off.gms
+*** SOF ./modules/21_tax/off/realization.gms
 
 *####################### R SECTION START (PHASES) ##############################
 $Ifi "%phase%" == "bounds" $include "./modules/21_tax/off/bounds.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/21_tax/off.gms
+*** EOF ./modules/21_tax/off/realization.gms

--- a/modules/22_subsidizeLearning/globallyOptimal/realization.gms
+++ b/modules/22_subsidizeLearning/globallyOptimal/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/22_subsidizeLearning/globallyOptimal.gms
+*** SOF ./modules/22_subsidizeLearning/globallyOptimal/realization.gms
 
 *' @description
 *' This realization is meaningful in order to find the global optimal solution or co-operative solution w.r.t. learning spillovers under the Nash algorithm.
@@ -22,4 +22,4 @@ $Ifi "%phase%" == "bounds" $include "./modules/22_subsidizeLearning/globallyOpti
 $Ifi "%phase%" == "presolve" $include "./modules/22_subsidizeLearning/globallyOptimal/presolve.gms"
 $Ifi "%phase%" == "postsolve" $include "./modules/22_subsidizeLearning/globallyOptimal/postsolve.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/22_subsidizeLearning/globallyOptimal.gms
+*** EOF ./modules/22_subsidizeLearning/globallyOptimal/realization.gms

--- a/modules/22_subsidizeLearning/module.gms
+++ b/modules/22_subsidizeLearning/module.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/22_subsidizeLearning/22_subsidizeLearning.gms
+*** SOF ./modules/22_subsidizeLearning/module.gms
 *' @title Subsidies on learning technologies
 *'
 *' @description
@@ -19,4 +19,4 @@
 $Ifi "%subsidizeLearning%" == "globallyOptimal" $include "./modules/22_subsidizeLearning/globallyOptimal/realization.gms"
 $Ifi "%subsidizeLearning%" == "off" $include "./modules/22_subsidizeLearning/off/realization.gms"
 *###################### R SECTION END (MODULETYPES) ############################
-*** EOF ./modules/22_subsidizeLearning/22_subsidizeLearning.gms
+*** EOF ./modules/22_subsidizeLearning/module.gms

--- a/modules/22_subsidizeLearning/off/realization.gms
+++ b/modules/22_subsidizeLearning/off/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/22_subsidizeLearning/off.gms
+*** SOF ./modules/22_subsidizeLearning/off/realization.gms
 
 *' @description
 *' There is no subsidizing of learning technologies (fixed to zero). Under this realization we get different results from Negishi and Nash solutions.
@@ -23,4 +23,4 @@ $Ifi "%phase%" == "declarations" $include "./modules/22_subsidizeLearning/off/de
 $Ifi "%phase%" == "bounds" $include "./modules/22_subsidizeLearning/off/bounds.gms"
 $Ifi "%phase%" == "postsolve" $include "./modules/22_subsidizeLearning/off/postsolve.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/22_subsidizeLearning/off.gms
+*** EOF ./modules/22_subsidizeLearning/off/realization.gms

--- a/modules/23_capitalMarket/debt_limit/datainput.gms
+++ b/modules/23_capitalMarket/debt_limit/datainput.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/23_capitalMarket/perfect/datainput.gms
+*** SOF ./modules/23_capitalMarket/debt_limit/datainput.gms
 
 pm_ies(regi) = 1;
 pm_risk_premium(regi) = 0.0;
@@ -18,4 +18,4 @@ $offdelim
 /
 ;
 
-*** EOF ./modules/23_capitalMarket/perfect/datainput.gms
+*** EOF ./modules/23_capitalMarket/debt_limit/datainput.gms

--- a/modules/23_capitalMarket/debt_limit/declarations.gms
+++ b/modules/23_capitalMarket/debt_limit/declarations.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/23_capitalMarket/perfect/declarations.gms
+*** SOF ./modules/23_capitalMarket/debt_limit/declarations.gms
 
 Parameters
 
@@ -21,4 +21,4 @@ Equations
   q23_limit_surplus_growth(ttot,all_regi)     "surplus growth constraint"
 ;
 
-*** EOF ./modules/23_capitalMarket/perfect/declarations.gms
+*** EOF ./modules/23_capitalMarket/debt_limit/declarations.gms

--- a/modules/23_capitalMarket/debt_limit/equations.gms
+++ b/modules/23_capitalMarket/debt_limit/equations.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/23_capitalMarket/imperfect/equations.gms
+*** SOF ./modules/23_capitalMarket/debt_limit/equations.gms
 
 q23_limit_debt_growth(t,regi)..
   vm_cesIO(t,regi,"inco") * p23_debt_growthCoeff(regi)
@@ -26,4 +26,4 @@ q23_limit_surplus_growth(t,regi)..
   + vm_budgetTradeM(t,regi) - vm_budgetTradeX(t,regi)
 ;
 
-*** EOF ./modules/23_capitalMarket/imperfect/equations.gms 
+*** EOF ./modules/23_capitalMarket/debt_limit/equations.gms

--- a/modules/23_capitalMarket/debt_limit/realization.gms
+++ b/modules/23_capitalMarket/debt_limit/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./module/23_capitalMarket/perfect.gms
+*** SOF ./modules/23_capitalMarket/debt_limit/realization.gms
 
 *'
 *' @description
@@ -21,4 +21,4 @@ $Ifi "%phase%" == "datainput" $include "./modules/23_capitalMarket/debt_limit/da
 $Ifi "%phase%" == "equations" $include "./modules/23_capitalMarket/debt_limit/equations.gms"
 *######################## R SECTION END (PHASES) ###############################
 
-*** EOF ./module/23_capitalMarket/perfect.gms
+*** EOF ./modules/23_capitalMarket/debt_limit/realization.gms

--- a/modules/23_capitalMarket/imperfect/equations.gms
+++ b/modules/23_capitalMarket/imperfect/equations.gms
@@ -29,4 +29,4 @@ q23_limit_debt_growth(t,regi)..
   + vm_budgetTradeM(t,regi) - vm_budgetTradeX(t,regi)
 ;
 
-*** EOF ./modules/23_capitalMarket/imperfect/equations.gms 
+*** EOF ./modules/23_capitalMarket/imperfect/equations.gms

--- a/modules/23_capitalMarket/imperfect/realization.gms
+++ b/modules/23_capitalMarket/imperfect/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./module/23_capitalMarket/perfect.gms
+*** SOF ./modules/23_capitalMarket/imperfect/realization.gms
 
 *'
 *' @description
@@ -25,4 +25,4 @@ $Ifi "%phase%" == "datainput" $include "./modules/23_capitalMarket/imperfect/dat
 $Ifi "%phase%" == "equations" $include "./modules/23_capitalMarket/imperfect/equations.gms"
 *######################## R SECTION END (PHASES) ###############################
 
-*** EOF ./module/23_capitalMarket/perfect.gms
+*** EOF ./modules/23_capitalMarket/imperfect/realization.gms

--- a/modules/23_capitalMarket/module.gms
+++ b/modules/23_capitalMarket/module.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./module/23_capitalMarket/23_capitalMarket.gms
+*** SOF ./modules/23_capitalMarket/module.gms
 
 *' @title Capital Market
 *'
@@ -21,4 +21,4 @@ $Ifi "%capitalMarket%" == "imperfect" $include "./modules/23_capitalMarket/imper
 $Ifi "%capitalMarket%" == "perfect" $include "./modules/23_capitalMarket/perfect/realization.gms"
 *###################### R SECTION END (MODULETYPES) ############################
 
-*** EOF ./module/23_capitalMarket/23_capitalMarket.gms
+*** EOF ./modules/23_capitalMarket/module.gms

--- a/modules/23_capitalMarket/perfect/realization.gms
+++ b/modules/23_capitalMarket/perfect/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./module/23_capitalMarket/perfect.gms
+*** SOF ./modules/23_capitalMarket/perfect/realization.gms
 
 *'
 *' @description
@@ -22,4 +22,4 @@ $Ifi "%phase%" == "declarations" $include "./modules/23_capitalMarket/perfect/de
 $Ifi "%phase%" == "datainput" $include "./modules/23_capitalMarket/perfect/datainput.gms"
 *######################## R SECTION END (PHASES) ###############################
 
-*** EOF ./module/23_capitalMarket/perfect.gms
+*** EOF ./modules/23_capitalMarket/perfect/realization.gms

--- a/modules/24_trade/capacity/declarations.gms
+++ b/modules/24_trade/capacity/declarations.gms
@@ -84,4 +84,4 @@ EQUATIONS
   q24_costTradePrice(ttot,all_regi,all_enty)                                  "Total income or expense generated from trade"
 ;
 
-*** EOF ./modules/24_trade/capacity/declarations
+*** EOF ./modules/24_trade/capacity/declarations.gms

--- a/modules/24_trade/capacity/realization.gms
+++ b/modules/24_trade/capacity/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/24_trade/realization.gms
+*** SOF ./modules/24_trade/capacity/realization.gms
 
 *####################### R SECTION START (PHASES) ##############################
 $Ifi "%phase%" == "sets" $include "./modules/24_trade/capacity/sets.gms"
@@ -16,4 +16,4 @@ $Ifi "%phase%" == "bounds" $include "./modules/24_trade/capacity/bounds.gms"
 $Ifi "%phase%" == "presolve" $include "./modules/24_trade/capacity/presolve.gms"
 $Ifi "%phase%" == "postsolve" $include "./modules/24_trade/capacity/postsolve.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/24_trade/realization.gms
+*** EOF ./modules/24_trade/capacity/realization.gms

--- a/modules/24_trade/se_trade/realization.gms
+++ b/modules/24_trade/se_trade/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/24_trade/realization.gms
+*** SOF ./modules/24_trade/se_trade/realization.gms
 
 *####################### R SECTION START (PHASES) ##############################
 $Ifi "%phase%" == "sets" $include "./modules/24_trade/se_trade/sets.gms"
@@ -15,4 +15,4 @@ $Ifi "%phase%" == "bounds" $include "./modules/24_trade/se_trade/bounds.gms"
 $Ifi "%phase%" == "presolve" $include "./modules/24_trade/se_trade/presolve.gms"
 $Ifi "%phase%" == "postsolve" $include "./modules/24_trade/se_trade/postsolve.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/24_trade/realization.gms
+*** EOF ./modules/24_trade/se_trade/realization.gms

--- a/modules/24_trade/standard/realization.gms
+++ b/modules/24_trade/standard/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/24_trade/realization.gms
+*** SOF ./modules/24_trade/standard/realization.gms
 
 *####################### R SECTION START (PHASES) ##############################
 $Ifi "%phase%" == "sets" $include "./modules/24_trade/standard/sets.gms"
@@ -14,4 +14,4 @@ $Ifi "%phase%" == "bounds" $include "./modules/24_trade/standard/bounds.gms"
 $Ifi "%phase%" == "presolve" $include "./modules/24_trade/standard/presolve.gms"
 $Ifi "%phase%" == "postsolve" $include "./modules/24_trade/standard/postsolve.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/24_trade/realization.gms
+*** EOF ./modules/24_trade/standard/realization.gms

--- a/modules/26_agCosts/costs/presolve.gms
+++ b/modules/26_agCosts/costs/presolve.gms
@@ -4,6 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/26_agCosts/costs/presolve.gms
 
 *' @code
 *' **Total agricultural costs (excluding MAC costs)**
@@ -20,3 +21,5 @@ pm_totLUcosts(ttot,regi) =  p26_totLUcosts_withMAC(ttot,regi) - p26_macCostLu(tt
 *' while including the variable v30_pebiolc_costs.
 
 *' @stop
+
+*** EOF ./modules/26_agCosts/costs/presolve.gms

--- a/modules/26_agCosts/costs/realization.gms
+++ b/modules/26_agCosts/costs/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/26_agCosts/costs.gms
+*** SOF ./modules/26_agCosts/costs/realization.gms
 
 *' @description
 *' Agricultural production costs in REMIND consist of the following components: actual production costs 
@@ -17,4 +17,4 @@ $Ifi "%phase%" == "declarations" $include "./modules/26_agCosts/costs/declaratio
 $Ifi "%phase%" == "datainput" $include "./modules/26_agCosts/costs/datainput.gms"
 $Ifi "%phase%" == "presolve" $include "./modules/26_agCosts/costs/presolve.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/26_agCosts/costs.gms
+*** EOF ./modules/26_agCosts/costs/realization.gms

--- a/modules/26_agCosts/costs_trade/realization.gms
+++ b/modules/26_agCosts/costs_trade/realization.gms
@@ -4,9 +4,9 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/26_agCosts/costs_trade.gms
+*** SOF ./modules/26_agCosts/costs_trade/realization.gms
 
 *####################### R SECTION START (PHASES) ##############################
 $Ifi "%phase%" == "datainput" $include "./modules/26_agCosts/costs_trade/datainput.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/26_agCosts/costs_trade.gms
+*** EOF ./modules/26_agCosts/costs_trade/realization.gms

--- a/modules/26_agCosts/module.gms
+++ b/modules/26_agCosts/module.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/26_agCosts/26_agCosts.gms
+*** SOF ./modules/26_agCosts/module.gms
 
 *' @title Agricultural costs
 *'
@@ -17,4 +17,4 @@ $Ifi "%agCosts%" == "costs" $include "./modules/26_agCosts/costs/realization.gms
 $Ifi "%agCosts%" == "costs_trade" $include "./modules/26_agCosts/costs_trade/realization.gms"
 $Ifi "%agCosts%" == "off" $include "./modules/26_agCosts/off/realization.gms"
 *###################### R SECTION END (MODULETYPES) ############################
-*** EOF ./modules/26_agCosts/26_agCosts.gms
+*** EOF ./modules/26_agCosts/module.gms

--- a/modules/26_agCosts/off/realization.gms
+++ b/modules/26_agCosts/off/realization.gms
@@ -4,9 +4,9 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/26_agCosts/off.gms
+*** SOF ./modules/26_agCosts/off/realization.gms
 
 *####################### R SECTION START (PHASES) ##############################
 $Ifi "%phase%" == "declarations" $include "./modules/26_agCosts/off/declarations.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/26_agCosts/off.gms
+*** EOF ./modules/26_agCosts/off/realization.gms

--- a/modules/29_CES_parameters/calibrate/realization.gms
+++ b/modules/29_CES_parameters/calibrate/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/29_CES_parameters/calibrate.gms
+*** SOF ./modules/29_CES_parameters/calibrate/realization.gms
 
 *' @description 
 *' The macro-calibration takes place in `modules/29_CES_parameters/calibration/`. The calibration itself is in the file `preloop.gms`.
@@ -232,4 +232,4 @@ $Ifi "%phase%" == "preloop" $include "./modules/29_CES_parameters/calibrate/prel
 $Ifi "%phase%" == "bounds" $include "./modules/29_CES_parameters/calibrate/bounds.gms"
 $Ifi "%phase%" == "output" $include "./modules/29_CES_parameters/calibrate/output.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/29_CES_parameters/calibrate.gms
+*** EOF ./modules/29_CES_parameters/calibrate/realization.gms

--- a/modules/29_CES_parameters/load/realization.gms
+++ b/modules/29_CES_parameters/load/realization.gms
@@ -4,11 +4,11 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/29_CES_parameters/load.gms
+*** SOF ./modules/29_CES_parameters/load/realization.gms
 
 *####################### R SECTION START (PHASES) ##############################
 $Ifi "%phase%" == "sets" $include "./modules/29_CES_parameters/load/sets.gms"
 $Ifi "%phase%" == "datainput" $include "./modules/29_CES_parameters/load/datainput.gms"
 $Ifi "%phase%" == "preloop" $include "./modules/29_CES_parameters/load/preloop.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/29_CES_parameters/load.gms
+*** EOF ./modules/29_CES_parameters/load/realization.gms

--- a/modules/29_CES_parameters/module.gms
+++ b/modules/29_CES_parameters/module.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/29_CES_parameters/29_CES_parameters.gms
+*** SOF ./modules/29_CES_parameters/module.gms
 
 *' @title CES parameters
 *'
@@ -14,4 +14,4 @@
 $Ifi "%CES_parameters%" == "calibrate" $include "./modules/29_CES_parameters/calibrate/realization.gms"
 $Ifi "%CES_parameters%" == "load" $include "./modules/29_CES_parameters/load/realization.gms"
 *###################### R SECTION END (MODULETYPES) ############################
-*** EOF ./modules/29_CES_parameters/29_CES_parameters.gms
+*** EOF ./modules/29_CES_parameters/module.gms

--- a/modules/30_biomass/exogenous/realization.gms
+++ b/modules/30_biomass/exogenous/realization.gms
@@ -4,11 +4,11 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/30_biomass/exogenous.gms
+*** SOF ./modules/30_biomass/exogenous/realization.gms
 
 *####################### R SECTION START (PHASES) ##############################
 $Ifi "%phase%" == "declarations" $include "./modules/30_biomass/exogenous/declarations.gms"
 $Ifi "%phase%" == "datainput" $include "./modules/30_biomass/exogenous/datainput.gms"
 $Ifi "%phase%" == "bounds" $include "./modules/30_biomass/exogenous/bounds.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/30_biomass/exogenous.gms
+*** EOF ./modules/30_biomass/exogenous/realization.gms

--- a/modules/30_biomass/magpie_40/bounds.gms
+++ b/modules/30_biomass/magpie_40/bounds.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/30_biomass/magpie_4/bounds.gms
+*** SOF ./modules/30_biomass/magpie_40/bounds.gms
 *** -------------------------------------------------------------
 *** Bounds on pedem
 *** -------------------------------------------------------------
@@ -121,4 +121,4 @@ vm_fuExtr.up(t,regi,"pebiolc","1") = p30_max_pebiolc_path(regi,t) + pm_pedem_res
 *** FS: test regional bounds on pebiolc.1 production
 ***vm_fuExtr.up(t,"DEU","pebiolc","1")$(t.val ge 2030) = 0.0077;
 
-*** EOF ./modules/30_biomass/magpie_4/bounds.gms
+*** EOF ./modules/30_biomass/magpie_40/bounds.gms

--- a/modules/30_biomass/magpie_40/declarations.gms
+++ b/modules/30_biomass/magpie_40/declarations.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/30_biomass/magpie_4/declarations.gms
+*** SOF ./modules/30_biomass/magpie_40/declarations.gms
 
 scalars
 s30_D2TD                "Multiplicative factor to convert from Dollar to TeraDollar"     /1.0e-12/
@@ -69,4 +69,4 @@ q30_limitTeBio(ttot,all_regi)      "Limit BECCS in policy runs relative to refer
 q30_limitProdtoHist(ttot,all_regi) "Limit regional energy crop production to multiple of cm_bioprod_histlim times 2015 level, active if cm_bioprod_histlim >= 0"
 q30_BioPEProdTotal(ttot,all_regi)  "Calculate total domestic PE biomass production"
 ;
-*** EOF ./modules/30_biomass/magpie_4/declarations.gms
+*** EOF ./modules/30_biomass/magpie_40/declarations.gms

--- a/modules/30_biomass/magpie_40/equations.gms
+++ b/modules/30_biomass/magpie_40/equations.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/30_biomass/magpie_4/equations.gms
+*** SOF ./modules/30_biomass/magpie_40/equations.gms
 ***---------------------------------------------------------------------------
 ***                      FUEL COSTS FOR BIOENERGY
 ***---------------------------------------------------------------------------
@@ -136,4 +136,4 @@ q30_limitProdtoHist(t,regi)$(cm_bioprod_histlim ge 0 AND t.val ge cm_startyear A
 
 
  
-*** EOF ./modules/30_biomass/magpie_4/equations.gms
+*** EOF ./modules/30_biomass/magpie_40/equations.gms

--- a/modules/30_biomass/magpie_40/output.gms
+++ b/modules/30_biomass/magpie_40/output.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/30_biomass/magpie_4/output.gms
+*** SOF ./modules/30_biomass/magpie_40/output.gms
 *LB* save data for exogenous biomass module
 file p30_fix_costfu_bio;
 put p30_fix_costfu_bio;
@@ -41,4 +41,4 @@ put remind_modelstat;
 put o_modelstat /;
 putclose;
 
-*** EOF ./modules/30_biomass/magpie_4/output.gms
+*** EOF ./modules/30_biomass/magpie_40/output.gms

--- a/modules/30_biomass/magpie_40/postsolve.gms
+++ b/modules/30_biomass/magpie_40/postsolve.gms
@@ -5,7 +5,7 @@
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
 
-*** SOF ./modules/30_biomass/magpie_40/postsolve.gm
+*** SOF ./modules/30_biomass/magpie_40/postsolve.gms
 
 p30_demPe(ttot,regi) =
   sum(pe2se(enty,enty2,te)$(sameas(enty,"peoil") OR sameas(enty,"pecoal") OR sameas(enty,"pegas") OR sameas(enty,"pebiolc") OR sameas(enty,"pebios") OR sameas(enty,"pebioil")),

--- a/modules/30_biomass/magpie_40/preloop.gms
+++ b/modules/30_biomass/magpie_40/preloop.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/30_biomass/magpie_4/preloop.gms
+*** SOF ./modules/30_biomass/magpie_40/preloop.gms
 
 ***=============================================================
 ***  BEGIN: calculate shift factors for bioenergy prices 
@@ -117,5 +117,5 @@ vm_fuExtr.l(ttot,regi,"pebiolc","1")  = p30_pebiolc_demandmag(ttot,regi);
 ***  END: calculate shift factors
 ***-------------------------------------------------------------
 
-*** EOF ./modules/30_biomass/magpie_4/preloop.gms
+*** EOF ./modules/30_biomass/magpie_40/preloop.gms
 

--- a/modules/30_biomass/magpie_40/realization.gms
+++ b/modules/30_biomass/magpie_40/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/30_biomass/magpie_linear.gms
+*** SOF ./modules/30_biomass/magpie_40/realization.gms
 
 *' @description
 *' The costs for purpose grown ligno-cellulosic biomass 
@@ -21,4 +21,4 @@ $Ifi "%phase%" == "presolve" $include "./modules/30_biomass/magpie_40/presolve.g
 $Ifi "%phase%" == "postsolve" $include "./modules/30_biomass/magpie_40/postsolve.gms"
 $Ifi "%phase%" == "output" $include "./modules/30_biomass/magpie_40/output.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/30_biomass/magpie_linear.gms
+*** EOF ./modules/30_biomass/magpie_40/realization.gms

--- a/modules/30_biomass/magpie_40/sets.gms
+++ b/modules/30_biomass/magpie_40/sets.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/30_biomass/magpie_4/sets.gms
+*** SOF ./modules/30_biomass/magpie_40/sets.gms
 
 sets
 all_charScen                 "coefficients of the emulator formulas"   
@@ -24,4 +24,4 @@ peren2cont30(all_enty,rlf)   "map biomass energy to grades with continous supply
 
 ;
 
-*** EOF ./modules/30_biomass/magpie_4/sets.gms
+*** EOF ./modules/30_biomass/magpie_40/sets.gms

--- a/modules/30_biomass/module.gms
+++ b/modules/30_biomass/module.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/30_biomass/30_biomass.gms
+*** SOF ./modules/30_biomass/module.gms
 
 *' @title Biomass
 *'
@@ -17,4 +17,4 @@
 $Ifi "%biomass%" == "exogenous" $include "./modules/30_biomass/exogenous/realization.gms"
 $Ifi "%biomass%" == "magpie_40" $include "./modules/30_biomass/magpie_40/realization.gms"
 *###################### R SECTION END (MODULETYPES) ############################
-*** EOF ./modules/30_biomass/30_biomass.gms
+*** EOF ./modules/30_biomass/module.gms

--- a/modules/31_fossil/MOFEX/realization.gms
+++ b/modules/31_fossil/MOFEX/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/31_fossil/MOFEX.gms
+*** SOF ./modules/31_fossil/MOFEX/realization.gms
 
 *' @description This realization is dedicated to the running the standalone version of MOFEX (Model Of Fossil EXtraction), 
 *' which minimizes the discounted extraction and trade costs of fossils while balancing trade for each time step. 
@@ -21,4 +21,4 @@ $Ifi "%phase%" == "bounds" $include "./modules/31_fossil/MOFEX/bounds.gms"
 $Ifi "%phase%" == "solve" $include "./modules/31_fossil/MOFEX/solve.gms"
 $Ifi "%phase%" == "output" $include "./modules/31_fossil/MOFEX/output.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/31_fossil/MOFEX.gms
+*** EOF ./modules/31_fossil/MOFEX/realization.gms

--- a/modules/31_fossil/exogenous/realization.gms
+++ b/modules/31_fossil/exogenous/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/31_fossil/exogenous.gms
+*** SOF ./modules/31_fossil/exogenous/realization.gms
 
 *' @description For this realization exogenous fossil extraction and costs are used. The data are from a baseline run.
 *' 
@@ -15,4 +15,4 @@ $Ifi "%phase%" == "declarations" $include "./modules/31_fossil/exogenous/declara
 $Ifi "%phase%" == "datainput" $include "./modules/31_fossil/exogenous/datainput.gms"
 $Ifi "%phase%" == "bounds" $include "./modules/31_fossil/exogenous/bounds.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/31_fossil/exogenous.gms
+*** EOF ./modules/31_fossil/exogenous/realization.gms

--- a/modules/31_fossil/grades2poly/realization.gms
+++ b/modules/31_fossil/grades2poly/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/31_fossil/grades2poly.gms
+*** SOF ./modules/31_fossil/grades2poly/realization.gms
 
 *' @description This realization parametrizes fossil extraction cost curves into 3rd-order polynomials for each fuel (oil, gas and coal) in each region.
 *' Input data are taken from REMIND runs with the timeDepGrades fossil realization under various fossil fuel availability assumptions.
@@ -18,4 +18,4 @@ $Ifi "%phase%" == "equations" $include "./modules/31_fossil/grades2poly/equation
 $Ifi "%phase%" == "preloop" $include "./modules/31_fossil/grades2poly/preloop.gms"
 $Ifi "%phase%" == "bounds" $include "./modules/31_fossil/grades2poly/bounds.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/31_fossil/grades2poly.gms
+*** EOF ./modules/31_fossil/grades2poly/realization.gms

--- a/modules/31_fossil/module.gms
+++ b/modules/31_fossil/module.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/31_fossil/31_fossil.gms
+*** SOF ./modules/31_fossil/module.gms
 
 *' @title Fossil
 *'
@@ -18,4 +18,4 @@ $Ifi "%fossil%" == "exogenous" $include "./modules/31_fossil/exogenous/realizati
 $Ifi "%fossil%" == "grades2poly" $include "./modules/31_fossil/grades2poly/realization.gms"
 $Ifi "%fossil%" == "timeDepGrades" $include "./modules/31_fossil/timeDepGrades/realization.gms"
 *###################### R SECTION END (MODULETYPES) ############################
-*** EOF ./modules/31_fossil/31_fossil.gms
+*** EOF ./modules/31_fossil/module.gms

--- a/modules/31_fossil/timeDepGrades/realization.gms
+++ b/modules/31_fossil/timeDepGrades/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/31_fossil/timeDepGrades.gms
+*** SOF ./modules/31_fossil/timeDepGrades/realization.gms
 
 *' @description This realization represents fossil fuel resources as a time-dependent cost grade structure. The grades are each defined   
 *' by a minimum and a maximum price, and these cost brackets change over time based on the rate of technological change as prescribed 
@@ -26,4 +26,4 @@ $Ifi "%phase%" == "preloop" $include "./modules/31_fossil/timeDepGrades/preloop.
 $Ifi "%phase%" == "bounds" $include "./modules/31_fossil/timeDepGrades/bounds.gms"
 $Ifi "%phase%" == "output" $include "./modules/31_fossil/timeDepGrades/output.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/31_fossil/timeDepGrades.gms
+*** EOF ./modules/31_fossil/timeDepGrades/realization.gms

--- a/modules/32_power/DTcoup/bounds.gms
+++ b/modules/32_power/DTcoup/bounds.gms
@@ -4,6 +4,8 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/32_power/DTcoup/bounds.gms
+
 ***-----------------------------------------------------------
 ***                  module specific bounds
 ***------------------------------------------------------------
@@ -61,5 +63,4 @@ loop(regi$(p32_factorStorage(regi,"csp") < 1),
 *** Fix capacity to 0 for elh2VRE now that the equation q32_elh2VREcapfromTestor pushes elh2, not anymore elh2VRE, and capital costs are 1
 vm_cap.fx(t,regi,"elh2VRE",rlf) = 0;
 
-
-
+*** EOF ./modules/32_power/DTcoup/bounds.gms

--- a/modules/32_power/DTcoup/datainput.gms
+++ b/modules/32_power/DTcoup/datainput.gms
@@ -4,6 +4,8 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/32_power/DTcoup/datainput.gms
+
 *------------------------------------------------------------------------------------
 ***                        IntC specific data input
 *------------------------------------------------------------------------------------
@@ -86,3 +88,5 @@ $offtext
 
 *** initialize p32_PriceDurSlope parameter
 p32_PriceDurSlope(regi,"elh2") = cm_PriceDurSlope_elh2;
+
+*** EOF ./modules/32_power/DTcoup/datainput.gms

--- a/modules/32_power/DTcoup/declarations.gms
+++ b/modules/32_power/DTcoup/declarations.gms
@@ -4,6 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/32_power/DTcoup/declarations.gms
 
 parameters
     p32_grid_factor(all_regi)						"multiplicative factor that scales total grid requirements down in comparatively small or homogeneous regions like Japan, Europe or India"
@@ -51,3 +52,5 @@ variables
 v32_flexPriceShare(tall,all_regi,all_te)            "share of average electricity price that flexible technologies see [share: 0...1]"
 v32_flexPriceShareMin(tall,all_regi,all_te)         "possible minimum of share of average electricity price that flexible technologies see [share: 0...1]"
 ;
+
+*** EOF ./modules/32_power/DTcoup/declarations.gms

--- a/modules/32_power/DTcoup/equations.gms
+++ b/modules/32_power/DTcoup/equations.gms
@@ -4,6 +4,8 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/32_power/DTcoup/equations.gms
+
 ***---------------------------------------------------------------------------
 *** Balance equation for electricity secondary energy type:
 ***---------------------------------------------------------------------------
@@ -233,4 +235,4 @@ q32_flexAdj(t,regi,te)$(teFlexTax(te))..
 	(1-v32_flexPriceShare(t,regi,te)) * pm_SEPrice(t,regi,"seel")$(cm_flex_tax eq 1 AND t.val ge 2025)
 ;
 
-*** EOF ./modules/32_power/IntC/equations.gms
+*** EOF ./modules/32_power/DTcoup/equations.gms

--- a/modules/32_power/DTcoup/postsolve.gms
+++ b/modules/32_power/DTcoup/postsolve.gms
@@ -4,11 +4,11 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/32_power/IntC/postsolve.gms
+*** SOF ./modules/32_power/DTcoup/postsolve.gms
 
 *** calculation of SE electricity price (useful for internal use and reporting purposes)
 pm_SEPrice(ttot,regi,entySE)$(abs (qm_budget.m(ttot,regi)) gt sm_eps AND sameas(entySE,"seel")) = 
        q32_balSe.m(ttot,regi,entySE) / qm_budget.m(ttot,regi);
 
-*** EOF ./modules/32_power/IntC/postsolve.gms
+*** EOF ./modules/32_power/DTcoup/postsolve.gms
 

--- a/modules/32_power/DTcoup/preloop.gms
+++ b/modules/32_power/DTcoup/preloop.gms
@@ -5,11 +5,11 @@
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
 
-*** SOF ./modules/32_power/IntC/preloop.gms
+*** SOF ./modules/32_power/DTcoup/preloop.gms
 
 *** read marginal of seel balance equation
 Execute_Loadpoint 'input' q32_balSe.m = q32_balSe.m;
 
 
 
-*** EOF ./modules/32_power/IntC/preloop.gms
+*** EOF ./modules/32_power/DTcoup/preloop.gms

--- a/modules/32_power/DTcoup/presolve.gms
+++ b/modules/32_power/DTcoup/presolve.gms
@@ -4,11 +4,11 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/32_power/IntC/presolve.gms
+*** SOF ./modules/32_power/DTcoup/presolve.gms
 
 
 *** calculation of SE electricity price (useful for internal use and reporting purposes)
 pm_SEPrice(t,regi,entySE)$(abs (qm_budget.m(t,regi)) gt sm_eps AND sameas(entySE,"seel")) = 
        q32_balSe.m(t,regi,entySE) / qm_budget.m(t,regi);
 
-*** EOF ./modules/32_power/IntC/presolve.gms
+*** EOF ./modules/32_power/DTcoup/presolve.gms

--- a/modules/32_power/DTcoup/realization.gms
+++ b/modules/32_power/DTcoup/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/32_power/IntC/realization.gms
+*** SOF ./modules/32_power/DTcoup/realization.gms
 
 *' @description  
 *'
@@ -40,4 +40,4 @@ $Ifi "%phase%" == "presolve" $include "./modules/32_power/DTcoup/presolve.gms"
 $Ifi "%phase%" == "postsolve" $include "./modules/32_power/DTcoup/postsolve.gms"
 *######################## R SECTION END (PHASES) ###############################
 
-*** EOF ./modules/32_power/IntC/realization.gms
+*** EOF ./modules/32_power/DTcoup/realization.gms

--- a/modules/32_power/IntC/bounds.gms
+++ b/modules/32_power/IntC/bounds.gms
@@ -4,6 +4,8 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/32_power/IntC/bounds.gms
+
 ***-----------------------------------------------------------
 ***                  module specific bounds
 ***------------------------------------------------------------
@@ -74,5 +76,4 @@ loop(regi$(p32_factorStorage(regi,"csp") < 1),
 *** Fix capacity to 0 for elh2VRE now that the equation q32_elh2VREcapfromTestor pushes elh2, not anymore elh2VRE, and capital costs are 1
 vm_cap.fx(t,regi,"elh2VRE",rlf) = 0;
 
-
-
+*** EOF ./modules/32_power/IntC/bounds.gms

--- a/modules/32_power/IntC/datainput.gms
+++ b/modules/32_power/IntC/datainput.gms
@@ -4,6 +4,8 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/32_power/IntC/datainput.gms
+
 *------------------------------------------------------------------------------------
 ***                        IntC specific data input
 *------------------------------------------------------------------------------------
@@ -86,3 +88,5 @@ $offtext
 
 *** initialize p32_PriceDurSlope parameter
 p32_PriceDurSlope(regi,"elh2") = cm_PriceDurSlope_elh2;
+
+*** EOF ./modules/32_power/IntC/datainput.gms

--- a/modules/32_power/IntC/declarations.gms
+++ b/modules/32_power/IntC/declarations.gms
@@ -4,6 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/32_power/IntC/declarations.gms
 
 parameters
     p32_grid_factor(all_regi)						"multiplicative factor that scales total grid requirements down in comparatively small or homogeneous regions like Japan, Europe or India"
@@ -53,3 +54,5 @@ variables
 v32_flexPriceShare(tall,all_regi,all_te)            "share of average electricity price that flexible technologies see [share: 0...1]"
 v32_flexPriceShareMin(tall,all_regi,all_te)         "possible minimum of share of average electricity price that flexible technologies see [share: 0...1]"
 ;
+
+*** EOF ./modules/32_power/IntC/declarations.gms

--- a/modules/32_power/IntC/equations.gms
+++ b/modules/32_power/IntC/equations.gms
@@ -4,6 +4,8 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/32_power/IntC/equations.gms
+
 ***---------------------------------------------------------------------------
 *** Balance equation for electricity secondary energy type:
 ***---------------------------------------------------------------------------

--- a/modules/32_power/RLDC/bounds.gms
+++ b/modules/32_power/RLDC/bounds.gms
@@ -4,6 +4,8 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/32_power/RLDC/bounds.gms
+
 ***-----------------------------------------------------------
 ***                  module specific bounds
 ***------------------------------------------------------------
@@ -176,3 +178,5 @@ $if %cm_Full_Integration% == "on" vm_cap.fx(t,regi,"storspv","1")               
 $if %cm_Full_Integration% == "on" vm_deltaCap.fx(t,regi,"storspv","1")           = 0;
 
 vm_deltaCap.up(t,regi,"dot",rlf)$(t.val > 2040) = 1e-5;
+
+*** EOF ./modules/32_power/RLDC/bounds.gms

--- a/modules/32_power/RLDC/datainput.gms
+++ b/modules/32_power/RLDC/datainput.gms
@@ -4,6 +4,8 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/32_power/RLDC/datainput.gms
+
 *------------------------------------------------------------------------------------
 ***                        RLDC specific data input
 *------------------------------------------------------------------------------------
@@ -102,3 +104,4 @@ if (cm_solwindenergyscen = 8,  !! RI No Integration scenario
 
 ***display p32_capFacDem, p32_capFacLoB, p32_RLDCcoeff, p32_avCapFac, p32_ResMarg, p32_curtOn, p32_shCHP, p32_grid_factor;
 
+*** EOF ./modules/32_power/RLDC/datainput.gms

--- a/modules/32_power/RLDC/declarations.gms
+++ b/modules/32_power/RLDC/declarations.gms
@@ -4,6 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/32_power/RLDC/declarations.gms
 
 parameters
     p32_capFacDem(all_regi)						"Average demand factor of a power sector [0,1]"
@@ -72,3 +73,5 @@ equations
     q32_limitCapTeGrid(ttot,all_regi)   		"Calculate the additional grid capacity required by VRE"
     q32_limitSolarWind(tall,all_regi)    		"Limits on fluctuating renewables, only turned on for special EMF27 scenarios"
 ;
+
+*** EOF ./modules/32_power/RLDC/declarations.gms

--- a/modules/32_power/RLDC/equations.gms
+++ b/modules/32_power/RLDC/equations.gms
@@ -4,6 +4,8 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/32_power/RLDC/equations.gms
+
 ***---------------------------------------------------------------------------
 *** Balance equation for electricity secondary energy type:
 ***---------------------------------------------------------------------------
@@ -335,3 +337,5 @@ q32_limitSolarWind(t,regi)$( (cm_solwindenergyscen = 2) OR (cm_solwindenergyscen
 	=l=
 	0.2 * vm_usableSe(t,regi,"seel")
 ;
+
+*** EOF ./modules/32_power/RLDC/equations.gms

--- a/modules/32_power/RLDC/sets.gms
+++ b/modules/32_power/RLDC/sets.gms
@@ -4,6 +4,8 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/32_power/RLDC/sets.gms
+
 ***-----------------------------------------------------------
 ***                  module specific sets
 ***------------------------------------------------------------
@@ -137,3 +139,5 @@ $offtext
 ***		biochp
 	/	
 ;
+
+*** EOF ./modules/32_power/RLDC/sets.gms

--- a/modules/33_CDR/DAC/datainput.gms
+++ b/modules/33_CDR/DAC/datainput.gms
@@ -4,6 +4,8 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/33_CDR/DAC/datainput.gms
+
 !! Beutler et al. 2019 (Climeworks)
 !!fe demand electricity for ventilation
 p33_dac_fedem_el("feels") = 5.28;
@@ -15,3 +17,5 @@ p33_dac_fedem_heat("feels") = 21.12;
 *** FS: INNOPATHS sensitivity on DAC efficiency
 $if not "%cm_INNOPATHS_DAC_eff%" == "off" parameter p33_dac_fedem_fac(entyFeStat) / %cm_INNOPATHS_DAC_eff% /;
 $if not "%cm_INNOPATHS_DAC_eff%" == "off" p33_dac_fedem(entyFeStat) = p33_dac_fedem(entyFeStat) * p33_dac_fedem_fac(entyFeStat);
+
+*** EOF ./modules/33_CDR/DAC/datainput.gms

--- a/modules/33_CDR/DAC/realization.gms
+++ b/modules/33_CDR/DAC/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/33_CDR/DAC.gms
+*** SOF ./modules/33_CDR/DAC/realization.gms
 
 *' @description 
 *' In this realization, direct air capture can be used to remove CO2 from the atmosphere in addition to BECCS and afforestation. Based on Broehm et al. we assume an energy demand of 
@@ -17,4 +17,4 @@ $Ifi "%phase%" == "datainput" $include "./modules/33_CDR/DAC/datainput.gms"
 $Ifi "%phase%" == "equations" $include "./modules/33_CDR/DAC/equations.gms"
 $Ifi "%phase%" == "bounds" $include "./modules/33_CDR/DAC/bounds.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/33_CDR/DAC.gms
+*** EOF ./modules/33_CDR/DAC/realization.gms

--- a/modules/33_CDR/all/realization.gms
+++ b/modules/33_CDR/all/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/33_CDR/all.gms
+*** SOF ./modules/33_CDR/all/realization.gms
 
 *' @description 
 *' In this realization, direct air capture and enhanced weathering can be used to remove CO2 from the atmosphere in addition to BECCS and afforestation. Based on Broehm et al. we assume an energy demand of 
@@ -18,4 +18,4 @@ $Ifi "%phase%" == "datainput" $include "./modules/33_CDR/all/datainput.gms"
 $Ifi "%phase%" == "equations" $include "./modules/33_CDR/all/equations.gms"
 $Ifi "%phase%" == "bounds" $include "./modules/33_CDR/all/bounds.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/33_CDR/all.gms
+*** EOF ./modules/33_CDR/all/realization.gms

--- a/modules/33_CDR/module.gms
+++ b/modules/33_CDR/module.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/33_CDR/33_CDR.gms
+*** SOF ./modules/33_CDR/module.gms
 
 *' @title CDR
 *'
@@ -18,4 +18,4 @@ $Ifi "%CDR%" == "all" $include "./modules/33_CDR/all/realization.gms"
 $Ifi "%CDR%" == "off" $include "./modules/33_CDR/off/realization.gms"
 $Ifi "%CDR%" == "weathering" $include "./modules/33_CDR/weathering/realization.gms"
 *###################### R SECTION END (MODULETYPES) ############################
-*** EOF ./modules/33_CDR/33_CDR.gms
+*** EOF ./modules/33_CDR/module.gms

--- a/modules/33_CDR/off/realization.gms
+++ b/modules/33_CDR/off/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/33_CDR/off.gms
+*** SOF ./modules/33_CDR/off/realization.gms
 
 *' @description 
 *' In this realization, no additional CDR option other than BECCS and afforestation is available.
@@ -13,4 +13,4 @@
 $Ifi "%phase%" == "declarations" $include "./modules/33_CDR/off/declarations.gms"
 $Ifi "%phase%" == "bounds" $include "./modules/33_CDR/off/bounds.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/33_CDR/off.gms
+*** EOF ./modules/33_CDR/off/realization.gms

--- a/modules/33_CDR/weathering/realization.gms
+++ b/modules/33_CDR/weathering/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/33_CDR/weathering.gms
+*** SOF ./modules/33_CDR/weathering/realization.gms
 
 *' @description 
 *' In this realization, enhanced weathering of rocks can be used to remove CO2 from the atmosphere in addition to BECCS and afforestation. 
@@ -17,4 +17,4 @@ $Ifi "%phase%" == "datainput" $include "./modules/33_CDR/weathering/datainput.gm
 $Ifi "%phase%" == "equations" $include "./modules/33_CDR/weathering/equations.gms"
 $Ifi "%phase%" == "bounds" $include "./modules/33_CDR/weathering/bounds.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/33_CDR/weathering.gms
+*** EOF ./modules/33_CDR/weathering/realization.gms

--- a/modules/35_transport/complex/realization.gms
+++ b/modules/35_transport/complex/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/35_transport/complex.gms
+*** SOF ./modules/35_transport/complex/realization.gms
 
 *' @description Transport demand composition is calculated for LDV categories, electric trains and an aggregate category HDV.
 *' The CES transport branch has 3 nodes (LDV, HDV and electric trains). LDVs are in turn divided into ICE cars, BEVs, FCEVs.
@@ -22,4 +22,4 @@ $Ifi "%phase%" == "preloop" $include "./modules/35_transport/complex/preloop.gms
 $Ifi "%phase%" == "bounds" $include "./modules/35_transport/complex/bounds.gms"
 $Ifi "%phase%" == "postsolve" $include "./modules/35_transport/complex/postsolve.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/35_transport/complex.gms
+*** EOF ./modules/35_transport/complex/realization.gms

--- a/modules/35_transport/edge_esm/realization.gms
+++ b/modules/35_transport/edge_esm/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/35_transport/edge_esm.gms
+*** SOF ./modules/35_transport/edge_esm/realization.gms
 
 *' @description Transport demand composition is calculated based on the EDGE-transport model.
 *' This realization allows the EDGE-transport model to interact with REMIND. EDGE is set to run in between iterations. 
@@ -27,4 +27,4 @@ $Ifi "%phase%" == "presolve" $include "./modules/35_transport/edge_esm/presolve.
 $Ifi "%phase%" == "postsolve" $include "./modules/35_transport/edge_esm/postsolve.gms"
 $Ifi "%phase%" == "output" $include "./modules/35_transport/edge_esm/output.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/35_transport/edge_esm.gms
+*** EOF ./modules/35_transport/edge_esm/realization.gms

--- a/modules/35_transport/module.gms
+++ b/modules/35_transport/module.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/35_transport/35_transport.gms
+*** SOF ./modules/35_transport/module.gms
 
 *' @title Transport
 *'
@@ -16,4 +16,4 @@
 $Ifi "%transport%" == "complex" $include "./modules/35_transport/complex/realization.gms"
 $Ifi "%transport%" == "edge_esm" $include "./modules/35_transport/edge_esm/realization.gms"
 *###################### R SECTION END (MODULETYPES) ############################
-*** EOF ./modules/35_transport/35_transport.gms
+*** EOF ./modules/35_transport/module.gms

--- a/modules/36_buildings/module.gms
+++ b/modules/36_buildings/module.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/36_buildings/36_buildings.gms
+*** SOF ./modules/36_buildings/module.gms
 *' @title Buildings
 *'
 *' @description  The 36_buildings module calculates the demand for energy from buildings.
@@ -19,4 +19,4 @@ $Ifi "%buildings%" == "services_putty" $include "./modules/36_buildings/services
 $Ifi "%buildings%" == "services_with_capital" $include "./modules/36_buildings/services_with_capital/realization.gms"
 $Ifi "%buildings%" == "simple" $include "./modules/36_buildings/simple/realization.gms"
 *###################### R SECTION END (MODULETYPES) ############################
-*** EOF ./modules/36_buildings/36_buildings.gms
+*** EOF ./modules/36_buildings/module.gms

--- a/modules/36_buildings/services_putty/realization.gms
+++ b/modules/36_buildings/services_putty/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/36_buildings/services_putty.gms
+*** SOF ./modules/36_buildings/services_putty/realization.gms
 
 *' @description 
 *' 
@@ -33,4 +33,4 @@ $Ifi "%phase%" == "bounds" $include "./modules/36_buildings/services_putty/bound
 $Ifi "%phase%" == "presolve" $include "./modules/36_buildings/services_putty/presolve.gms"
 $Ifi "%phase%" == "postsolve" $include "./modules/36_buildings/services_putty/postsolve.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/36_buildings/services_putty.gms
+*** EOF ./modules/36_buildings/services_putty/realization.gms

--- a/modules/36_buildings/services_with_capital/realization.gms
+++ b/modules/36_buildings/services_with_capital/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/36_buildings/services_with_capital.gms
+*** SOF ./modules/36_buildings/services_with_capital/realization.gms
 
 *' @description 
 *' 
@@ -32,4 +32,4 @@ $Ifi "%phase%" == "bounds" $include "./modules/36_buildings/services_with_capita
 $Ifi "%phase%" == "presolve" $include "./modules/36_buildings/services_with_capital/presolve.gms"
 $Ifi "%phase%" == "postsolve" $include "./modules/36_buildings/services_with_capital/postsolve.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/36_buildings/services_with_capital.gms
+*** EOF ./modules/36_buildings/services_with_capital/realization.gms

--- a/modules/36_buildings/simple/realization.gms
+++ b/modules/36_buildings/simple/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/36_buildings/simple.gms
+*** SOF ./modules/36_buildings/simple/realization.gms
 
 *' @description 
 *' 
@@ -24,4 +24,4 @@ $Ifi "%phase%" == "equations" $include "./modules/36_buildings/simple/equations.
 $Ifi "%phase%" == "bounds" $include "./modules/36_buildings/simple/bounds.gms"
 $Ifi "%phase%" == "postsolve" $include "./modules/36_buildings/simple/postsolve.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/36_buildings/simple.gms
+*** EOF ./modules/36_buildings/simple/realization.gms

--- a/modules/37_industry/module.gms
+++ b/modules/37_industry/module.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/37_industry/37_industry.gms
+*** SOF ./modules/37_industry/module.gms
 
 *' @title Industry
 *'
@@ -18,5 +18,5 @@
 $Ifi "%industry%" == "fixed_shares" $include "./modules/37_industry/fixed_shares/realization.gms"
 $Ifi "%industry%" == "subsectors" $include "./modules/37_industry/subsectors/realization.gms"
 *###################### R SECTION END (MODULETYPES) ############################
-*** EOF ./modules/37_industry/37_industry.gms
+*** EOF ./modules/37_industry/module.gms
 

--- a/modules/37_industry/subsectors/sets.gms
+++ b/modules/37_industry/subsectors/sets.gms
@@ -334,5 +334,5 @@ $endif.calibrate
 alias(secInd37_2_pf,secInd37_2_pf2);
 alias(fe2ppfen37,fe2ppfen37_2);
 
-*** EOF ./modules/37_industry_four_sectors/sets.gms
+*** EOF ./modules/37_industry/subsectors/sets.gms
 

--- a/modules/39_CCU/module.gms
+++ b/modules/39_CCU/module.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/39_CCU/39_CCU.gms
+*** SOF ./modules/39_CCU/module.gms
 
 *' @title CCU
 *'
@@ -24,4 +24,4 @@ $Ifi "%CCU%" == "on" $include "./modules/39_CCU/on/realization.gms"
 *######################## R SECTION END (MODULETYPES) ###############################
 
 
-*** EOF ./modules/39_CCU/39_CCU.gms
+*** EOF ./modules/39_CCU/module.gms

--- a/modules/39_CCU/off/bounds.gms
+++ b/modules/39_CCU/off/bounds.gms
@@ -10,4 +10,4 @@ vm_co2CCUshort.fx(t,regi,"cco2","ccuco2short",teCCU2rlf(te2,rlf)) = 0;
 vm_cap.fx(t,regi,"h22ch4",rlf)$te2rlf("h22ch4",rlf) = 0;
 vm_cap.fx(t,regi,"MeOH",rlf)$te2rlf("MeOH",rlf) = 0;
 
-*** EOF ./modules/39_CCU/39_CCU.gms
+*** EOF ./modules/39_CCU/off/bounds.gms

--- a/modules/39_CCU/off/realization.gms
+++ b/modules/39_CCU/off/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/39_CCU/off.gms
+*** SOF ./modules/39_CCU/off/realization.gms
 
 *####################### R SECTION START (PHASES) ##############################
 $Ifi "%phase%" == "sets" $include "./modules/39_CCU/off/sets.gms"
@@ -12,4 +12,4 @@ $Ifi "%phase%" == "declarations" $include "./modules/39_CCU/off/declarations.gms
 $Ifi "%phase%" == "bounds" $include "./modules/39_CCU/off/bounds.gms"
 *######################## R SECTION END (PHASES) ###############################
 
-*** EOF ./modules/39_CCU/off.gms
+*** EOF ./modules/39_CCU/off/realization.gms

--- a/modules/39_CCU/on/bounds.gms
+++ b/modules/39_CCU/on/bounds.gms
@@ -42,4 +42,4 @@ v39_shSynGas.lo(t,regi)$(t.val eq 2035) = cm_shSynGas / 4;
 v39_shSynGas.lo(t,regi)$(t.val eq 2040) = cm_shSynGas / 2;
 v39_shSynGas.lo(t,regi)$(t.val ge 2045) = cm_shSynGas;
 
-*** EOF ./modules/39_CCU/39_CCU.gms
+*** EOF ./modules/39_CCU/on/bounds.gms

--- a/modules/39_CCU/on/realization.gms
+++ b/modules/39_CCU/on/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/39_CCU/on.gms
+*** SOF ./modules/39_CCU/on/realization.gms
 
 *' @description Standard CCU realization including the possibility to produce synthetic gas and synthetic liquids 
 *' from hydrogen and captured CO2.  
@@ -21,4 +21,4 @@ $Ifi "%phase%" == "equations" $include "./modules/39_CCU/on/equations.gms"
 $Ifi "%phase%" == "bounds" $include "./modules/39_CCU/on/bounds.gms"
 *######################## R SECTION END (PHASES) ###############################
 
-*** EOF ./modules/39_CCU/on.gms
+*** EOF ./modules/39_CCU/on/realization.gms

--- a/modules/40_techpol/CombLowCandCoalPO/realization.gms
+++ b/modules/40_techpol/CombLowCandCoalPO/realization.gms
@@ -4,11 +4,11 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/40_techpol/CombLowCandCoalPO.gms
+*** SOF ./modules/40_techpol/CombLowCandCoalPO/realization.gms
 
 *####################### R SECTION START (PHASES) ##############################
 $Ifi "%phase%" == "declarations" $include "./modules/40_techpol/CombLowCandCoalPO/declarations.gms"
 $Ifi "%phase%" == "datainput" $include "./modules/40_techpol/CombLowCandCoalPO/datainput.gms"
 $Ifi "%phase%" == "equations" $include "./modules/40_techpol/CombLowCandCoalPO/equations.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/40_techpol/CombLowCandCoalPO.gms
+*** EOF ./modules/40_techpol/CombLowCandCoalPO/realization.gms

--- a/modules/40_techpol/EVmandates/datainput.gms
+++ b/modules/40_techpol/EVmandates/datainput.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/40_techpol/EVmandates/datainput.gms 
+*** SOF ./modules/40_techpol/EVmandates/datainput.gms
 * values chosen with view on fig. 10 of www.iea.org/publications/freepublications/publication/Global_EV_Outlook_2016.pdf
 p40_EV_share("2020",regi)$(sameas(regi,"EUR") OR sameas(regi,"JPN")  OR sameas(regi,"CHN"))  = 0.08; !! upper tier 
 p40_EV_share("2020",regi)$(sameas(regi,"OAS") OR sameas(regi,"USA")  OR sameas(regi,"ROW")) = 0.05; 		!!middle tier

--- a/modules/40_techpol/EVmandates/realization.gms
+++ b/modules/40_techpol/EVmandates/realization.gms
@@ -4,11 +4,11 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/40_techpol/EVmandates.gms
+*** SOF ./modules/40_techpol/EVmandates/realization.gms
 
 *####################### R SECTION START (PHASES) ##############################
 $Ifi "%phase%" == "declarations" $include "./modules/40_techpol/EVmandates/declarations.gms"
 $Ifi "%phase%" == "datainput" $include "./modules/40_techpol/EVmandates/datainput.gms"
 $Ifi "%phase%" == "equations" $include "./modules/40_techpol/EVmandates/equations.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/40_techpol/EVmandates.gms
+*** EOF ./modules/40_techpol/EVmandates/realization.gms

--- a/modules/40_techpol/NDC/bounds.gms
+++ b/modules/40_techpol/NDC/bounds.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/40_techpol/NDC/bounds.gms 
+*** SOF ./modules/40_techpol/NDC/bounds.gms
 
 *AM the lowbound of solar and pv for 2030 to be taken from the NDCs (in GW), therefore multiplying by 0.001 for TW*
 *** FS: activate capacity tarets only from 2025 on to be better in line with current trends

--- a/modules/40_techpol/NDC/datainput.gms
+++ b/modules/40_techpol/NDC/datainput.gms
@@ -4,8 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/40_techpol/NDC/datainput.gms 
-*** SOF means start fo file and EOF means end of file. Use these before and after the body of the code
+*** SOF ./modules/40_techpol/NDC/datainput.gms
 
 Table f40_TechBound(ttot,all_regi,NDC_version,all_te) "Table for all NDC versions with NDC capacity targets (GW)"
 $offlisting

--- a/modules/40_techpol/NDCplus/bounds.gms
+++ b/modules/40_techpol/NDCplus/bounds.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/40_techpol/NDCplus/bounds.gms 
+*** SOF ./modules/40_techpol/NDCplus/bounds.gms
 
 *AM the lowbound of solar and pv for 2025 and 2030 to be taken from the NDCs (in GW), therefore multiplying by 0.001 for TW*
 vm_cap.lo(t,regi,"spv","1")$(t.val lt 2031 AND t.val gt 2024) = p40_TechBound(t,regi,"spv")*0.001; 

--- a/modules/40_techpol/NDCplus/datainput.gms
+++ b/modules/40_techpol/NDCplus/datainput.gms
@@ -4,8 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/40_techpol/NDCplus/datainput.gms 
-*** SOF means start fo file and EOF means end of file. Use these before and after the body of the code
+*** SOF ./modules/40_techpol/NDCplus/datainput.gms
 
 Table f40_TechBound(ttot,all_regi,NDC_version,all_te) "Table for all NDC versions with NDC capacity targets (GW)"
 $offlisting

--- a/modules/40_techpol/NPi2018/bounds.gms
+++ b/modules/40_techpol/NPi2018/bounds.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/40_techpol/NPi2018/bounds.gms 
+*** SOF ./modules/40_techpol/NPi2018/bounds.gms
 
 *AM the lowbound of solar and pv for 2030 to be taken from the NDCs (in GW), therefore multiplying by 0.001 for TW*
 *NPi bounds are only applied after 2020, as NPi scenarios should always have cm_startyear higher than 2020.

--- a/modules/40_techpol/NPi2018/datainput.gms
+++ b/modules/40_techpol/NPi2018/datainput.gms
@@ -4,8 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/40_techpol/NPi2018/datainput.gms 
-*** SOF means start fo file and EOF means end of file. Use these before and after the body of the code
+*** SOF ./modules/40_techpol/NPi2018/datainput.gms
 
 Table f40_TechBound(ttot,all_regi,NDC_version,all_te) "Table for all NDC versions with NDC capacity targets (GW)"
 $offlisting

--- a/modules/40_techpol/NPi2018/realization.gms
+++ b/modules/40_techpol/NPi2018/realization.gms
@@ -4,10 +4,12 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-
+*** SOF ./modules/40_techpol/NPi2018/realization.gms
 *####################### R SECTION START (PHASES) ##############################
 $Ifi "%phase%" == "declarations" $include "./modules/40_techpol/NPi2018/declarations.gms"
 $Ifi "%phase%" == "datainput" $include "./modules/40_techpol/NPi2018/datainput.gms"
 $Ifi "%phase%" == "equations" $include "./modules/40_techpol/NPi2018/equations.gms"
 $Ifi "%phase%" == "bounds" $include "./modules/40_techpol/NPi2018/bounds.gms"
 *######################## R SECTION END (PHASES) ###############################
+
+*** EOF ./modules/40_techpol/NPi2018/realization.gms

--- a/modules/40_techpol/coalPhaseout/realization.gms
+++ b/modules/40_techpol/coalPhaseout/realization.gms
@@ -4,11 +4,11 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/40_techpol/coalPhaseout.gms
+*** SOF ./modules/40_techpol/coalPhaseout/realization.gms
 
 *####################### R SECTION START (PHASES) ##############################
 $Ifi "%phase%" == "declarations" $include "./modules/40_techpol/coalPhaseout/declarations.gms"
 $Ifi "%phase%" == "equations" $include "./modules/40_techpol/coalPhaseout/equations.gms"
 $Ifi "%phase%" == "bounds" $include "./modules/40_techpol/coalPhaseout/bounds.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/40_techpol/coalPhaseout.gms
+*** EOF ./modules/40_techpol/coalPhaseout/realization.gms

--- a/modules/40_techpol/coalPhaseoutRegional/bounds.gms
+++ b/modules/40_techpol/coalPhaseoutRegional/bounds.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/40_techpol/coalPhaseoutRegional.gms
+*** SOF ./modules/40_techpol/coalPhaseoutRegional/bounds.gms
 vm_deltaCap.up(t,regi,"pc","1")$(t.val gt 2023)        =0.000001;
 vm_deltaCap.up(t,regi,"igcc","1")$(t.val gt 2023)      =0.000001;
 vm_deltaCap.up(t,regi,"coalchp","1")$(t.val gt 2023)   =0.000001;

--- a/modules/40_techpol/coalPhaseoutRegional/realization.gms
+++ b/modules/40_techpol/coalPhaseoutRegional/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/40_techpol/coalPhaseoutRegional.gms
+*** SOF ./modules/40_techpol/coalPhaseoutRegional/realization.gms
 
 *####################### R SECTION START (PHASES) ##############################
 $Ifi "%phase%" == "declarations" $include "./modules/40_techpol/coalPhaseoutRegional/declarations.gms"
@@ -12,4 +12,4 @@ $Ifi "%phase%" == "datainput" $include "./modules/40_techpol/coalPhaseoutRegiona
 $Ifi "%phase%" == "equations" $include "./modules/40_techpol/coalPhaseoutRegional/equations.gms"
 $Ifi "%phase%" == "bounds" $include "./modules/40_techpol/coalPhaseoutRegional/bounds.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/40_techpol/coalPhaseoutRegional.gms
+*** EOF ./modules/40_techpol/coalPhaseoutRegional/realization.gms

--- a/modules/40_techpol/lowCarbonPush/realization.gms
+++ b/modules/40_techpol/lowCarbonPush/realization.gms
@@ -4,11 +4,11 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/40_techpol/lowCarbonPush.gms
+*** SOF ./modules/40_techpol/lowCarbonPush/realization.gms
 
 *####################### R SECTION START (PHASES) ##############################
 $Ifi "%phase%" == "declarations" $include "./modules/40_techpol/lowCarbonPush/declarations.gms"
 $Ifi "%phase%" == "datainput" $include "./modules/40_techpol/lowCarbonPush/datainput.gms"
 $Ifi "%phase%" == "equations" $include "./modules/40_techpol/lowCarbonPush/equations.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/40_techpol/lowCarbonPush.gms
+*** EOF ./modules/40_techpol/lowCarbonPush/realization.gms

--- a/modules/40_techpol/module.gms
+++ b/modules/40_techpol/module.gms
@@ -23,4 +23,4 @@ $Ifi "%techpol%" == "coalPhaseoutRegional" $include "./modules/40_techpol/coalPh
 $Ifi "%techpol%" == "lowCarbonPush" $include "./modules/40_techpol/lowCarbonPush/realization.gms"
 $Ifi "%techpol%" == "none" $include "./modules/40_techpol/none/realization.gms"
 *###################### R SECTION END (MODULETYPES) ############################
-*** EOF ./modules/40_techpol/40_techpol.gms
+*** EOF ./modules/40_techpol/module.gms

--- a/modules/40_techpol/none/realization.gms
+++ b/modules/40_techpol/none/realization.gms
@@ -4,8 +4,8 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/40_techpol/none.gms
+*** SOF ./modules/40_techpol/none/realization.gms
 
 *####################### R SECTION START (PHASES) ##############################
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/40_techpol/none.gms
+*** EOF ./modules/40_techpol/none/realization.gms

--- a/modules/41_emicapregi/AbilityToPay/realization.gms
+++ b/modules/41_emicapregi/AbilityToPay/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/41_emicapregi/AbilityToPay.gms
+*** SOF ./modules/41_emicapregi/AbilityToPay/realization.gms
 
 *' @description
 *' Emission caps/permits are allocated according to the ability to pay principle  
@@ -14,4 +14,4 @@ $Ifi "%phase%" == "declarations" $include "./modules/41_emicapregi/AbilityToPay/
 $Ifi "%phase%" == "datainput" $include "./modules/41_emicapregi/AbilityToPay/datainput.gms"
 $Ifi "%phase%" == "bounds" $include "./modules/41_emicapregi/AbilityToPay/bounds.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/41_emicapregi/AbilityToPay.gms
+*** EOF ./modules/41_emicapregi/AbilityToPay/realization.gms

--- a/modules/41_emicapregi/CandC/realization.gms
+++ b/modules/41_emicapregi/CandC/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/41_emicapregi/CandC.gms
+*** SOF ./modules/41_emicapregi/CandC/realization.gms
 
 *' @description
 *' Emission caps/permits are allocated according to the contraction and convergence 
@@ -16,4 +16,4 @@ $Ifi "%phase%" == "datainput" $include "./modules/41_emicapregi/CandC/datainput.
 $Ifi "%phase%" == "equations" $include "./modules/41_emicapregi/CandC/equations.gms"
 $Ifi "%phase%" == "bounds" $include "./modules/41_emicapregi/CandC/bounds.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/41_emicapregi/CandC.gms
+*** EOF ./modules/41_emicapregi/CandC/realization.gms

--- a/modules/41_emicapregi/GDPint/realization.gms
+++ b/modules/41_emicapregi/GDPint/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/41_emicapregi/GDPint.gms
+*** SOF ./modules/41_emicapregi/GDPint/realization.gms
 
 *' @description
 *' Emission caps/permits are allocated according to GDP intensity
@@ -14,4 +14,4 @@ $Ifi "%phase%" == "declarations" $include "./modules/41_emicapregi/GDPint/declar
 $Ifi "%phase%" == "datainput" $include "./modules/41_emicapregi/GDPint/datainput.gms"
 $Ifi "%phase%" == "equations" $include "./modules/41_emicapregi/GDPint/equations.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/41_emicapregi/GDPint.gms
+*** EOF ./modules/41_emicapregi/GDPint/realization.gms

--- a/modules/41_emicapregi/POPint/realization.gms
+++ b/modules/41_emicapregi/POPint/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/41_emicapregi/POPint.gms
+*** SOF ./modules/41_emicapregi/POPint/realization.gms
 
 *' @description
 *' Emission caps/permits are allocated according to each region's share on
@@ -18,4 +18,4 @@ $Ifi "%phase%" == "equations" $include "./modules/41_emicapregi/POPint/equations
 $Ifi "%phase%" == "preloop" $include "./modules/41_emicapregi/POPint/preloop.gms"
 $Ifi "%phase%" == "bounds" $include "./modules/41_emicapregi/POPint/bounds.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/41_emicapregi/POPint.gms
+*** EOF ./modules/41_emicapregi/POPint/realization.gms

--- a/modules/41_emicapregi/PerCapitaConvergence/realization.gms
+++ b/modules/41_emicapregi/PerCapitaConvergence/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/41_emicapregi/PerCapitaConvergence.gms
+*** SOF ./modules/41_emicapregi/PerCapitaConvergence/realization.gms
 
 *' @description
 *' Emission caps/permits are allocated according to the contraction and convergence 
@@ -15,4 +15,4 @@ $Ifi "%phase%" == "declarations" $include "./modules/41_emicapregi/PerCapitaConv
 $Ifi "%phase%" == "datainput" $include "./modules/41_emicapregi/PerCapitaConvergence/datainput.gms"
 $Ifi "%phase%" == "bounds" $include "./modules/41_emicapregi/PerCapitaConvergence/bounds.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/41_emicapregi/PerCapitaConvergence.gms
+*** EOF ./modules/41_emicapregi/PerCapitaConvergence/realization.gms

--- a/modules/41_emicapregi/exog/realization.gms
+++ b/modules/41_emicapregi/exog/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/41_emicapregi/exog.gms
+*** SOF ./modules/41_emicapregi/exog/realization.gms
 
 *' @description
 *' Emission caps/permits are allocated from an exogenous emission path that have 
@@ -15,4 +15,4 @@ $Ifi "%phase%" == "declarations" $include "./modules/41_emicapregi/exog/declarat
 $Ifi "%phase%" == "datainput" $include "./modules/41_emicapregi/exog/datainput.gms"
 $Ifi "%phase%" == "bounds" $include "./modules/41_emicapregi/exog/bounds.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/41_emicapregi/exog.gms
+*** EOF ./modules/41_emicapregi/exog/realization.gms

--- a/modules/41_emicapregi/module.gms
+++ b/modules/41_emicapregi/module.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/41_emicapregi/41_emicapregi.gms
+*** SOF ./modules/41_emicapregi/module.gms
 
 *' @title Regional Emission Caps 
 *'
@@ -29,4 +29,4 @@ $Ifi "%emicapregi%" == "PerCapitaConvergence" $include "./modules/41_emicapregi/
 $Ifi "%emicapregi%" == "exog" $include "./modules/41_emicapregi/exog/realization.gms"
 $Ifi "%emicapregi%" == "none" $include "./modules/41_emicapregi/none/realization.gms"
 *###################### R SECTION END (MODULETYPES) ############################
-*** EOF ./modules/41_emicapregi/41_emicapregi.gms
+*** EOF ./modules/41_emicapregi/module.gms

--- a/modules/41_emicapregi/none/realization.gms
+++ b/modules/41_emicapregi/none/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/41_emicapregi/none.gms
+*** SOF ./modules/41_emicapregi/none/realization.gms
 
 *' @description
 *' No allocation of regional emission caps/permits - applies to tax scenarios and 
@@ -14,4 +14,4 @@
 $Ifi "%phase%" == "datainput" $include "./modules/41_emicapregi/none/datainput.gms"
 $Ifi "%phase%" == "bounds" $include "./modules/41_emicapregi/none/bounds.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/41_emicapregi/none.gms
+*** EOF ./modules/41_emicapregi/none/realization.gms

--- a/modules/42_banking/banking/realization.gms
+++ b/modules/42_banking/banking/realization.gms
@@ -4,11 +4,11 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/42_banking/banking.gms
+*** SOF ./modules/42_banking/banking/realization.gms
 
 *####################### R SECTION START (PHASES) ##############################
 $Ifi "%phase%" == "declarations" $include "./modules/42_banking/banking/declarations.gms"
 $Ifi "%phase%" == "equations" $include "./modules/42_banking/banking/equations.gms"
 $Ifi "%phase%" == "bounds" $include "./modules/42_banking/banking/bounds.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/42_banking/banking.gms
+*** EOF ./modules/42_banking/banking/realization.gms

--- a/modules/42_banking/module.gms
+++ b/modules/42_banking/module.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/42_banking/42_banking.gms
+*** SOF ./modules/42_banking/module.gms
 
 *' @title Banking 
 *'
@@ -14,4 +14,4 @@
 $Ifi "%banking%" == "banking" $include "./modules/42_banking/banking/realization.gms"
 $Ifi "%banking%" == "off" $include "./modules/42_banking/off/realization.gms"
 *###################### R SECTION END (MODULETYPES) ############################
-*** EOF ./modules/42_banking/42_banking.gms
+*** EOF ./modules/42_banking/module.gms

--- a/modules/42_banking/off/realization.gms
+++ b/modules/42_banking/off/realization.gms
@@ -4,9 +4,9 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/42_banking/off.gms
+*** SOF ./modules/42_banking/off/realization.gms
 
 *####################### R SECTION START (PHASES) ##############################
 $Ifi "%phase%" == "bounds" $include "./modules/42_banking/off/bounds.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/42_banking/off.gms
+*** EOF ./modules/42_banking/off/realization.gms

--- a/modules/45_carbonprice/NDC2constant/realization.gms
+++ b/modules/45_carbonprice/NDC2constant/realization.gms
@@ -4,9 +4,12 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/45_carbonprice/NDC2constant/realization.gms
 
 *####################### R SECTION START (PHASES) ##############################
 $Ifi "%phase%" == "declarations" $include "./modules/45_carbonprice/NDC2constant/declarations.gms"
 $Ifi "%phase%" == "datainput" $include "./modules/45_carbonprice/NDC2constant/datainput.gms"
 $Ifi "%phase%" == "postsolve" $include "./modules/45_carbonprice/NDC2constant/postsolve.gms"
 *######################## R SECTION END (PHASES) ###############################
+
+*** EOF ./modules/45_carbonprice/NDC2constant/realization.gms

--- a/modules/45_carbonprice/NPi2018/realization.gms
+++ b/modules/45_carbonprice/NPi2018/realization.gms
@@ -4,9 +4,9 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/45_carbonprice/NPi2018.gms
+*** SOF ./modules/45_carbonprice/NPi2018/realization.gms
 
 *####################### R SECTION START (PHASES) ##############################
 $Ifi "%phase%" == "datainput" $include "./modules/45_carbonprice/NPi2018/datainput.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/45_carbonprice/NPi2018.gms
+*** EOF ./modules/45_carbonprice/NPi2018/realization.gms

--- a/modules/45_carbonprice/diffCurvPhaseIn2Lin/realization.gms
+++ b/modules/45_carbonprice/diffCurvPhaseIn2Lin/realization.gms
@@ -4,9 +4,12 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/45_carbonprice/diffCurvPhaseIn2Lin/realization.gms
 
 *####################### R SECTION START (PHASES) ##############################
 $Ifi "%phase%" == "declarations" $include "./modules/45_carbonprice/diffCurvPhaseIn2Lin/declarations.gms"
 $Ifi "%phase%" == "datainput" $include "./modules/45_carbonprice/diffCurvPhaseIn2Lin/datainput.gms"
 $Ifi "%phase%" == "postsolve" $include "./modules/45_carbonprice/diffCurvPhaseIn2Lin/postsolve.gms"
 *######################## R SECTION END (PHASES) ###############################
+
+*** EOF ./modules/45_carbonprice/diffCurvPhaseIn2Lin/realization.gms

--- a/modules/45_carbonprice/diffPhaseIn2Constant/realization.gms
+++ b/modules/45_carbonprice/diffPhaseIn2Constant/realization.gms
@@ -4,9 +4,12 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/45_carbonprice/diffPhaseIn2Constant/realization.gms
 
 *####################### R SECTION START (PHASES) ##############################
 $Ifi "%phase%" == "declarations" $include "./modules/45_carbonprice/diffPhaseIn2Constant/declarations.gms"
 $Ifi "%phase%" == "datainput" $include "./modules/45_carbonprice/diffPhaseIn2Constant/datainput.gms"
 $Ifi "%phase%" == "postsolve" $include "./modules/45_carbonprice/diffPhaseIn2Constant/postsolve.gms"
 *######################## R SECTION END (PHASES) ###############################
+
+*** EOF ./modules/45_carbonprice/diffPhaseIn2Constant/realization.gms

--- a/modules/45_carbonprice/diffPhaseIn2Lin/realization.gms
+++ b/modules/45_carbonprice/diffPhaseIn2Lin/realization.gms
@@ -4,9 +4,12 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/45_carbonprice/diffPhaseIn2Lin/realization.gms
 
 *####################### R SECTION START (PHASES) ##############################
 $Ifi "%phase%" == "declarations" $include "./modules/45_carbonprice/diffPhaseIn2Lin/declarations.gms"
 $Ifi "%phase%" == "datainput" $include "./modules/45_carbonprice/diffPhaseIn2Lin/datainput.gms"
 $Ifi "%phase%" == "postsolve" $include "./modules/45_carbonprice/diffPhaseIn2Lin/postsolve.gms"
 *######################## R SECTION END (PHASES) ###############################
+
+*** EOF ./modules/45_carbonprice/diffPhaseIn2Lin/realization.gms

--- a/modules/45_carbonprice/diffPhaseInLin2LinFlex/datainput.gms
+++ b/modules/45_carbonprice/diffPhaseInLin2LinFlex/datainput.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/45_carbonprice/diffPhaseIn2LinFlex/datainput.gms
+*** SOF ./modules/45_carbonprice/diffPhaseInLin2LinFlex/datainput.gms
 ***------------------------------------------------------------------------------------------------------------------------
 *** *BS* 20190930 linear convergence with starting points differentiated by GDP/capita, global price from 2040
 ***-----------------------------------------------------------------------------------------------------------------------
@@ -82,4 +82,4 @@ pm_taxCO2eq(t,regi) = p45_regCO2priceFactor(t,regi) * p45_CO2priceTrajDeveloped(
 
 display p45_regCO2priceFactor, p45_CO2priceTrajDeveloped, pm_taxCO2eq;
 
-*** EOF ./modules/45_carbonprice/diffPhaseIn2LinFlex/datainput.gms
+*** EOF ./modules/45_carbonprice/diffPhaseInLin2LinFlex/datainput.gms

--- a/modules/45_carbonprice/diffPhaseInLin2LinFlex/declarations.gms
+++ b/modules/45_carbonprice/diffPhaseInLin2LinFlex/declarations.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/45_carbonprice/diffPhaseIn2LinFlex/declarations.gms
+*** SOF ./modules/45_carbonprice/diffPhaseInLin2LinFlex/declarations.gms
 ***------------------------------------------------------------------------------------------------------------------------
 *** *BS* 20190930 linear convergence with starting points differentiated by GDP/capita, global price from 2040
 ***-----------------------------------------------------------------------------------------------------------------------
@@ -27,4 +27,4 @@ s45_convergenceCO2price                     "price to which the regional values 
 
 
 ;
-*** EOF ./modules/45_carbonprice/diffPhaseIn2LinFlex/declarations.gms
+*** EOF ./modules/45_carbonprice/diffPhaseInLin2LinFlex/declarations.gms

--- a/modules/45_carbonprice/diffPhaseInLin2LinFlex/postsolve.gms
+++ b/modules/45_carbonprice/diffPhaseInLin2LinFlex/postsolve.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/45_carbonprice/diffPhaseIn2LinFlex/postsolve.gms
+*** SOF ./modules/45_carbonprice/diffPhaseInLin2LinFlex/postsolve.gms
 ***------------------------------------------------------------------------------------------------------------------------
 *** *BS* 20190930 linear convergence with starting points differentiated by GDP/capita, global price from 2040
 ***-----------------------------------------------------------------------------------------------------------------------
@@ -29,4 +29,4 @@ loop(regi$(p45_gdppcap2015_PPP(regi) gt 30),
 pm_taxCO2eq(t,regi) = p45_regCO2priceFactor(t,regi) * p45_CO2priceTrajDeveloped(t);
 
 display pm_taxCO2eq;
-*** EOF ./modules/45_carbonprice/diffPhaseIn2LinFlex/postsolve.gms
+*** EOF ./modules/45_carbonprice/diffPhaseInLin2LinFlex/postsolve.gms

--- a/modules/45_carbonprice/diffPhaseInLin2LinFlex/realization.gms
+++ b/modules/45_carbonprice/diffPhaseInLin2LinFlex/realization.gms
@@ -4,9 +4,12 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/45_carbonprice/diffPhaseInLin2LinFlex/realization.gms
 
 *####################### R SECTION START (PHASES) ##############################
 $Ifi "%phase%" == "declarations" $include "./modules/45_carbonprice/diffPhaseInLin2LinFlex/declarations.gms"
 $Ifi "%phase%" == "datainput" $include "./modules/45_carbonprice/diffPhaseInLin2LinFlex/datainput.gms"
 $Ifi "%phase%" == "postsolve" $include "./modules/45_carbonprice/diffPhaseInLin2LinFlex/postsolve.gms"
 *######################## R SECTION END (PHASES) ###############################
+
+*** EOF ./modules/45_carbonprice/diffPhaseInLin2LinFlex/realization.gms

--- a/modules/45_carbonprice/diffPriceSameCost/realization.gms
+++ b/modules/45_carbonprice/diffPriceSameCost/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/45_carbonprice/diffPriceSameCost.gms
+*** SOF ./modules/45_carbonprice/diffPriceSameCost/realization.gms
 
 *#' @description This realization implements carbon price trajectories compatible with respect to a global target but with equal regional relative (NPV) mitigation cost. 
 
@@ -14,4 +14,4 @@ $Ifi "%phase%" == "declarations" $include "./modules/45_carbonprice/diffPriceSam
 $Ifi "%phase%" == "datainput" $include "./modules/45_carbonprice/diffPriceSameCost/datainput.gms"
 $Ifi "%phase%" == "postsolve" $include "./modules/45_carbonprice/diffPriceSameCost/postsolve.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/45_carbonprice/diffPriceSameCost.gms
+*** EOF ./modules/45_carbonprice/diffPriceSameCost/realization.gms

--- a/modules/45_carbonprice/exogenous/realization.gms
+++ b/modules/45_carbonprice/exogenous/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/45_carbonprice/exogenous.gms
+*** SOF ./modules/45_carbonprice/exogenous/realization.gms
 
 *#' @description This realization implements carbon price trajectories from an exogenous file (p45_tau_co2_tax.inc).  
 
@@ -13,4 +13,4 @@
 $Ifi "%phase%" == "declarations" $include "./modules/45_carbonprice/exogenous/declarations.gms"
 $Ifi "%phase%" == "datainput" $include "./modules/45_carbonprice/exogenous/datainput.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/45_carbonprice/exogenous.gms
+*** EOF ./modules/45_carbonprice/exogenous/realization.gms

--- a/modules/45_carbonprice/expoLinear/realization.gms
+++ b/modules/45_carbonprice/expoLinear/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/45_carbonprice/expoLinear.gms
+*** SOF ./modules/45_carbonprice/expoLinear/realization.gms
 
 *' @description  The exponential price path goes back to the “Hotelling rule”:  
 *' a price path that rises exponentially with the discount rate is economically optimal for extracting a finite resource, 
@@ -20,4 +20,4 @@
 $Ifi "%phase%" == "declarations" $include "./modules/45_carbonprice/expoLinear/declarations.gms"
 $Ifi "%phase%" == "datainput" $include "./modules/45_carbonprice/expoLinear/datainput.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/45_carbonprice/expoLinear.gms
+*** EOF ./modules/45_carbonprice/expoLinear/realization.gms

--- a/modules/45_carbonprice/exponential/realization.gms
+++ b/modules/45_carbonprice/exponential/realization.gms
@@ -4,11 +4,11 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/45_carbonprice/exponential.gms
+*** SOF ./modules/45_carbonprice/exponential/realization.gms
 
 *#' @description: This realization imeplents an exponential increase in carbon price from the predefined 2020 level. 
 
 *####################### R SECTION START (PHASES) ##############################
 $Ifi "%phase%" == "datainput" $include "./modules/45_carbonprice/exponential/datainput.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/45_carbonprice/exponential.gms
+*** EOF ./modules/45_carbonprice/exponential/realization.gms

--- a/modules/45_carbonprice/linear/realization.gms
+++ b/modules/45_carbonprice/linear/realization.gms
@@ -4,11 +4,11 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/45_carbonprice/linear.gms
+*** SOF ./modules/45_carbonprice/linear/realization.gms
 
 *#' @description: This realization imeplents an linear increase in carbon price from the predefined 2020 level. 
 
 *####################### R SECTION START (PHASES) ##############################
 $Ifi "%phase%" == "datainput" $include "./modules/45_carbonprice/linear/datainput.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/45_carbonprice/linear.gms
+*** EOF ./modules/45_carbonprice/linear/realization.gms

--- a/modules/45_carbonprice/module.gms
+++ b/modules/45_carbonprice/module.gms
@@ -36,4 +36,4 @@ $Ifi "%carbonprice%" == "linear" $include "./modules/45_carbonprice/linear/reali
 $Ifi "%carbonprice%" == "none" $include "./modules/45_carbonprice/none/realization.gms"
 $Ifi "%carbonprice%" == "temperatureNotToExceed" $include "./modules/45_carbonprice/temperatureNotToExceed/realization.gms"
 *###################### R SECTION END (MODULETYPES) ############################
-*** EOF ./modules/45_carbonprice/45_carbonprice.gms
+*** EOF ./modules/45_carbonprice/module.gms

--- a/modules/45_carbonprice/none/realization.gms
+++ b/modules/45_carbonprice/none/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/45_carbonprice/none.gms
+*** SOF ./modules/45_carbonprice/none/realization.gms
 
 
 *#' @description: This realization is for runs without carbon prices (BAU). 
@@ -12,4 +12,4 @@
 *####################### R SECTION START (PHASES) ##############################
 $Ifi "%phase%" == "datainput" $include "./modules/45_carbonprice/none/datainput.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/45_carbonprice/none.gms
+*** EOF ./modules/45_carbonprice/none/realization.gms

--- a/modules/45_carbonprice/temperatureNotToExceed/datainput.gms
+++ b/modules/45_carbonprice/temperatureNotToExceed/datainput.gms
@@ -4,6 +4,8 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/45_carbonprice/temperatureNotToExceed/datainput.gms
+
 * satisfy dependencies
 $ifi not %climate% == 'magicc' abort "module carbonprice=temperatureNotToExceed requires climate=magicc";
 $ifi not %cm_magicc_temperatureImpulseResponse% == 'on' abort "module carbonprice=temperatureNotToExceed requires cm_magicc_temperatureImpulseResponse=on";
@@ -18,3 +20,5 @@ s45_itrAdjExp =  0.04; !! Lower if no convergence
 
 * initialize
 p45_taxTempLimitLastItr(tall) = 0;
+
+*** EOF ./modules/45_carbonprice/temperatureNotToExceed/datainput.gms

--- a/modules/45_carbonprice/temperatureNotToExceed/declarations.gms
+++ b/modules/45_carbonprice/temperatureNotToExceed/declarations.gms
@@ -4,6 +4,8 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/45_carbonprice/temperatureNotToExceed/declarations.gms
+
 parameters
 p45_taxTempLimit(tall) "tax for Temperature limit [1000 $/tC]"
 p45_taxTempLimitLastItr(tall) "tax for Temperature limit, last iteration [1000 $/tC]"
@@ -12,3 +14,5 @@ s45_taxTempLimitConvMaxDeviation  "limit for temperature deviation"
 s45_eta              "inverse steepness of damage function at temperature limit (logistic function). Raise if no convergence" 
 s45_itrAdjExp       "exponent for iterative adjustment of taxes. Lower if no convergence."
 ;
+
+*** EOF ./modules/45_carbonprice/temperatureNotToExceed/declarations.gms

--- a/modules/45_carbonprice/temperatureNotToExceed/postsolve.gms
+++ b/modules/45_carbonprice/temperatureNotToExceed/postsolve.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-
+*** SOF ./modules/45_carbonprice/temperatureNotToExceed/postsolve.gms
 
 if(iteration.val gt 2,
 
@@ -66,4 +66,4 @@ s45_taxTempLimitConvMaxDeviation =
 p45_taxTempLimitLastItr(tall) = p45_taxTempLimit(tall);
 display s45_taxTempLimitConvMaxDeviation;
 
-
+*** EOF ./modules/45_carbonprice/temperatureNotToExceed/postsolve.gms

--- a/modules/45_carbonprice/temperatureNotToExceed/realization.gms
+++ b/modules/45_carbonprice/temperatureNotToExceed/realization.gms
@@ -4,6 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/45_carbonprice/temperatureNotToExceed/realization.gms
 
 *#' @description This realization chooses a carbon price trajectory consistent with a (non-overshoot) temperature target  
 *#' by staying within a peak budget of cumulative CO2 emissions. 
@@ -13,3 +14,5 @@ $Ifi "%phase%" == "declarations" $include "./modules/45_carbonprice/temperatureN
 $Ifi "%phase%" == "datainput" $include "./modules/45_carbonprice/temperatureNotToExceed/datainput.gms"
 $Ifi "%phase%" == "postsolve" $include "./modules/45_carbonprice/temperatureNotToExceed/postsolve.gms"
 *######################## R SECTION END (PHASES) ###############################
+
+*** EOF ./modules/45_carbonprice/temperatureNotToExceed/realization.gms

--- a/modules/46_carbonpriceRegi/netZero/realization.gms
+++ b/modules/46_carbonpriceRegi/netZero/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/46_CarbonPriceRegi/netZero/realization.gms
+*** SOF ./modules/46_carbonpriceRegi/netZero/realization.gms
 
 *' @description This realization adds a regional CO2 tax markup to satisfy the net-zero targets
 *' the carbon price follows a triangular trajectory, increasing until the net-zero year and going back to zero in 2100.
@@ -20,4 +20,4 @@ $Ifi "%phase%" == "datainput" $include "./modules/46_carbonpriceRegi/netZero/dat
 $Ifi "%phase%" == "postsolve" $include "./modules/46_carbonpriceRegi/netZero/postsolve.gms"
 *######################## R SECTION END (PHASES) ###############################
 
-*** EOF ./modules/46_CarbonPriceRegi/netZero/realization.gms
+*** EOF ./modules/46_carbonpriceRegi/netZero/realization.gms

--- a/modules/47_regipol/none/realization.gms
+++ b/modules/47_regipol/none/realization.gms
@@ -4,11 +4,11 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/47_regipol/none.gms
+*** SOF ./modules/47_regipol/none/realization.gms
 
 *####################### R SECTION START (PHASES) ##############################
 $Ifi "%phase%" == "declarations" $include "./modules/47_regipol/none/declarations.gms"
 $Ifi "%phase%" == "datainput" $include "./modules/47_regipol/none/datainput.gms"
 $Ifi "%phase%" == "bounds" $include "./modules/47_regipol/none/bounds.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/47_regipol/none.gms
+*** EOF ./modules/47_regipol/none/realization.gms

--- a/modules/47_regipol/regiCarbonPrice/equations.gms
+++ b/modules/47_regipol/regiCarbonPrice/equations.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/47_regiPol/regiCarbonPrice/equations.gms
+*** SOF ./modules/47_regipol/regiCarbonPrice/equations.gms
 
 ***$ifThen.regicarbonprice not "%cm_regiCO2target%" == "off"
 *** FS: calculate emissions used in regional target
@@ -139,4 +139,4 @@ q47_implFETax(t,regi)$(t.val ge max(2010,cm_startyear))..
 
 $endIf.cm_implicitFE
 
-*** EOF ./modules/47_regiPol/regiCarbonPrice/equations.gms
+*** EOF ./modules/47_regipol/regiCarbonPrice/equations.gms

--- a/modules/50_damages/BurkeLike/bounds.gms
+++ b/modules/50_damages/BurkeLike/bounds.gms
@@ -4,15 +4,11 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-
+*** SOF ./modules/50_damages/BurkeLike/bounds.gms
 
 loop(ttot$(ttot.val ge 2005),
 	loop(tall$(pm_ttot_2_tall(ttot,tall)),
 	    vm_damageFactor.fx(ttot,regi) = pm_damage(tall,regi);
 ));
 
-
-
-
-
-
+*** EOF ./modules/50_damages/BurkeLike/bounds.gms

--- a/modules/50_damages/BurkeLike/datainput.gms
+++ b/modules/50_damages/BurkeLike/datainput.gms
@@ -4,6 +4,8 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/50_damages/BurkeLike/datainput.gms
+
 * satisfy dependencies
 $ifi not %downscaleTemperature% == 'CMIP5' abort "module damages=BurkeLike requires downscaleTemperature=CMIP5";
 
@@ -29,4 +31,4 @@ pm_damage(tall,regi) = 1;
 pm_damageGrowthRate(tall,regi)         = 0;
 pm_damageMarginal(tall,regi)           = 0;
 
-
+*** EOF ./modules/50_damages/BurkeLike/datainput.gms

--- a/modules/50_damages/BurkeLike/postsolve.gms
+++ b/modules/50_damages/BurkeLike/postsolve.gms
@@ -4,6 +4,8 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/50_damages/BurkeLike/postsolve.gms
+
 * Damage function based on Burke et al. (2015), extended by finite persistence/adaptation parameterization
 * For details refer to Schultes et al. (2018) supplementary material
 * time index mapping from supplement to code:  tall = t ; tall2 = t' ; tall3 = t''
@@ -32,7 +34,6 @@ pm_damage(tall,regi)$(tall.val ge 2000 and tall.val le 2300) =
 pm_damageMarginal(tall,regi)$(tall.val ge 2000 and tall.val le 2300) = 
   ( p50_damageFuncCoef1  + 2 * p50_damageFuncCoef2 * pm_regionalTemperature(tall,regi) );
 
-
-
-
 display pm_damage;
+
+*** EOF ./modules/50_damages/BurkeLike/postsolve.gms

--- a/modules/50_damages/BurkeLike/realization.gms
+++ b/modules/50_damages/BurkeLike/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/50_damages/BurkeLike.gms
+*** SOF ./modules/50_damages/BurkeLike/realization.gms
 
 *' @description Output damages are calculated based on the damage function from @Burke2015, extended by a finite persistence term. The details are described in @Schultes2020. The persistence is a parameter to be specified in the config file (cm_damages_BurkeLike_persistenceTime). Two different damage realizations can be chosen via the switch cm_damages_BurkeLike_specification. "0" uses the short-run specification without lags, "1" the long-run specification. Damages are calculated on the regional level, the global temperature path from MAGICC is scaled to REMIND regions in module 16_downscaleTemperature, requiring the setting downscaleTemperature=CMIP5. 
 
@@ -16,4 +16,4 @@ $Ifi "%phase%" == "datainput" $include "./modules/50_damages/BurkeLike/datainput
 $Ifi "%phase%" == "bounds" $include "./modules/50_damages/BurkeLike/bounds.gms"
 $Ifi "%phase%" == "postsolve" $include "./modules/50_damages/BurkeLike/postsolve.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/50_damages/BurkeLike.gms
+*** EOF ./modules/50_damages/BurkeLike/realization.gms

--- a/modules/50_damages/DiceLike/bounds.gms
+++ b/modules/50_damages/DiceLike/bounds.gms
@@ -4,6 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/50_damages/DiceLike/bounds.gms
 
 vm_damageFactor.fx("2005",regi) = 1;
 
@@ -12,8 +13,4 @@ loop(ttot$(ttot.val ge 2010),
 	    vm_damageFactor.fx(ttot,regi) = pm_damage(tall,regi);
 ));
 
-
-
-
-
-
+*** EOF ./modules/50_damages/DiceLike/bounds.gms

--- a/modules/50_damages/DiceLike/datainput.gms
+++ b/modules/50_damages/DiceLike/datainput.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-
+*** SOF ./modules/50_damages/DiceLike/datainput.gms
 
 p50_damageFuncCoef1 = 0;
 p50_damageFuncCoef2 = 0;
@@ -28,4 +28,4 @@ $ifi %cm_damage_DiceLike_specification% == "KWpanelPop" p50_damageFuncCoef2 = 0.
 pm_damage(tall,regi) = 1;
 pm_damageMarginal(tall,regi)           = 0;
 
-
+*** EOF ./modules/50_damages/DiceLike/datainput.gms

--- a/modules/50_damages/DiceLike/postsolve.gms
+++ b/modules/50_damages/DiceLike/postsolve.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-
+*** SOF ./modules/50_damages/DiceLike/postsolve.gms
 
 
 pm_damage(tall,regi)$(tall.val ge 2010 and tall.val le 2300) = 
@@ -15,3 +15,5 @@ pm_damage(tall,regi)$(tall.val ge 2010 and tall.val le 2300) =
 * derivative of damage function w.r.t. teperature (used in 51_internalizeDamages)
 pm_damageMarginal(tall,"USA")$(tall.val ge 2000 and tall.val le 2300) =     !! USA stands in as a dummy for a gobal value here
   ( p50_damageFuncCoef1  + 2 * p50_damageFuncCoef2 * pm_globalMeanTemperatureZeroed1900(tall) );
+
+*** EOF ./modules/50_damages/DiceLike/postsolve.gms

--- a/modules/50_damages/DiceLike/realization.gms
+++ b/modules/50_damages/DiceLike/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/50_damages/DiceLike.gms
+*** SOF ./modules/50_damages/DiceLike/realization.gms
 
 *' @description Output damages are calculated based on the DICE-based damage function (see @DICEdocumentation). Multiple different specifications can be chosen: DICE2013R, DICE2016, Howard (@Howard2017) or different options from Kalkuhl & Wenz (2020) (KWcross for the cross-sectional specification, KWpanelPop for the panel specification with population weighting) through the switch cm_damage_DiceLike_specification. They are based on the global mean temperature pathway from MAGICC.
 
@@ -16,4 +16,4 @@ $Ifi "%phase%" == "datainput" $include "./modules/50_damages/DiceLike/datainput.
 $Ifi "%phase%" == "bounds" $include "./modules/50_damages/DiceLike/bounds.gms"
 $Ifi "%phase%" == "postsolve" $include "./modules/50_damages/DiceLike/postsolve.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/50_damages/DiceLike.gms
+*** EOF ./modules/50_damages/DiceLike/realization.gms

--- a/modules/50_damages/KWLike/postsolve.gms
+++ b/modules/50_damages/KWLike/postsolve.gms
@@ -46,4 +46,4 @@ pm_damageMarginalTm2(tall,regi)$(tall.val ge 2000 and tall.val le 2300) =
 
 display pm_damageGrowthRate,pm_damage;
 
-***EOF ./modules/50_damages/KWLike/postsolve.gms
+*** EOF ./modules/50_damages/KWLike/postsolve.gms

--- a/modules/50_damages/module.gms
+++ b/modules/50_damages/module.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/50_damages/50_damages.gms
+*** SOF ./modules/50_damages/module.gms
 
 *' @title Damages
 *'
@@ -18,4 +18,4 @@ $Ifi "%damages%" == "DiceLike" $include "./modules/50_damages/DiceLike/realizati
 $Ifi "%damages%" == "KWLike" $include "./modules/50_damages/KWLike/realization.gms"
 $Ifi "%damages%" == "off" $include "./modules/50_damages/off/realization.gms"
 *###################### R SECTION END (MODULETYPES) ############################
-*** EOF ./modules/50_damages/50_damages.gms
+*** EOF ./modules/50_damages/module.gms

--- a/modules/50_damages/off/bounds.gms
+++ b/modules/50_damages/off/bounds.gms
@@ -4,11 +4,8 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/50_damages/off/bounds.gms
 
 vm_damageFactor.fx(ttot,regi) = 1;
 
-
-
-
-
-
+*** EOF ./modules/50_damages/off/bounds.gms

--- a/modules/50_damages/off/realization.gms
+++ b/modules/50_damages/off/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/50_damages/off.gms
+*** SOF ./modules/50_damages/off/realization.gms
 
 *' @description The off-realization of the damage module sets the damage factor on output to 1, meaning no damage.
 
@@ -12,4 +12,4 @@
 $Ifi "%phase%" == "declarations" $include "./modules/50_damages/off/declarations.gms"
 $Ifi "%phase%" == "bounds" $include "./modules/50_damages/off/bounds.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/50_damages/off.gms
+*** EOF ./modules/50_damages/off/realization.gms

--- a/modules/51_internalizeDamages/BurkeLikeItr/datainput.gms
+++ b/modules/51_internalizeDamages/BurkeLikeItr/datainput.gms
@@ -4,6 +4,8 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/51_internalizeDamages/BurkeLikeItr/datainput.gms
+
 * satisfy dependencies
 $ifi not %damages% == 'BurkeLike' abort "module internalizeDamages=BurkeLikeItr requires module damages=BurkeLike";
 $ifi not %cm_magicc_temperatureImpulseResponse% == 'on' abort "module internalizeDamages=BurkeLikeItr requires cm_magicc_temperatureImpulseResponse=on";
@@ -18,4 +20,4 @@ loop(ttot$(ttot.val ge 2010),
 	    pm_taxCO2eqSCC(ttot,regi)$(ttot.val ge 2010) = p51_scc(tall)   * (44/12)/1000;
 	));
 
-
+*** EOF ./modules/51_internalizeDamages/BurkeLikeItr/datainput.gms

--- a/modules/51_internalizeDamages/BurkeLikeItr/declarations.gms
+++ b/modules/51_internalizeDamages/BurkeLikeItr/declarations.gms
@@ -4,9 +4,9 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/51_internalizeDamages/BurkeLikeItr/declarations.gms
+
 parameters
-
-
 
 p51_marginalDamageCumul(tall,tall,all_regi) "marginal cumulative damage damages"
 p51_scc(tall) "Social cost of carbon (due to GDP damages) [$ per tCO2eq]"
@@ -17,3 +17,4 @@ p51_sccParts(tall,tall,all_regi) "Social cost of carbon components (time, region
 p51_sccConvergenceMaxDeviation "max deviation of SCC from last iteration [percent]"
 ;
 
+*** EOF ./modules/51_internalizeDamages/BurkeLikeItr/declarations.gms

--- a/modules/51_internalizeDamages/BurkeLikeItr/postsolve.gms
+++ b/modules/51_internalizeDamages/BurkeLikeItr/postsolve.gms
@@ -4,8 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-
-
+*** SOF ./modules/51_internalizeDamages/BurkeLikeItr/postsolve.gms
 
 * this is the third sum in Eq. (1). computed seperately for computational effectiveness. (this is still expensive, at a couple of seconds!)
 p51_marginalDamageCumul(tall,tall2,regi2)$((tall2.val ge tall.val) and (tall.val le 2250) and (tall2.val le 2250)) = 
@@ -66,5 +65,4 @@ display p51_scc,pm_taxCO2eqSCC;
 p51_sccConvergenceMaxDeviation = 100 * smax(tall$(tall.val ge cm_startyear and tall.val lt 2150),abs(p51_scc(tall)/max(p51_sccLastItr(tall),1e-8) - 1) );
 display p51_sccConvergenceMaxDeviation;
 
-
-
+*** EOF ./modules/51_internalizeDamages/BurkeLikeItr/postsolve.gms

--- a/modules/51_internalizeDamages/BurkeLikeItr/realization.gms
+++ b/modules/51_internalizeDamages/BurkeLikeItr/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/51_internalizeDamages/51_internalizeDamages/BurkeLikeItr/BurkeLikeItr.gms
+*** SOF ./modules/51_internalizeDamages/BurkeLikeItr/realization.gms
 
 *' @description Based on the analytic expression derived in @Schultes2020 the social cost of carbon corresponding to the Burke-based damages calculated in module 50_damages/BurkeLike are calculated.
  
@@ -13,4 +13,4 @@ $Ifi "%phase%" == "declarations" $include "./modules/51_internalizeDamages/Burke
 $Ifi "%phase%" == "datainput" $include "./modules/51_internalizeDamages/BurkeLikeItr/datainput.gms"
 $Ifi "%phase%" == "postsolve" $include "./modules/51_internalizeDamages/BurkeLikeItr/postsolve.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/51_internalizeDamages/51_internalizeDamages/BurkeLikeItr/BurkeLikeItr.gms
+*** EOF ./modules/51_internalizeDamages/BurkeLikeItr/realization.gms

--- a/modules/51_internalizeDamages/DiceLikeItr/datainput.gms
+++ b/modules/51_internalizeDamages/DiceLikeItr/datainput.gms
@@ -4,6 +4,8 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/51_internalizeDamages/DiceLikeItr/datainput.gms
+
 * satisfy dependencies
 $ifi not %damages% == 'DiceLike' abort "module internalizeDamages=DiceLikeItr requires module damages=DiceLike";
 $ifi not %cm_magicc_temperatureImpulseResponse% == 'on' abort "module internalizeDamages=DiceLikeItr requires cm_magicc_temperatureImpulseResponse=on";
@@ -17,3 +19,4 @@ loop(ttot$(ttot.val ge 2010),
 	    pm_taxCO2eqSCC(ttot,regi)$(ttot.val ge 2010) = p51_scc(tall)   * (44/12)/1000;
 	));
 
+*** EOF ./modules/51_internalizeDamages/DiceLikeItr/datainput.gms

--- a/modules/51_internalizeDamages/DiceLikeItr/declarations.gms
+++ b/modules/51_internalizeDamages/DiceLikeItr/declarations.gms
@@ -4,9 +4,13 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/51_internalizeDamages/DiceLikeItr/declarations.gms
+
 parameters
 p51_scc(tall) "Social cost of carbon (due to GDP damages) [$ per tCO2eq]"
 p51_sccLastItr(tall) "Social cost of carbon (due to GDP damages) from last iteration [$ per tCO2eq]"
 
 p51_sccConvergenceMaxDeviation "max deviation of SCC from last iteration [percent]"
 ;
+
+*** EOF ./modules/51_internalizeDamages/DiceLikeItr/declarations.gms

--- a/modules/51_internalizeDamages/DiceLikeItr/postsolve.gms
+++ b/modules/51_internalizeDamages/DiceLikeItr/postsolve.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-
+*** SOF ./modules/51_internalizeDamages/DiceLikeItr/postsolve.gms
 
 p51_sccLastItr(tall) = p51_scc(tall);
 p51_scc(tall)$((tall.val ge 2010) and (tall.val le 2150)) = 1000 *
@@ -40,4 +40,4 @@ display p51_scc,pm_taxCO2eqSCC;
 p51_sccConvergenceMaxDeviation = 100 * smax(tall$(tall.val ge cm_startyear and tall.val lt 2150),abs(p51_scc(tall)/max(p51_sccLastItr(tall),1e-8) - 1) );
 display p51_sccConvergenceMaxDeviation;
 
-
+*** EOF ./modules/51_internalizeDamages/DiceLikeItr/postsolve.gms

--- a/modules/51_internalizeDamages/DiceLikeItr/realization.gms
+++ b/modules/51_internalizeDamages/DiceLikeItr/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/51_internalizeDamages/51_internalizeDamages/DiceLikeItr/DiceLikeItr.gms
+*** SOF ./modules/51_internalizeDamages/DiceLikeItr/realization.gms
 
 *' @description Based on the analytic expression derived in @Schultes2020 the social cost of carbon corresponding to the DICE-based damages calculated in module 50_damages/DiceLike are calculated. 
 
@@ -13,4 +13,4 @@ $Ifi "%phase%" == "declarations" $include "./modules/51_internalizeDamages/DiceL
 $Ifi "%phase%" == "datainput" $include "./modules/51_internalizeDamages/DiceLikeItr/datainput.gms"
 $Ifi "%phase%" == "postsolve" $include "./modules/51_internalizeDamages/DiceLikeItr/postsolve.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/51_internalizeDamages/51_internalizeDamages/DiceLikeItr/DiceLikeItr.gms
+*** EOF ./modules/51_internalizeDamages/DiceLikeItr/realization.gms

--- a/modules/51_internalizeDamages/KWlikeItr/datainput.gms
+++ b/modules/51_internalizeDamages/KWlikeItr/datainput.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/51_internalizeDamages/KWlikeItr/bounds.gms
+*** SOF ./modules/51_internalizeDamages/KWlikeItr/datainput.gms
 
 * satisfy dependencies
 $ifi not %damages% == 'KWLike' abort "module internalizeDamages=KWlikeItr requires module damages=KWLike";
@@ -21,4 +21,4 @@ loop(ttot$(ttot.val ge 2010),
 	));
 
 
-*** EOF ./modules/51_internalizeDamages/KWlikeItr/bounds.gms
+*** EOF ./modules/51_internalizeDamages/KWlikeItr/datainput.gms

--- a/modules/51_internalizeDamages/module.gms
+++ b/modules/51_internalizeDamages/module.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/51_internalizeDamages/51_internalizeDamages.gms
+*** SOF ./modules/51_internalizeDamages/module.gms
 
 *' @title internalizeDamages
 *'
@@ -18,4 +18,4 @@ $Ifi "%internalizeDamages%" == "DiceLikeItr" $include "./modules/51_internalizeD
 $Ifi "%internalizeDamages%" == "KWlikeItr" $include "./modules/51_internalizeDamages/KWlikeItr/realization.gms"
 $Ifi "%internalizeDamages%" == "off" $include "./modules/51_internalizeDamages/off/realization.gms"
 *###################### R SECTION END (MODULETYPES) ############################
-*** EOF ./modules/51_internalizeDamages/51_internalizeDamages.gms
+*** EOF ./modules/51_internalizeDamages/module.gms

--- a/modules/51_internalizeDamages/off/datainput.gms
+++ b/modules/51_internalizeDamages/off/datainput.gms
@@ -4,5 +4,8 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/51_internalizeDamages/off/datainput.gms
 
 pm_taxCO2eqSCC(ttot,regi) = 0;
+
+*** EOF ./modules/51_internalizeDamages/off/datainput.gms

--- a/modules/51_internalizeDamages/off/realization.gms
+++ b/modules/51_internalizeDamages/off/realization.gms
@@ -4,11 +4,11 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/51_internalizeDamages/51_internalizeDamages/off/off.gms
+*** SOF ./modules/51_internalizeDamages/off/realization.gms
 
 *' @description The off-realization of the internalizeDamages module sets the parameter pm_taxCO2eqSCC to zero, meaning no social costs of carbon are included in the optimization.
 
 *####################### R SECTION START (PHASES) ##############################
 $Ifi "%phase%" == "datainput" $include "./modules/51_internalizeDamages/off/datainput.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/51_internalizeDamages/51_internalizeDamages/off/off.gms
+*** EOF ./modules/51_internalizeDamages/off/realization.gms

--- a/modules/70_water/exogenous/realization.gms
+++ b/modules/70_water/exogenous/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/70_water/exogenous.gms
+*** SOF ./modules/70_water/exogenous/realization.gms
 
 *' @description Exogenous water demand is calculated based on data on water demand coefficients and cooling shares.
 *' @limitations Water demand is calculated in a post-processing of REMIND and not part of the optimization.
@@ -15,4 +15,4 @@ $Ifi "%phase%" == "declarations" $include "./modules/70_water/exogenous/declarat
 $Ifi "%phase%" == "datainput" $include "./modules/70_water/exogenous/datainput.gms"
 $Ifi "%phase%" == "output" $include "./modules/70_water/exogenous/output.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/70_water/exogenous.gms
+*** EOF ./modules/70_water/exogenous/realization.gms

--- a/modules/70_water/heat/realization.gms
+++ b/modules/70_water/heat/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/70_water/heat.gms
+*** SOF ./modules/70_water/heat/realization.gms
 
 *' @description Exogenous water demand is calculated based on data on water demand coefficients and cooling shares. 
 *' Vintage structure in combination with time dependent cooling shares as vintages and efficiency factors are also considered.
@@ -17,4 +17,4 @@ $Ifi "%phase%" == "declarations" $include "./modules/70_water/heat/declarations.
 $Ifi "%phase%" == "datainput" $include "./modules/70_water/heat/datainput.gms"
 $Ifi "%phase%" == "output" $include "./modules/70_water/heat/output.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/70_water/heat.gms
+*** EOF ./modules/70_water/heat/realization.gms

--- a/modules/70_water/module.gms
+++ b/modules/70_water/module.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/70_water/70_water.gms
+*** SOF ./modules/70_water/module.gms
 
 *' @title Water
 *'
@@ -17,4 +17,4 @@ $Ifi "%water%" == "exogenous" $include "./modules/70_water/exogenous/realization
 $Ifi "%water%" == "heat" $include "./modules/70_water/heat/realization.gms"
 $Ifi "%water%" == "off" $include "./modules/70_water/off/realization.gms"
 *###################### R SECTION END (MODULETYPES) ############################
-*** EOF ./modules/70_water/70_water.gms
+*** EOF ./modules/70_water/module.gms

--- a/modules/70_water/off/realization.gms
+++ b/modules/70_water/off/realization.gms
@@ -4,11 +4,11 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/70_water/off.gms
+*** SOF ./modules/70_water/off/realization.gms
 
 *' @description The off-realization of the water module takes no water demand into account.
 *' @limitations REMIND calculates no results regarding water demand.
 
 *####################### R SECTION START (PHASES) ##############################
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/70_water/off.gms
+*** EOF ./modules/70_water/off/realization.gms

--- a/modules/80_optimization/nash/realization.gms
+++ b/modules/80_optimization/nash/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/80_optimization/nash.gms
+*** SOF ./modules/80_optimization/nash/realization.gms
 
 *' @description
 *' Unlike in Negishi-mode, each region forms its own optimization problem in Nash mode.
@@ -33,4 +33,4 @@ $Ifi "%phase%" == "solve" $include "./modules/80_optimization/nash/solve.gms"
 $Ifi "%phase%" == "postsolve" $include "./modules/80_optimization/nash/postsolve.gms"
 $Ifi "%phase%" == "output" $include "./modules/80_optimization/nash/output.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/80_optimization/nash.gms
+*** EOF ./modules/80_optimization/nash/realization.gms

--- a/modules/80_optimization/negishi/realization.gms
+++ b/modules/80_optimization/negishi/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/80_optimization/negishi.gms
+*** SOF ./modules/80_optimization/negishi/realization.gms
 
 *' @description
 *' In Negishi mode, all regions forms a big optimization problem, as opposed to separate optimizations in Nash mode.
@@ -30,4 +30,4 @@ $Ifi "%phase%" == "solve" $include "./modules/80_optimization/negishi/solve.gms"
 $Ifi "%phase%" == "postsolve" $include "./modules/80_optimization/negishi/postsolve.gms"
 $Ifi "%phase%" == "output" $include "./modules/80_optimization/negishi/output.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/80_optimization/negishi.gms
+*** EOF ./modules/80_optimization/negishi/realization.gms

--- a/modules/81_codePerformance/module.gms
+++ b/modules/81_codePerformance/module.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/81_codePerformance/81_codePerformance.gms
+*** SOF ./modules/81_codePerformance/module.gms
 
 *' @title Codeperformance
 *'
@@ -17,4 +17,4 @@
 $Ifi "%codePerformance%" == "off" $include "./modules/81_codePerformance/off/realization.gms"
 $Ifi "%codePerformance%" == "on" $include "./modules/81_codePerformance/on/realization.gms"
 *###################### R SECTION END (MODULETYPES) ############################
-*** EOF ./modules/81_codePerformance/81_codePerformance.gms
+*** EOF ./modules/81_codePerformance/module.gms

--- a/modules/81_codePerformance/off/realization.gms
+++ b/modules/81_codePerformance/off/realization.gms
@@ -4,8 +4,8 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/81_codePerformance/off.gms
+*** SOF ./modules/81_codePerformance/off/realization.gms
 
 *####################### R SECTION START (PHASES) ##############################
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/81_codePerformance/off.gms
+*** EOF ./modules/81_codePerformance/off/realization.gms

--- a/modules/81_codePerformance/on/realization.gms
+++ b/modules/81_codePerformance/on/realization.gms
@@ -4,7 +4,7 @@
 *** |  AGPL-3.0, you are granted additional permissions described in the
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
-*** SOF ./modules/81_codePerformance/on.gms
+*** SOF ./modules/81_codePerformance/on/realization.gms
 
 
 *' @description BAU, tax30, and tax150 runs are set in a loop of 30 runs in total.
@@ -17,4 +17,4 @@ $Ifi "%phase%" == "datainput" $include "./modules/81_codePerformance/on/datainpu
 $Ifi "%phase%" == "presolve" $include "./modules/81_codePerformance/on/presolve.gms"
 $Ifi "%phase%" == "postsolve" $include "./modules/81_codePerformance/on/postsolve.gms"
 *######################## R SECTION END (PHASES) ###############################
-*** EOF ./modules/81_codePerformance/on.gms
+*** EOF ./modules/81_codePerformance/on/realization.gms


### PR DESCRIPTION
to facilitate debugging…

Searched for files missing this information using:
```
grep -L "\*\*\* SOF.*$" modules/*.gms modules/*/*.gms modules/*/*/*.gms
grep -L "\*\*\* EOF.*$" modules/*.gms modules/*/*.gms modules/*/*/*.gms
```
Add `*** SOF` and `*** EOF` and then run the following command on all files:
```
for i in modules/*.gms modules/*/*.gms modules/*/*/*.gms
do 
   sed -i "s>\*\*\* SOF.*$>\*\*\* SOF ./${i}>g;s>\*\*\* EOF.*$>\*\*\* EOF ./${i}>g" $i
done
```