### PR TITLE
add a copy of the scenario config csv to the run folder

### DIFF
--- a/start.R
+++ b/start.R
@@ -230,7 +230,7 @@ configure_cfg <- function(icfg, iscen, iscenarios, isettings) {
     names(gdxlist) <- path_gdx_list
 
     # add gdxlist to list of files2export
-    icfg$files2export$start <- c(icfg$files2export$start, gdxlist)
+    icfg$files2export$start <- c(icfg$files2export$start, gdxlist, config.file)
 
     # add table with information about runs that need the fulldata.gdx of the current run as input
     icfg$RunsUsingTHISgdxAsInput <- iscenarios %>% select(contains("path_gdx")) %>%              # select columns that have "path_gdx" in their name


### PR DESCRIPTION
I've added this to the list of files to be copied to the output folder, so there is a record of what the REMIND cascade looked like in the run folder, and allow users to be able to compare scenario config from finished runs
(this will complement cfg.txt, which only merges the default.cfg and config.csv, but is agnostic about what were in the config csv) 

It seems that [many people want this feature](https://mattermost.pik-potsdam.de/rd3/pl/wx6nfs57gjnu9r3uddskkywese) in the group channel, but hopefully it won't cram up the run folder too much