### PR TITLE
reenable direct option for testOneRegi and output, fixing 741

### DIFF
--- a/output.R
+++ b/output.R
@@ -138,18 +138,18 @@ choose_mode <- function(title = "Please choose the output mode") {
 }
 
 choose_slurmConfig_priority_standby <- function(title = "Please enter the slurm mode, uses priority if empty") {
-  slurm_options <- c("priority", "short", "standby", "priority --mem=8000", "priority --mem=32000")
+  slurm_options <- c("--qos=priority", "--qos=short", "--qos=standby", "--qos=priority --mem=8000", "--qos=priority --mem=32000", "direct")
   cat("\n\n", title, ":\n\n")
-  cat(paste(seq_along(slurm_options), slurm_options, sep = ": "), sep = "\n")
+  cat(paste(seq_along(slurm_options), gsub("qos=", "", gsub("--", "", slurm_options)), sep = ": "), sep = "\n")
   cat("\nNumber: ")
   identifier <- get_line()
   if (identifier == "") {
     identifier <- 1
   }
   if (!identifier %in% seq(length(slurm_options))) {
-    stop("This slurm mode is invalid. Please choose a valid mode.")
+    return(choose_slurmConfig_priority_standby(title= "This slurm mode is invalid. Please choose a valid mode"))
   }
-  return(paste0("--qos=", slurm_options[as.numeric(identifier)]))
+  return(slurm_options[as.numeric(identifier)])
 }
 
 choose_filename_prefix <- function(modules, title = "") {

--- a/start.R
+++ b/start.R
@@ -275,11 +275,7 @@ ignorederrors <- 0 # counts ignored errors in --test mode
 
 ###################### Choose submission type #########################
 
-if ("--testOneRegi" %in% argv) {
-  message("\nWhich region should testOneRegi use? Type it, or leave empty to keep settings:\n",
-  "Examples are CAZ, CHA, EUR, IND, JPN, LAM, MEA, NEU, OAS, REF, SSA, USA.")
-  testOneRegi_region <- get_line()
-}
+testOneRegi_region <- ""
 
 # Restart REMIND in existing results folder (if required by user)
 if (any(c("--reprepare", "--restart") %in% argv)) {
@@ -291,6 +287,11 @@ if (any(c("--reprepare", "--restart") %in% argv)) {
   outputdirs <- chooseFromList(possibledirs, "runs to be restarted", returnboolean = FALSE)
   message("\nAlso restart subsequent runs? Enter y, else leave empty:")
   restart_subsequent_runs <- get_line() %in% c("Y", "y")
+  if ("--testOneRegi" %in% argv) {
+    message("\nWhich region should testOneRegi use? Type it, or leave empty to keep settings:\n",
+    "Examples are CAZ, CHA, EUR, IND, JPN, LAM, MEA, NEU, OAS, REF, SSA, USA.")
+    testOneRegi_region <- get_line()
+  }
   if ("--reprepare" %in% argv) {
     message("\nBecause of the flag --reprepare, move full.gms -> full_old.gms and fulldata.gdx -> fulldata_old.gdx such that runs are newly prepared.\n")
   }
@@ -451,6 +452,11 @@ if (any(c("--reprepare", "--restart") %in% argv)) {
     if ("--debug" %in% argv) {
       cfg$gms$cm_nash_mode <- "debug"
       cfg$slurmConfig      <- slurmConfig
+    }
+
+    if (cfg$slurmConfig %in% c(NA, "")) {
+      if(! exists("slurmConfig")) slurmConfig <- choose_slurmConfig()
+      cfg$slurmConfig <- slurmConfig
     }
 
     # save the cfg object for the later automatic start of subsequent runs (after preceding run finished)


### PR DESCRIPTION
fixing issue #741.
- make sure that some slurmConfig is always specified
- add direct mode in output.R
- ask for testOneRegi region only if runs are restarted, where no easy option to specify / change it exists.