### PR TITLE
Added switch for aborting after consecutive fails.

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -294,6 +294,7 @@ cfg$gms$codePerformance <- "off"        # def = off
 #                          SWITCHES
 #-----------------------------------------------------------------------------
 cfg$gms$cm_iteration_max       <- 1       # def <- 1
+cfg$gms$cm_abortOnConsecFail   <- 0       # def <- 0
 cfg$gms$c_solver_try_max       <- 2       # def <- 2
 cfg$gms$c_keep_iteration_gdxes <- 0       # def <- 0
 cfg$gms$cm_keep_presolve_gdxes  <- 0       # def <- 0
@@ -732,6 +733,7 @@ cfg$gms$c_BaselineAgriEmiRed <- 0
 
 #-------------------- switches ----------------------------------------------------
 # cm_iteration_max    "number of Negishi iterations"
+# cm_abortOnConsecFail "number of iterations of consecutive failures of one region after which to abort"
 # c_solver_try_max      "maximum number of inner iterations within one Negishi iteration (<10)"
 #*** Careful: for each inner_itr_count, the size of remind.lst can increase by 50MB!
 # cm_nash_autoconverge "choice of nash convergence mode"

--- a/main.gms
+++ b/main.gms
@@ -220,6 +220,7 @@ $setGlobal codePerformance  off       !! def = off
 ***--------------- declaration of parameters for switches ----------------------
 parameters
   cm_iteration_max          "number of Negishi iterations"
+  cm_abortOnConsecFail      "number of iterations of consecutive failures of one region after which to abort"
   c_solver_try_max          "maximum number of inner iterations within one Negishi iteration (<10)"
   c_keep_iteration_gdxes    "save intermediate iteration gdxes"
   cm_keep_presolve_gdxes    "save gdxes for all regions/solver tries/nash iterations for debugging"
@@ -355,6 +356,7 @@ parameters
 *** --------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 cm_iteration_max       = 1;     !! def = 1
+cm_abortOnConsecFail   = 0;     !! def = 0
 c_solver_try_max       = 2;     !! def = 2
 c_keep_iteration_gdxes = 0;     !! def = 0
 cm_keep_presolve_gdxes  = 0;     !! def = 0

--- a/modules/80_optimization/nash/declarations.gms
+++ b/modules/80_optimization/nash/declarations.gms
@@ -57,6 +57,7 @@ p80_repy_iteration(all_regi,solveinfo80,iteration) "summary report from solver i
 p80_repyLastOptim(all_regi,solveinfo80)    "p80_repy from last iteration"
 p80_messageFailedMarket(tall,all_enty)     "nash display helper"
 p80_messageShow(convMessage80)             "nash display helper"
+p80_trackConsecFail(all_regi)              "Parameter to keep track of consecutive solve failurs of regions in Nash mode."
 
 p80_curracc(ttot,all_regi)                 "current account"
 p80_t_interpolate(tall,tall)               "weights to interpolate from t_input_gdx to t"

--- a/modules/80_optimization/nash/postsolve.gms
+++ b/modules/80_optimization/nash/postsolve.gms
@@ -533,6 +533,26 @@ if(s80_bool eq 1,
 );
 
 
+*** check if any region has failed to solve consecutively for a certain number of times
+if(cm_abortOnConsecFail, !! execute only if consecutive failures switch is non-zero
+    loop(regi,
+        if(((p80_repy(regi,'modelstat') eq 1) and (p80_repy(regi,'solvestat') eq 2))
+        or ((p80_repy(regi,'modelstat') eq 4) and (p80_repy(regi,'solvestat') eq 7)), !! region was solved successfully
+            p80_trackConsecFail(regi) = 0;
+        else
+            p80_trackConsecFail(regi) = p80_trackConsecFail(regi) + 1;
+        );
+
+        if(p80_trackConsecFail(regi) >= cm_abortOnConsecFail,
+            execute_unload "abort.gdx";
+
+            abort "Run was aborted because the maximum number of consecutive failures was reached in at least one region!";
+        );
+    )
+)
+
+
+
 
 
 ***Fade out LT correction terms, they should only be important in the first iterations and might interfere with ST corrections.

--- a/modules/80_optimization/negishi/not_used.txt
+++ b/modules/80_optimization/negishi/not_used.txt
@@ -17,6 +17,7 @@ pm_Xport0,                      parameter,  ???
 pm_shPerm,                      parameter,  ???
 pm_emicapglob,                  parameter,  ???
 cm_iteration_max,               switch,     ???
+cm_abortOnConsecFail,           switch,     ???
 cm_nash_autoconverge,           switch,     ???
 sm_eps,                         scalar,     ???
 pm_emissions0,                  parameter,  ???

--- a/modules/80_optimization/testOneRegi/not_used.txt
+++ b/modules/80_optimization/testOneRegi/not_used.txt
@@ -13,6 +13,7 @@ vm_effGr,                       variable,   ???
 pm_welf,                        parameter,  ???
 pm_prtp,                        parameter,  ???
 cm_iteration_max,               switch,     ???
+cm_abortOnConsecFail,           switch,     ???
 cm_nash_autoconverge,           switch,     ???
 sm_eps,                         scalar,     ???
 pm_emissions0,                  parameter,  ???


### PR DESCRIPTION
The creation of this new switch (called `cm_abortOnConsecFail`) was discussed in the REMIND channel. When set to a
non-zero integer value N, it will cause REMIND to abort its run in Nash mode after at least one region failed to solve N times consecutively.

The default value is zero for the moment, which means it has to be actively turned on to have any effect.

I successfully tested the behaviour of this new switch. Most importantly, it doesn't affect any runs when set to zero, hence ensuring back-compatibility and avoiding unexpected behaviour for users of the develop branch.