### PR TITLE
fix offset quantities for industry/subsectors H2/HTH in calibration

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -293,13 +293,13 @@ cfg$gms$codePerformance <- "off"        # def = off
 #-----------------------------------------------------------------------------
 #                          SWITCHES
 #-----------------------------------------------------------------------------
-cfg$gms$cm_iteration_max       <- 1       # def <- 1
-cfg$gms$cm_abortOnConsecFail   <- 0       # def <- 0
-cfg$gms$c_solver_try_max       <- 2       # def <- 2
-cfg$gms$c_keep_iteration_gdxes <- 0       # def <- 0
-cfg$gms$cm_keep_presolve_gdxes  <- 0       # def <- 0
-cfg$gms$cm_nash_autoconverge   <- 1       # def <- 1
-cfg$gms$cm_MAgPIE_coupling     <- "off"   # def <- "off"
+cfg$gms$cm_iteration_max          <- 1       # def <- 1
+cfg$gms$cm_abortOnConsecFail      <- 0       # def <- 0
+cfg$gms$c_solver_try_max          <- 2       # def <- 2
+cfg$gms$c_keep_iteration_gdxes    <- 0       # def <- 0
+cfg$gms$cm_keep_presolve_gdxes    <- 0       # def <- 0
+cfg$gms$cm_nash_autoconverge      <- 1       # def <- 1
+cfg$gms$cm_MAgPIE_coupling        <- "off"   # def <- "off"
 
 cfg$gms$cm_emiscen                <- 1              # def <- 1
 cfg$gms$cm_rcp_scen               <- "none"         # def <- "none"

--- a/modules/29_CES_parameters/calibrate/datainput.gms
+++ b/modules/29_CES_parameters/calibrate/datainput.gms
@@ -394,6 +394,14 @@ loop ((t,regi_dyn29(regi)),
     );
   );
 );
+
+* Use offset quantities for historic industry H2/HTH_el use, since it actually
+* didn't happen.
+loop (pf_quantity_shares_37(in,in2),
+  pm_cesdata(t_29hist(t),regi_dyn29(regi),in,"offset_quantity")$(
+                                  pm_cesdata(t,regi,in,"offset_quantity") eq 0 )
+  = -pm_cesdata(t,regi,in,"quantity");
+);
 $endif.subsectors
 
 $ifthen.indst_H2_offset "%industry%" == "fixed_shares"


### PR DESCRIPTION
- feh2_ and feelhth_ quantites are not calculated by mrremind
- since they are not zero anymore, the old mechanism of assigning offset
  quantites didn't work anymore