### PR TITLE
stop prepare_and_run if GAMS failed, improve logging

### DIFF
--- a/scripts/output/single/emulator.R
+++ b/scripts/output/single/emulator.R
@@ -99,13 +99,13 @@ regions <- sort(getRegions(x$supplycurve))
 for (y in years) {
 
   title <- paste0(y) 
-  dat <- gginput(x$supplycurve[regions,y,],scatter="type")
+  dat <- gginput(x$supplycurve[regions,y,], scatter = "type", verbose = FALSE)
   dat$year<-factor(dat$year)
 
   p <- ggplot(dat, aes(x=.value.x,y=.value.y)) +
     geom_line(aes(colour=scenario, linetype=curve)) + #geom_line(size=0.5) + 
-    geom_point(data=gginput(x$rem_point[regions,y,],scatter = "variable"),aes(x=.value.x,y=.value.y,colour=scenario)) +
-    geom_point(data=gginput(x$mag_point[regions,y,],scatter = "variable"),aes(x=.value.x,y=.value.y,colour=scenario),shape=5) +
+    geom_point(data=gginput(x$rem_point[regions,y,],scatter = "variable", verbose = FALSE),aes(x=.value.x,y=.value.y,colour=scenario)) +
+    geom_point(data=gginput(x$mag_point[regions,y,],scatter = "variable", verbose = FALSE),aes(x=.value.x,y=.value.y,colour=scenario),shape=5) +
     facet_wrap(~region) +
     ggtitle(title) + ylab("$/GJ") + xlab("EJ") + coord_cartesian(xlim=c(0,80),ylim=c(0,30)) +
     theme(legend.position="top") + guides(linetype=guide_legend(nrow=2,byrow=TRUE, title.position = "top")) + 


### PR DESCRIPTION
stop if REMIND failed
-----
- currently, if GAMS failed at the start, the lack of a fulldata.gdx created an error while submitting the runstatistics
- but if an earlier iteration converged and REMIND failed then, R continued with output generation and started subsequent runs and send a mail that everything was fine.
- With this PR, prepare_and_run.R checks whether the GAMS log states "Normal completion". If not, GAMS had produced an error and the scripts stops without output generation and starting subsequent runs.
- If REMIND does not converge within the usual 100 iteration, it still finishes with "Normal completion", so this PR is not affecting this case, as discussed here: https://github.com/remindmodel/remind/issues/173
- I also check whether the GAMS files were generated etc, providing a clearer error if something went wrong

logging improvement
----
- I added the modelstat and number of iterations to the Model Summary section of the log.
- Fixed the `Settings are unknown in provided cfg (cfg$remind_folder)!` warning
- set in emulator.R the gginput call to quiet, as it fills `log.txt` with ~35 very similar and not really helpful success stories:
```
        Data successfully prepared for ggplot!
         data columns: .spat1 = region .temp1 = year .data1 = scenario .data2 = sample
         value columns:  .value1 = .value.x .value2 = .value.y
```
- added an extract of nashstat to the log.txt

For `/p/tmp/pascalwe/ariadne/remind/output/Base_2022-03-25_10.36.44`, it prints:
```
Infeasibilities extracted from full.lst with nashstat -F:
itr   region   solvestat              modelstat                 resusd     objval
  1   CHA      NORMAL COMPLETION        LOCALLY INFEASIBLE      0.333    45.0892103043586   F
... 953 infeasibilities omitted, show all with nashstat -a ...
 51   USA   TERMINATED BY SOLVER   INTERMEDIATE INFEASIBLE      0.025   -336.924644266471   F
```

For a run without infeasibilities, it prints:
```
Infeasibilities extracted from full.lst with nashstat -F:
no infeasibilities found
```

On my local machine, it prints:
```
Infeasibilities extracted from full.lst with nashstat -F:
Error: nashstat not found, search for p80_repy in full.lst yourself.
```

This first gives you an overview whether there were INFES during the run, but also helps newbies to find this useful tool.