### PR TITLE
add debugging tutorial, improve logs

### DIFF
--- a/scripts/start/prepare_and_run.R
+++ b/scripts/start/prepare_and_run.R
@@ -991,7 +991,7 @@ run <- function(start_subsequent_runs = TRUE) {
       if (! file.exists("abort.gdx")) {
         message("  abort.gdx does not exist, which is a file written automatically for some types of errors.")
       } else {
-        message("! abort.gdx exists, containing the latest GAMS data including changes after the last solve statement.")
+        message("! abort.gdx exists, which is a file containing the latest data at the point GAMS aborted execution.")
       }
       if(! file.exists("fulldata.gdx")) {
         message("! fulldata.gdx does not exist, so output generation will fail.")
@@ -1009,15 +1009,17 @@ run <- function(start_subsequent_runs = TRUE) {
     }
   }
 
-  message("Infeasibilities extracted from full.lst with nashstat -F:")
-  command <- paste(
-    "li=$(nashstat -F | wc -l); cat",
-    "<(if (($li < 2)); then echo no infeasibilities found; fi)",
-    "<(if (($li > 1)); then nashstat -F | head -n 2 | sed -r 's/\\x1B\\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g'; fi)",
-    "<(if (($li > 4)); then echo ... $(($li - 3)) infeasibilities omitted, show all with nashstat -a ...; fi)",
-    "<(if (($li > 2)); then nashstat -F | tail -n 1 | sed -r 's/\\x1B\\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g'; fi)")
-  nashstatres <- try(system2("/bin/bash", args = c("-c", shQuote(command))))
-  if (nashstatres != 0) message("Error: nashstat not found, search for p80_repy in full.lst yourself.")
+  if (identical(cfg$gms$optimization, "nash") && file.exists("full.lst")) {
+    message("\nInfeasibilities extracted from full.lst with nashstat -F:")
+    command <- paste(
+      "li=$(nashstat -F | wc -l); cat",
+      "<(if (($li < 2)); then echo no infeasibilities found; fi)",
+      "<(if (($li > 1)); then nashstat -F | head -n 2 | sed -r 's/\\x1B\\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g'; fi)",
+      "<(if (($li > 4)); then echo ... $(($li - 3)) infeasibilities omitted, show all with nashstat -a ...; fi)",
+      "<(if (($li > 2)); then nashstat -F | tail -n 1 | sed -r 's/\\x1B\\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g'; fi)")
+    nashstatres <- try(system2("/bin/bash", args = c("-c", shQuote(command))))
+    if (nashstatres != 0) message("nashstat not found, search for p80_repy in full.lst yourself.")
+  }
   message("")
 
   if (stoprun) {

--- a/scripts/start/prepare_and_run.R
+++ b/scripts/start/prepare_and_run.R
@@ -244,7 +244,10 @@ prepare <- function() {
 
   # Check configuration for consistency
   cfg <- check_config(cfg, reference_file="config/default.cfg",
-                      settings_config = "config/settings_config.csv", extras = c("remind_folder"))
+                      settings_config = "config/settings_config.csv",
+                      extras = c("backup", "remind_folder", "pathToMagpieReport", "cm_nash_autoconverge_lastrun",
+                                 "gms$c_expname", "restart_subsequent_runs", "gms$c_GDPpcScen",
+                                 "gms$cm_CES_configuration", "gms$c_description"))
 
   # Check for compatibility with subsidizeLearning
   if ( (cfg$gms$optimization != 'nash') & (cfg$gms$subsidizeLearning == 'globallyOptimal') ) {
@@ -988,7 +991,7 @@ run <- function(start_subsequent_runs = TRUE) {
       if (! file.exists("abort.gdx")) {
         message("  abort.gdx does not exist, which is a file written automatically for some types of errors.")
       } else {
-        message("! abort.gdx exists, which is a file written automatically for some types of errors.")
+        message("! abort.gdx exists, containing the latest GAMS data including changes after the last solve statement.")
       }
       if(! file.exists("fulldata.gdx")) {
         message("! fulldata.gdx does not exist, so output generation will fail.")
@@ -998,7 +1001,7 @@ run <- function(start_subsequent_runs = TRUE) {
         message("  Number of iterations: ",
                          as.numeric(readGDX(gdx="fulldata.gdx", "o_iterationNumber", format = "simplest")))
         message("  Modelstat: ", as.numeric(readGDX(gdx="fulldata.gdx", "o_modelstat", format="simplest")),
-                " (see https://www.gams.com/mccarlGuide/modelstat_tmodstat.htm).")
+                " (see https://github.com/remindmodel/remind/blob/develop/tutorials/10_DebuggingREMIND.md).")
       }
       logStatus <- grep("*** Status", readLines("full.log"), fixed = TRUE, value = TRUE)
       message("  full.log states: ", paste(logStatus, collapse = ", "))
@@ -1006,20 +1009,20 @@ run <- function(start_subsequent_runs = TRUE) {
     }
   }
 
-  if ( file.exists("full.lst")) {
-    message("Infeasibilities extracted from full.lst with nashstat -F:")
-    command <- paste("li=$(nashstat -F | wc -l); cat",
-               "<(if (($li < 2)); then echo no infeasibilities found; fi)",
-               "<(if (($li > 1)); then nashstat -F | head -n 2; fi)",
-               "<(if (($li > 4)); then echo ... $(($li - 3)) infeasibilities omitted, show all with nashstat -a ...; fi)",
-               "<(if (($li > 2)); then nashstat -F | tail -n 1; fi)")
-    nashstatres <- try(system2("/bin/bash", args = c("-c", shQuote(command))))
-    if (nashstatres != 0) message("Error: nashstat not found, search for p80_repy in full.lst yourself.")
-    message("")
-  }
+  message("Infeasibilities extracted from full.lst with nashstat -F:")
+  command <- paste(
+    "li=$(nashstat -F | wc -l); cat",
+    "<(if (($li < 2)); then echo no infeasibilities found; fi)",
+    "<(if (($li > 1)); then nashstat -F | head -n 2 | sed -r 's/\\x1B\\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g'; fi)",
+    "<(if (($li > 4)); then echo ... $(($li - 3)) infeasibilities omitted, show all with nashstat -a ...; fi)",
+    "<(if (($li > 2)); then nashstat -F | tail -n 1 | sed -r 's/\\x1B\\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g'; fi)")
+  nashstatres <- try(system2("/bin/bash", args = c("-c", shQuote(command))))
+  if (nashstatres != 0) message("Error: nashstat not found, search for p80_repy in full.lst yourself.")
+  message("")
 
   if (stoprun) {
-    stop("GAMS did not complete its run, so stopping here:\n       No output is generated, no subsequent runs are started.")
+    stop("GAMS did not complete its run, so stopping here:\n       No output is generated, no subsequent runs are started.\n",
+         "       See the debugging tutorial at https://github.com/remindmodel/remind/blob/develop/tutorials/10_DebuggingREMIND.md")
   }
 
   message("\nCollect and submit run statistics to central data base.")

--- a/start.R
+++ b/start.R
@@ -135,6 +135,13 @@ chooseFromList <- function(thelist, type = "runs", returnboolean = FALSE, multip
   if (returnboolean) return(booleanlist) else return(originallist[identifier])
 }
 
+############## Define function: select_testOneRegi_region #############
+select_testOneRegi_region <- function() {
+  message("\nWhich region should testOneRegi use? Type it, or leave empty to keep settings:\n",
+  "Examples are CAZ, CHA, EUR, IND, JPN, LAM, MEA, NEU, OAS, REF, SSA, USA.")
+  return(get_line())
+}
+
 ############## Define function: configure_cfg #########################
 
 configure_cfg <- function(icfg, iscen, iscenarios, isettings) {
@@ -296,11 +303,7 @@ if (any(c("--reprepare", "--restart") %in% argv)) {
   outputdirs <- chooseFromList(sort(unique(possibledirs)), "runs to be restarted", returnboolean = FALSE)
   message("\nAlso restart subsequent runs? Enter y, else leave empty:")
   restart_subsequent_runs <- get_line() %in% c("Y", "y")
-  if ("--testOneRegi" %in% argv) {
-    message("\nWhich region should testOneRegi use? Type it, or leave empty to keep settings:\n",
-    "Examples are CAZ, CHA, EUR, IND, JPN, LAM, MEA, NEU, OAS, REF, SSA, USA.")
-    testOneRegi_region <- get_line()
-  }
+  if ("--testOneRegi" %in% argv) testOneRegi_region <- select_testOneRegi_region()
   if ("--reprepare" %in% argv) {
     message("\nBecause of the flag --reprepare, move full.gms -> full_old.gms and fulldata.gdx -> fulldata_old.gdx such that runs are newly prepared.\n")
   }
@@ -346,6 +349,8 @@ if (any(c("--reprepare", "--restart") %in% argv)) {
     possiblecsv <- possiblecsv[! grepl(".*scenario_config_coupled.*csv$", possiblecsv)]
     config.file <- chooseFromList(possiblecsv, type = "one config file", returnboolean = FALSE, multiple = FALSE, allowempty = TRUE)
   }
+
+  if (all(c("--testOneRegi", "--interactive") %in% argv)) testOneRegi_region <- select_testOneRegi_region()
 
   ###################### Load csv if provided  ###########################
 

--- a/tutorials/10_DebuggingREMIND.md
+++ b/tutorials/10_DebuggingREMIND.md
@@ -1,8 +1,8 @@
 Debugging REMIND
 ================
-Collaborative effort, coordinated by Oliver Richters, 31 March, 2022
+Collaborative effort, coordinated by Oliver Richters, March–May, 2022
 
-When running and changing REMIND, a multitude of errors may occur. In such a collaborative effort, they need not have been created by you and the REMIND team will help you solve them. So an important part of debugging is to find out whether something you changed created the error, or whether you were unfortunate enough to find errors you are not responsible for.
+When running and changing REMIND, a multitude of errors may occur. In such a collaborative effort, they need not have been created by you. So an important part of debugging is to find out whether something you changed created the error, or whether there is a general problem. The `develop` branch is permanently developed and may temporarily contain bugs, so use a release instead.
 
 First, find out the state of your run by executing this in the run directory:
 ```bash
@@ -58,9 +58,9 @@ less full.lst
 ```
 Hit `G` to go to the end of the file and search backwards for errors whose lines start with four asterisks by typing:
 ```
-/^\*\*\*\*
+?^\*\*\*\*
 ```
-(You can also use `vi full.lst`, and if you add `map f /*\*\*\*<CR>` to your `/home/username/.vimrc` file, you can simply press `f`).
+(You can also use `vi full.lst`, and if you add `map f /*\*\*\*<CR>` to your `/home/username/.vimrc` file, you can simply press `f`, which overwrites the search for single characters. In text editors such as `notepad++`, search for `****`).
 Going upwards to the next matches using `N`, you should eventually find an error message (`n` searches downwards).
 The error is indicated directly at the point in the code where it occurs.
 It is worth looking at the `.gms` file this equation is part of, by searching for `SOF` (start of file) and `EOF` (end of file) marks above and below the equation.
@@ -80,7 +80,7 @@ Rscript start.R --restart
 ### Case 2b: execution errors
 
 For execution errors, again try to identify the location of the error in the `full.lst` file.
-If it points to a specific line number where the error occured, mark this number, then type `/` and paste it into the editor which is then searching for this number, and typing `n` (eventually multiple times) should bring you to the source code part at the beginning of the file.
+If it points to a specific line number where the error occured, mark this number, then type `?` and paste it into the editor which is then searching backwards for this number, and typing `n` (eventually multiple times) should bring you to the source code part at the beginning of the file.
 You should now see the equation where the error was created. If you recently changed this equation, this may have caused the error.
 Again, tutorials such as as the [McCarl GAMS User Guide](https://www.gams.com/mccarlGuide/) may be helpful.
 If not, it is worth looking at the `.gms` file this equation is part of, by searching for `SOF` (start of file) and `EOF` (end of file) marks above and below the equation. Then navigate to this file in github and see in the history whether it was recently changed, which may have caused this error.
@@ -177,6 +177,7 @@ Asking for help
 
 In any case, don't hesitate to ask for help in [pik-piam/discussions](https://github.com/pik-piam/discussions). Please provide:
 
+- which version of REMIND was used
 - as much information on your run, such as the scenario config file and the run name
 - PIK cluster users should supply the path on the cluster
 - a summary of things you already checked or found out

--- a/tutorials/10_DebuggingREMIND.md
+++ b/tutorials/10_DebuggingREMIND.md
@@ -1,0 +1,169 @@
+Debugging REMIND
+================
+Collaborative effort, coordinated by Oliver Richters, 31 March, 2022
+
+When running and changing REMIND, a multitude of errors may occur. In such a collaborative effort, they need not have been created by you and the REMIND team will help you solve them. So an important part of debugging is to find out whether something your changes to the model created the error, or whether you were unfortunate enough to find errors you are not responsible for.
+
+First, find out the state of your run by executing this in the run directory:
+```bash
+Rscript -e "modelstats::loopRuns('.')"
+```
+PIK cluster users can access all their runs in one go by executing `rs2 -c`.
+In case of errors, this tutorial if for you.
+
+Case 1: REMIND did not start
+----------------------------
+
+The first place to look is `log.txt` in the output subfolder for each run. It shows you the log of running [`prepare_and_run.R`](https://github.com/remindmodel/remind/blob/develop/scripts/start/prepare_and_run.R). If it states "Starting REMIND..." somewhere, this shows that the input preparation scripts were successful. If not, this can be caused by the following reasons:
+
+- the model remains locked? start `vi .lock` in the REMIND folder and carefully delete (with `dd`, then save with `:w`) the lines of older runs that may still be present there because you killed these runs.
+- because of a locked folder in the R libraries, outdated packages were loaded: consider [creating a new snapshot](4_RunningREMINDandMAgPIE.md#create-snapshot-of-r-libraries)
+- input files are missing or outdated? delete `input/source_files.log` or set `cfg$force_download <- TRUE` to force the loading of new ones. If this doesn't help, the input generation may be broken
+- you use an outdated git branch? check `git log` or use main branch with `git checkout main/develop; git pull`
+- a recent change in `prepare_and_run` may have broken the prepare scripts, check the [file history](https://github.com/remindmodel/remind/commits/develop/scripts/start/prepare_and_run.R) for changes.
+
+Case 2: REMIND did produce an error
+-----------------------------------
+
+In this case, after "REMIND run finished!", you find a short "Model Summary", where the script looks for some files in the output subfolder and gives you its interpretation which is helpful for knowing were to look next:
+```
+  gams_runtime is 10.6 hours.
+  full.gms exists, so the REMIND GAMS code was generated.
+  full.log and full.lst exist, so GAMS did run.
+! abort.gdx exists, containing the latest GAMS data including changes after the last solve statement.
+  fulldata.gdx exists, so at least one iteration was successful.
+  Number of iterations: 14
+  Modelstat: 4
+! full.log states: *** Status: Execution error(s)
+```
+
+If gams_runtime was short (say: up to 10 minutes), this implies an error right at the beginning of the run.
+If full.gms does not exist, it is an error in the preparation script, not in GAMS.
+
+If full.log exists, this is the next place to look at. Either open it in your favorite text editor or use the console, change directory to the output subfolder and type:
+```bash
+vi full.log
+```
+and then type `G` to get to the end of the file. `:q` finishes looking at the file.
+
+You may find:
+
+### Case 2a: compilation errors
+
+These are errors in the GAMS code. Run `gamscompile` in the REMIND folder to get more information and try to identify incorrect GAMS code.
+Tutorials such as as the [McCarl GAMS User Guide](https://www.gams.com/mccarlGuide/) may be helpful.
+
+### Case 2b: execution errors
+
+Have the next look at
+
+```
+vi full.lst
+```
+Hit `G` to go to the end of the file and search backwards for errors whose lines start with four asterisks by typing:
+```
+?^\*\*\*\*
+```
+(If you add `map f /*\*\*\*<CR>` to your `/home/username/.vimrc` file, you can simply press `f`).
+Going upwards to the next matches using `N`, you should eventually find an error message (`n` searches downwards).
+
+If it points to a specific line number where the error occured, mark this number, then type `?` and paste it into the editor which is then searching for this number, and typing `n` (eventually multiple times) should bring you to the source code part at the beginning of the file.
+You should now see the equation where the error was created. If you recently changed this equation, this may have caused the error. If not, it is worth looking at the `.gms` file this equation is part of, by searching for `SOF` (start of file) and `EOF` (end of file) marks above and below the equation. Then navigate to this file in github and see in the history whether it was recently changed, which may have caused this error.
+But it is important that the error may have first appeared in this equation, but may have been caused somewhere else.
+
+The file `abort.gdx` contains the latest GAMS data including changes after the last solve statement.
+
+### Case 2c: GDX or R file missing
+
+Try to find out where this file should have come from by searching within the REMIND repository. Again, having a look at `full.lst`, searching for the filename and looking for `SOF` and `EOF` may help
+
+
+Case 3: REMIND ran into infeasibilities
+----------------------------------------
+
+If some infeasibility was created, the next suggested step is to search for `p80_repy` in `full.lst` and how it changes over the iterations.
+On the PIK cluster,
+```bash
+nashstat -a [folder]
+```
+or just `nashstat -a` in the folder provides an overview, with a short extract also found in `log.txt`.
+It is worth looking at this information already while the model is running to see whether the model runs smoothly.
+An explanation of the modelstat and solvestat numbers can be found in the tables below:
+
+|model   status in GAMS | |
+|--- | ---|
+|Modelstat = 1 | Optimal|
+|Modelstat = 2 | Locally Optimal|
+|Modelstat = 3 | Unbounded|
+|Modelstat = 4 | Infeasible|
+|Modelstat = 5 | Locally Infeasible|
+|Modelstat = 6 | Intermediate Infeasible|
+|Modelstat = 7 | Intermediate Nonoptimal|
+| | |
+|Solvestat = 1 | Normal Completion|
+|Solvestat = 2 | Iteration Interrupt|
+|Solvestat = 3 | Resource Interrupt|
+|Solvestat = 4 | Terminated by Solver|
+
+|Desirable Status in REMIND|
+|---|
+|Solve + Model stat = 1 + 2 | solution found|
+|Solve + Model stat = 4 + 7 | feasible but slow convergence|
+
+If infeasibilities show up already in the first iteration, it may be related to a wrong `input.gdx` (specified with `path_gdx` in the `scenario_config_XYZ.csv`) or some general error in the GAMS code. Via the international trade, infeasibilities in one region may propagate to other regions in later iterations, but then it is worth knowing where it started.
+
+If you find out that your run stopped specifically in iteration 14, you likely have a problem with the EDGE-T transport model. It runs iteratively with REMIND, but only after iteration 14. In your run folder, you can find the model script on [`EDGE_transport.R`](https://github.com/remindmodel/remind/blob/develop/scripts/iterative/EDGE_transport.R) and its input/output data in the `EDGE-T` subfolder. You should find an error message in `log.txt`. If this is not helpful, try opening that script in an interactive `R` session (on your run's folder) and run it line by line, you'll have a better idea of what the problem actually was. Forcing the model to redownload it's input data (see above) can help if something in either model changed when you created that folder.
+
+There are different types of solver infeasibilities: pre-triangular and optimization infeasibilities. In pre-triangular infeasibilities, GAMS shows you in the solution report the equations that are incompatible with each other. For optimization infeasibilies, the CONOPT solver tries to reduce the infeasibility to the thing that less affects the objective function. It does not show all affected equations, as it is not a simply problem as a non-square system of equations like in the pre-triangular case. You need to check if it is bound-related: the variables bounds, and the equation bounds starting from the infeasibility and going through the variables that have relation with it. You can always force in another run the variable that is infeasible to a feasible value to see what else is affected by it. But this is usually not necessary as just checking the logic behind the equation and the infeasible variable is usually sufficient to find the limitation.
+
+More information needed? debug runs
+--------------------------
+
+If you would like GAMS to print specific information, add a `display` statement as close to the solve statement as possible, i.e., in presolve, or right after the data is loaded in datainput, and use `Rscript start.R --reprepare` to regenerate the `full.gms` file and restart the model, or just change `full.gms` directly and rerun the folder directly.
+
+If this is not sufficient, you may start a "debug" run which is more generous in logging, but runs on one single node only instead of the parallel mode with one node per region. Therefore, they take a lot of time and the log files are substantially increased to GB of data.
+
+To restart a run in "debug" mode, run
+```bash
+Rscript start.R --debug --reprepare
+```
+in the REMIND main folder and select the runs to be restarted (the shortcut is `Rscript start.R -dR`). This will recreate move `full.gms` and `fulldata.gdx` to filenames with an appended `_old` and restart the input preparation and the model run.
+
+If you only want to look at a specific region that created the infeasibility, you can either specify `c_testOneRegi_region` in `scenario_config_XYZ.csv`:
+```bash
+Rscript start.R --debug --interactive --testOneRegi scenario_config_XYZ.csv
+```
+and you will be asked which region you want to look at (the shortcut is `Rscript start.R -di1` + the file name).
+
+If the error was not in the first iteration, a faster and more convenient way might be to start the run again in parallel mode with `c_keep_iteration_gdxes = 1` specified in `config/default.cfg` or the `scenario_config_XYZ.csv`. And then start a debug run that uses the `fulldata_07.gdx` (or the first iteration in which this occurs) of this first run as `input.gdx` specified in `path_gdx` of `scenario_config_XYZ.csv`. That way, you should see where the infeasibility is in the first iteration of the debug run already and not have to wait until the 7th iteration.
+
+If the iterations are not sufficient to converge, you can run REMIND for more iterations by modifying `cm_iteration_max` in [`80_optimization/nash/datainput.gms`](../modules/80_optimization/nash/datainput.gms) and the set iteration in [`core/sets.gms`](../core/sets.gms), which by default only goes to 200.
+
+If you want a closer look on the GAMS CONOPT output during a REMIND run, you can access the solver logs by moving to the output folder an running:
+
+```bash
+find -name gmsgrid.log | xargs tail -n 12
+```
+
+Only the first five columns are of particular interest:
+
+- `Iter`: CONOPT Iteration number
+- `Phase`: 0/1/2 means CONOPT is looking for a feasible solution, 3/4 means it's looking for an optimal solution
+- `Ninf`: if during phase 1/2, the number of infeasibilities
+- `Infeasibility/Objective`: The left hand side during search for a feasible solution, and the objective value during phase 3/4
+- `RGmax`: if during phase 1-2 the sum of infeasibilities, it should always converge to a very small value (< 10e-7). If during phase 3/4 the reduced gradient (when small you are close to optimality)
+- `NSB`: the number of superbasic variables (basically the current number of degrees of freedom)
+- `Step`: the ?x of the search algorithm
+- `InItr`: internal iterations
+- `MX`: `T` if the line search was terminated by a variable reaching a bound, `F` if the optimal step length was determined by nonlinearities
+- `OK`: `T` if the line search was well-behaved, `F` if the line search was terminated because it was not possible to find a feasible solution for large step lengths
+
+Asking for help
+----------------------------------
+
+In any case, don't hesitate to ask for help in [pik-piam/discussions](https://github.com/pik-piam/discussions). Please provide:
+
+- as much information on your run, such as the scenario config file and the run name
+- PIK cluster users should supply the path on the cluster
+- a summary of things you already checked or found out
+- information on what you changed in the REMIND GAMS code

--- a/tutorials/10_DebuggingREMIND.md
+++ b/tutorials/10_DebuggingREMIND.md
@@ -2,14 +2,14 @@ Debugging REMIND
 ================
 Collaborative effort, coordinated by Oliver Richters, 31 March, 2022
 
-When running and changing REMIND, a multitude of errors may occur. In such a collaborative effort, they need not have been created by you and the REMIND team will help you solve them. So an important part of debugging is to find out whether something your changes to the model created the error, or whether you were unfortunate enough to find errors you are not responsible for.
+When running and changing REMIND, a multitude of errors may occur. In such a collaborative effort, they need not have been created by you and the REMIND team will help you solve them. So an important part of debugging is to find out whether something you changed created the error, or whether you were unfortunate enough to find errors you are not responsible for.
 
 First, find out the state of your run by executing this in the run directory:
 ```bash
 Rscript -e "modelstats::loopRuns('.')"
 ```
-PIK cluster users can access all their runs in one go by executing `rs2 -c`.
-In case of errors, this tutorial if for you.
+PIK cluster users can access information on all their runs in all directories by executing `rs2 -c` (or `rs2 -a` for only active runs).
+In case of errors, this tutorial should help you.
 
 Case 1: REMIND did not start
 ----------------------------
@@ -17,9 +17,9 @@ Case 1: REMIND did not start
 The first place to look is `log.txt` in the output subfolder for each run. It shows you the log of running [`prepare_and_run.R`](https://github.com/remindmodel/remind/blob/develop/scripts/start/prepare_and_run.R). If it states "Starting REMIND..." somewhere, this shows that the input preparation scripts were successful. If not, this can be caused by the following reasons:
 
 - the model remains locked? start `vi .lock` in the REMIND folder and carefully delete (with `dd`, then save with `:w`) the lines of older runs that may still be present there because you killed these runs.
-- because of a locked folder in the R libraries, outdated packages were loaded: consider [creating a new snapshot](4_RunningREMINDandMAgPIE.md#create-snapshot-of-r-libraries)
-- input files are missing or outdated? delete `input/source_files.log` or set `cfg$force_download <- TRUE` to force the loading of new ones. If this doesn't help, the input generation may be broken
-- you use an outdated git branch? check `git log` or use main branch with `git checkout main/develop; git pull`
+- because of a locked folder in the R libraries, outdated packages were loaded: consider [creating a new snapshot](4_RunningREMINDandMAgPIE.md#create-snapshot-of-r-libraries).
+- input files are missing or outdated? delete `input/source_files.log` or set `cfg$force_download <- TRUE` to force the loading of new ones. If this doesn't help, the input generation may be broken.
+- you use an outdated git branch? check `git log` or use main branch with `git checkout main/develop; git pull`.
 - a recent change in `prepare_and_run` may have broken the prepare scripts, check the [file history](https://github.com/remindmodel/remind/commits/develop/scripts/start/prepare_and_run.R) for changes.
 
 Case 2: REMIND did produce an error
@@ -30,7 +30,7 @@ In this case, after "REMIND run finished!", you find a short "Model Summary", wh
   gams_runtime is 10.6 hours.
   full.gms exists, so the REMIND GAMS code was generated.
   full.log and full.lst exist, so GAMS did run.
-! abort.gdx exists, containing the latest GAMS data including changes after the last solve statement.
+! abort.gdx exists, containing the latest data at the point GAMS aborted execution.
   fulldata.gdx exists, so at least one iteration was successful.
   Number of iterations: 14
   Modelstat: 4
@@ -42,40 +42,55 @@ If full.gms does not exist, it is an error in the preparation script, not in GAM
 
 If full.log exists, this is the next place to look at. Either open it in your favorite text editor or use the console, change directory to the output subfolder and type:
 ```bash
-vi full.log
+less full.log
 ```
-and then type `G` to get to the end of the file. `:q` finishes looking at the file.
+and then type `G` to get to the end of the file. `q` finishes looking at the file.
+Another option is to use the editor `vi` by typing `vi full.log`, in which case `:q` closes the editor. `less` is generally faster when looking at large file, but doesn't offer color coding.
 
 You may find:
 
 ### Case 2a: compilation errors
 
-These are errors in the GAMS code. Run `gamscompile` in the REMIND folder to get more information and try to identify incorrect GAMS code.
-Tutorials such as as the [McCarl GAMS User Guide](https://www.gams.com/mccarlGuide/) may be helpful.
-
-### Case 2b: execution errors
-
-Have the next look at
+These are errors in the GAMS code. Have the next look at
 
 ```
-vi full.lst
+less full.lst
 ```
 Hit `G` to go to the end of the file and search backwards for errors whose lines start with four asterisks by typing:
 ```
-?^\*\*\*\*
+/^\*\*\*\*
 ```
-(If you add `map f /*\*\*\*<CR>` to your `/home/username/.vimrc` file, you can simply press `f`).
+(You can also use `vi full.lst`, and if you add `map f /*\*\*\*<CR>` to your `/home/username/.vimrc` file, you can simply press `f`).
 Going upwards to the next matches using `N`, you should eventually find an error message (`n` searches downwards).
+The error is indicated directly at the point in the code where it occurs.
+It is worth looking at the `.gms` file this equation is part of, by searching for `SOF` (start of file) and `EOF` (end of file) marks above and below the equation.
+For fixing this error, the [section on compilation errors in the McCarl GAMS Guide](https://www.gams.com/mccarlGuide/fixing_compilation_errors_1.htm) may be helpful.
 
-If it points to a specific line number where the error occured, mark this number, then type `?` and paste it into the editor which is then searching for this number, and typing `n` (eventually multiple times) should bring you to the source code part at the beginning of the file.
-You should now see the equation where the error was created. If you recently changed this equation, this may have caused the error. If not, it is worth looking at the `.gms` file this equation is part of, by searching for `SOF` (start of file) and `EOF` (end of file) marks above and below the equation. Then navigate to this file in github and see in the history whether it was recently changed, which may have caused this error.
+You can either fix the error directly in the corresponding REMIND model file, or in `full.gms` in the output folder.
+In the first case, the PIK cluster provides the command `gamscompile` that can be run in the REMIND folder to see whether the change fixes the compilation error.
+Then, you can recreate the `full.gms` with running
+```
+Rscript start.R --reprepare
+```
+and selecting the run with the error. If you fix the code in the `full.gms` file (and only later transfer it to the REMIND directory), you can restart the run without the prepare part by running
+```
+Rscript start.R --restart
+```
+
+### Case 2b: execution errors
+
+For execution errors, again try to identify the location of the error in the `full.lst` file.
+If it points to a specific line number where the error occured, mark this number, then type `/` and paste it into the editor which is then searching for this number, and typing `n` (eventually multiple times) should bring you to the source code part at the beginning of the file.
+You should now see the equation where the error was created. If you recently changed this equation, this may have caused the error.
+Again, tutorials such as as the [McCarl GAMS User Guide](https://www.gams.com/mccarlGuide/) may be helpful.
+If not, it is worth looking at the `.gms` file this equation is part of, by searching for `SOF` (start of file) and `EOF` (end of file) marks above and below the equation. Then navigate to this file in github and see in the history whether it was recently changed, which may have caused this error.
 But it is important that the error may have first appeared in this equation, but may have been caused somewhere else.
 
-The file `abort.gdx` contains the latest GAMS data including changes after the last solve statement.
+The file `abort.gdx` contains the latest data at the point GAMS aborted execution, which can be analysed using GAMS Studio.
 
 ### Case 2c: GDX or R file missing
 
-Try to find out where this file should have come from by searching within the REMIND repository. Again, having a look at `full.lst`, searching for the filename and looking for `SOF` and `EOF` may help
+Try to find out where this file should have come from by searching within the REMIND repository. Again, having a look at `full.lst`, searching for the filename and looking for `SOF` and `EOF` may help.
 
 
 Case 3: REMIND ran into infeasibilities
@@ -114,14 +129,14 @@ If infeasibilities show up already in the first iteration, it may be related to 
 
 If you find out that your run stopped specifically in iteration 14, you likely have a problem with the EDGE-T transport model. It runs iteratively with REMIND, but only after iteration 14. In your run folder, you can find the model script on [`EDGE_transport.R`](https://github.com/remindmodel/remind/blob/develop/scripts/iterative/EDGE_transport.R) and its input/output data in the `EDGE-T` subfolder. You should find an error message in `log.txt`. If this is not helpful, try opening that script in an interactive `R` session (on your run's folder) and run it line by line, you'll have a better idea of what the problem actually was. Forcing the model to redownload it's input data (see above) can help if something in either model changed when you created that folder.
 
-There are different types of solver infeasibilities: pre-triangular and optimization infeasibilities. In pre-triangular infeasibilities, GAMS shows you in the solution report the equations that are incompatible with each other. For optimization infeasibilies, the CONOPT solver tries to reduce the infeasibility to the thing that less affects the objective function. It does not show all affected equations, as it is not a simply problem as a non-square system of equations like in the pre-triangular case. You need to check if it is bound-related: the variables bounds, and the equation bounds starting from the infeasibility and going through the variables that have relation with it. You can always force in another run the variable that is infeasible to a feasible value to see what else is affected by it. But this is usually not necessary as just checking the logic behind the equation and the infeasible variable is usually sufficient to find the limitation.
+There are different types of solver infeasibilities: pre-triangular and optimization infeasibilities. In pre-triangular infeasibilities, GAMS shows you in the solution report the equations that are incompatible with each other. For optimization infeasibilies, the CONOPT solver tries to reduce the infeasibility to the thing that less affects the objective function. It does not show all affected equations, as it is not a simple problem as a non-square system of equations like in the pre-triangular case. You need to check if it is bound-related: the variables bounds, and the equation bounds starting from the infeasibility and going through the variables that have relation with it. You can always force in another run the variable that is infeasible to a feasible value to see what else is affected by it. But this is usually not necessary as just checking the logic behind the equation and the infeasible variable is usually sufficient to find the limitation.
 
 More information needed? debug runs
 --------------------------
 
-If you would like GAMS to print specific information, add a `display` statement as close to the solve statement as possible, i.e., in presolve, or right after the data is loaded in datainput, and use `Rscript start.R --reprepare` to regenerate the `full.gms` file and restart the model, or just change `full.gms` directly and rerun the folder directly.
+If you would like GAMS to print specific information, add a `display` statement as close to the solve statement as possible, i.e., in presolve, or right after the data is loaded in datainput, and use `Rscript start.R --reprepare` to regenerate the `full.gms` file and restart the model, or change `full.gms` directly and restart the folder with `Rscript start.R --restart`.
 
-If this is not sufficient, you may start a "debug" run which is more generous in logging, but runs on one single node only instead of the parallel mode with one node per region. Therefore, they take a lot of time and the log files are substantially increased to GB of data.
+If this is not sufficient, you may start a "debug" run which is more generous in logging. It runs on one single node only instead of the parallel mode with one node per region, which can take a lot of time.
 
 To restart a run in "debug" mode, run
 ```bash
@@ -134,29 +149,28 @@ If you only want to look at a specific region that created the infeasibility, yo
 Rscript start.R --debug --interactive --testOneRegi scenario_config_XYZ.csv
 ```
 and you will be asked which region you want to look at (the shortcut is `Rscript start.R -di1` + the file name).
+You can also run `Rscript start.R --reprepare --debug --testOneRegi` to get the results in the same output folder.
+Running `Rscript start.R --reprepare` a second time then resets the settings to the original ones.
 
 If the error was not in the first iteration, a faster and more convenient way might be to start the run again in parallel mode with `c_keep_iteration_gdxes = 1` specified in `config/default.cfg` or the `scenario_config_XYZ.csv`. And then start a debug run that uses the `fulldata_07.gdx` (or the first iteration in which this occurs) of this first run as `input.gdx` specified in `path_gdx` of `scenario_config_XYZ.csv`. That way, you should see where the infeasibility is in the first iteration of the debug run already and not have to wait until the 7th iteration.
 
 If the iterations are not sufficient to converge, you can run REMIND for more iterations by modifying `cm_iteration_max` in [`80_optimization/nash/datainput.gms`](../modules/80_optimization/nash/datainput.gms) and the set iteration in [`core/sets.gms`](../core/sets.gms), which by default only goes to 200.
 
-If you want a closer look on the GAMS CONOPT output during a REMIND run, you can access the solver logs by moving to the output folder an running:
+If you want a closer look on the GAMS CONOPT output during a REMIND run, you can access the solver logs by moving to the output folder and running:
 
 ```bash
 find -name gmsgrid.log | xargs tail -n 12
 ```
+Users of the PIK cluster can use `conoptspy` instead.
 
 Only the first five columns are of particular interest:
 
-- `Iter`: CONOPT Iteration number
-- `Phase`: 0/1/2 means CONOPT is looking for a feasible solution, 3/4 means it's looking for an optimal solution
-- `Ninf`: if during phase 1/2, the number of infeasibilities
-- `Infeasibility/Objective`: The left hand side during search for a feasible solution, and the objective value during phase 3/4
-- `RGmax`: if during phase 1-2 the sum of infeasibilities, it should always converge to a very small value (< 10e-7). If during phase 3/4 the reduced gradient (when small you are close to optimality)
-- `NSB`: the number of superbasic variables (basically the current number of degrees of freedom)
-- `Step`: the ?x of the search algorithm
-- `InItr`: internal iterations
-- `MX`: `T` if the line search was terminated by a variable reaching a bound, `F` if the optimal step length was determined by nonlinearities
-- `OK`: `T` if the line search was well-behaved, `F` if the line search was terminated because it was not possible to find a feasible solution for large step lengths
+- `Iter`: CONOPT Iteration number.
+- `Phase`: 0/1/2 means CONOPT is looking for a feasible solution, 3/4 means it's looking for an optimal solution.
+- `Ninf`: if during phase 1/2, the number of infeasibilities.
+- `Infeasibility/Objective`: The left hand side during search for a feasible solution, and the objective value during phase 3/4.
+- `RGmax`: if during phase 1-2 the sum of infeasibilities, it should always converge to a very small value (< 10e-7). If during phase 3/4 the reduced gradient (when small you are close to optimality).
+- `NSB`: the number of superbasic variables (basically the current number of degrees of freedom).
 
 Asking for help
 ----------------------------------


### PR DESCRIPTION
#### debugging tutorial
- add the debugging tutorial. It was a collaborative effort and I'm happy to name anyone who wants as co-authors, but sometimes I don't even know who contributed what. Would be happy if @0UmfHxcvx5J7JoaOhFSs5mncnisTJJ6q, @Renato-Rodrigues, @giannou, @LaviniaBaumstark and who ever wants have a look at it, as it certainly is far from perfect, but I can't improve it at the moment and I think it is better than nothing.
- Please comment also if `10_` is good, because this messes with the sorting within the github folder (1, 10, 2, 3…) or whether it should get a different number
- If you think some information is too much or not necessary, tell me, but I didn't want to delete input people provided, which I did only if someone else commented that it was wrong or outdated

#### minor log and start script improvements
- in `scripts/start/prepare_and_run.R`, add known `cfg` elements to `extras` to avoid warnings in particular for coupled runs, which is now possible because of [`gms` PR #14](https://github.com/pik-piam/gms/pull/14).
- add a `sed` that deletes the color codes from the `nashstat` results in the log
- in `start.R`, add the question which region `--testOneRegi` should look at, but only if `--interactive --testOneRegi` flags are provided, not for `--testOneRegi` alone