### PR TITLE
Save FE prices between iterations.

### DIFF
--- a/core/declarations.gms
+++ b/core/declarations.gms
@@ -214,9 +214,10 @@ pm_share_CCS_CCO2(ttot,all_regi)                      "share of stored CO2 from 
 pm_delta_histCap(tall,all_regi,all_te)                "parameter to store data of historic capacity additions [TW/yr]"
 
 * Fuel Prices
-pm_FEPrice(ttot,all_regi,all_enty,sector,emiMkt)      "parameter to capture all FE prices across sectors and markets (tr$2005/TWa)"
-pm_SEPrice(ttot,all_regi,all_enty)                    "parameter to capture all SE prices (tr$2005/TWa)"
-pm_PEPrice(ttot,all_regi,all_enty)                    "parameter to capture all PE prices (tr$2005/TWa)"
+pm_FEPrice(ttot,all_regi,all_enty,sector,emiMkt)                "parameter to capture all FE prices across sectors and markets (tr$2005/TWa)"
+pm_FEPrice_iter(iteration,ttot,all_regi,all_enty,sector,emiMkt) "parameter to capture all FE prices across sectors and markets (tr$2005/TWa) across iterations"
+pm_SEPrice(ttot,all_regi,all_enty)                              "parameter to capture all SE prices (tr$2005/TWa)"
+pm_PEPrice(ttot,all_regi,all_enty)                              "parameter to capture all PE prices (tr$2005/TWa)"
 
 pm_tau_fe_tax(ttot,all_regi,emi_sectors,all_enty)    "tax path for final energy"
 pm_tau_fe_sub(ttot,all_regi,emi_sectors,all_enty)    "subsidy path for final energy"

--- a/modules/80_optimization/nash/postsolve.gms
+++ b/modules/80_optimization/nash/postsolve.gms
@@ -190,6 +190,10 @@ if(s80_fadeoutPriceAnticipStartingPeriod ne 0,
 );
 display s80_fadeoutPriceAnticipStartingPeriod, sm_fadeoutPriceAnticip;
 
+*** Save FE prices in each iteration for easier monitoring
+pm_FEPrice_iter(iteration,t,regi,enty,sector,emiMkt) =
+  pm_FEPrice(t,regi,enty,sector,emiMkt);
+
 
 ***Decide, on whether to end iterating now. if any of the following criteria (contained in the set convMessage80(surplus,infes,nonopt)) is not met, s80_bool is set to 0, and the convergence process is NOT stopped
 ***reset some indicators

--- a/modules/80_optimization/negishi/not_used.txt
+++ b/modules/80_optimization/negishi/not_used.txt
@@ -59,3 +59,5 @@ pm_ESRTarget_dev_iter,          input,      ??
 pm_emiCurrentETS,               input,      ??
 cm_keep_presolve_gdxes,         switch,     not needed
 vm_capacityTradeBalance,        variable,   not implemented yet
+pm_FEPrice,                     parameter,  not needed
+pm_FEPrice_iter,                parameter,  not needed

--- a/modules/80_optimization/testOneRegi/postsolve.gms
+++ b/modules/80_optimization/testOneRegi/postsolve.gms
@@ -18,5 +18,9 @@ loop(trade$(NOT tradeSe(trade)),
     );
 );
 
+*** Save FE prices in each iteration for easier monitoring
+pm_FEPrice_iter(iteration,t,regi,enty,sector,emiMkt) =
+  pm_FEPrice(t,regi,enty,sector,emiMkt);
+
 *-----------------------------------------------------------------------------------------------
 *** EOF ./modules/80_optimization/testOneRegi/postsolve.gms


### PR DESCRIPTION
The new parameter `pm_FEPrice_iter` saves the values of `pm_FEPrice` between each iteration to allow for easier monitoring. This should help developing price targets.