### PR TITLE
restore comments that were wrongly changed by lucode2::manipulateFile

### DIFF
--- a/main.gms
+++ b/main.gms
@@ -76,6 +76,8 @@
 *' number added as a suffix. If the set is used in more than one module no suffix is given. 
 *' 
 *' The units (e.g., TWa, EJ, GtC, GtCO2, ...) of variables and parameters are documented in the declaration files.
+*'
+*' For the labels of parameters, scalars and set, use double quotes only.
 
 
 
@@ -167,7 +169,7 @@ $setGlobal growth  exogenous          !! def = exogenous
 $setGlobal tax  on                    !! def = on
 ***---------------------    22_subsidizeLearning    -----------------------------
 $setGlobal subsidizeLearning  off     !! def = off
-***---------------------    23_capitalMarket    -----------------------------
+***---------------------    23_capitalMarket    ---------------------------------
 $setGlobal capitalMarket  debt_limit     !! def = debt_limit
 ***---------------------    24_trade    -----------------------------------------
 $setGlobal trade  standard     !! def = standard
@@ -179,7 +181,7 @@ $setglobal CES_parameters  load       !! def = load
 $setGlobal biomass  magpie_40 !! def = magpie_40
 ***---------------------    31_fossil    ----------------------------------------
 $setGlobal fossil  grades2poly        !! def = grades2poly
-***---------------------    32_power    ----------------------------------------
+***---------------------    32_power    -----------------------------------------
 $setGlobal power  IntC               !! def = IntC
 ***---------------------    33_cdr       ----------------------------------------
 $setGlobal CDR  DAC                   !! def = DAC
@@ -189,7 +191,7 @@ $setGlobal transport  edge_esm         !! def = edge_esm
 $setglobal buildings  simple          !! def = simple
 ***---------------------    37_industry    --------------------------------------
 $setglobal industry  subsectors     !! def = subsectors
-***---------------------    39_CCU    --------------------------------------
+***---------------------    39_CCU    -------------------------------------------
 $setglobal CCU  on !! def = on
 ***---------------------    40_techpol  -----------------------------------------
 $setglobal techpol  none              !! def = none
@@ -199,13 +201,13 @@ $setglobal emicapregi  none           !! def = none
 $setglobal banking  off               !! def = off
 ***---------------------    45_carbonprice  -------------------------------------
 $setglobal carbonprice  none          !! def = none
-***---------------------    46_carbonpriceRegi  -------------------------------------
+***---------------------    46_carbonpriceRegi  ---------------------------------
 $setglobal carbonpriceRegi  none      !! def = none
-***---------------------    47_regipol  -------------------------------------
+***---------------------    47_regipol  -----------------------------------------
 $setglobal regipol  none              !! def = none
 ***---------------------    50_damages    ---------------------------------------
 $setGlobal damages  off               !! def = off
-***---------------------    51_internalizeDamages    ---------------------------------------
+***---------------------    51_internalizeDamages    ----------------------------
 $setGlobal internalizeDamages  off               !! def = off
 ***---------------------    70_water  -------------------------------------------
 $setglobal water  off                 !! def = off
@@ -324,11 +326,11 @@ parameters
   cm_PriceDurSlope_elh2       "slope of price duration curve of electrolysis"
   cm_FlexTaxFeedback          "switch deciding whether flexibility tax feedback on buildlings and industry electricity prices is on"
   cm_VRE_supply_assumptions        "default (0), optimistic (1), sombre (2), or bleak (3) assumptions on VRE supply"
-  cm_build_H2costAddH2Inv     "additional h2 distribution costs for low diffusion levels (default value: 6.5$/ 100 /Kwh)"
+  cm_build_H2costAddH2Inv     "additional h2 distribution costs for low diffusion levels (default value: 6.5$/kg = 0.2 $/Kwh)"
   cm_build_costDecayStart     "simplified logistic function end of full value (ex. 5%  -> between 0 and 5% the function will have the value 1). [%]"
   cm_build_H2costDecayEnd     "simplified logistic function start of null value (ex. 10% -> after 10% the function will have the value 0). [%]"
   cm_build_AdjCostActive      "Activate adjustment cost to penalise inter-temporal variation of area-specific weatherisation demand and space cooling efficiency slope (only in putty)"
-  cm_indst_H2costAddH2Inv     "additional h2 distribution costs for low diffusion levels. [3.25$/ 0.1 /kWh]"
+  cm_indst_H2costAddH2Inv     "additional h2 distribution costs for low diffusion levels (default value: 3.25$kg = 0.1 $/kWh)"
   cm_indst_costDecayStart     "simplified logistic function end of full value   (ex. 5%  -> between 0 and 5% the simplified logistic function will have the value 1). [%]"
   cm_indst_H2costDecayEnd     "simplified logistic function start of null value (ex. 10% -> between 10% and 100% the simplified logistic function will have the value 0). [%]"
   cm_BioSupply_Adjust_EU      "factor for scaling sub-EU bioenergy supply curves"
@@ -539,7 +541,7 @@ cm_build_H2costAddH2Inv = 0.2;  !! def 6.5$/kg = 0.2 $/Kwh
 cm_build_costDecayStart = 0.05; !! def 5%
 cm_build_H2costDecayEnd = 0.1;  !! def 10%
 
-cm_indst_H2costAddH2Inv = 0.1;  !! def 6.5$/kg = 0.2 $/Kwh
+cm_indst_H2costAddH2Inv = 0.1;  !! def 3.25$/kg = 0.1 $/Kwh
 cm_indst_costDecayStart = 0.05; !! def 5%
 cm_indst_H2costDecayEnd = 0.1;  !! def 10%
 


### PR DESCRIPTION
As discussed in issue https://github.com/pik-piam/lucode2/issues/88 and fixed in PR https://github.com/pik-piam/lucode2/pull/89, `lucode2::manipulateFile` was wrongly replacing values within comments. As this is fixed now, I restored these values, and also set one of the default values there [to the value stated in default.cfg](https://github.com/remindmodel/remind/blob/develop/config/default.cfg#L457).

The improved regex substitution in `manipulateFile` works only if all label descriptions are in double quotes, not single quotes, which they are, but I also added that to the etiquette such that it remains this way. If there is a better place for that, let me know.

Additionally, I did some beauty repairs in the module list and made each line the same length.