### PR TITLE
new CES parameters and gdx files for SDP_EI, SDP_RC, SSP1, SSP2EU, SS…

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -25,10 +25,10 @@ cfg$description <- "REMIND run with default settings"
 cfg$regionmapping <- "config/regionmappingH12.csv"
 
 #### Current input data revision (<mainrevision>.<subrevision>) ####
-cfg$inputRevision <- 6.308
+cfg$inputRevision <- 6.309
 
 #### Current CES parameter and GDX revision (commit hash) ####
-cfg$CESandGDXversion <- "71393826a384e7e709ed98550fca78574be2b574"
+cfg$CESandGDXversion <- "b3fe4f454f63be6f807412babaf2d7dae02a603a"
 
 #### Force the model to download new input data ####
 cfg$force_download <- FALSE


### PR DESCRIPTION
…P2EU_lowEn, SSP5 for input data 6.309

# Purpose of this PR

## Checklist:
* updated in code documentation
* adjusted reporting if needed
* checked that REMIND still compiles
