### PR TITLE
Missing input file for edge-t shipped correctly to output folder.

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -682,7 +682,8 @@ cfg$files2export$start <- c("config/conopt3.opt",
                             "modules/35_transport/edge_esm/input/harmonized_intensities.cs4r",
                             "modules/35_transport/edge_esm/input/UCD_NEC_iso.cs4r",
                             "modules/35_transport/edge_esm/input/price_nonmot.cs4r",
-                            "modules/35_transport/edge_esm/input/loadFactor.cs4r")
+                            "modules/35_transport/edge_esm/input/loadFactor.cs4r",
+			    "modules/35_transport/edge_esm/input/ptab4W.cs4r")
 
 # Files that should be copied after the REMIND run is finished
 cfg$files2export$end <- NULL


### PR DESCRIPTION
Bugfix: the file was previously not correctly copied to the output folder, leading to an error.