### PR TITLE
updating CES and GDX version for latest calibration files

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -28,7 +28,7 @@ cfg$regionmapping <- "config/regionmappingH12.csv"
 cfg$inputRevision <- 6.303
 
 #### Current CES parameter and GDX revision (commit hash) ####
-cfg$CESandGDXversion <- "0e40e568f3c59432aa69f6f55b50f15739d31af7"
+cfg$CESandGDXversion <- "210a7bda0669eb80ef1c08558454b5acd1be119c"
 
 #### Force the model to download new input data ####
 cfg$force_download <- FALSE


### PR DESCRIPTION
updating CES and GDX version for pack including the latest SSP2EU H12 and EU21 calibrations files.