### PR TITLE
move on.exit to position where wd is changed to avoid confusing warning

### DIFF
--- a/scripts/start/prepare_and_run.R
+++ b/scripts/start/prepare_and_run.R
@@ -846,7 +846,6 @@ prepare <- function() {
 run <- function(start_subsequent_runs = TRUE) {
 
   load("config.Rdata")
-  on.exit(setwd(cfg$results_folder))
 
   # Save start time
   timeGAMSStart <- Sys.time()
@@ -1037,6 +1036,7 @@ run <- function(start_subsequent_runs = TRUE) {
 
   # go up to the main folder, where the cfg files for subsequent runs are stored and the output scripts are executed from
   setwd(cfg$remind_folder)
+  on.exit(setwd(cfg$results_folder))
 
   #====================== Subsequent runs ===========================
 


### PR DESCRIPTION
Regularly, if something fails within the `run` function of `prepare_and_run.R` including all cases where no `fulldata.gdx` is produced, `log.txt` states:
```
Error in setwd(cfg$results_folder) : cannot change working directory
Calls: run -> setwd
```
This is caused by the fact that
```
on.exit(setwd(cfg$results_folder))
```
was loaded, but the run failed before executing
```
setwd(cfg$remind_folder)
```
so the working directory was still `cfg$results_folder` and couldn't be changed (as results_folder is a relativ path).

By moving the on.exit call next to the setwd call, this is avoided.