### PR TITLE
Add 2nd gen bioenergy phaseout switch

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -327,15 +327,16 @@ cfg$gms$cm_CCS_steel              <-  1           #  def  <-  1
 cfg$gms$cm_secondary_steel_bound  <-  "scenario"  #  def  <-  "scenario"
 cfg$gms$c_solscen                 <-  1           #  def  <-  1
 
-cfg$gms$c_regi_earlyreti_rate  <- "GLO 0.09, EUR_regi 0.15" # def <- GLO 0.09, EUR_regi 0.15
-cfg$gms$c_tech_earlyreti_rate  <- "GLO.(biodiesel 0.14, bioeths 0.14), EUR_regi.(biodiesel 0.15, bioeths 0.15), USA_regi.pc 0.13, REF_regi.pc 0.13, CHA_regi.pc 0.13" # def <- GLO.(biodiesel 0.14, bioeths 0.14), EUR.(biodiesel 0.15, bioeths 0.15), USA_regi.pc 0.13, REF_regi.pc 0.13, CHA_regi.pc 0.13, DEU.(tnrs 0.2)
-cfg$gms$cm_bioenergy_tax        <- 1.5       # def <- 1.5
-cfg$gms$cm_bioenergymaxscen     <- 0         # def <- 0
-cfg$gms$cm_tradecost_bio        <- 2         # def <- 2
-cfg$gms$cm_LU_emi_scen          <- "SSP2"    # def <- "SSP2"
-cfg$gms$cm_1stgen_phaseout      <- 0         # def <- 0
-cfg$gms$cm_tradbio_phaseout   <-  "default" #def  <-  "default"
-cfg$gms$cm_cprice_red_factor    <- 1         # def <- 1
+cfg$gms$c_regi_earlyreti_rate   <- "GLO 0.09, EUR_regi 0.15" # def <- GLO 0.09, EUR_regi 0.15
+cfg$gms$c_tech_earlyreti_rate   <- "GLO.(biodiesel 0.14, bioeths 0.14), EUR_regi.(biodiesel 0.15, bioeths 0.15), USA_regi.pc 0.13, REF_regi.pc 0.13, CHA_regi.pc 0.13" # def <- GLO.(biodiesel 0.14, bioeths 0.14), EUR.(biodiesel 0.15, bioeths 0.15), USA_regi.pc 0.13, REF_regi.pc 0.13, CHA_regi.pc 0.13, DEU.(tnrs 0.2)
+cfg$gms$cm_bioenergy_tax        <- 1.5            # def <- 1.5
+cfg$gms$cm_bioenergymaxscen     <- 0              # def <- 0
+cfg$gms$cm_tradecost_bio        <- 2              # def <- 2
+cfg$gms$cm_LU_emi_scen          <- "SSP2"         # def <- "SSP2"
+cfg$gms$cm_1stgen_phaseout      <- 0              # def <- 0
+cfg$gms$cm_tradbio_phaseout     <- "default"      # def <- "default"
+cfg$gms$cm_biolc_tech_phaseout  <- 0              # def <- 0
+cfg$gms$cm_cprice_red_factor    <- 1              # def <- 1
 
 cfg$gms$cm_POPscen            <- "pop_SSP2EU"     # def <- "pop_SSP2EU"
 cfg$gms$cm_GDPscen            <- "gdp_SSP2EU"     # def <- "gdp_SSP2EU"
@@ -825,18 +826,23 @@ cfg$gms$c_BaselineAgriEmiRed <- 0
 #  GLO 0.09, EUR_regi 0.15: default value. (0.09 means full retirement after 11 years, 10% standing after 10 years)
 # c_tech_earlyreti_rate  "maximum portion of capital stock that can be retired in one year for a technology in a region"
 #  GLO.(biodiesel 0.14, bioeths 0.1), EUR_regi.(biodiesel 0.15, bioeths 0.15), USA_regi.pc 0.13, REF_regi.pc 0.13, CHA_regi.pc 0.13: default value, including retirement of 1st gen biofuels, higher rate of coal phase-out for USA, REF and CHA
-# cm_bioenergy_tax    "level of bioenergy tax in fraction of bioenergy price"
-#  (0): default setting equivalent to no tax
-#  (any number >= 0): tax level, e.g. for a 100% tax cm_bioenergy_tax has to be 1
+# cm_bioenergy_tax    "level of bioenergy sustainability tax in fraction of bioenergy price"
+#  The tax is only applied to purpose grown 2nd generation (lignocellulosic)
+#  biomass and the level increases linearly with bioenergy demand. A value of 1
+#  refers to a tax level of 100% at a production of 200 EJ/yr globally (implies
+#  50% at 100 EJ/yr or 150% at 300 EJ/yr, for example).
+#  (0):               setting equivalent to no tax
+#  (1.5):             (default), implying a tax level of 150% at a demand of
+#                     200 EJ/yr (or 75% at 100 EJ/yr)
+#  (any number >= 0): defines tax level at 200 EJ/yr
 # cm_bioenergymaxscen   "bound on global pebiolc production excluding residues"
-# optional scaling of bioenergy costs in generisdata.inc (at the moment: no scaling for both cases)
 #  (0): no bound
-#  (1): 100 EJ global bioenergy potential (bound in boundsextra.inc)
-#  (2): 200 EJ global bioenergy potential (bound in boundsextra.inc)
-#  (3): 300 EJ global bioenergy potential (bound in boundsextra.inc)
-#  (4): 152 EJ global bioenergy potential, i.e. 100 EJ 2nd generation (bound in boundsextra.inc)
-#  (5): (placeholder for scenario from DIPOL branch that is not yet merged)
-#  (6): 75 EJ (2050) and 90 EJ (2100) global bioenergy potential (linear interpolation in between)
+#  (1): 100 EJ global bioenergy potential
+#  (2): 200 EJ global bioenergy potential
+#  (3): 300 EJ global bioenergy potential
+#  (4): 152 EJ global bioenergy potential
+#  (6): 75 EJ (2050) and 90 EJ (2100) global bioenergy potential (linear
+#       interpolation in between)
 # cm_tradecost_bio  "choose financal tradecosts for biomass (purpose grown pebiolc)"
 #  (1): low   tradecosts (for other SSP scenarios than SSP2)
 #  (2): high  tradecosts (default and SSP2)
@@ -850,6 +856,14 @@ cfg$gms$c_BaselineAgriEmiRed <- 0
 # cm_tradbio_phaseout "Switch that allows for a faster phase out of traditional biomass"
 #  (default):  Default assumption, reaching zero demand in 2100
 #  (fast):     Fast phase out, starting in 2025 reaching zero demand in 2070 (close to zero in 2060)
+# cm_biolc_tech_phaseout "Switch that allows for a full phaseout of all bioenergy technologies globally"
+#  (0): (default) No phaseout
+#  (1): Phaseout capacities of all bioenergy technologies using pebiolc, as far
+#       as historical bounds on bioenergy technologies allow it. This covers 
+#       all types of lignocellulosic feedstocks, i.e. purpose grown biomass and
+#       residues. Lower bounds on future electricity production due to NDC 
+#       tagets in p40_ElecBioBound are removed. The first year, in which no new
+#       capacities are allowed, is 2025 or cm_startyear if larger.
 # cm_POPscen      "Population growth scenarios from UN data and IIASA projection used in SSP"
 # pop_SSP1    "SSP1 population scenario"
 # pop_SSP2    "SSP2 population scenario"

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -857,6 +857,7 @@ cfg$gms$c_BaselineAgriEmiRed <- 0
 #  (default):  Default assumption, reaching zero demand in 2100
 #  (fast):     Fast phase out, starting in 2025 reaching zero demand in 2070 (close to zero in 2060)
 # cm_biolc_tech_phaseout "Switch that allows for a full phaseout of all bioenergy technologies globally"
+#  Only working with magpie_40 realization of 30_biomass module. 
 #  (0): (default) No phaseout
 #  (1): Phaseout capacities of all bioenergy technologies using pebiolc, as far
 #       as historical bounds on bioenergy technologies allow it. This covers

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -859,9 +859,9 @@ cfg$gms$c_BaselineAgriEmiRed <- 0
 # cm_biolc_tech_phaseout "Switch that allows for a full phaseout of all bioenergy technologies globally"
 #  (0): (default) No phaseout
 #  (1): Phaseout capacities of all bioenergy technologies using pebiolc, as far
-#       as historical bounds on bioenergy technologies allow it. This covers 
+#       as historical bounds on bioenergy technologies allow it. This covers
 #       all types of lignocellulosic feedstocks, i.e. purpose grown biomass and
-#       residues. Lower bounds on future electricity production due to NDC 
+#       residues. Lower bounds on future electricity production due to NDC
 #       tagets in p40_ElecBioBound are removed. The first year, in which no new
 #       capacities are allowed, is 2025 or cm_startyear if larger.
 # cm_POPscen      "Population growth scenarios from UN data and IIASA projection used in SSP"

--- a/main.gms
+++ b/main.gms
@@ -246,11 +246,12 @@ parameters
   cm_CCS_chemicals          "CCS for chemicals sub-sector"
   cm_CCS_steel              "CCS for steel sub-sector"
   c_solscen                 "solar option choice"
-  cm_bioenergy_tax          "level of bioenergy tax in fraction of bioenergy price"
+  cm_bioenergy_tax          "level of bioenergy sustainability tax in fraction of bioenergy price"
   cm_bioenergymaxscen       "choose bound on global pebiolc production excluding residues"
   cm_tradecost_bio          "choose financal tradecosts for biomass (purpose grown pebiolc)"
   cm_1stgen_phaseout        "choose if 1st generation biofuels should phase out after 2030 (vm_deltaCap=0)"
   cm_tradbio_phaseout       "Switch that allows for a faster phase out of traditional biomass"
+  cm_biolc_tech_phaseout    "Switch that allows for a full phaseout of all bioenergy technologies globally"
   cm_cprice_red_factor      "reduction factor for price on co2luc when calculating the revenues. Replicates the reduction applied in MAgPIE"
   cm_startyear              "first optimized modelling time step [year]"
   c_start_budget            "start of GHG budget limit"
@@ -395,6 +396,7 @@ cm_tradecost_bio     = 2;         !! def = 2
 $setglobal cm_LU_emi_scen  SSP2   !! def = SSP2
 cm_1stgen_phaseout  = 0;         !! def = 0
 $setglobal cm_tradbio_phaseout  default  !! def = default
+cm_biolc_tech_phaseout = 0;        !! def = 0
 cm_cprice_red_factor  = 1;         !! def = 1
 
 $setglobal cm_POPscen  pop_SSP2EU  !! def = pop_SSP2EU

--- a/modules/30_biomass/exogenous/not_used.txt
+++ b/modules/30_biomass/exogenous/not_used.txt
@@ -21,3 +21,5 @@ vm_prodSe,variable,not needed
 cm_emiscen,variable,not needed
 cm_bioprod_histlim,input,questionnaire
 cm_BioSupply_Adjust_EU,input,questionnaire
+cm_biolc_tech_phaseout,input,questionnaire
+vm_deltaCap,variable,no needed

--- a/modules/30_biomass/magpie_40/bounds.gms
+++ b/modules/30_biomass/magpie_40/bounds.gms
@@ -122,7 +122,7 @@ vm_fuExtr.up(t,regi,"pebiolc","1") = p30_max_pebiolc_path(regi,t) + pm_pedem_res
 ***vm_fuExtr.up(t,"DEU","pebiolc","1")$(t.val ge 2030) = 0.0077;
 
 *** -------------------------------------------------------------
-*** Phase out capacities of bioenergy technologies that use 
+*** Phase out capacities of bioenergy technologies that use
 *** pebiolc as feedstock, if defined in config
 *** -------------------------------------------------------------
 if (cm_biolc_tech_phaseout eq 1,

--- a/modules/30_biomass/magpie_40/bounds.gms
+++ b/modules/30_biomass/magpie_40/bounds.gms
@@ -121,4 +121,23 @@ vm_fuExtr.up(t,regi,"pebiolc","1") = p30_max_pebiolc_path(regi,t) + pm_pedem_res
 *** FS: test regional bounds on pebiolc.1 production
 ***vm_fuExtr.up(t,"DEU","pebiolc","1")$(t.val ge 2030) = 0.0077;
 
+*** -------------------------------------------------------------
+*** Phase out capacities of bioenergy technologies that use 
+*** pebiolc as feedstock, if defined in config
+*** -------------------------------------------------------------
+if (cm_biolc_tech_phaseout eq 1,
+    loop(t$(t.val ge max(2025, cm_startyear)),
+        loop(regi,
+            loop(te(teBioPebiolc),
+                loop(rlf,
+                    if(vm_deltaCap.up(t,regi,te,rlf) eq INF,
+                       vm_deltaCap.up(t,regi,te,rlf) = 1e-5;
+                    );
+                );
+            );
+        );
+    );
+);
+
+
 *** EOF ./modules/30_biomass/magpie_40/bounds.gms

--- a/modules/40_techpol/CombLowCandCoalPO/not_used.txt
+++ b/modules/40_techpol/CombLowCandCoalPO/not_used.txt
@@ -20,3 +20,4 @@ cm_startyear,input,questionnaire
 cm_bioprod_histlim,input,questionnaire
 cm_H2targets,input,questionnaire
 cm_NDC_version,input,questionnaire
+cm_biolc_tech_phaseout,input,questionnaire

--- a/modules/40_techpol/EVmandates/not_used.txt
+++ b/modules/40_techpol/EVmandates/not_used.txt
@@ -22,3 +22,4 @@ cm_startyear,input,questionnaire
 cm_bioprod_histlim,input,questionnaire
 cm_H2targets,input,questionnaire
 cm_NDC_version,input,questionnaire
+cm_biolc_tech_phaseout,input,questionnaire

--- a/modules/40_techpol/NDC/datainput.gms
+++ b/modules/40_techpol/NDC/datainput.gms
@@ -24,6 +24,12 @@ if (cm_bioprod_histlim ge 0,
   p40_ElecBioBound(t,regi) = 0;
   );
 
+*** In scenarios with 2nd generation bioenergy technology phaseout,
+*** switch-off biomass capacity targets of NDC
+if (cm_biolc_tech_phaseout eq 1,
+  p40_ElecBioBound(t,regi) = 0;
+  );
+
 *** inputs for hard-coded share targets: they only apply if the respective country (or EU28) is a native region in the chosen REMIND setting
 *** otherwise, they are not considered in the model
 *** to add further targets, include both the respective parameter value below, and extend the equation domain in equations.gms

--- a/modules/40_techpol/NDCplus/datainput.gms
+++ b/modules/40_techpol/NDCplus/datainput.gms
@@ -18,6 +18,12 @@ p40_TechBound(ttot,all_regi,all_te) = f40_TechBound(ttot,all_regi,"%cm_NDC_versi
 
 p40_ElecBioBound("2030",regi) = p40_TechBound("2030",regi,"bioigcc");
 
+*** In scenarios with 2nd generation bioenergy technology phaseout,
+*** switch-off biomass capacity targets of NDC
+if (cm_biolc_tech_phaseout eq 1,
+  p40_ElecBioBound(t,regi) = 0;
+  );
+
 *** inputs for hard-coded share targets: they only apply if the respective country (or EU28) is a native region in the chosen REMIND setting
 *** otherwise, they are not considered in the model
 *** to add further targets, include both the respective parameter value below, and extend the equation domain in equations.gms

--- a/modules/40_techpol/NPi2018/datainput.gms
+++ b/modules/40_techpol/NPi2018/datainput.gms
@@ -18,6 +18,12 @@ p40_TechBound(ttot,all_regi,all_te) = f40_TechBound(ttot,all_regi,"%cm_NDC_versi
 
 p40_ElecBioBound("2030",regi) = p40_TechBound("2030",regi,"bioigcc");
 
+*** In scenarios with 2nd generation bioenergy technology phaseout,
+*** switch-off biomass capacity targets of NDC
+if (cm_biolc_tech_phaseout eq 1,
+  p40_ElecBioBound(t,regi) = 0;
+  );
+
 *** inputs for hard-coded share targets: they only apply if the respective country (or EU28) is a native region in the chosen REMIND setting
 *** otherwise, they are not considered in the model
 *** to add further targets, include both the respective parameter value below, and extend the equation domain in equations.gms

--- a/modules/40_techpol/coalPhaseout/not_used.txt
+++ b/modules/40_techpol/coalPhaseout/not_used.txt
@@ -21,3 +21,4 @@ cm_startyear,input,questionnaire
 cm_bioprod_histlim,input,questionnaire
 cm_H2targets,input,questionnaire
 cm_NDC_version,input,questionnaire
+cm_biolc_tech_phaseout,input,questionnaire

--- a/modules/40_techpol/coalPhaseoutRegional/not_used.txt
+++ b/modules/40_techpol/coalPhaseoutRegional/not_used.txt
@@ -20,3 +20,4 @@ cm_startyear,input,questionnaire
 cm_bioprod_histlim,input,questionnaire
 cm_H2targets,input,questionnaire
 cm_NDC_version,input,questionnaire
+cm_biolc_tech_phaseout,input,questionnaire

--- a/modules/40_techpol/lowCarbonPush/not_used.txt
+++ b/modules/40_techpol/lowCarbonPush/not_used.txt
@@ -22,3 +22,4 @@ cm_startyear,input,questionnaire
 cm_bioprod_histlim,input,questionnaire
 cm_H2targets,input,questionnaire
 cm_NDC_version,input,questionnaire
+cm_biolc_tech_phaseout,input,questionnaire

--- a/modules/40_techpol/none/not_used.txt
+++ b/modules/40_techpol/none/not_used.txt
@@ -23,3 +23,4 @@ cm_startyear,input,questionnaire
 cm_bioprod_histlim,input,questionnaire
 cm_H2targets,input,questionnaire
 cm_NDC_version,input,questionnaire
+cm_biolc_tech_phaseout,input,questionnaire


### PR DESCRIPTION
Additions:
- Switch to phase out capacities of technologies using pebiolc as an input (turned off by default)
- Minor clean-up of switch descriptions

Example of the phaseout for a PkBudg500 run (note: here also cm_1stgen_phaseout was set to 1, in order to also phase out 1st generation biofuels, which is not covered by the new cm_biolc_tech_phaseout switch):
![vm_cap_teBio_stack_full_bio_phaseout](https://user-images.githubusercontent.com/58845874/168260320-13e4895c-a09a-43d3-b5e8-a9723fc534d0.png)
s