### PR TITLE
bugfix to #746 with wrong setting of cm_steel_secondary_max_share_scenario in default.cfg

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -451,7 +451,7 @@ cfg$gms$cm_indst_H2costDecayEnd <- 0.1  # Industry def 10%
 # Share is faded in from cm_startyear/2020 to the denoted level by region/year.
 # Example: "2040.EUR 0.6" will cap the share of secondary steel production at
 # 60 % in EUR from 2040 onwards.
-cfg$gms$cm_steel_secondary_max_share_scenario <- "2050.EUR 0.5"   # def <- "off"
+cfg$gms$cm_steel_secondary_max_share_scenario <- "off"   # def <- "off"
 
 ### start EU specific switches (apply only to EU subregions in REMIND-EU)
 # EU-specific bioenergy adjustments


### PR DESCRIPTION
- only harmful to H12 non-calibration runs, which we don't do now
- but crashes all EU21 runs, since there is no `EUR` region