### PR TITLE
avoid inconsistent policyCosts if reporting is rerun, fix identical logs for output slurms

### DIFF
--- a/output.R
+++ b/output.R
@@ -301,7 +301,7 @@ if (comp == TRUE) {
     # Get values of config if output.R is called standalone
     if (!exists("source_include")) {
       magpie_folder <- getwd()
-      print(file.path(outputdir, "config.Rdata"))
+      message("Load data from ", file.path(outputdir, "config.Rdata"))
       if (file.exists(file.path(outputdir, "config.Rdata"))) {
         load(file.path(outputdir, "config.Rdata"))
         title <- cfg$title
@@ -323,7 +323,7 @@ if (comp == TRUE) {
     # included as source (instead of a load from command line)
     source_include <- TRUE
 
-    cat(paste("\nStarting output generation for", outputdir, "\n\n"))
+    message("\nStarting output generation for ", outputdir, "\n")
 
     ###################################################################################
     # Execute R scripts
@@ -349,17 +349,18 @@ if (comp == TRUE) {
             }
           } else {
             # send the output script to slurm
-            slurmcmd <- paste0("sbatch ", slurmConfig, " --job-name=", outputdir, " --output=", outputdir,
-                               ".txt --mail-type=END --comment=REMIND --wrap=\"Rscript scripts/output/single/", rout,
+            logfile <- paste0(outputdir, "/log_", rout, ".txt")
+            slurmcmd <- paste0("sbatch ", slurmConfig, " --job-name=", logfile, " --output=", logfile,
+                               " --mail-type=END --comment=REMIND --wrap=\"Rscript scripts/output/single/", rout,
                                ".R  outputdir=", outputdir, "\"")
-            message("Sending to slurm: ", name)
+            message("Sending to slurm: ", name, ". Find log in ", logfile)
             system(slurmcmd)
             Sys.sleep(1)
           }
         }
       }
       # finished
-      message("\nFinished ", ifelse(slurmConfig == "direct", "", "starting "), "output generation for ", outputdir, "!\n")
+      message("\nFinished ", ifelse(slurmConfig == "direct", "", "starting jobs for "), "output generation for ", outputdir, "!\n")
     }
 
     rm(source_include)

--- a/scripts/output/comparison/policyCosts.R
+++ b/scripts/output/comparison/policyCosts.R
@@ -7,16 +7,16 @@
 
 # policyCosts.R
 #
-# This script produces a pdf in which the policy costs of policy-runs with 
+# This script produces a pdf in which the policy costs of policy-runs with
 # respect to specified reference runs are displayed.
-# It can be called via the output.R script. If that is the case, the order 
+# It can be called via the output.R script. If that is the case, the order
 # in which the runs are selected is important:
 #   1: policy run 1
 #   2: reference run 1
 #   3: policy run 2
 #   4: reference run 2
-# and so on... 
-# 
+# and so on...
+#
 
 suppressPackageStartupMessages(library(tidyverse))
 
@@ -40,9 +40,9 @@ rm_timestamp <- function(strings,
 
 policy_costs_pdf <- function(policy_costs, 
                              fileName="PolicyCost.pdf") {
-  
-  cat(paste0("A pdf with the name ",crayon::green(fileName)," is being created in the main remind folder.\n"))
-  
+
+  message("A pdf with the name ", crayon::green(fileName), " is being created in the main remind folder.")
+
   template <-  c("\\documentclass[a4paper,landscape,twocolumn]{article}",
                  "\\setlength{\\oddsidemargin}{-0.8in}",
                  "\\setlength{\\evensidemargin}{-0.5in}",
@@ -68,17 +68,17 @@ policy_costs_pdf <- function(policy_costs,
   
   # Create temporaray folder in which to create the policyCost pdf
   system("mkdir tmp_policyCost")
-  
+
   # Open stream in tmp_folder
   sw <- lusweave::swopen(fileName, folder = "tmp_policyCost", template = template)
-  
+
   # Write title
   lusweave::swlatex(sw,"\\section{Policy Costs}")
-  
+
   # Loop over subsections and create plots
   sub_section_variables <- grep("Policy Cost", names(policy_costs), value = T)
   sub_section_titles <- str_match(sub_section_variables, "\\|(.*) \\(|\\|")[,2]
-  
+
   my_ggplot <- function(data, y_var) {
     gg1 <- ggplot(data) +
       geom_line(aes(x=period, y=!!sym(y_var), color = `Model Output`)) +
@@ -95,65 +95,65 @@ policy_costs_pdf <- function(policy_costs,
             axis.title.y = element_text(face="bold"))
     return(gg1)
   }
-  
+
   for(i in 1:length(sub_section_titles)){
     lusweave::swlatex(sw, paste0("\\subsection{", sub_section_titles[i], "}"))
-    
+
     p <- my_ggplot(filter(policy_costs, region=="GLO"), sub_section_variables[i])
     lusweave::swfigure(sw,print,p,sw_option="height=8,width=8")
-    
+
     p <- my_ggplot(filter(policy_costs, region!="GLO"), sub_section_variables[i])
     lusweave::swfigure(sw,print,p,sw_option="height=9,width=8")
   }
-  
+
   # Close stream to-pdf
   lusweave::swclose(sw)
-  
+
   # Copy pdf from tmp folder to remind folder and delete tmp folder
   system(paste0("mv tmp_policyCost/",fileName," ."))
   system("rm -r tmp_policyCost")
-  
+
 }
 
 
-write_new_reporting <- function(mif_path, 
-                                scen_name, 
+write_new_reporting <- function(mif_path,
+                                scen_name,
                                 new_polCost_data) {
-  
+
   new_mif_path <- paste0(substr(mif_path,1,nchar(mif_path)-4),"_adjustedPolicyCosts.mif")
-  
-  cat(paste0("A mif file with the name ",crayon::green(paste0("REMIND_generic_",scen_name,"_adjustedPolicyCosts.mif"))," is being created in the ",scen_name," output folder.\n"))
-  
-  my_data <- magclass::read.report(mif_path) 
+
+  message("A mif file with the name ", crayon::green(paste0("REMIND_generic_",scen_name,"_adjustedPolicyCosts.mif"))," is being created in the ",scen_name," output folder.")
+
+  my_data <- magclass::read.report(mif_path)
   my_variables <- grep("Policy Cost", magclass::getNames(my_data[[1]][[1]]), value = TRUE, invert = T)
-  
+
   magclass::getSets(new_polCost_data)[1] <- "region"
   magclass::getSets(new_polCost_data)[2] <- "year"
   magclass::getSets(new_polCost_data)[3] <- "variable"
-  
+
   my_data <- magclass::mbind(my_data[[1]][[1]][,,my_variables], new_polCost_data)
   my_data <- magclass::add_dimension(my_data,dim=3.1,add = "model",nm = "REMIND")
   my_data <- magclass::add_dimension(my_data,dim=3.1,add = "scenario",nm = scen_name)
-  
+
   magclass::write.report(my_data, file = new_mif_path, ndigit = 7)
-  
+
   return(new_mif_path)
 }
 
 
 report_transfers <- function(pol_mif, ref_mif) {
-  
+
   # Read in reporting files
   pol_run <- magclass::read.report(pol_mif,as.list = F)
   ref_run <- magclass::read.report(ref_mif,as.list = F)
-  
+
   # Get model and scenario names
   md <- magclass::getItems(pol_run,3.2)
   sc <- magclass::getItems(pol_run,3.1)
-  
+
   # Tell the user what's going on
-  cat(paste0("Adding ",crayon::green("transfers")," to ",paste0("REMIND_generic_",sc,"_adjustedPolicyCosts.mif"),".\n"))
-  
+  message("Adding ",crayon::green("transfers")," to REMIND_generic_",sc,"_adjustedPolicyCosts.mif")
+
 
   # Get gdploss 
   gdploss <- pol_run[,,"Policy Cost|GDP Loss (billion US$2005/yr)"]
@@ -163,15 +163,15 @@ report_transfers <- function(pol_mif, ref_mif) {
   # Get gdp
   gdp_ref <- ref_run[,,"GDP|MER (billion US$2005/yr)"]
   gdp_policy <- pol_run[,,"GDP|MER (billion US$2005/yr)"]
-  
-  # Calculate difference to global rel gdploss  
+
+  # Calculate difference to global rel gdploss
   delta_gdploss <- gdploss_rel[,,] - gdploss_rel["GLO",,]
   # Calculate transfer required to equalize rel gdploss across regions
   delta_transfer <- magclass::setNames(delta_gdploss * gdp_ref, 
                                        "Policy Cost|Transfers equal effort (billion US$2005/yr)")
   delta_transfer_rel <- 100*magclass::setNames(delta_transfer/gdp_ref, 
                                                "Policy Cost|Transfers equal effort|Relative to Reference GDP (percent)")
-  
+
 
   # Calculate new gdp variables
   gdp_withtransfers <- magclass::setNames(gdp_policy + delta_transfer,
@@ -180,7 +180,7 @@ report_transfers <- function(pol_mif, ref_mif) {
                                               "Policy Cost|GDP Loss|w/ transfers equal effort (billion US$2005/yr)")
   gdploss_withtransfers_rel <- 100*magclass::setNames(gdploss_withtransfers/gdp_ref,
                                                       "Policy Cost|GDP Loss|w/ transfers equal effort|Relative to Reference GDP (percent)")
-  
+
   # Correct sets
   magclass::getSets(delta_transfer, fulldim = F)[3] <- "variable"
   magclass::getSets(delta_transfer_rel, fulldim = F)[3] <- "variable"
@@ -215,12 +215,12 @@ report_transfers <- function(pol_mif, ref_mif) {
 # is being called from another (output.R most likely), and the input variable 
 # "outputdirs" is already in the environment. If not found, "outputdirs" is given
 # default values, and made over-writable with the command line.
-if(!exists("source_include")) {
+if (!exists("source_include")) {
   # Set default value
   outputdirs <- c("base_noEffChange_2020-03-09_17.16.28/",
                   "base_allT_lab_1point25_2020-03-27_16.12.35/",
                   "base_allT_lab_1point25_2020-03-27_16.12.35/",
-                  "base_noEffChange_2020-03-09_17.16.28/")   
+                  "base_noEffChange_2020-03-09_17.16.28/")
   special_requests <- c("2")
   # Make over-writtable from command line
   lucode2::readArgs("outputdirs","special_requests")
@@ -233,68 +233,69 @@ happy_with_input <- FALSE
 while (!happy_with_input) {
   # Check that "outputdirs" has an even number of entries.
   if (length(outputdirs) %% 2!=0) {
-    cat(paste0(crayon::red("\nERROR: "), "The number of directories is not even!\n"))
-    cat("Remember, your choice of directories should be made in the follwing manner:\n")
-    cat("\t1: policy run 1\n\t2: reference run 1\n\t3: policy run 2\n\t4: reference run 2\nand so on...\n")
+    message(crayon::red("\nERROR: "), "The number of directories is not even!")
+    message("Remember, your choice of directories should be made in the follwing manner:")
+    message("\t1: policy run 1\n\t2: reference run 1\n\t3: policy run 2\n\t4: reference run 2\nand so on...")
     if (exists("choose_folder")) {
-      outputdirs <- choose_folder("./output",crayon::blue("Please reselect your ouput folders"))
+      outputdirs <- choose_folder("./output",crayon::blue("Please reselect your output folders"))
       outputdirs <- paste0("output/",outputdirs)
     } else {
-      cat(crayon::red("\nStopping execution now.\n\n"))
+      message(crayon::red("\nStopping execution now.\n"))
       stop("Number of directories is not even!")
     }
     next()
   }
-  
+
   # Get gdx paths
   pol_gdxs <- paste0(outputdirs[seq(1,length(outputdirs),2)], "/fulldata.gdx")
   ref_gdxs <- paste0(outputdirs[seq(2,length(outputdirs),2)], "/fulldata.gdx")
-  
+  cp_ref_gdxs_to <- paste0(outputdirs[seq(1,length(outputdirs),2)], "/input_refpolicycost.gdx")
+
   # Get run names
   pol_names <- rm_timestamp(basename(dirname(pol_gdxs)))
   ref_names <- rm_timestamp(basename(dirname(ref_gdxs)))
-  
+
   # Define pol-ref, policyCost pair names
-  pc_pairs <- paste0(pol_names, "_w.r.t_",ref_names)
-  
-  # If this scrpit was called from output.R, check with user if the pol-ref pairs 
+  pc_pairs <- paste0(crayon::green(pol_names), " w.r.t. ", crayon::green(ref_names))
+
+  # If this script was called from output.R, check with user if the pol-ref pairs
   # are the ones she wanted. 
   if(exists("source_include")) {
-    cat(crayon::blue("\nPlease confirm the set-up:\n"))
-    cat("From the order with which you selected the directories, the following policy costs will be computed:\n")
-    cat(crayon::green(paste0("\t", pc_pairs ,"\n")))
-    cat("Is that what you intended?\n")
-    cat(paste0("Type '",crayon::green("y"),"' to continue, '",crayon::blue("r"),"' to reselect output directories, '",crayon::red("n"),"' to abort: "))
-    
+    message(crayon::blue("\nPlease confirm the set-up:"))
+    message("From the order with which you selected the directories, the following policy costs will be computed:")
+    message(paste0("\t", pc_pairs, "\n"))
+    message("Is that what you intended?")
+    message("Type '",crayon::green("y"),"' to continue, '",crayon::blue("r"),"' to reselect output directories, '",crayon::red("n"),"' to abort: ")
+
     user_input <- get_line()
-    
+
     if(user_input %in% c("y","Y","yes")) {
       happy_with_input <- TRUE
-      cat(crayon::green("Great!\n"))
+      message(crayon::green("Great!"))
       
       # Get special requests from user
-      cat(crayon::blue("\nDo you have any special requests?\n"))
-      cat("1: Skip creation of adjustedPolicyCost reporting\n")
-      cat("2: Add transfers to adjustedPolicyCost reporting\n")
-      cat("3: Skip plot creation\n")
-      cat("4: Plot until 2150 in pdf\n")
-      cat("Type the number (or numbers seperated by a comma) to choose the special requests, or nothing to continue without any: ")
-      special_requests <- get_line() %>% str_split(",",simplify = T) %>% as.vector()
-      
-    } else if(user_input %in% c("r","R","reselect")) {
+      message(crayon::blue("\nDo you have any special requests?"))
+      message("1: Skip creation of adjustedPolicyCost reporting")
+      message("2: Add transfers to adjustedPolicyCost reporting")
+      message("3: Skip plot creation")
+      message("4: Plot until 2150 in pdf")
+      message("Type the number (or numbers seperated by a comma) to choose the special requests, or nothing to continue without any: ")
+      special_requests <- get_line() %>% str_split(",",simplify = TRUE) %>% as.vector()
+
+    } else if (user_input %in% c("r","R","reselect")) {
       if (exists("choose_folder")) {
-        cat("Remember, the order in which you choose the directories should be:\n")
-        cat("\t1: policy run 1\n\t2: reference run 1\n\t3: policy run 2\n\t4: reference run 2\nand so on...\n")
-        outputdirs <- choose_folder("./output",crayon::blue("Reselect your ouput folders now"))
+        message("Remember, the order in which you choose the directories should be:")
+        message("\t1: policy run 1\n\t2: reference run 1\n\t3: policy run 2\n\t4: reference run 2\nand so on...")
+        outputdirs <- choose_folder("./output",crayon::blue("Reselect your output folders now"))
         outputdirs <- paste0("output/",outputdirs)
       } else {
-        cat(crayon::red("\nStopping execution now.\n\n"))
+        message(crayon::red("\nStopping execution now.\n"))
         stop("Couldn't find choosefolder() function")
       }
     } else {
-      cat(crayon::red("\nGood-bye (windows xp shutting down music)... \n"))
-      cat(crayon::red("\nStopping execution now.\n\n"))
-      stop("I can't figure this **** out. I give up. ")
+      message(crayon::red("\nGood-bye (windows xp shutting down music)..."))
+      message(crayon::red("Stopping execution now.\n\n"))
+      stop("I can't figure this **** out. I give up.")
     }
   } else {
     happy_with_input <- TRUE
@@ -302,33 +303,38 @@ while (!happy_with_input) {
 }
 
 
+message("Copy fulldata.gdx of policy refs to input_refpolicycost.gdx in output folders, overwriting these files if they exist.")
+message("If you rerun the reporting, the policy run specified here will be used from now on.")
+file.copy(ref_gdxs, cp_ref_gdxs_to, overwrite = TRUE, copy.mode = TRUE, copy.date = TRUE)
+
+
 # Get Policy costs for every policy-reference pair
-cat(crayon::blue("\nComputing Policy costs:\n"))
-tmp_policy_costs_magpie <- mapply(remind2::reportPolicyCosts, pol_gdxs, ref_gdxs, SIMPLIFY = FALSE)
-cat(crayon::green("Done!\n"))
+message(crayon::blue("\nComputing Policy costs:\n"))
+tmp_policy_costs_magpie <- mapply(remind2::reportPolicyCosts, pol_gdxs, cp_ref_gdxs_to, SIMPLIFY = FALSE)
+message(crayon::green("Done!"))
 
 
 # Create "adjustedPolicyCost" reporting file
 if (!"1" %in% special_requests) {
-  cat(crayon::blue("\nCreating new reportings:\n"))
+  message(crayon::blue("\nCreating new reportings:\n"))
   pol_mifs <- paste0(dirname(pol_gdxs), "/REMIND_generic_", pol_names, ".mif")
   new_reporting_files <- mapply(write_new_reporting, pol_mifs, pol_names, tmp_policy_costs_magpie)
-  cat(crayon::green("Done!\n"))
+  message(crayon::green("Done!"))
 }
 
 
 # Add transfer variables to "adjustedPolicyCost" reporting file
 if ("2" %in% special_requests && !"1" %in% special_requests) {
-  cat(crayon::blue("\nComputing transfers:\n"))
+  message(crayon::blue("\nComputing transfers:"))
   ref_mifs <- paste0(dirname(ref_gdxs), "/REMIND_generic_", ref_names, ".mif")
   transfer_info <- mapply(report_transfers, new_reporting_files, ref_mifs, SIMPLIFY = F)
-  cat(crayon::green("Done!\n"))
+  message(crayon::green("Done!"))
 }
 
 
 # Create Pdf
 if (!"3" %in% special_requests) {
-  cat(crayon::blue("\nCreating plots:\n"))
+  message(crayon::blue("\nCreating plots:\n"))
   
   # Add transfers, if they exist
   if (exists("transfer_info")) {
@@ -360,7 +366,7 @@ if (!"3" %in% special_requests) {
   
   time_stamp <- format(Sys.time(), "_%Y-%m-%d_%H.%M.%S")
   policy_costs_pdf(policy_costs, fileName = paste0("PolicyCost",time_stamp,".pdf"))
-  cat(crayon::green("Done!\n"))
+  message(crayon::green("Done!"))
 }
 
-cat("\n")
+message("")


### PR DESCRIPTION
- in output.R, if multiple single output scripts were selected, they were writing to the same log. Now, save the log in the outputfolder such as `log_validation.txt` or `log_reporting.txt`, also print the log name and use it as slurm name so it can be found easier
- in policyCosts.R, copy the fulldata.gdx of the reference run to input_refpolicycost.gdx in the output folder to get consistency
- in reporting.R, delete the adjusted policy mif. Because input_refpolicycost.gdx was overwritten, the normal mif file then contains the correct policy comparison
- bit of cleanup, better logging including time stamps