### PR TITLE
let cs2 work with absolute paths starting with / as well

### DIFF
--- a/scripts/utils/run_compareScenarios2.R
+++ b/scripts/utils/run_compareScenarios2.R
@@ -18,11 +18,12 @@ if (!exists("source_include")) {
 run_compareScenarios2 <- function(outputdirs, shortTerm, outfilename, regionList, mainRegName) {
 
   scenNames <- getScenNames(outputdirs)
-  # Add '../' in front of the paths as compareScenarios2() will be run in individual temporary subfolders (see below).
-  mif_path  <- file.path("..", outputdirs, paste("REMIND_generic_", scenNames, ".mif", sep = ""))
-  mif_path_polCosts  <- file.path("..", outputdirs, paste("REMIND_generic_", scenNames, "_adjustedPolicyCosts.mif", sep = ""))
-  hist_path <- file.path("..", outputdirs[1], "historical.mif")
-  scen_config_path  <- file.path("..", outputdirs, "config.Rdata")
+  # for non-absolute paths, add '../' in front of the paths as compareScenarios2() will be run in individual temporary subfolders (see below).
+  outputdirs <- ifelse(substr(outputdirs,1,1) == "/", outputdirs, file.path("..", outputdirs))
+  mif_path  <- file.path(outputdirs, paste("REMIND_generic_", scenNames, ".mif", sep = ""))
+  mif_path_polCosts  <- file.path(outputdirs, paste("REMIND_generic_", scenNames, "_adjustedPolicyCosts.mif", sep = ""))
+  hist_path <- file.path(outputdirs[1], "historical.mif")
+  scen_config_path  <- file.path(outputdirs, "config.Rdata")
   default_config_path  <- file.path("..", "config", "default.cfg")
 
   # Use adjustedPolicyCosts mif, if available


### PR DESCRIPTION
for cs2, add `../` to outputdirs only if these are not absolute paths, thus starting with `/`. Fixed #769. In `/p/tmp/oliverr/remind`, you can find the pdfs starting with `compScen-oldnew_SSP2-Base-2022-04-23`, one started with relative, one with absolute paths.