### PR TITLE
avoid that reporting is called with low memory

### DIFF
--- a/output.R
+++ b/output.R
@@ -137,8 +137,10 @@ choose_mode <- function(title = "Please choose the output mode") {
   return(comp)
 }
 
-choose_slurmConfig_priority_standby <- function(title = "Please enter the slurm mode, uses priority if empty") {
-  slurm_options <- c("--qos=priority", "--qos=short", "--qos=standby", "--qos=priority --mem=8000", "--qos=short --mem=8000",
+choose_slurmConfig_priority_standby <- function(high_mem = FALSE,
+                                                title = "Please enter the slurm mode, uses priority if empty") {
+  slurm_options <- c(if (! high_mem) c("--qos=priority", "--qos=short", "--qos=standby"),
+                     "--qos=priority --mem=8000", "--qos=short --mem=8000",
                      "--qos=standby --mem=8000", "--qos=priority --mem=32000", "direct")
   cat("\n\n", title, ":\n\n")
   cat(paste(seq_along(slurm_options), gsub("qos=", "", gsub("--", "", slurm_options)), sep = ": "), sep = "\n")
@@ -274,10 +276,12 @@ if (comp == TRUE) {
 
   # define slurm class or direct execution
   if (! exists("source_include")) {
+    modules_using_high_mem <- c("reporting")
+    need_high_mem <- isTRUE(any(modules_using_high_mem %in% output))
     # if this script is not being sourced by another script but called from the command line via Rscript let the user
     # choose the slurm options
     if (! exists("slurmConfig")) {
-      slurmConfig <- choose_slurmConfig_priority_standby()
+      slurmConfig <- choose_slurmConfig_priority_standby(high_mem = need_high_mem)
       if (slurmConfig != "direct") slurmConfig <- paste(slurmConfig, "--nodes=1 --tasks-per-node=1")
     }
     if (slurmConfig %in% c("priority", "short", "standby")) {


### PR DESCRIPTION
the normal output reporting cannot be run with the standard memory setting. After this PR, the low memory settings are not offered anymore, if `reporting` is selected.