### PR TITLE
fix bug in start.R for default runs

### DIFF
--- a/start.R
+++ b/start.R
@@ -200,7 +200,7 @@ configure_cfg <- function(icfg, iscen, iscenarios, isettings) {
 if(!exists("argv")) argv <- commandArgs(trailingOnly = TRUE)
 config.file <- argv[1]
 
-if (config.file == "--test") {
+if (any("--test" %in% config.file)) {
   stop("--test mode works only with scenario_config file provided as first argument.")
 }
 


### PR DESCRIPTION
bit ironic that a newly introduced test function failed on the most basic default usecase.
Sorry for that. See https://github.com/remindmodel/remind/issues/716#event-6313523586