### PR TITLE
Add DAC to teLearn from the CDR module

### DIFF
--- a/core/equations.gms
+++ b/core/equations.gms
@@ -368,7 +368,7 @@ qm_deltaCapCumNet(ttot,regi,teLearn)$(ord(ttot) lt card(ttot) AND pm_ttot_val(tt
 ***---------------------------------------------------------------------------
 *' Initial values for cumulated capacities (learning technologies only):
 ***---------------------------------------------------------------------------
-q_capCumNet(t0,regi,teLearn)$(cm_startyear LE t0.val)..
+q_capCumNet(t0,regi,teLearn)..
   vm_capCum(t0,regi,teLearn)
   =e=
   pm_data(regi,"ccap0",teLearn);

--- a/core/sets.gms
+++ b/core/sets.gms
@@ -1312,7 +1312,6 @@ $IFTHEN.WindOff %cm_wind_offshore% == "1"
         storwindoff "storage technology for wind offshore"
 $ENDIF.WindOff
         storcsp     "storage technology for csp"
-        dac         "direct air capture"
         elh2        "hydrogen elecrolysis"
 /
 

--- a/modules/33_CDR/DAC/sets.gms
+++ b/modules/33_CDR/DAC/sets.gms
@@ -26,12 +26,18 @@ adjte_dyn33(all_te)           "technologies with linearly growing constraint on 
 /
       dac
 /
+
+teLearn_dyn33(all_te)         "learning technologies"
+/
+      dac
+/
 ;
 
 ***-------------------------------------------------------------------------
 ***  add module specific sets and mappings to the global sets and mappings
 ***-------------------------------------------------------------------------
-te(te_dyn33)								   = YES;
+te(te_dyn33)                                   = YES;
+teLearn(teLearn_dyn33)                         = YES;
 teNoTransform(teNoTransform_dyn33)             = YES;
 teNoTransform2rlf(teNoTransform2rlf_dyn33)     = YES;
 teAdj(adjte_dyn33)                             = YES;

--- a/modules/33_CDR/all/sets.gms
+++ b/modules/33_CDR/all/sets.gms
@@ -29,12 +29,18 @@ adjte_dyn33(all_te)           "technologies with linearly growing constraint on 
 /
       dac
 /
+
+teLearn_dyn33(all_te)         "learning technologies"
+/
+      dac
+/
 ;
 
 ***-------------------------------------------------------------------------
 ***  add module specific sets and mappings to the global sets and mappings
 ***-------------------------------------------------------------------------
-te(te_dyn33)								   = YES;
+te(te_dyn33)                                   = YES;
+teLearn(teLearn_dyn33)                         = YES;
 teNoTransform(teNoTransform_dyn33)             = YES;
 teNoTransform2rlf(teNoTransform2rlf_dyn33)     = YES;
 teAdj(adjte_dyn33)                             = YES;


### PR DESCRIPTION
Fix to #771 - installing maximum deltaCap of DAC, when the CDR module is off.

After discussing with Jessica, we agreed that `dac` can be added to `teLearn` from the CDR module only when DAC is used. This way, when there is no DAC, it will not be accounted for in `SubsidizeLearning`.

Additionally, this could fix issue #728, which was introduced in #713 - I removed the condition in `q_capCumNet`, since if `dac` is not in `teLearn`, we'll not run into infeasibilities.