### PR TITLE
add modification of ppf prices to ensure labour xi >= 0.1

### DIFF
--- a/modules/29_CES_parameters/calibrate/declarations.gms
+++ b/modules/29_CES_parameters/calibrate/declarations.gms
@@ -7,34 +7,30 @@
 *** SOF ./modules/29_CES_parameters/calibrate/declarations.gms
 
 Parameters
-  p29_CESderivative(tall,all_regi,all_in,all_in)   "derivative of the CES function for calculating prices"
-  
-  p29_alpha(all_regi,all_in)                       "XXX"
-  p29_beta(all_regi,all_in)                        "XXX"
-  p29_cesdata_load(tall,all_regi,all_in,cesParameter)  "pm_cesdata from the gdx file"
-  p29_cesIO_load(tall,all_regi,all_in)                "production factor vm_cesIO from input.gdx"
-  p29_cesIOdelta_load(tall,all_regi,all_in)                "production factor vm_cesIOdelta from input.gdx"
-  p29_effGr(tall,all_regi,all_in)                                   "growth of factor efficiency from input.gdx"
+  p29_CESderivative(tall,all_regi,all_in,all_in)                      "derivative of the CES function for calculating prices"
+  p29_alpha(all_regi,all_in)                                          "XXX"
+  p29_beta(all_regi,all_in)                                           "XXX"
+  p29_cesdata_load(tall,all_regi,all_in,cesParameter)                 "pm_cesdata from the gdx file"
+  p29_cesIO_load(tall,all_regi,all_in)                                "production factor vm_cesIO from input.gdx"
+  p29_cesIOdelta_load(tall,all_regi,all_in)                           "production factor vm_cesIOdelta from input.gdx"
+  p29_effGr(tall,all_regi,all_in)                                     "growth of factor efficiency from input.gdx"
+  p29_esdemand(tall,all_regi,all_in)                                  "energy service demand"
+  p29_efficiency_growth(tall,all_regi,all_in)                         "efficency level paths for ppf beyond calibration"
+  p29_capitalQuantity(tall,all_regi,all_in)                           "capital quantities"
+  p29_capitalPrice(tall,all_regi)                                     "capital prices"
+  p29_test_CES_recursive(tall,all_regi,all_in)                        "test the technological consistency of pm_cesdata"
+  p29_test_CES_putty_recursive(tall,all_regi,all_in)                  "test the technological consistency of pm_cesdata_putty"
+  f29_capitalUnitProjections(all_regi,all_in,index_Nr,capUnitType)    "Capital cost per unit of consumed energy and FE per unit of UE (or UE per unit of ES) used to calibrate some Esubs. kap is in $/kWh; UE and FE in kWh. Data for new investments and for standing capital"
+  p29_capitalUnitProjections(all_regi,all_in,index_Nr)                "Capital cost per unit of consumed energy and final energy per unit of useful energy (or UE per unit of ES) used to calibrate some elasticities of substitution. kap is in $/kWh; UE and FE in kWh"
+  p29_output_estimation(all_regi,all_in)                              "scaling of the target quantity for comparability with technological data"                                          
+  p29_esubGrowth                                                      "long term growth of the elasticity of substitution"
+  p29_t_tmp(tall)                                                     "tmp value for calculations over t"
+  p29_share_H2HTH_traj_indst(ttot,all_regi,all_in)                    "H2 and electricity HTH baseline trajectories as share of gas (for H2) and low-temperature electricity (for HTH electricity) trajectories in industry"
+  p29_ppf_price_multiplicator(ttot,all_regi)                          "multiplicator factor to check/ensure that labour xi >= 0.1"
+
 $ifthen.transpmodule "%transport%" == "edge_esm"
-  p29_trpdemand(tall,all_regi,all_GDPscen,EDGE_scenario_all,all_in) "transport demand for the edge_esm transport module, unit: trillion passenger/ton km"
-$endif.transpmodule
-  p29_esdemand(tall,all_regi,all_in)                  "energy service demand"
-  p29_efficiency_growth(tall,all_regi,all_in)         "efficency level paths for ppf beyond calibration"
-  p29_capitalQuantity(tall,all_regi,all_in)            "capital quantities"
-  p29_capitalPrice(tall,all_regi)                "capital prices"
-  
-   p29_test_CES_recursive(tall,all_regi,all_in)      "test the technological consistency of pm_cesdata"
-   p29_test_CES_putty_recursive(tall,all_regi,all_in)      "test the technological consistency of pm_cesdata_putty"
-   
-  f29_capitalUnitProjections(all_regi,all_in,index_Nr,capUnitType)   "Capital cost per unit of consumed energy and FE per unit of UE (or UE per unit of ES) used to calibrate some Esubs. kap is in $/kWh; UE and FE in kWh. Data for new investments and for standing capital"
-  p29_capitalUnitProjections(all_regi,all_in,index_Nr)  "Capital cost per unit of consumed energy and final energy per unit of useful energy (or UE per unit of ES) used to calibrate some elasticities of substitution. kap is in $/kWh; UE and FE in kWh"
-  p29_output_estimation(all_regi,all_in)       "scaling of the target quantity for comparability with technological data"                                          
-
-  p29_esubGrowth         "long term growth of the elasticity of substitution"
-
-  p29_t_tmp(tall)                                       "tmp value for calculations over t"
-
-  p29_share_H2HTH_traj_indst(ttot,all_regi,all_in)  "H2 and electricity HTH baseline trajectories as share of gas (for H2) and low-temperature electricity (for HTH electricity) trajectories in industry"
+  p29_trpdemand(tall,all_regi,all_GDPscen,EDGE_scenario_all,all_in)   "transport demand for the edge_esm transport module, unit: trillion passenger/ton km"
+$endif.transpmodule                                                   
 ;
 
 *** in case of a putty formulation, the model putty_paths will try to 

--- a/modules/29_CES_parameters/load/not_used.txt
+++ b/modules/29_CES_parameters/load/not_used.txt
@@ -4,29 +4,30 @@
 # |  AGPL-3.0, you are granted additional permissions described in the
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
-name,type,reason
-vm_cesIO, variable, ???
-sm_tmp, switch, ???
-vm_effGr, variable, ???
-vm_deltaCap,variable,???
-pm_shPPPMER,parameter,???
-pm_gdp,parameter,???
-pm_lab,parameter,???
-sm_EJ_2_TWa,input,questionnaire
-pm_cesdata_sigma,input,questionnaire
-vm_cesIOdelta,input,questionnaire
-pm_cesdata_putty,input,questionnaire
-pm_dt,input,questionnaire
-pm_cumDeprecFactor_old,input,questionnaire
-pm_cumDeprecFactor_new,input,questionnaire
-sm_mega_2_non,input,questionnaire
-pm_delta_kap,input,questionnaire
-sm_tmp2,input,questionnaire
-pm_ttot_val,input,questionnaire
-sm_trillion_2_non,input,questionnaire
-sm_TWa_2_kWh,input,questionnaire
-pm_ue_eff_target,parameter,not needed
-pm_calibrate_eff_scale,parameter,not needed
-pm_fedemand,parameter,not needed
-pm_energy_limit
+name,                         type,       reason
+vm_cesIO,                     variable,   ???
+sm_tmp,                       switch,     ???
+vm_effGr,                     variable,   ???
+vm_deltaCap,                  variable,   ???
+pm_shPPPMER,                  parameter,  ???
+pm_gdp,                       parameter,  ???
+pm_lab,                       parameter,  ???
+sm_EJ_2_TWa,                  input,      questionnaire
+pm_cesdata_sigma,             input,      questionnaire
+vm_cesIOdelta,                input,      questionnaire
+pm_cesdata_putty,             input,      questionnaire
+pm_dt,                        input,      questionnaire
+pm_cumDeprecFactor_old,       input,      questionnaire
+pm_cumDeprecFactor_new,       input,      questionnaire
+sm_mega_2_non,                input,      questionnaire
+pm_delta_kap,                 input,      questionnaire
+sm_tmp2,                      input,      questionnaire
+pm_ttot_val,                  input,      questionnaire
+sm_trillion_2_non,            input,      questionnaire
+sm_TWa_2_kWh,                 input,      questionnaire
+pm_ue_eff_target,             parameter,  not needed
+pm_calibrate_eff_scale,       parameter,  not needed
+pm_fedemand,                  parameter,  not needed
+pm_energy_limit,              parameter,  not needed
+p29_ppf_price_multiplicator,  parameter,  not needed
 


### PR DESCRIPTION
- If the sum of the products of target quantities and calibration prices
  of all `ppf` less labour exceed `inco`, the calibration would assign
  a negative price to labour to even the Euler identity on the root CES
  level, resulting in an aborted calibration.
- Therefore it is checked that labour has an income share of at least
  10 %, and all other `ppf` prices are scaled down as needed to ensure
  that.
- Theoretically, this should not occur in later calibration iterations.
  But for now, the test for that is deactivated to observe the
  calibration behaviour.