### PR TITLE
RCP-dependent building demand

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -774,6 +774,7 @@ cfg$gms$c_BaselineAgriEmiRed <- 0
 #  (rcp45): RCP4.5
 #  (rcp60): RCP6.0
 #  (rcp85): RCP8.5
+# cm_rcp_scen_build     "chooses RCP scenario for demand in buildings (climate change impact)"
 # cm_NDC_version     "data version of nationally determined contributions (NDC) UNFCCC database"
 #  (2022_cond):   all NDCs conditional to international financial support
 #  (2022_uncond): all NDCs independent of international financial support

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -25,7 +25,7 @@ cfg$description <- "REMIND run with default settings"
 cfg$regionmapping <- "config/regionmappingH12.csv"
 
 #### Current input data revision (<mainrevision>.<subrevision>) ####
-cfg$inputRevision <- 6.306
+cfg$inputRevision <- 6.308
 
 #### Current CES parameter and GDX revision (commit hash) ####
 cfg$CESandGDXversion <- "d3f10023e6fb928f88cbaaafba220626ef0226c2"

--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -242,12 +242,11 @@ pm_ccsinjecrate(regi) = s_ccsinjecrate;
 
 *** OR: overwrite with regional values of ccs injection rate
 $ifThen.c_ccsinjecrateRegi not "%c_ccsinjecrateRegi%" == "off"
-  Parameter
-  p_extRegiccsinjecrateRegi(ext_regi) "Regional CCS injection rate factor. 1/a. (extended regions)" / %c_ccsinjecrateRegi% /;
-  loop((ext_regi)$p_extRegiccsinjecrateRegi(ext_regi),
-    pm_ccsinjecrate(regi)$(regi_group(ext_regi,regi)) = p_extRegiccsinjecrateRegi(ext_regi);
-  );
-  pm_ccsinjecrate(regi) = s_ccsinjecrate;
+Parameter p_extRegiccsinjecrateRegi(ext_regi) "Regional CCS injection rate factor. 1/a. (extended regions)" / %c_ccsinjecrateRegi% /;
+loop((ext_regi)$p_extRegiccsinjecrateRegi(ext_regi),
+  pm_ccsinjecrate(regi)$(regi_group(ext_regi,regi)) = p_extRegiccsinjecrateRegi(ext_regi);
+);
+pm_ccsinjecrate(regi) = s_ccsinjecrate;
 ;
 $endIf.c_ccsinjecrateRegi
 
@@ -1490,8 +1489,7 @@ pm_fedemand(tall,all_regi,in) = f_fedemand(tall,all_regi,"%cm_demScen%",in);
 
 *** RCP-dependent demands in buildings (climate impact)
 $ifthen.cm_rcp_scen_build NOT "%cm_rcp_scen_build%" == "none"
-Parameter
-f_fedemand_build(tall,all_regi,all_demScen,all_rcp_scen,all_in) "RCP-dependent final energy demand in buildings"
+Parameter f_fedemand_build(tall,all_regi,all_demScen,all_rcp_scen,all_in) "RCP-dependent final energy demand in buildings"
 /
 $ondelim
 $include "./core/input/f_fedemand_build.cs4r"

--- a/modules/36_buildings/services_putty/not_used.txt
+++ b/modules/36_buildings/services_putty/not_used.txt
@@ -16,4 +16,3 @@ cm_CESMkup_build,input,questionnaire
 vm_costCESMkup,input,questionnaire
 sm_trillion_2_non,input,questionnaire
 sm_TWa_2_kWh,input,questionnaire
-cm_rcp_scen_build

--- a/modules/36_buildings/services_with_capital/not_used.txt
+++ b/modules/36_buildings/services_with_capital/not_used.txt
@@ -21,4 +21,3 @@ cm_CESMkup_build,input,questionnaire
 vm_costCESMkup,input,questionnaire
 sm_trillion_2_non,input,questionnaire
 sm_TWa_2_kWh,input,questionnaire
-cm_rcp_scen_build

--- a/modules/36_buildings/simple/datainput.gms
+++ b/modules/36_buildings/simple/datainput.gms
@@ -44,14 +44,14 @@ p36_floorspace(ttot,regi) = p36_floorspace_scen(ttot,regi,"%cm_demScen%") * 1e-3
 
 *** UE demand for reporting
 Parameter
-f36_uedemand_build(tall,all_regi,all_demScen,all_in)   "useful energy demand in buildings"
+f36_uedemand_build(tall,all_regi,all_demScen,all_rcp_scen,all_in)   "useful energy demand in buildings"
 /
 $ondelim
 $include "./modules/36_buildings/simple/input/f36_uedemand_build.cs4r"
 $offdelim
 /
 ;
-p36_uedemand_build(ttot,regi,in) = f36_uedemand_build(ttot,regi,"%cm_demScen%",in);
+p36_uedemand_build(ttot,regi,in) = f36_uedemand_build(ttot,regi,"%cm_demScen%","%cm_rcp_scen_build%",in);
 
 $IFTHEN.cm_INNOPATHS_enb not "%cm_INNOPATHS_enb%" == "off" 
   pm_cesdata_sigma(ttot,"enb")$pm_cesdata_sigma(ttot,"enb") = pm_cesdata_sigma(ttot,"enb") * %cm_INNOPATHS_enb%;


### PR DESCRIPTION
This PR adds RCP-dependent building demands to REMIND. This allows to analyse climate change impacts on heating and cooling. For this, REMIND requires different Input data that comes with rev 6.308.
The default behavior remains unchanged and no climate change is assumed unless `cm_rcp_scen_build` is set to an alternative RCP scenario.