### PR TITLE
fix R4.0 error that starts subsequent coupled runs with 1 CPU

### DIFF
--- a/start.R
+++ b/start.R
@@ -297,6 +297,9 @@ modeltestRunsUsed <- 0
 
 testOneRegi_region <- ""
 
+# Save whether model is locked before runs are started
+model_was_locked <- file.exists(".lock")
+
 # Restart REMIND in existing results folder (if required by user)
 if (any(c("--reprepare", "--restart") %in% argv)) {
   # choose results folder from list
@@ -344,6 +347,7 @@ if (any(c("--reprepare", "--restart") %in% argv)) {
     cfg$remind_folder <- getwd()                      # overwrite remind_folder: run to be restarted may have been moved from other repository
     cfg$results_folder <- paste0("output/",outputdir) # overwrite results_folder in cfg with name of the folder the user wants to restart, because user might have renamed the folder before restarting
     save(cfg,file=paste0("output/",outputdir,"/config.Rdata"))
+    startedRuns <- startedRuns + 1
     if (! '--test' %in% argv) {
       submit(cfg, restart = TRUE)
     } else {
@@ -433,9 +437,6 @@ if (any(c("--reprepare", "--restart") %in% argv)) {
       message("\nYour slurmConfig selection will overwrite the settings in your scenario_config file.")
     }
   }
-
-  # Save whether model is locked before runs are started
-  model_was_locked <- if (file.exists(".lock")) TRUE else FALSE
 
   # Modify and save cfg for all runs
   for (scen in rownames(scenarios)) {

--- a/start_coupled.R
+++ b/start_coupled.R
@@ -313,7 +313,7 @@ start_coupled <- function(path_remind, path_magpie, cfg_rem, cfg_mag, runname, m
         # for the sbatch command set the number of tasks per node
         if (subseq.env$cfg_rem$gms$optimization == "nash" && subseq.env$cfg_rem$gms$cm_nash_mode == "parallel") {
           # for nash: set the number of CPUs per node to number of regions + 1
-          nr_of_regions <- length(levels(read.csv2(subseq.env$cfg_rem$regionmapping)$RegionCode)) + 1
+          nr_of_regions <- length(unique(read.csv2(subseq.env$cfg_rem$regionmapping)$RegionCode)) + 1
         } else {
           # for negishi: use only one CPU
           nr_of_regions <- 1


### PR DESCRIPTION
because strings are not read as factors anymore, `levels` returns `0` and the expression evaluates to `1` :(

also, fix that the model lock message and the counting of runs also works for restarting runs.