### PR TITLE
Add peatland non-CO2 emissionss from MAgPIE in the couping

### DIFF
--- a/core/sets.gms
+++ b/core/sets.gms
@@ -1838,7 +1838,7 @@ emiMacSector(all_enty)  "types of climate-relevant non-energy emissions with mac
         ch4wstl    "ch4 emissions from solid waste disposal on land"
         ch4wsts    "ch4 emissions from waste water"
         ch4rice    "ch4 emissions from rice cultivation (rice_ch4)"
-        ch4peatland "ch4 emissions from peatlands peatland_ch4)"
+        ch4peatland "ch4 emissions from peatlands (no MAC available)"
         ch4animals "ch4 emissions from enteric fermentation of ruminants (ent_ferm_ch4)"
         ch4anmlwst "ch4 emissions from animal waste management(awms_ch4)"
         ch4agwaste "ch4 emissions from agricultural waste burning (no MAC available)"
@@ -1889,8 +1889,10 @@ MacSectorMagpie(all_enty)  "land-use sectors for which mac curves exist in REMIN
         ch4rice    "rice cultivation"
         ch4animals "enteric fermentation of ruminants"
         ch4anmlwst "animal waste management"
+        ch4peatland "ch4 emissions from peatlands (no MAC available)"
         n2ofert    "Inorganic fertilizers"
         n2oanwst   "manure applied to croplands"
+        n2opeatland "n2o emissions from peatlands (no MAC available)"        
         co2luc     "land use change"
 /
 

--- a/core/sets.gms
+++ b/core/sets.gms
@@ -1903,6 +1903,7 @@ emiMacMagpieN2O(all_enty)  "types of climate-relevant non-energy N2O emissions w
         n2ofertcr  "n2o emissions from decay of crop residues (resid_n2o)"
         n2ofertsom "n2o emissions from soil organic matter loss (som_n2o)"
         n2oanwstc  "n2o emissions from manure applied to croplands (man_crop_n2o)"
+        ch4peatland "ch4 emissions from peatlands (peatland_ch4)"        
         n2oanwstm  "n2o emissions from animal waste management (awms_n2o)"
         n2opeatland "n2o emissions from peatlands (no MAC available)"        
         n2oanwstp  "n2o emissions from manure excreted on pasture (man_past_n2o)"

--- a/core/sets.gms
+++ b/core/sets.gms
@@ -386,6 +386,7 @@ all_enty             "all types of quantities"
         ch4wstl    "ch4 emissions from solid waste disposal on land"
         ch4wsts    "ch4 emissions from waste water"
         ch4rice    "ch4 emissions from rice cultivation (rice_ch4)"
+        ch4peatland "ch4 emissions from peatlands (no MAC available)"
         ch4animals "ch4 emissions from enteric fermentation of ruminants (ent_ferm_ch4)"
         ch4anmlwst "ch4 emissions from animal waste management(awms_ch4)"
         ch4agwaste "ch4 emissions from agricultural waste burning (no MAC available)"
@@ -406,6 +407,7 @@ all_enty             "all types of quantities"
         n2oanwstm  "n2o emissions from animal waste management (awms_n2o)"
         n2oanwstp  "n2o emissions from manure excreted on pasture (man_past_n2o)"
         n2oagwaste "n2o emissions from agricultural waste burning (no MAC available)"
+        n2opeatland "n2o emissions from peatlands (no MAC available)"
         n2owaste   "n2o emissions from waste (domestic sewage)"
         co2luc     "co2 emissions from land use change"
         co2cement_process  "co2 from cement production (only process emissions)"
@@ -1613,6 +1615,7 @@ enty(all_enty)       "all types of quantities"
         ch4wstl    "ch4 emissions from solid waste disposal on land"
         ch4wsts    "ch4 emissions from waste water"
         ch4rice    "ch4 emissions from rice cultivation (rice_ch4)"
+        ch4peatland "ch4 emissions from peatlands (no MAC available)"
         ch4animals "ch4 emissions from enteric fermentation of ruminants (ent_ferm_ch4)"
         ch4anmlwst "ch4 emissions from animal waste management(awms_ch4)"
         ch4agwaste "ch4 emissions from agricultural waste burning (no MAC available)"
@@ -1633,6 +1636,7 @@ enty(all_enty)       "all types of quantities"
         n2oanwstm  "n2o emissions from animal waste management (awms_n2o)"
         n2oanwstp  "n2o emissions from manure excreted on pasture (man_past_n2o)"
         n2oagwaste "n2o emissions from agricultural waste burning (no MAC available)"
+        n2opeatland "n2o emissions from peatlands (no MAC available)"        
         n2owaste   "n2o emissions from waste (domestic sewage)"
         co2luc     "co2 emissions from land use change"
         co2cement_process  "co2 from cement production (only process emissions)"
@@ -1834,6 +1838,7 @@ emiMacSector(all_enty)  "types of climate-relevant non-energy emissions with mac
         ch4wstl    "ch4 emissions from solid waste disposal on land"
         ch4wsts    "ch4 emissions from waste water"
         ch4rice    "ch4 emissions from rice cultivation (rice_ch4)"
+        ch4peatland "ch4 emissions from peatlands peatland_ch4)"
         ch4animals "ch4 emissions from enteric fermentation of ruminants (ent_ferm_ch4)"
         ch4anmlwst "ch4 emissions from animal waste management(awms_ch4)"
         ch4agwaste "ch4 emissions from agricultural waste burning (no MAC available)"
@@ -1851,6 +1856,7 @@ emiMacSector(all_enty)  "types of climate-relevant non-energy emissions with mac
         n2oanwstm  "n2o emissions from animal waste management (awms_n2o)"
         n2oanwstp  "n2o emissions from manure excreted on pasture (man_past_n2o)"
         n2oagwaste "n2o emissions from agricultural waste burning (no MAC available)"
+        n2opeatland "n2o emissions from peatlands (no MAC available)"        
         n2owaste   "n2o emissions from waste (domestic sewage)"
         co2luc     "co2 emissions from land use change"
         co2cement_process  "co2 from cement production (only process emissions)"
@@ -1896,6 +1902,7 @@ emiMacMagpieN2O(all_enty)  "types of climate-relevant non-energy N2O emissions w
         n2ofertsom "n2o emissions from soil organic matter loss (som_n2o)"
         n2oanwstc  "n2o emissions from manure applied to croplands (man_crop_n2o)"
         n2oanwstm  "n2o emissions from animal waste management (awms_n2o)"
+        n2opeatland "n2o emissions from peatlands (no MAC available)"        
         n2oanwstp  "n2o emissions from manure excreted on pasture (man_past_n2o)"
 /
 emiMacMagpieCH4(all_enty)  "types of climate-relevant non-energy CH4 emissions with mac curve where baseline emissions come from MAgPIE only"
@@ -1903,6 +1910,7 @@ emiMacMagpieCH4(all_enty)  "types of climate-relevant non-energy CH4 emissions w
         ch4rice    "ch4 emissions from rice cultivation (rice_ch4)"
         ch4animals "ch4 emissions from enteric fermentation of ruminants (ent_ferm_ch4)"
         ch4anmlwst "ch4 emissions from animal waste management(awms_ch4)"
+        ch4peatland "ch4 emissions from peatlands peatland_ch4)"        
 /
 emiMacMagpieCO2(all_enty)  "types of climate-relevant non-energy CH4 emissions with mac curve where baseline emissions come from MAgPIE only"
 /
@@ -2062,6 +2070,7 @@ macSector2emiMkt(all_enty,all_emiMkt)  "mapping mac sectors to emission markets"
         ch4animals.ES
         ch4anmlwst.ES
         ch4agwaste.ES
+        ch4peatland.other        
         ch4forest.other
         ch4savan.other
         n2oforest.other
@@ -2077,6 +2086,7 @@ macSector2emiMkt(all_enty,all_emiMkt)  "mapping mac sectors to emission markets"
         n2oanwstp.ES
         n2oagwaste.ES
         n2owaste.ES
+        n2opeatland.other        
         co2luc.other
         co2cement_process.ETS
 /
@@ -2629,8 +2639,8 @@ emi2fuel(all_enty,all_enty) "map emissions to fuel extraction"
 emiMacSector2emiMac(all_enty,all_enty)   "mapping of sub-emissions to their sum"
 /
         (co2luc,co2cement_process)                          .co2
-        (n2otrans,n2oadac,n2onitac,n2ofertin,n2ofertcr, n2ofertsom, n2oanwstc,n2oanwstm, n2oanwstp,n2oagwaste,n2oforest,n2osavan,n2owaste).n2o
-        (ch4coal,ch4gas,ch4oil,ch4rice,ch4animals,ch4anmlwst,ch4agwaste,ch4forest,ch4savan,ch4wstl,ch4wsts).ch4
+        (n2otrans,n2oadac,n2onitac,n2ofertin,n2ofertcr, n2ofertsom, n2oanwstc,n2oanwstm,n2opeatland,n2oanwstp,n2oagwaste,n2oforest,n2osavan,n2owaste).n2o
+        (ch4coal,ch4gas,ch4oil,ch4rice,ch4animals,ch4anmlwst,ch4agwaste,ch4peatland,ch4forest,ch4savan,ch4wstl,ch4wsts).ch4
 /
 emiMac2mac(all_enty,all_enty)            "mapping of emission sources to MACs - caution: not all MACs exist, in that case they are zero"
 /
@@ -2643,6 +2653,7 @@ emiMac2mac(all_enty,all_enty)            "mapping of emission sources to MACs - 
         ch4animals.ch4animals
         ch4anmlwst.ch4anmlwst
         ch4agwaste.ch4agwaste
+        ch4peatland.ch4peatland
         ch4forest.ch4forest
         ch4savan.ch4savan
         n2otrans.n2otrans
@@ -2651,6 +2662,7 @@ emiMac2mac(all_enty,all_enty)            "mapping of emission sources to MACs - 
         (n2ofertin, n2ofertcr, n2ofertsom).n2ofert
         (n2oanwstc, n2oanwstm, n2oanwstp).n2oanwst
         n2oagwaste.n2oagwaste
+        n2opeatland.n2opeatland
         n2owaste.n2owaste
         n2osavan.n2osavan
         n2oforest.n2oforest
@@ -2666,13 +2678,13 @@ emiMac2sector(all_enty,emi_sectors,sector_types,all_enty)            "mapping of
         (ch4coal, ch4gas, ch4oil).extraction.process.ch4
         (ch4wstl, ch4wsts).waste.process.ch4
         (ch4rice, ch4animals, ch4anmlwst, ch4agwaste).agriculture.process.ch4
-        (ch4forest, ch4savan).lulucf.process.ch4
+        (ch4forest, ch4savan, ch4peatland).lulucf.process.ch4
 
         (n2otrans).trans.process.n2o
         (n2oadac, n2onitac).indst.process.n2o
         (n2owaste).waste.process.n2o
         (n2ofertin, n2ofertcr, n2ofertsom, n2oanwstc, n2oanwstm, n2oanwstp, n2oagwaste).agriculture.process.n2o
-        (n2oforest, n2osavan).lulucf.process.n2o
+        (n2oforest, n2osavan, n2opeatland).lulucf.process.n2o
 
         (co2cement_process,co2cement,co2chemicals,co2steel).indst.process.co2
         (co2luc).lulucf.process.co2

--- a/scripts/start/prepare_and_run.R
+++ b/scripts/start/prepare_and_run.R
@@ -75,7 +75,7 @@ getReportData <- function(path_to_report,inputpath_mag="magpie",inputpath_acc="c
       map <- rbind(map,data.frame(emimag="Emissions|N2O|Land|Agriculture|Agricultural Soils|+|Decay of Crop Residues (Mt N2O/yr)",         emirem="n2ofertcr", factor_mag2rem=28/44,stringsAsFactors=FALSE))
       map <- rbind(map,data.frame(emimag="Emissions|N2O|Land|Agriculture|Agricultural Soils|+|Soil Organic Matter Loss (Mt N2O/yr)",       emirem="n2ofertsom",factor_mag2rem=28/44,stringsAsFactors=FALSE))
       map <- rbind(map,data.frame(emimag="Emissions|N2O|Land|Agriculture|Agricultural Soils|+|Pasture (Mt N2O/yr)",                        emirem="n2oanwstp", factor_mag2rem=28/44,stringsAsFactors=FALSE))
-      map <- rbind(map,data.frame(emimag="Emissions|CO2|Land|Cumulative|Land-use Change|+|Peatland (Mt N2O/yr)",                           emirem="n2opeatland", factor_mag2rem=28/44,stringsAsFactors=FALSE))      
+      map <- rbind(map,data.frame(emimag="Emissions|N2O|Land|+|Peatland (Mt N2O/yr)",                                                      emirem="n2opeatland", factor_mag2rem=28/44,stringsAsFactors=FALSE))      
       map <- rbind(map,data.frame(emimag="Emissions|CH4|Land|Agriculture|+|Rice (Mt CH4/yr)",                                              emirem="ch4rice",   factor_mag2rem=1,stringsAsFactors=FALSE))
       map <- rbind(map,data.frame(emimag="Emissions|CH4|Land|Agriculture|+|Animal waste management (Mt CH4/yr)",                           emirem="ch4anmlwst",factor_mag2rem=1,stringsAsFactors=FALSE))
       map <- rbind(map,data.frame(emimag="Emissions|CH4|Land|Agriculture|+|Enteric fermentation (Mt CH4/yr)",                              emirem="ch4animals",factor_mag2rem=1,stringsAsFactors=FALSE))

--- a/scripts/start/prepare_and_run.R
+++ b/scripts/start/prepare_and_run.R
@@ -75,9 +75,11 @@ getReportData <- function(path_to_report,inputpath_mag="magpie",inputpath_acc="c
       map <- rbind(map,data.frame(emimag="Emissions|N2O|Land|Agriculture|Agricultural Soils|+|Decay of Crop Residues (Mt N2O/yr)",         emirem="n2ofertcr", factor_mag2rem=28/44,stringsAsFactors=FALSE))
       map <- rbind(map,data.frame(emimag="Emissions|N2O|Land|Agriculture|Agricultural Soils|+|Soil Organic Matter Loss (Mt N2O/yr)",       emirem="n2ofertsom",factor_mag2rem=28/44,stringsAsFactors=FALSE))
       map <- rbind(map,data.frame(emimag="Emissions|N2O|Land|Agriculture|Agricultural Soils|+|Pasture (Mt N2O/yr)",                        emirem="n2oanwstp", factor_mag2rem=28/44,stringsAsFactors=FALSE))
+      map <- rbind(map,data.frame(emimag="Emissions|CO2|Land|Cumulative|Land-use Change|+|Peatland (Mt N2O/yr)",                           emirem="n2opeatland", factor_mag2rem=28/44,stringsAsFactors=FALSE))      
       map <- rbind(map,data.frame(emimag="Emissions|CH4|Land|Agriculture|+|Rice (Mt CH4/yr)",                                              emirem="ch4rice",   factor_mag2rem=1,stringsAsFactors=FALSE))
       map <- rbind(map,data.frame(emimag="Emissions|CH4|Land|Agriculture|+|Animal waste management (Mt CH4/yr)",                           emirem="ch4anmlwst",factor_mag2rem=1,stringsAsFactors=FALSE))
       map <- rbind(map,data.frame(emimag="Emissions|CH4|Land|Agriculture|+|Enteric fermentation (Mt CH4/yr)",                              emirem="ch4animals",factor_mag2rem=1,stringsAsFactors=FALSE))
+      map <- rbind(map,data.frame(emimag="Emissions|CH4|Land|+|Peatland (Mt CH4/yr)",                                                      emirem="ch4peatland",factor_mag2rem=1,stringsAsFactors=FALSE))
     } else if("Emissions|N2O-N|Land|Agriculture|+|Animal Waste Management (Mt N2O-N/yr)" %in% getNames(mag)) {
       # MAgPIE 4 (intermediate - wrong units)
       map <- rbind(map,data.frame(emimag="Emissions|CO2|Land|+|Land-use Change (Mt CO2/yr)",                                               emirem="co2luc",    factor_mag2rem=1/1000*12/44,stringsAsFactors=FALSE))


### PR DESCRIPTION
MAgPIE now includes peatland CH4 and N2O emissions. These were not being taken from the MAgPIE report during the coupling.

This PR creates new `n2opeatland` and `ch4peatland` `enty`s in the relevant emissions sets, which are mapped to `lulucf.process`. These are read from `./core/input/f_macBaseMagpie_coupling.cs4r`, which now has the relevant variables from MAgPIE added via `prepare_and_run.R`.