### PR TITLE
Update gas policy assumptions for China in 40_techpol/NDC and others

### DIFF
--- a/modules/40_techpol/NDC/datainput.gms
+++ b/modules/40_techpol/NDC/datainput.gms
@@ -54,9 +54,9 @@ p40_noncombust_acc_eff(t,"CHN",te)$(sameas(te,"spv") OR sameas(te,"csp") OR same
 p40_noncombust_acc_eff(t,"CHA",te)$(sameas(te,"spv") OR sameas(te,"csp") OR sameas(te,"wind") OR sameas(te,"windoff") OR sameas(te,"tnrs") OR sameas(te,"spv") OR sameas(te,"geohdr") OR sameas(te,"hydro")) = 0.38; !! substitution accounting for low-carbon electricity generation at coal efficiency of 38%
 *** lower bound on gas share in PE
 p40_PEgasBound("2020","CHN") = 0.08; 
-p40_PEgasBound(t,"CHN")$(t.val gt 2020) = min(0.08 + (t.val -2020) * 0.004	,0.1 - (t.val - 2030) * 0.004 ); !! rising to 10% in 2025 and 2030 and then declining to zero around 2050
+p40_PEgasBound(t,"CHN")$(t.val gt 2020) = min(0.08 + (t.val -2020) * 0.004	,0.1 - (t.val - 2030) * 0.005 ); !! rising to 10% in 2025 and 2030 and then declining to zero around 2050
 p40_PEgasBound("2020","CHA") = 0.08; 
-p40_PEgasBound(t,"CHA")$(t.val gt 2020) = min(0.08 + (t.val -2020) * 0.004	,0.1 - (t.val - 2030) * 0.004 ); !! rising to 10% in 2025 and 2030 and then declining to zero around 2050
+p40_PEgasBound(t,"CHA")$(t.val gt 2020) = min(0.08 + (t.val -2020) * 0.004	,0.1 - (t.val - 2030) * 0.005 ); !! rising to 10% in 2025 and 2030 and then declining to zero around 2050
 *** lower bound on low carbon share in PE
 p40_PElowcarbonBound("2020","CHN") = 0.15; 
 p40_PElowcarbonBound(t,"CHN")$(t.val ge 2030) = min(0.2 + (t.val -2030) * 0.004,0.75); !!Chinas INDC plus extrapolation, is mostly non-binding beyond 2035

--- a/modules/40_techpol/NDC/datainput.gms
+++ b/modules/40_techpol/NDC/datainput.gms
@@ -53,10 +53,10 @@ p40_FE_RenShare(tall,regi) = f40_FE_RenShare(tall,regi);  !! rescale unit from [
 p40_noncombust_acc_eff(t,"CHN",te)$(sameas(te,"spv") OR sameas(te,"csp") OR sameas(te,"wind") OR sameas(te,"windoff") OR sameas(te,"tnrs") OR sameas(te,"spv") OR sameas(te,"geohdr") OR sameas(te,"hydro")) = 0.38; !! substitution accounting for low-carbon electricity generation at coal efficiency of 38%
 p40_noncombust_acc_eff(t,"CHA",te)$(sameas(te,"spv") OR sameas(te,"csp") OR sameas(te,"wind") OR sameas(te,"windoff") OR sameas(te,"tnrs") OR sameas(te,"spv") OR sameas(te,"geohdr") OR sameas(te,"hydro")) = 0.38; !! substitution accounting for low-carbon electricity generation at coal efficiency of 38%
 *** lower bound on gas share in PE
-p40_PEgasBound("2020","CHN") = 0.1; 
-p40_PEgasBound(t,"CHN")$(t.val gt 2020) = min(0.1 + (t.val -2020) * 0.005	,0.2 - (t.val - 2040) * 0.005 ); !! rising to 20% in 2040 and then declining again, to allow for high LC shares (no bound on gas after 2080)
-p40_PEgasBound("2020","CHA") = 0.1; 
-p40_PEgasBound(t,"CHA")$(t.val gt 2020) = min(0.1 + (t.val -2020) * 0.005	,0.2 - (t.val - 2040) * 0.005 ); !! rising to 20% in 2040 and then declining again, to allow for high LC shares (no bound on gas after 2080)
+p40_PEgasBound("2020","CHN") = 0.08; 
+p40_PEgasBound(t,"CHN")$(t.val gt 2020) = min(0.08 + (t.val -2020) * 0.004	,0.1 - (t.val - 2030) * 0.004 ); !! rising to 10% in 2025 and 2030 and then declining to zero around 2050
+p40_PEgasBound("2020","CHA") = 0.08; 
+p40_PEgasBound(t,"CHA")$(t.val gt 2020) = min(0.08 + (t.val -2020) * 0.004	,0.1 - (t.val - 2030) * 0.004 ); !! rising to 10% in 2025 and 2030 and then declining to zero around 2050
 *** lower bound on low carbon share in PE
 p40_PElowcarbonBound("2020","CHN") = 0.15; 
 p40_PElowcarbonBound(t,"CHN")$(t.val ge 2030) = min(0.2 + (t.val -2030) * 0.004,0.75); !!Chinas INDC plus extrapolation, is mostly non-binding beyond 2035

--- a/modules/40_techpol/NDCplus/datainput.gms
+++ b/modules/40_techpol/NDCplus/datainput.gms
@@ -47,10 +47,10 @@ p40_FE_RenShare(tall,regi) = f40_FE_RenShare(tall,regi);  !! rescale unit from [
 p40_noncombust_acc_eff(t,"CHN",te)$(sameas(te,"spv") OR sameas(te,"csp") OR sameas(te,"wind") OR sameas(te,"windoff") OR sameas(te,"tnrs") OR sameas(te,"spv") OR sameas(te,"geohdr") OR sameas(te,"hydro")) = 0.38; !! substitution accounting for low-carbon electricity generation at coal efficiency of 38%
 p40_noncombust_acc_eff(t,"CHA",te)$(sameas(te,"spv") OR sameas(te,"csp") OR sameas(te,"wind") OR sameas(te,"windoff") OR sameas(te,"tnrs") OR sameas(te,"spv") OR sameas(te,"geohdr") OR sameas(te,"hydro")) = 0.38; !! substitution accounting for low-carbon electricity generation at coal efficiency of 38%
 *** lower bound on gas share in PE
-p40_PEgasBound("2020","CHN") = 0.1; 
-p40_PEgasBound(t,"CHN")$(t.val gt 2020) = min(0.1 + (t.val -2020) * 0.005	,0.2 - (t.val - 2040) * 0.005 ); !! rising to 20% in 2040 and then declining again, to allow for high LC shares (no bound on gas after 2080)
-p40_PEgasBound("2020","CHA") = 0.1; 
-p40_PEgasBound(t,"CHA")$(t.val gt 2020) = min(0.1 + (t.val -2020) * 0.005	,0.2 - (t.val - 2040) * 0.005 ); !! rising to 20% in 2040 and then declining again, to allow for high LC shares (no bound on gas after 2080)
+p40_PEgasBound("2020","CHN") = 0.08; 
+p40_PEgasBound(t,"CHN")$(t.val gt 2020) = min(0.08 + (t.val -2020) * 0.004	,0.1 - (t.val - 2030) * 0.005 ); !! rising to 10% in 2025 and 2030 and then declining to zero around 2050
+p40_PEgasBound("2020","CHA") = 0.08; 
+p40_PEgasBound(t,"CHA")$(t.val gt 2020) = min(0.08 + (t.val -2020) * 0.004	,0.1 - (t.val - 2030) * 0.005 ); !! rising to 10% in 2025 and 2030 and then declining to zero around 2050
 *** lower bound on low carbon share in PE
 p40_PElowcarbonBound("2020","CHN") = 0.15; 
 p40_PElowcarbonBound(t,"CHN")$(t.val ge 2030) = min(0.2 + (t.val -2030) * 0.004,0.75	); !!Chinas INDC plus extrapolation, is mostly non-binding beyond 2035

--- a/modules/40_techpol/NPi2018/datainput.gms
+++ b/modules/40_techpol/NPi2018/datainput.gms
@@ -38,10 +38,10 @@ p40_FE_RenShare(t,iso_regi)              = 0;
 p40_noncombust_acc_eff(t,"CHN",te)$(sameas(te,"spv") OR sameas(te,"csp") OR sameas(te,"wind") OR sameas(te,"windoff") OR sameas(te,"tnrs") OR sameas(te,"spv") OR sameas(te,"geohdr") OR sameas(te,"hydro")) = 0.38; !! substitution accounting for low-carbon electricity generation at coal efficiency of 38%
 p40_noncombust_acc_eff(t,"CHA",te)$(sameas(te,"spv") OR sameas(te,"csp") OR sameas(te,"wind") OR sameas(te,"windoff") OR sameas(te,"tnrs") OR sameas(te,"spv") OR sameas(te,"geohdr") OR sameas(te,"hydro")) = 0.38; !! substitution accounting for low-carbon electricity generation at coal efficiency of 38%
 *** lower bound on gas share in PE
-p40_PEgasBound("2020","CHN") = 0.1; 
-p40_PEgasBound(t,"CHN")$(t.val gt 2020) = min(0.1 ,0.1 - (t.val - 2050) * 0.005 ); !! 10% until 2050 and then declining again, to allow for high LC shares (no bound on gas after 2080)
-p40_PEgasBound("2020","CHA") = 0.1; 
-p40_PEgasBound(t,"CHA")$(t.val gt 2020) = min(0.1 ,0.1 - (t.val - 2050) * 0.005 ); !! 10% until 2050 and then declining again, to allow for high LC shares (no bound on gas after 2080)
+p40_PEgasBound("2020","CHN") = 0.08; 
+p40_PEgasBound(t,"CHN")$(t.val gt 2020) = min(0.08 ,0.08 - (t.val - 2030) * 0.005 ); !! 8% until 2030 and then declining again
+p40_PEgasBound("2020","CHA") = 0.08; 
+p40_PEgasBound(t,"CHA")$(t.val gt 2020) = min(0.08 ,0.08 - (t.val - 2030) * 0.005 ); !! 8% until 2030 and then declining again
 *** lower bound on low carbon share in PE
 p40_PElowcarbonBound("2020","CHN") = 0.15; 
 p40_PElowcarbonBound(t,"CHN")$(t.val ge 2030)=min(0.15 + (t.val -2030) * 0.00,0.75	); !!Chinas INDC plus extrapolation, is mostly non-binding beyond 2035


### PR DESCRIPTION
Update gas policy assumptions for China in NPi and NDC, and NDCplus, reducing the gas bridge in policy scenarios (as 40_techpol/NDC is typically activated in policy runs)
- 8% in 2020 achieves getting PE|Gas close to actual 2020 data
- an increasing trajectory towards 2025 (and plateauing at 10% until 2030) is in line with policy ambition
- decreasing values after 2030 allow for larger low-carbon penetration with increasing coal phase-out
- exact values can be debated and improved further, but this should be a good first-order improvement over the status quo