### PR TITLE
Replace edgeTrpLib references with edgeTranport ones.

### DIFF
--- a/scripts/iterative/EDGE_transport.R
+++ b/scripts/iterative/EDGE_transport.R
@@ -17,7 +17,7 @@ opt = parse_args(opt_parser);
 library(data.table)
 library(gdx)
 library(gdxdt)
-library(edgeTrpLib)
+library(edgeTransport)
 require(devtools)
 library(rmndt)
 library(mrremind)

--- a/scripts/start/prepare_and_run.R
+++ b/scripts/start/prepare_and_run.R
@@ -225,7 +225,7 @@ prepare <- function() {
     right_join(
     # list all packages of interest here
         tribble(
-            ~Package, "data.table", "devtools", "dplyr", "edgeTrpLib",
+            ~Package, "data.table", "devtools", "dplyr", "edgeTransport",
             "flexdashboard", "gdx", "gdxdt", "gdxrrw", "ggplot2", "gtools",
             "lucode", "luplot", "luscale", "magclass", "magpie", "methods",
             "mip", "mrremind", "mrvalidation", "optparse", "parallel",


### PR DESCRIPTION
This is part of an effort to merge `edgeTrpLib` and `edgeTransport` to reduce the organizational overhead generated by the parallel development of two packages.