### PR TITLE
fix: Error in explain_modelstat[modelstat] : invalid subscript type 'list'

### DIFF
--- a/scripts/start/prepare_and_run.R
+++ b/scripts/start/prepare_and_run.R
@@ -995,7 +995,7 @@ run <- function(start_subsequent_runs = TRUE) {
 
   explain_modelstat <- c("1" = "Optimal", "2" = "Locally Optimal", "3" = "Unbounded", "4" = "Infeasible",
                          "5" = "Locally Infeasible", "6" = "Intermediate Infeasible", "7" = "Intermediate Nonoptimal")
-  modelstat <- NULL
+  modelstat <- numeric(0)
   stoprun <- FALSE
 
   # to facilitate debugging, look which files were created.


### PR DESCRIPTION
When using R version 4, prepare_and_run.R may result in "Error in explain_modelstat[modelstat] : invalid subscript type 'list'". 

This is due to a change in behavior of code like this: `x <- NULL; x[["asdf"]] <- 1`. In R v4, `x` is now a list. In R v3, `x` is a numeric vector. See https://cran.r-project.org/doc/manuals/r-devel/NEWS.html an search for `N <- NULL; N[[1]] <- val` to see this change mentioned in the offical R change log. 

This PR makes sure, that the variable `modelstat` is a numeric vector as intended and not a list - even in R v4.