### PR TITLE
Store the full EDGE-T vintages file for the new reporting

### DIFF
--- a/scripts/iterative/EDGE_transport.R
+++ b/scripts/iterative/EDGE_transport.R
@@ -231,8 +231,7 @@ intensity <- shares_int_dem[["demandI"]] ##in million pkm/EJ
 norm_demand <- shares_int_dem[["demandF_plot_pkm"]] ## totla demand normalized to 1; if opt$reporting, in million km
 
 if (opt$reporting) {
-  saveRDS(vintages[["vintcomp"]], file = datapath("vintcomp.RDS"))
-  saveRDS(vintages[["newcomp"]], file = datapath("newcomp.RDS"))
+  saveRDS(vintages, file = datapath("vintages.RDS"))
   saveRDS(shares, file = datapath("shares.RDS"))
   saveRDS(logit_data$EF_shares, file = datapath("EF_shares.RDS"))
   saveRDS(logit_data$mj_km_data, file = datapath("mj_km_data.RDS"))
@@ -245,6 +244,9 @@ if (opt$reporting) {
   saveRDS(logit_params, file = datapath("logit_params.RDS"))
   saveRDS(logit_data, file = datapath("logit_data.RDS"))
 
+  ## the following vintages calculation is deprecated and shall not be updated!
+  ## as soon as the new reporting (edgeTransport::reportEDGETransport2) is used,
+  ## this can be deleted.
   vint <- vintages[["vintcomp_startyear"]]
   newd <- vintages[["newcomp"]]
   sharesVS1 <- shares[["VS1_shares"]]


### PR DESCRIPTION
# Purpose of this PR

the new EDGE-T reporting (`edgeTransport::reportEDGETransport2`) will use the full vintages file `vintages.RDS` to calculate, e.g., stock and sales data.
The large CSV file `vintcomp.csv` that currently contains the vintages data can then be removed from the output folder.

## Checklist:
* updated in code documentation
does not apply
* adjusted reporting if needed:
checked, the files which are removed from the output are not used in the reporting
* checked that REMIND still compiles
does not affect REMIND
