### PR TITLE
for restarted runs, overwrite remind_folder

### DIFF
--- a/start.R
+++ b/start.R
@@ -328,6 +328,7 @@ if (any(c("--reprepare", "--restart") %in% argv)) {
       try(system(paste0("mv output/", outputdir, "/fulldata.gdx output/", outputdir, "/fulldata_old.gdx")))
     }
     cfg$slurmConfig <- combine_slurmConfig(cfg$slurmConfig,slurmConfig) # update the slurmConfig setting to what the user just chose
+    cfg$remind_folder <- getwd()                      # overwrite remind_folder: run to be restarted may have been moved from other repository
     cfg$results_folder <- paste0("output/",outputdir) # overwrite results_folder in cfg with name of the folder the user wants to restart, because user might have renamed the folder before restarting
     save(cfg,file=paste0("output/",outputdir,"/config.Rdata"))
     if (! '--test' %in% argv) {


### PR DESCRIPTION
is of relevance if an output folder is restarted/reprepared that was copied/moved from a different repo.
Fixes https://github.com/remindmodel/remind/issues/775