### PR TITLE
make --quick compatible with --restart

### DIFF
--- a/start.R
+++ b/start.R
@@ -28,17 +28,22 @@ helpText <- "
 #'
 #' --debug, -d: start a debug run with cm_nash_mode = debug
 #'
-#' --interactive, -i: interactively select run(s) to be started
+#' --interactive, -i: interactively select config file and run(s) to be started
+#'
+#' --quick, -q: starting one fast REMIND run with one region, one iteration and
+#'              reduced convergence criteria for testing the full model.
 #'
 #' --reprepare, -R: rewrite full.gms and restart run
 #'
 #' --restart, -r: interactively restart run(s)
 #'
-#' --test, -t: Test configuration
+#' --test, -t: Test scenario configuration and writing the RData files in the
+#'             REMIND main folder without starting the runs.
 #'
 #' --testOneRegi, -1: starting the REMIND run(s) in testOneRegi mode
 #'
-#' --quick, -q: starting one fast REMIND run for testing the full model.
+#' You can combine --reprepare with --debug, --testOneRegi or --quick and the selected folders will be restarted using these settings.
+#' Afterwards, using --reprepare alone will restart the runs using their original settings.
 "
 source("scripts/start/submit.R")
 source("scripts/start/choose_slurmConfig.R")
@@ -292,8 +297,8 @@ if ("--help" %in% argv) {
   q()
 }
 
-if (any(c("--testOneRegi", "--debug") %in% argv) & "--restart" %in% argv & ! "--reprepare" %in% argv) {
-  message("\nIt is impossible to combine --restart with --testOneRegi or --debug because full.gms has to be rewritten.\n",
+if (any(c("--testOneRegi", "--debug", "--quick") %in% argv) & "--restart" %in% argv & ! "--reprepare" %in% argv) {
+  message("\nIt is impossible to combine --restart with --debug, --quick or --testOneRegi because full.gms has to be rewritten.\n",
   "If this is what you want, use --reprepare instead, or answer with y:")
   if (get_line() %in% c("Y", "y")) argv <- c(argv, "--reprepare")
 }
@@ -331,18 +336,26 @@ if (any(c("--reprepare", "--restart") %in% argv)) {
     message("Restarting ", outputdir)
     load(paste0("output/", outputdir, "/config.Rdata")) # read config.Rdata from results folder
     cfg$restart_subsequent_runs <- restart_subsequent_runs
+    # for debug, testOneRegi, quick: save original settings to cfg$backup; restore them from there if not set.
     if ("--debug" %in% argv) {
       if (is.null(cfg[["backup"]][["cm_nash_mode"]])) cfg$backup$cm_nash_mode <- cfg$gms$cm_nash_mode
       cfg$gms$cm_nash_mode <- "debug"
     } else {
       if (! is.null(cfg[["backup"]][["cm_nash_mode"]])) cfg$gms$cm_nash_mode <- cfg$backup$cm_nash_mode
     }
+    cfg$gms$cm_quick_mode <- if ("--quick" %in% argv) "on" else "off"
     if (any(c("--quick", "--testOneRegi") %in% argv)) {
       if (is.null(cfg[["backup"]][["optimization"]])) cfg$backup$optimization <- cfg$gms$optimization
       cfg$gms$optimization <- "testOneRegi"
       if (testOneRegi_region != "") cfg$gms$c_testOneRegi_region <- testOneRegi_region
     } else {
       if (! is.null(cfg[["backup"]][["optimization"]])) cfg$gms$optimization <- cfg$backup$optimization
+    }
+    if ("--quick" %in% argv) {
+      if (is.null(cfg[["backup"]][["cm_iteration_max"]])) cfg$backup$cm_iteration_max <- cfg$gms$cm_iteration_max
+      cfg$gms$cm_iteration_max <- 1
+    } else {
+      if (! is.null(cfg[["backup"]][["cm_iteration_max"]])) cfg$gms$cm_iteration_max <- cfg$backup$cm_iteration_max
     }
     if ("--reprepare" %in% argv & ! "--test" %in% argv) {
       try(system(paste0("mv output/", outputdir, "/full.gms output/", outputdir, "/full_old.gms")))


### PR DESCRIPTION
## Purpose of this PR

Small fix to #875, allowing to combine --quick with --reprepare. Sort and expand start.R help text

## Type of change

- New start feature 

## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [x] Changes are commented, particularly in hard-to-understand areas
- [x] I have updated the in-code documentation
- no adjusted reporting needed
- [x] The model compiles and runs successfully (`Rscript start.R -q`)

## Tests

Take a testOneRegi run and rerun using `./start.R -rq`: the scripts asks to move to `--reprepare` as desired, then runs it in quick setting successfully. With `./start.R -R` and selecting the run, I get the normal testOneRegi back with `cfg$gms$cm_quick_mode = off`.