### PR TITLE
overwrite mif file with new policyCosts, provide information whether mif/gdx files exist

### DIFF
--- a/output.R
+++ b/output.R
@@ -340,16 +340,15 @@ if (comp == "Exit") {
     # included as source (instead of a load from command line)
     source_include <- TRUE
 
-    message("\nStarting output generation for ", outputdir, "\n")
-
     ###################################################################################
     # Execute R scripts
     ###################################################################################
 
     # output creation for --testOneRegi was switched off in start.R in this commit: https://github.com/remindmodel/remind/commit/5905d9dd814b4e4a62738d282bf1815e6029c965
     if (all(is.na(output))) {
-      message("No output generation, as output was set to NA, as for example for --testOneRegi.")
+      message("\nNo output generation, as output was set to NA, as for example for --testOneRegi or --quick.")
     } else {
+      message("\nStarting output generation for ", outputdir, "\n")
       for (rout in output) {
         name <- paste(rout, ".R", sep = "")
         if (file.exists(paste0("scripts/output/single/", name))) {

--- a/scripts/output/comparison/policyCosts.R
+++ b/scripts/output/comparison/policyCosts.R
@@ -120,9 +120,9 @@ write_new_reporting <- function(mif_path,
                                 scen_name,
                                 new_polCost_data) {
 
-  new_mif_path <- paste0(substr(mif_path,1,nchar(mif_path)-4),"_adjustedPolicyCosts.mif")
+  new_mif_path <- mif_path # paste0(substr(mif_path,1,nchar(mif_path)-4),"_adjustedPolicyCosts.mif")
 
-  message("A mif file with the name ", crayon::green(paste0("REMIND_generic_",scen_name,"_adjustedPolicyCosts.mif"))," is being created in the ",scen_name," output folder.")
+  message("The mif file '", crayon::green(new_mif_path), "' is overwritten in the ",scen_name," output folder.")
 
   my_data <- magclass::read.report(mif_path)
   my_variables <- grep("Policy Cost", magclass::getNames(my_data[[1]][[1]]), value = TRUE, invert = T)
@@ -132,8 +132,8 @@ write_new_reporting <- function(mif_path,
   magclass::getSets(new_polCost_data)[3] <- "variable"
 
   my_data <- magclass::mbind(my_data[[1]][[1]][,,my_variables], new_polCost_data)
-  my_data <- magclass::add_dimension(my_data,dim=3.1,add = "model",nm = "REMIND")
-  my_data <- magclass::add_dimension(my_data,dim=3.1,add = "scenario",nm = scen_name)
+  my_data <- magclass::add_dimension(my_data, dim=3.1, add = "model", nm = "REMIND")
+  my_data <- magclass::add_dimension(my_data, dim=3.1, add = "scenario", nm = scen_name)
 
   magclass::write.report(my_data, file = new_mif_path, ndigit = 7)
 
@@ -152,7 +152,7 @@ report_transfers <- function(pol_mif, ref_mif) {
   sc <- magclass::getItems(pol_run,3.1)
 
   # Tell the user what's going on
-  message("Adding ",crayon::green("transfers")," to REMIND_generic_",sc,"_adjustedPolicyCosts.mif")
+  message("Adding ", crayon::green("transfers")," to mif file")
 
 
   # Get gdploss 
@@ -223,9 +223,8 @@ if (!exists("source_include")) {
                   "base_noEffChange_2020-03-09_17.16.28/")
   special_requests <- c("2")
   # Make over-writable from command line
-  lucode2::readArgs("outputdirs","special_requests")
+  lucode2::readArgs("outputdirs", "special_requests")
 }
-
 
 
 # Go into a while loop, until the user is happy with his input, or gives up and exits
@@ -254,14 +253,17 @@ while (!happy_with_input) {
   # Get run names
   pol_names <- rm_timestamp(basename(dirname(pol_gdxs)))
   ref_names <- rm_timestamp(basename(dirname(ref_gdxs)))
+  pol_mifs <- paste0(dirname(pol_gdxs), "/REMIND_generic_", pol_names, ".mif")
 
   # Define pol-ref, policyCost pair names
-  pc_pairs <- paste0(crayon::green(pol_names), " w.r.t. ", crayon::green(ref_names))
+  pc_pairs <- paste0(ifelse(file.exists(pol_mifs) & file.exists(pol_gdxs), crayon::green(pol_names), crayon::red(pol_names)),
+                     " w.r.t. ", ifelse(file.exists(ref_gdxs), crayon::green(ref_names), crayon::red(ref_names)))
 
   # If this script was called from output.R, check with user if the pol-ref pairs
   # are the ones she wanted. 
   if(exists("source_include")) {
-    message(crayon::blue("\nPlease confirm the set-up:"))
+    message(crayon::blue("\nPlease confirm the set-up."))
+    if (! all(file.exists(c(pol_mifs, pol_gdxs, ref_gdxs)))) message(crayon::red("Red"), " folder names have no fitting mif or gdx file, first run the reporting.")
     message("From the order with which you selected the directories, the following policy costs will be computed:")
     message(paste0("\t", pc_pairs, "\n"))
     message("Is that what you intended?")
@@ -317,7 +319,6 @@ message(crayon::green("Done!"))
 # Create "adjustedPolicyCost" reporting file
 if (!"1" %in% special_requests) {
   message(crayon::blue("\nCreating new reportings:\n"))
-  pol_mifs <- paste0(dirname(pol_gdxs), "/REMIND_generic_", pol_names, ".mif")
   new_reporting_files <- mapply(write_new_reporting, pol_mifs, pol_names, tmp_policy_costs_magpie)
   message(crayon::green("Done!"))
 }
@@ -327,7 +328,7 @@ if (!"1" %in% special_requests) {
 if ("2" %in% special_requests && !"1" %in% special_requests) {
   message(crayon::blue("\nComputing transfers:"))
   ref_mifs <- paste0(dirname(ref_gdxs), "/REMIND_generic_", ref_names, ".mif")
-  transfer_info <- mapply(report_transfers, new_reporting_files, ref_mifs, SIMPLIFY = F)
+  transfer_info <- mapply(report_transfers, new_reporting_files, ref_mifs, SIMPLIFY = FALSE)
   message(crayon::green("Done!"))
 }
 
@@ -338,7 +339,7 @@ if (!"3" %in% special_requests) {
   
   # Add transfers, if they exist
   if (exists("transfer_info")) {
-    tmp_policy_costs_magpie <- mapply(magclass::mbind, tmp_policy_costs_magpie, transfer_info, SIMPLIFY = F)
+    tmp_policy_costs_magpie <- mapply(magclass::mbind, tmp_policy_costs_magpie, transfer_info, SIMPLIFY = FALSE)
   }
   
   tmp_policy_costs <- tmp_policy_costs_magpie %>% 

--- a/scripts/output/export/xlsx_IIASA.R
+++ b/scripts/output/export/xlsx_IIASA.R
@@ -55,7 +55,7 @@ temporarydelete <- NULL # c("Price|Agriculture|Corn|Index", "Price|Agriculture|N
 if (! exists("project")) {
   project <- FALSE
 } else {
-  message("# Overwriting settings with project settings for '", project, ".")
+  message("# Overwriting settings with project settings for '", project, "'.")
   if ("NGFS" %in% project) {
     MODEL <- "REMIND-MAgPIE 3.0-4.4"
     MAPPING <- "mapping_r30m44_AR6NGFS.csv"


### PR DESCRIPTION
## Purpose of this PR

- instead of writing a new  `_adjustedPolicyCosts.mif`, overwrite the usual file, making post-processing easier. Also improve used feedback with coloring dependent on whether the mif/gdx files exist. Helpful if the script is called via command line…
- don't let output.R write "starting output generation" if there is no output to generate (testOneRegi, quick mode)

## Type of change

- [x] faciliate post-processing
- [x] better user communication

## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [x] I tested the script and it runs successfully