### PR TITLE
Reactivate global couple products for CHP technologies

### DIFF
--- a/modules/04_PE_FE_parameters/iea2014/datainput.gms
+++ b/modules/04_PE_FE_parameters/iea2014/datainput.gms
@@ -236,11 +236,11 @@ loop(pc2te(enty,enty2,te,enty3),
 display pm_prodCouple;
 
 *** define global values for couple production that can be used if the regional IEA data are 0
-***p04_prodCoupleGlob("pecoal","seel","coalchp","sehe")        = 0.61;
-***p04_prodCoupleGlob("pegas","seel","gaschp","sehe")          = 0.42;
+p04_prodCoupleGlob("pecoal","seel","coalchp","sehe")        = 0.61;
+p04_prodCoupleGlob("pegas","seel","gaschp","sehe")          = 0.42;
 p04_prodCoupleGlob("pecoal","seh2","coalh2","seel")         = 0.081;
 p04_prodCoupleGlob("pecoal","seh2","coalh2c","seel")        = 0.054;
-***p04_prodCoupleGlob("pebiolc","seel","biochp","sehe")        = 0.72;
+p04_prodCoupleGlob("pebiolc","seel","biochp","sehe")        = 0.72;
 p04_prodCoupleGlob("pebiolc","seliqbio","bioftrec","seel")  = 0.147; !! from Liu et al. 2011 (Making Fischer-Tropsch Fuels and Electricity from Coal and Biomass: Performance and Cost Analysis)
 p04_prodCoupleGlob("pebiolc","seliqbio","bioftcrec","seel") = 0.108; !! from Liu et al. 2011 (Making Fischer-Tropsch Fuels and Electricity from Coal and Biomass: Performance and Cost Analysis)
 p04_prodCoupleGlob("pebiolc","seliqbio","bioethl","seel")   = 0.153;


### PR DESCRIPTION
# Purpose of this PR
This PR reactivates the global fallback values for couple product (heat) conversion efficiencies of CHP technologies. Due to inconsistencies in the input data REMIND was infeasible for historic time steps, when some in regions CHP technologies produced heat as a secondary product, so as a quick fix the coupling products were disabled. [This bugfix](https://github.com/pik-piam/mrremind/pull/272) in mrremind corrects the inconsistencies. 

The new corrected input data also has the effect that now in all regions for all CHP technologies a region-specific couple product efficiency can be derived. Therefore reactivating the global fallback values (that will only become active if no region-specific value is available) will have no effect at the moment. However, since input data may change again, we nevertheless activate the global fallback values.

## Type of change

- [x] Bug fix 


## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [x] Changes are commented, particularly in hard-to-understand areas (not applicable)
- [x] I have updated the in-code documentation (not applicable)
- [x] I have adjusted reporting where it was needed (not applicable)
- [x] The model compiles and starts successfully




