### PR TITLE
add scenario limitations to max secondary steel share

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -446,6 +446,13 @@ cfg$gms$cm_indst_H2costAddH2Inv <- 0.1  # Industry def 0.1 $/Kwh (3.2$/kg)
 cfg$gms$cm_indst_costDecayStart <- 0.05 # Industry def 5%
 cfg$gms$cm_indst_H2costDecayEnd <- 0.1  # Industry def 10%
 
+# industry
+# maximum secondary steel share
+# Share is faded in from cm_startyear/2020 to the denoted level by region/year.
+# Example: "2040.EUR 0.6" will cap the share of secondary steel production at
+# 60 % in EUR from 2040 onwards.
+cfg$gms$cm_steel_secondary_max_share_scenario <- "2050.EUR 0.5"   # def <- "off"
+
 ### start EU specific switches (apply only to EU subregions in REMIND-EU)
 # EU-specific bioenergy adjustments
 cfg$gms$cm_BioSupply_Adjust_EU <- 3 # def 3, 3*bioenergy supply slope

--- a/main.gms
+++ b/main.gms
@@ -538,6 +538,10 @@ cm_indst_H2costAddH2Inv = 0.1;  !! def 6.5$/kg = 0.2 $/Kwh
 cm_indst_costDecayStart = 0.05; !! def 5%
 cm_indst_H2costDecayEnd = 0.1;  !! def 10%
 
+*** industry
+* minimum secondary steel share
+$setglobal cm_steel_secondary_max_share_scenario  2050.EUR 0.5 !! def off
+
 *** EU bioenergy switches
 cm_BioSupply_Adjust_EU = 3; !! def 1
 cm_BioImportTax_EU = 1; !! def 0.25

--- a/modules/37_industry/subsectors/declarations.gms
+++ b/modules/37_industry/subsectors/declarations.gms
@@ -31,6 +31,11 @@ Parameters
 $ifThen.CESMkup not "%cm_CESMkup_ind%" == "standard" 
   p37_CESMkup_input(all_in)  "markup cost parameter read in from config for CES levels in industry to influence demand-side cost and efficiencies in CES tree [trUSD/CES input]" / %cm_CESMkup_ind% /
 $endIf.CESMkup
+
+$ifthen.sec_steel_scen NOT "%cm_steel_secondary_max_share_scenario%" == "off"   !! cm_steel_secondary_max_share_scenario
+  p37_steel_secondary_max_share_scenario(tall,all_regi)   "scenario limits on share of secondary steel production"
+  / %cm_steel_secondary_max_share_scenario% /
+$endif.sec_steel_scen
 ;
 
 Positive Variables

--- a/modules/37_industry/subsectors/not_used.txt
+++ b/modules/37_industry/subsectors/not_used.txt
@@ -1,5 +1,4 @@
 name,type,reason
-sm_tmp,input,questionnaire
 vm_effGr,input,questionnaire
 pm_ppfen_shares,input,questionnaire
 pm_priceCO2,input,questionnaire


### PR DESCRIPTION
This re-creates functionality from [fschreyer/remind/tree/ariadne_develop](https://github.com/fschreyer/remind/commit/ac267e2a6a033f1caac9df54931767083a0ad01b) to limit the share of secondary steel to arbitrary values in scenarios.
Calibration is excluded, since it would break if incompatible restrictions are placed on the secondary steel share.