### PR TITLE
add CES markup cost to cement electricity node for modeling different levels of electrification

### DIFF
--- a/modules/37_industry/subsectors/datainput.gms
+++ b/modules/37_industry/subsectors/datainput.gms
@@ -203,6 +203,7 @@ p37_CESMkup(t,regi,"feelhth_chemicals") = 200* sm_TWa_2_MWh * 1e-12;
 p37_CESMkup(t,regi,"feelhth_otherInd") = 200* sm_TWa_2_MWh * 1e-12;
 p37_CESMkup(t,regi,"feel_steel_secondary") = 200* sm_TWa_2_MWh * 1e-12;
 p37_CESMkup(t,regi,"feel_steel_primary") = 200* sm_TWa_2_MWh * 1e-12;
+p37_CESMkup(t,regi,"feel_cement") = 200* sm_TWa_2_MWh * 1e-12;
 
 *** place markup cost of 100 USD/MWh(H2) on H2 nodes
 *** to represent demand-side cost of hydrogen usage and reach higher subsitution rates


### PR DESCRIPTION
 * choose for now same cost level as for HTH electricity use in chemicals and other industry
 * see calibration run here: ``/p/tmp/schreyer/Modeling/remind/Current/output/SSP2EU-calibrate_CementMkup_2022-05-06_11.44.50``
 * as an orientation: additional cost from that in 2015 are ~ 0.08% GDP for EUR, 0.8% GDP for CHA