### PR TITLE
in output.R put direct slurm option as last, correct inconsistent message

### DIFF
--- a/output.R
+++ b/output.R
@@ -139,13 +139,13 @@ choose_mode <- function(title = "Please choose the output mode") {
   return(comp)
 }
 
-choose_slurmConfig_priority_standby <- function(title = "Please enter the slurm mode, uses priority if empty",
+choose_slurmConfig_priority_standby <- function(title = "Please enter the slurm mode, uses the first option if empty",
                                                 slurmExceptions = NULL) {
   slurm_options <- c("--qos=priority", "--qos=short", "--qos=standby",
                      "--qos=priority --mem=8000", "--qos=short --mem=8000",
                      "--qos=standby --mem=8000", "--qos=priority --mem=32000", "direct")
   if (!is.null(slurmExceptions)) {
-    slurm_options <- unique(c("direct", grep(slurmExceptions, slurm_options, value = TRUE)))
+    slurm_options <- unique(c(grep(slurmExceptions, slurm_options, value = TRUE), "direct"))
   }
   if (length(slurm_options) == 1) return(slurm_options[[1]])
   cat("\n\n", title, ":\n\n")


### PR DESCRIPTION
output.R was telling you that priority was used if left empty, when in reality the first option was used which was direct. Therefore: direct back to last option and state that the first is used.

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [x] checked that output.R works