### PR TITLE
improve description of cm_iteration_max

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -738,7 +738,7 @@ cfg$gms$c_BaselineAgriEmiRed <- 0
 ############################################################
 
 #-------------------- switches ----------------------------------------------------
-# cm_iteration_max    "number of Negishi iterations"
+# cm_iteration_max    "number of iterations, if optimization is set to negishi or testOneRegi; used in nash mode only with cm_nash_autoconvergence = 0"
 # cm_abortOnConsecFail "number of iterations of consecutive failures of one region after which to abort"
 # c_solver_try_max      "maximum number of inner iterations within one Negishi iteration (<10)"
 #*** Careful: for each inner_itr_count, the size of remind.lst can increase by 50MB!

--- a/main.gms
+++ b/main.gms
@@ -221,7 +221,7 @@ $setGlobal codePerformance  off       !! def = off
 ***-----------------------------------------------------------------------------
 ***--------------- declaration of parameters for switches ----------------------
 parameters
-  cm_iteration_max          "number of Negishi iterations"
+  cm_iteration_max          "number of iterations, if optimization is set to negishi or testOneRegi; used in nash mode only with cm_nash_autoconvergence = 0"
   cm_abortOnConsecFail      "number of iterations of consecutive failures of one region after which to abort"
   c_solver_try_max          "maximum number of inner iterations within one Negishi iteration (<10)"
   c_keep_iteration_gdxes    "save intermediate iteration gdxes"

--- a/tutorials/3_RunningBundleOfRuns.md
+++ b/tutorials/3_RunningBundleOfRuns.md
@@ -62,7 +62,7 @@ Before you start the runs, you can test whether the right runs would be started 
 ```bash
 Rscript start.R --test config/scenario_config_XYZ.csv
 ```
-Running the complete chain of runs, but with only one iteration and one region each can be started with:
+Running the complete chain of runs, but only for one region and one iteration (as long as `cm_iteration_max = 1` wasn't changed), can be started with:
 ```bash
 Rscript start.R --testOneRegi config/scenario_config_XYZ.csv
 ```
@@ -79,8 +79,6 @@ as a shortcut, meaning `1` for `--testOneRegi`, `i` for `--interactive`, `t` for
 
 Further notes:
 --------------
-
-* To check the functioning of the `scenario_config*.csv`, edit [`default.cfg`](./config/default.cfg) and set `cfg$gms$optimization` to `testOneRegi` which runs one iteration in one region for each run.
 
 * The cells need not contain only a single value, but for example module realization [`47_regipol/regiCarbonPrice`](../modules/47_regipol/regiCarbonPrice) allows to specify in the parameter `cm_regiCO2target` to enter comma separated values `2020.2050.USA.year.netGHG 1, 2020.2050.EUR.year.netGHG 1` to specify emission goals for multiple regions.
 


### PR DESCRIPTION
- improve description of cm_iteration_max in default.cfg and main.gms
- warn about changing `cm_iteration_max` also in the tutorials
- the `further note` was redundant to the text above