### PR TITLE
Use adjusted policy costs mif, if available

### DIFF
--- a/scripts/utils/run_compareScenarios2.R
+++ b/scripts/utils/run_compareScenarios2.R
@@ -20,10 +20,16 @@ run_compareScenarios2 <- function(outputdirs, shortTerm, outfilename, regionList
   scenNames <- getScenNames(outputdirs)
   # Add '../' in front of the paths as compareScenarios2() will be run in individual temporary subfolders (see below).
   mif_path  <- file.path("..", outputdirs, paste("REMIND_generic_", scenNames, ".mif", sep = ""))
+  mif_path_polCosts  <- file.path("..", outputdirs, paste("REMIND_generic_", scenNames, "_adjustedPolicyCosts.mif", sep = ""))
   hist_path <- file.path("..", outputdirs[1], "historical.mif")
   scen_config_path  <- file.path("..", outputdirs, "config.Rdata")
   default_config_path  <- file.path("..", "config", "default.cfg")
 
+  # Use adjustedPolicyCosts mif, if available
+  if (file.exists(mif_path_polCosts)) {
+    mif_path <- mif_path_polCosts
+  }
+ 
   # Create temporary folder. This is necessary because each compareScenarios2 creates a folder names 'figure'.
   # If multiple compareScenarios2 run in parallel they would interfere with the others' figure folder.
   # So we create a temporary subfolder in which each compareScenarios2 creates its own figure folder.


### PR DESCRIPTION
The idea is to use the adjusted policy costs mif, if it was created.
It contains all the same variables as the normal mif, with some adjusted and additional policy costs variables. 