### PR TITLE
let InitialCap model run only if cm_startyear is 2005, otherwise load from input_ref gdx file

### DIFF
--- a/modules/05_initialCap/on/declarations.gms
+++ b/modules/05_initialCap/on/declarations.gms
@@ -43,5 +43,9 @@ Scalars
   s05_aux_prod_remaining   "auxiliary calculation parameter for the capacities in different grades: production that still has to be distributed to a grade"
 ;
 
+File report_capini;            
+File check_INIdemEn0 / check_INIdemEn0.csv /; 
+
+
 *** EOF ./modules/05_initialCap/on/declarations.gms
 


### PR DESCRIPTION
This is done to avoid that InitialCap changes any capacity values in years before cm_startyear for subsequent runs based on a baseline run.

In the past, this has sometimes led to small infeasibilities in q_cap due to differences in the historic values of ``vm_deltaCap`` in input_ref.gdx and the output of InitialCap in particular for small regions. For an example, see: ``vm_deltaCap`` for ``2000.EWN.geohdr.1`` in ``/p/tmp/schreyer/Modeling/remind/ariadne/output/EWN_Bal_2022-05-04_09.14.49``. 

Update: Furthermore, this issue also leads to emissions factors being different across Base and follow-up runs as emissions factors are adapted in InitialCap. This leads to inconsistent emissions across runs. Compare ``pm_emifac``, for example, between ``fulldata.gdx`` and ``input_ref.gdx`` in

``/p/projects/remind/runs/REMIND_2022_05_02/remind/output/SSP2EU-NDC_2022-05-03_05.27.55``. 


I rearranged the code in InitialCap a bit for the if-clause. The model equations and model defintion are now on the top, while the model call and further calculations are below in an if-clause. 

Test runs (with 21 regions) you can find here:

Base: ``/p/tmp/schreyer/Modeling/remind/EU21_Tests/output/Base_2022-05-18_15.57.02``
Ref_gd40: ``/p/tmp/schreyer/Modeling/remind/EU21_Tests/output/Ref-gd40_2022-05-19_22.23.28``

