### PR TITLE
initialize modelHistExclude for backward compatibility

### DIFF
--- a/scripts/utils/run_compareScenarios2.R
+++ b/scripts/utils/run_compareScenarios2.R
@@ -8,6 +8,7 @@ library(lucode2) # getScenNames
 library(remind2)
 
 if (!exists("source_include")) {
+  modelHistExclude <- c()
   readArgs("outputdirs", "shortTerm", "outfilename", "regionList", "mainRegName", "modelsHistExclude")
 }
 


### PR DESCRIPTION
## Purpose of this PR

#846 added modelHistExclude as an option, but if the script is called without it, it breaks. Initialize it to an empty vector for backward compatibility, it is overwritten if it is specified

## Checklist:
* no update in code documentation
* no adjusted reporting
* checked that REMIND still compiles
