### PR TITLE
Bugfixes in the CDR module

### DIFF
--- a/core/sets.gms
+++ b/core/sets.gms
@@ -1988,6 +1988,7 @@ entyFe2Sector(all_enty,emi_sectors) "final energy (stationary and transportation
 		fehes.cdr
                 fegas.cdr
                 feh2s.cdr
+                fedie.cdr
 /
 
 ppfEn2Sector(all_in,emi_sectors) "primary energy production factors mapping to sectors"

--- a/modules/33_CDR/DAC/equations.gms
+++ b/modules/33_CDR/DAC/equations.gms
@@ -22,7 +22,7 @@ q33_demFeCDR(t,regi,entyFe)$(entyFe2Sector(entyFe,"cdr")) ..
 q33_capconst_dac(t,regi)..
 	v33_emiDAC(t,regi)
 	=e=
-	- sum(teNoTransform2rlf_dyn33(te,rlf2), vm_capFac(t,regi,"dac") * vm_cap(t,regi,"dac",rlf2))
+	- sum(teNoTransform2rlf_dyn33("dac",rlf2), vm_capFac(t,regi,"dac") * vm_cap(t,regi,"dac",rlf2))
 	-  (1 / pm_eta_conv(t,regi,"gash2c")) * fm_dataemiglob("pegas","seh2","gash2c","cco2") * vm_otherFEdemand(t,regi,"fegas")
 	;
 
@@ -50,7 +50,7 @@ q33_DacFEdemand_el(t,regi,entyFe)$(t.val ge 2025)..
 q33_DacFEdemand_heat(t,regi,entyFe)$(t.val ge 2025)..
     v33_DacFEdemand_heat(t,regi,entyFe)
     =e=
-    - vm_emiCdr(t,regi,"co2") * sm_EJ_2_TWa * p33_dac_fedem_heat(entyFe)
+    - v33_emiDAC(t,regi) * sm_EJ_2_TWa * p33_dac_fedem_heat(entyFe)
     - v33_DacFEdemand_heat(t,regi,"feh2s")$((sameas(entyFe,"fegas"))OR(sameas(entyFe,"fehes"))OR(sameas(entyFe,"feels"))) 
 	- v33_DacFEdemand_heat(t,regi,"fegas")$((sameas(entyFe,"feh2s"))OR(sameas(entyFe,"fehes"))OR(sameas(entyFe,"feels")))
 	- v33_DacFEdemand_heat(t,regi,"feels")$((sameas(entyFe,"feh2s"))OR(sameas(entyFe,"fehes"))OR(sameas(entyFe,"fegas")))

--- a/modules/33_CDR/all/equations.gms
+++ b/modules/33_CDR/all/equations.gms
@@ -21,7 +21,7 @@ q33_demFeCDR(t,regi,entyFe)$(entyFe2Sector(entyFe,"cdr")) ..
 q33_capconst_grindrock(t,regi)..
 	sum(rlf2,sum(rlf, v33_grindrock_onfield(t,regi,rlf,rlf2)))
 	=l=
-	sum(teNoTransform2rlf_dyn33(te,rlf2), vm_capFac(t,regi,"rockgrind") * vm_cap(t,regi,"rockgrind",rlf2))
+	sum(teNoTransform2rlf_dyn33("rockgrind",rlf2), vm_capFac(t,regi,"rockgrind") * vm_cap(t,regi,"rockgrind",rlf2))
 	;
 	
 ***---------------------------------------------------------------------------
@@ -31,8 +31,8 @@ q33_capconst_grindrock(t,regi)..
 q33_grindrock_onfield_tot(ttot,regi,rlf,rlf2)$(ttot.val ge max(2010, cm_startyear))..
 	v33_grindrock_onfield_tot(ttot,regi,rlf,rlf2)
 	=e=
-    v33_grindrock_onfield_tot(ttot-1,regi,rlf,rlf2) * exp(-p33_co2_rem_rate(rlf) * pm_ts(ttot)) + 
-	v33_grindrock_onfield(ttot-1,regi,rlf,rlf2) * (sum(tall $ ((tall.val lt (ttot.val-pm_ts(ttot)/2)) $ (tall.val gt (ttot.val-pm_ts(ttot)))),exp(-p33_co2_rem_rate(rlf) * (ttot.val-tall.val)))) + 
+    v33_grindrock_onfield_tot(ttot-1,regi,rlf,rlf2) * exp(-p33_co2_rem_rate(rlf) * pm_ts(ttot)) +
+	v33_grindrock_onfield(ttot-1,regi,rlf,rlf2) * (sum(tall $ ((tall.val lt (ttot.val-pm_ts(ttot)/2)) $ (tall.val ge (ttot.val-pm_ts(ttot)))),exp(-p33_co2_rem_rate(rlf) * (ttot.val-tall.val)))) +
 	v33_grindrock_onfield(ttot,regi,rlf,rlf2) * (sum(tall $ ((tall.val le ttot.val) $ (tall.val gt (ttot.val-pm_ts(ttot)/2))),exp(-p33_co2_rem_rate(rlf) * (ttot.val-tall.val))))
 ;  
 
@@ -54,7 +54,7 @@ q33_emiEW(t,regi)..
 q33_capconst_dac(t,regi)..
 	v33_emiDAC(t,regi)
 	=e=
-	-sum(teNoTransform2rlf_dyn33(te,rlf2), vm_capFac(t,regi,"dac") * vm_cap(t,regi,"dac",rlf2))
+	-sum(teNoTransform2rlf_dyn33("dac",rlf2), vm_capFac(t,regi,"dac") * vm_cap(t,regi,"dac",rlf2))
 	-  (1 / pm_eta_conv(t,regi,"gash2c")) * fm_dataemiglob("pegas","seh2","gash2c","cco2") * vm_otherFEdemand(t,regi,"fegas")	
 	;
 
@@ -84,7 +84,7 @@ q33_DacFEdemand_el(t,regi,entyFe)..
 q33_DacFEdemand_heat(t,regi,entyFe)..
     v33_DacFEdemand_heat(t,regi,entyFe)
     =e=
-    - vm_emiCdr(t,regi,"co2") * sm_EJ_2_TWa * p33_dac_fedem_heat(entyFe)
+    - v33_emiDAC(t,regi) * sm_EJ_2_TWa * p33_dac_fedem_heat(entyFe)
     - v33_DacFEdemand_heat(t,regi,"feh2s")$((sameas(entyFe,"fegas"))OR(sameas(entyFe,"fehes"))OR(sameas(entyFe,"feels"))) 
 	- v33_DacFEdemand_heat(t,regi,"fegas")$((sameas(entyFe,"feh2s"))OR(sameas(entyFe,"fehes"))OR(sameas(entyFe,"feels")))
 	- v33_DacFEdemand_heat(t,regi,"feels")$((sameas(entyFe,"feh2s"))OR(sameas(entyFe,"fehes"))OR(sameas(entyFe,"fegas")))

--- a/modules/33_CDR/all/sets.gms
+++ b/modules/33_CDR/all/sets.gms
@@ -24,6 +24,11 @@ teNoTransform2rlf_dyn33(all_te,rlf)      "mapping for final energy to grades"
       (rockgrind) . 1
 	  (dac) . 1
 /
+
+adjte_dyn33(all_te)           "technologies with linearly growing constraint on control variable"
+/
+      dac
+/
 ;
 
 ***-------------------------------------------------------------------------
@@ -32,5 +37,6 @@ teNoTransform2rlf_dyn33(all_te,rlf)      "mapping for final energy to grades"
 te(te_dyn33)								   = YES;
 teNoTransform(teNoTransform_dyn33)             = YES;
 teNoTransform2rlf(teNoTransform2rlf_dyn33)     = YES;
+teAdj(adjte_dyn33)                             = YES;
 
 *** EOF ./modules/33_CDR/all/sets.gms

--- a/modules/33_CDR/weathering/equations.gms
+++ b/modules/33_CDR/weathering/equations.gms
@@ -42,8 +42,8 @@ q33_capconst_grindrock(t,regi)..
 q33_grindrock_onfield_tot(ttot,regi,rlf,rlf2)$((ttot.val ge max(2010, cm_startyear))$(rlf.val le 2))..
 	v33_grindrock_onfield_tot(ttot,regi,rlf,rlf2)$(rlf.val le 2)
 	=e=
-    v33_grindrock_onfield_tot(ttot-1,regi,rlf,rlf2)$(rlf.val le 2) * exp(-p33_co2_rem_rate(rlf)$(rlf.val le 2) * pm_ts(ttot)) + 
-	v33_grindrock_onfield(ttot-1,regi,rlf,rlf2)$(rlf.val le 2) * (sum(tall $ ((tall.val lt (ttot.val-pm_ts(ttot)/2)) $ (tall.val gt (ttot.val-pm_ts(ttot)))),exp(-p33_co2_rem_rate(rlf)$(rlf.val le 2) * (ttot.val-tall.val)))) + 
+    v33_grindrock_onfield_tot(ttot-1,regi,rlf,rlf2)$(rlf.val le 2) * exp(-p33_co2_rem_rate(rlf)$(rlf.val le 2) * pm_ts(ttot)) +
+	v33_grindrock_onfield(ttot-1,regi,rlf,rlf2)$(rlf.val le 2) * (sum(tall $ ((tall.val lt (ttot.val-pm_ts(ttot)/2)) $ (tall.val ge (ttot.val-pm_ts(ttot)))),exp(-p33_co2_rem_rate(rlf)$(rlf.val le 2) * (ttot.val-tall.val)))) +
 	v33_grindrock_onfield(ttot,regi,rlf,rlf2)$(rlf.val le 2) * (sum(tall $ ((tall.val le ttot.val) $ (tall.val gt (ttot.val-pm_ts(ttot)/2))),exp(-p33_co2_rem_rate(rlf)$(rlf.val le 2) * (ttot.val-tall.val))))
 ;  
 


### PR DESCRIPTION

Fixing a few bugs in the CDR module: 
- `fedie.cdr` was missing in `entyFe2Sector`, which led to wrong computations in `reportFE`,
- `q33_grindrock_onfield_tot`: missing one step for timesteps that are even numbers,
- in `all`, computations in `q33_capconst_dac` and `q33_capconst_grindrock` summed over the whole mapping `teNoTransform2rlf_dyn33`, which resulted in capacity * number of all elements in that mapping, instead of only the ones for a given technology,
- `q33_DacFEdemand_heat`: to compute DAC heat demand, all CDR emissions were used instead of DAC emissions only,
- in the `DAC` realization, DAC technology is added to `teAdj` and in realization `all` it is not.