### PR TITLE
Fix MEA infeasibilities in calibration runs (and other similar problems)

### DIFF
--- a/scripts/start/prepare_and_run.R
+++ b/scripts/start/prepare_and_run.R
@@ -894,7 +894,7 @@ run <- function(start_subsequent_runs = TRUE) {
   if (cfg$gms$CES_parameters == "load") {
 
     system(paste0(cfg$gamsv, " full.gms -errmsg=1 -a=", cfg$action,
-                  " -ps=0 -pw=185 -pc=2 -gdxcompress=1 -logoption=", cfg$logoption))
+                  " -ps=0 -pw=185 -pc=2 -gdxcompress=1 -holdFixedAsync=1 -logoption=", cfg$logoption))
 
   } else if (cfg$gms$CES_parameters == "calibrate") {
 
@@ -913,7 +913,7 @@ run <- function(start_subsequent_runs = TRUE) {
                     "\\).*/\\1", cal_itr, "/' full.gms"))
 
       system(paste0(cfg$gamsv, " full.gms -errmsg=1 -a=", cfg$action,
-                    " -ps=0 -pw=185 -pc=2 -gdxcompress=1 -logoption=", cfg$logoption))
+                    " -ps=0 -pw=185 -pc=2 -gdxcompress=1 -holdFixedAsync=1 -logoption=", cfg$logoption))
 
       # If GAMS found a solution
       if (   file.exists("fulldata.gdx")


### PR DESCRIPTION
To solve the issue with Nash parallel runs showing infeasibilities that don't show up when running in `debug` mode, this PR adds an option to the GAMS command line parameters that keeps fixed variables as parameters during solve even when REMIND runs in parallel mode. See here for more info: https://www.gams.com/latest/docs/UG_GamsCall.html#GAMSAOholdfixedasync

# Purpose of this PR


## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix 


## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [x] The model compiles and runs successfully (`Rscript start.R -q`)

## Further information (optional):

* Test runs are here: `/p/tmp/giannou/tmp/testremind8/remind/output/SSP2EU-calibrate_2022-07-05_10.34.35`
* Comparison of results (what changes by this PR?): 


