### PR TITLE
modify en prices after first CES iteration if negative labour prices would result otherwise

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -25,7 +25,7 @@ cfg$description <- "REMIND run with default settings"
 cfg$regionmapping <- "config/regionmappingH12.csv"
 
 #### Current input data revision (<mainrevision>.<subrevision>) ####
-cfg$inputRevision <- 6.288
+cfg$inputRevision <- 6.294
 
 #### Current CES parameter and GDX revision (commit hash) ####
 cfg$CESandGDXversion <- "151402067096f94a7abc308b65ba1119ab40cdd4"


### PR DESCRIPTION
Fixes `OAS`/`2030` bug in last `SSP2EU` calibration.
Heads up:  this also updates the input data revision to 6.294.