### PR TITLE
CDR realizations

### DIFF
--- a/modules/33_CDR/DAC/bounds.gms
+++ b/modules/33_CDR/DAC/bounds.gms
@@ -8,9 +8,6 @@
 vm_emiCdr.fx(t,regi,emi)$(not sameas(emi,"co2")) = 0.0;
 vm_emiCdr.l(t,regi,"co2")$(t.val gt 2020 AND cm_ccapturescen ne 2) = -sm_eps;
 vm_omcosts_cdr.fx(t,regi) = 0.0;
-v33_emiEW.fx(t,regi) = 0.0;
-v33_grindrock_onfield.fx(t,regi,rlf,rlf2) = 0;
-v33_grindrock_onfield_tot.fx(t,regi,rlf,rlf2) = 0;
 if (cm_emiscen ne 1,
     vm_cap.lo(t,regi,"dac",rlf)$(teNoTransform2rlf_dyn33("dac",rlf) AND (t.val ge max(2025,cm_startyear))) = 1e-7;  
 );

--- a/modules/33_CDR/DAC/declarations.gms
+++ b/modules/33_CDR/DAC/declarations.gms
@@ -14,12 +14,9 @@ p33_dac_fedem_heat(all_enty)         "specific heat demand for direct air captur
 variables
 vm_ccs_cdr(ttot,all_regi,all_enty,all_enty,all_te,rlf)  "CCS emissions from CDR [GtC / a]"
 v33_emiDAC(ttot,all_regi)       "negative CO2 emission from DAC [GtC / a]"
-v33_emiEW(ttot,all_regi)        "negative CO2 emission from EW [GtC / a] - fixed to 0, only defined for reporting reasons"
 ;
 
 positive variables
-v33_grindrock_onfield(ttot,all_regi,rlf,rlf)         "amount of ground rock spread on fields in each timestep [Gt]"
-v33_grindrock_onfield_tot(ttot,all_regi,rlf,rlf)     "total amount of ground rock on fields [Gt]"
 v33_DacFEdemand_el(ttot,all_regi,all_enty)          "DAC FE electricity demand [TWa]"
 v33_DacFEdemand_heat(ttot,all_regi,all_enty)        "DAC FE heat demand [TWa]"
 ;

--- a/modules/33_CDR/off/bounds.gms
+++ b/modules/33_CDR/off/bounds.gms
@@ -10,7 +10,5 @@ vm_cap.fx(t,regi,"rockgrind",rlf) = 0;
 vm_emiCdr.fx(t,regi,enty) = 0;   
 vm_omcosts_cdr.fx(t,regi) = 0;
 vm_ccs_cdr.fx(t,regi,enty,enty2,te,rlf)$ccs2te(enty,enty2,te) = 0;
-v33_grindrock_onfield.fx(t,regi,rlf,rlf2) = 0;
-v33_grindrock_onfield_tot.fx(t,regi,rlf,rlf2) = 0;
 
 *** EOF ./modules/33_CDR/off/bounds.gms

--- a/modules/33_CDR/off/declarations.gms
+++ b/modules/33_CDR/off/declarations.gms
@@ -9,9 +9,4 @@ variables
 vm_ccs_cdr(ttot,all_regi,all_enty,all_enty,all_te,rlf)    "CCS emissions from CDR [GtC / a]"
 ;
 
-positive variables
-v33_grindrock_onfield(ttot,all_regi,rlf,rlf)         "amount of ground rock spread on fields in each timestep [Gt]"
-v33_grindrock_onfield_tot(ttot,all_regi,rlf,rlf)     "total amount of ground rock on fields [Gt]"
-;
-
 *** EOF ./modules/33_CDR/off/declarations.gms

--- a/modules/33_CDR/weathering/bounds.gms
+++ b/modules/33_CDR/weathering/bounds.gms
@@ -11,5 +11,4 @@ v33_grindrock_onfield_tot.fx("2005",regi,rlf,rlf2) = 0.0;
 v33_grindrock_onfield.fx(t,regi,rlf,rlf2)$(rlf2.val gt 10) = 0;
 v33_grindrock_onfield_tot.fx(t,regi,rlf,rlf2)$(rlf2.val gt 10) = 0;
 vm_ccs_cdr.fx(t,regi,enty,enty2,te,rlf)$ccs2te(enty,enty2,te) = 0;
-v33_emiDAC.fx(t,regi) = 0.0;
 *** EOF ./modules/33_CDR/weathering/bounds.gms

--- a/modules/33_CDR/weathering/declarations.gms
+++ b/modules/33_CDR/weathering/declarations.gms
@@ -28,7 +28,6 @@ v33_grindrock_onfield_tot(ttot,all_regi,rlf,rlf)     "total amount of ground roc
 variables
 vm_ccs_cdr(ttot,all_regi,all_enty,all_enty,all_te,rlf) "CCS emissions from CDR [GtC / a]"
 v33_emiEW(ttot,all_regi)        "negative CO2 emission from EW [GtC / a]"
-v33_emiDAC(ttot,all_regi)       "negative CO2 emission from DAC [GtC / a] - fixed to 0, only defined for reporting reasons"
 ;
 
 equations
@@ -37,7 +36,7 @@ q33_otherFEdemand(ttot,all_regi,all_enty)              "calculates final energy 
 q33_capconst_grindrock(ttot,all_regi)                  "calculates amount of ground rock spread on fields"
 q33_grindrock_onfield_tot(ttot,all_regi,rlf,rlf)       "calculates total amount of ground rock on fields"
 q33_emicdrregi(ttot,all_regi)                          "calculates the (negative) emissions due to CDR technologies"
-q33_omcosts_onfield(ttot,all_regi)                     "calculates O&M costs for spreading ground rocks on fields"
+q33_omcosts(ttot,all_regi)                             "calculates O&M costs for spreading ground rocks on fields"
 q33_potential(ttot,all_regi,rlf)                       "limits the total potential per region and grade"
 q33_emiEW(ttot,all_regi)                               "calculates amount of carbon captured by EW"
 q33_LimEmiEW(ttot,all_regi)                            "limits EW to a maximal annual amount of ground rock of cm_LimRock"

--- a/modules/33_CDR/weathering/equations.gms
+++ b/modules/33_CDR/weathering/equations.gms
@@ -70,7 +70,7 @@ q33_emicdrregi(t,regi)..
 ***---------------------------------------------------------------------------
 *'  O&M costs of EW, consisting of fix costs for mining, grinding and spreading, and transportation costs.
 ***---------------------------------------------------------------------------	
-q33_omcosts_onfield(t,regi)..
+q33_omcosts(t,regi)..
 	vm_omcosts_cdr(t,regi)
 	=e=
 	sum(rlf$(rlf.val le 2), 

--- a/scripts/start/prepare_and_run.R
+++ b/scripts/start/prepare_and_run.R
@@ -677,6 +677,93 @@ prepare <- function() {
                                 list(c("q40_CoalBound.M", "!!q40_CoalBound.M")))
     }
 
+    #KK CDR module realizations
+    if(cfg$gms$CDR == 'DAC'){
+      fixings_manipulateThis <- c(fixings_manipulateThis,
+                                  list(c("v33_emiEW.FX", "!!v33_emiEW.FX")),
+                                  list(c("v33_grindrock_onfield.FX", "!!v33_grindrock_onfield.FX")),
+                                  list(c("v33_grindrock_onfield_tot.FX", "!!v33_grindrock_onfield_tot.FX")))
+
+      levs_manipulateThis <- c(levs_manipulateThis,
+                               list(c("v33_emiEW.L", "!!v33_emiEW.L")),
+                               list(c("v33_grindrock_onfield.L", "!!v33_grindrock_onfield.L")),
+                               list(c("v33_grindrock_onfield_tot.L", "!!v33_grindrock_onfield_tot.L")))
+
+      margs_manipulateThis <- c(margs_manipulateThis,
+                                list(c("v33_emiEW.M", "!!v33_emiEW.M")),
+                                list(c("v33_grindrock_onfield.M", "!!v33_grindrock_onfield.M")),
+                                list(c("v33_grindrock_onfield_tot.M", "!!v33_grindrock_onfield_tot.M")),
+                                list(c("q33_capconst_grindrock.M", "!!q33_capconst_grindrock.M")),
+                                list(c("q33_grindrock_onfield_tot.M", "!!q33_grindrock_onfield_tot.M")),
+                                list(c("q33_omcosts.M", "!!q33_omcosts.M")),
+                                list(c("q33_potential.M", "!!q33_potential.M")),
+                                list(c("q33_emiEW.M", "!!q33_emiEW.M")),
+                                list(c("q33_LimEmiEW.M", "!!q33_LimEmiEW.M")))
+    }
+
+    if(cfg$gms$CDR == 'weathering'){
+      fixings_manipulateThis <- c(fixings_manipulateThis,
+                                  list(c("v33_emiDAC.FX", "!!v33_emiDAC.FX")),
+                                  list(c("v33_DacFEdemand_el.FX", "!!v33_DacFEdemand_el.FX")),
+                                  list(c("v33_DacFEdemand_heat.FX", "!!v33_DacFEdemand_heat.FX")))
+
+      levs_manipulateThis <- c(levs_manipulateThis,
+                               list(c("v33_emiDAC.L", "!!v33_emiDAC.L")),
+                               list(c("v33_DacFEdemand_el.L", "!!v33_DacFEdemand_el.L")),
+                               list(c("v33_DacFEdemand_heat.L", "!!v33_DacFEdemand_heat.L")))
+
+      margs_manipulateThis <- c(margs_manipulateThis,
+                                list(c("v33_emiDAC.M", "!!v33_emiDAC.")),
+                                list(c("v33_DacFEdemand_el.M", "!!v33_DacFEdemand_el.M")),
+                                list(c("v33_DacFEdemand_heat.M", "!!v33_DacFEdemand_heat.M")),
+                                list(c("q33_DacFEdemand_heat.M", "!!q33_DacFEdemand_heat.M")),
+                                list(c("q33_DacFEdemand_el.M", "!!q33_DacFEdemand_el.M")),
+                                list(c("q33_capconst_dac.M", "!!q33_capconst_dac.M")),
+                                list(c("q33_ccsbal.M", "!!q33_ccsbal.M")),
+                                list(c("q33_H2bio_lim.M", "!!q33_H2bio_lim.M")))
+    }
+
+    if(cfg$gms$CDR == 'off'){
+      fixings_manipulateThis <- c(fixings_manipulateThis,
+                                  list(c("v33_emiDAC.FX", "!!v33_emiDAC.FX")),
+                                  list(c("v33_emiEW.FX", "!!v33_emiEW.FX")),
+                                  list(c("v33_DacFEdemand_el.FX", "!!v33_DacFEdemand_el.FX")),
+                                  list(c("v33_DacFEdemand_heat.FX", "!!v33_DacFEdemand_heat.FX")),
+                                  list(c("v33_grindrock_onfield.FX", "!!v33_grindrock_onfield.FX")),
+                                  list(c("v33_grindrock_onfield_tot.FX", "!!v33_grindrock_onfield_tot.FX")))
+
+      levs_manipulateThis <- c(levs_manipulateThis,
+                               list(c("v33_emiDAC.L", "!!v33_emiDAC.L")),
+                               list(c("v33_emiEW.L", "!!v33_emiEW.L")),
+                               list(c("v33_DacFEdemand_el.L", "!!v33_DacFEdemand_el.L")),
+                               list(c("v33_DacFEdemand_heat.L", "!!v33_DacFEdemand_heat.L")),
+                               list(c("v33_grindrock_onfield.L", "!!v33_grindrock_onfield.L")),
+                               list(c("v33_grindrock_onfield_tot.L", "!!v33_grindrock_onfield_tot.L")))
+
+      margs_manipulateThis <- c(margs_manipulateThis,
+                                list(c("v33_emiDAC.M", "!!v33_emiDAC.M")),
+                                list(c("v33_emiEW.M", "!!v33_emiEW.M")),
+                                list(c("v33_grindrock_onfield.M", "!!v33_grindrock_onfield.M")),
+                                list(c("v33_grindrock_onfield_tot.M", "!!v33_grindrock_onfield_tot.M")),
+                                list(c("v33_DacFEdemand_el.M", "!!v33_DacFEdemand_el.M")),
+                                list(c("v33_DacFEdemand_heat.M", "!!v33_DacFEdemand_heat.M")),
+                                list(c("q33_capconst_grindrock.M", "!!q33_capconst_grindrock.M")),
+                                list(c("q33_grindrock_onfield_tot.M", "!!q33_grindrock_onfield_tot.M")),
+                                list(c("q33_omcosts.M", "!!q33_omcosts.M")),
+                                list(c("q33_potential.M", "!!q33_potential.M")),
+                                list(c("q33_emiEW.M", "!!q33_emiEW.M")),
+                                list(c("q33_LimEmiEW.M", "!!q33_LimEmiEW.M")),
+                                list(c("q33_DacFEdemand_heat.M", "!!q33_DacFEdemand_heat.M")),
+                                list(c("q33_DacFEdemand_el.M", "!!q33_DacFEdemand_el.M")),
+                                list(c("q33_capconst_dac.M", "!!q33_capconst_dac.M")),
+                                list(c("q33_ccsbal.M", "!!q33_ccsbal.M")),
+                                list(c("q33_H2bio_lim.M", "!!q33_H2bio_lim.M")),
+                                list(c("q33_demFeCDR.M", "!!q33_demFeCDR.M")),
+                                list(c("q33_emicdrregi.M", "!!q33_emicdrregi.M")),
+                                list(c("q33_otherFEdemand.M", "!!q33_otherFEdemand.M")))
+    }
+    # end of CDR module realizations
+
     levs_manipulateThis <- c(levs_manipulateThis, 
                                list(c("vm_shBioFe.L","!!vm_shBioFe.L")))
     fixings_manipulateThis <- c(fixings_manipulateThis, 
@@ -721,12 +808,12 @@ prepare <- function() {
 
     # Perform actual manipulation on levs.gms, fixings.gms, and margs.gms in
     # single, respective, parses of the texts.
-    manipulateFile("levs.gms", levs_manipulateThis)
-    manipulateFile("fixings.gms", fixings_manipulateThis)
-    manipulateFile("margs.gms", margs_manipulateThis)
+    manipulateFile("levs.gms", levs_manipulateThis, fixed = TRUE)
+    manipulateFile("fixings.gms", fixings_manipulateThis, fixed = TRUE)
+    manipulateFile("margs.gms", margs_manipulateThis, fixed = TRUE)
 
     # Perform actual manipulation on full.gms, in single parse of the text.
-    manipulateFile("full.gms", full_manipulateThis)
+    manipulateFile("full.gms", full_manipulateThis, fixed = TRUE)
   }
 
   #AJS set MAGCFG file


### PR DESCRIPTION
Enables using different CDR module realizations between the base and policy runs, e.g., switching from `all` to `DAC` only.
 
Variables/equations that are unknown symbols when switching between realizations are handled in `levs.gms`, `fixings.gms` and/or `margs.gms`. Additionally, I used this opportunity to clean up the variables that are not used in a given realization (e.g.  `v33_grindrock_onfield` declared in DAC). I think they were added there so reporting doesn't crash and the values from the base run were set to zero anyways.  

Handling `v33_grindrock_onfield` in the reporting is [here](https://github.com/pik-piam/remind2/blob/a7ccbd0f572b5656bb40828c5840a505e51a3ec0/R/reportFE.R#L1281) and `v33_emiEW` and `v33_emiDAC` [here](https://github.com/pik-piam/remind2/blob/cec0792efd7b9acfdefbd29fbe4a31f02c4fdff8/R/reportEmi.R#L157), so it shouldn't create any problems.

Switching between realizations caused infeasibility in `q_capCumNet`, which was addressed in #713.

To consider: Supposedly we're switching from DAC to weathering, then we won't be able to access variables in DAC from t < cm_startyear. However, the core variables copied from the base run do account for DAC.