### PR TITLE
bugfixes in cs2 start scripts for coupled runs

### DIFF
--- a/start_bundle_coupled.R
+++ b/start_bundle_coupled.R
@@ -553,12 +553,12 @@ for(scen in common){
 if (! "--test" %in% argv) {
  system(paste0("cp ", path_remind, ".Rprofile ", path_magpie, ".Rprofile"))
  message("\nCopied REMIND .Rprofile to MAgPIE folder.")
-  cs_runs <- paste0(common, "-rem-", max_iterations, collapse = ",")
+  cs_runs <- paste0("output/", common, "-rem-", max_iterations, collapse = ",")
   cs_name <- paste0("compScen-all-rem-", max_iterations)
   cs_qos <- if (! isFALSE(run_compareScenarios)) run_compareScenarios else "short"
   cs_command <- paste0("sbatch --qos=", cs_qos, " --job-name=", cs_name, " --output=", cs_name, ".out --error=",
     cs_name, ".out --mail-type=END --time=60 --wrap='Rscript scripts/utils/run_compareScenarios2.R outputdirs=",
-    paste(cs_runs, collapse=","), " shortTerm=FALSE outfilename=", cs_name,
+    cs_runs, " shortTerm=FALSE outfilename=", cs_name,
     " regionList=World,LAM,OAS,SSA,EUR,NEU,MEA,REF,CAZ,CHA,IND,JPN,USA mainRegName=World'")
   message("\n### To start a compareScenario once everything is finished, run:")
   message(cs_command)

--- a/start_coupled.R
+++ b/start_coupled.R
@@ -397,7 +397,7 @@ start_coupled <- function(path_remind, path_magpie, cfg_rem, cfg_mag, runname, m
         message(cs_command)
         system(cs_command)
       } else {
-        message("### Coupling ### If you want a compareScenario with prefix ", cs_prefix, ", run:")
+        message("### Coupling ### If you want a compareScenario with name ", cs_name, ", run:")
         message(cs_command)
       }
     }


### PR DESCRIPTION
add "output" to folders and cs_prefix is not defined anymore, replace by cs_name in the message