### PR TITLE
fix 8326783; use ref instead of bau gdx to get baseline industry solids use

### DIFF
--- a/modules/37_industry/subsectors/datainput.gms
+++ b/modules/37_industry/subsectors/datainput.gms
@@ -344,7 +344,7 @@ $endif.sec_steel_scen
 
 *' load baseline industry ETS solids demand
 if (cm_emiscen ne 1,   !! not a BAU scenario
-execute_load "input_bau.gdx", vm_demFEsector;
+execute_load "input_ref.gdx", vm_demFEsector;
   p37_BAU_industry_ETS_solids(t,regi)
   = sum(se2fe(entySE,"fesos",te),
       vm_demFEsector.l(t,regi,entySE,"fesos","indst","ETS")


### PR DESCRIPTION
- [x] Bug fix 

- [x] My code follows the coding etiquette
- [ ] I have performed a self-review of my own code
- [x] Changes are commented, particularly in hard-to-understand areas
- [ ] I have updated the in-code documentation
- [x] I have adjusted reporting where it was needed
- [x] The model compiles and runs successfully (`Rscript start.R -q`)