### PR TITLE
restrict q37_limit_secondary_steel_share 

### DIFF
--- a/modules/37_industry/subsectors/equations.gms
+++ b/modules/37_industry/subsectors/equations.gms
@@ -31,7 +31,13 @@ q37_energy_limits(ttot,regi,industry_ue_calibration_target_dyn37(out))$(
 ;
 
 *' Limit the share of secondary steel to historic values, fading to 90 % in 2050
-q37_limit_secondary_steel_share(ttot,regi)$( ttot.val ge cm_startyear ) ..
+q37_limit_secondary_steel_share(ttot,regi)$(
+         ttot.val ge cm_startyear
+$ifthen.fixed_production "%cm_import_EU%" == "bal"   !! cm_import_EU
+         !! do not limit steel production shares for fixed production
+     AND p37_industry_quantity_targets(ttot,regi,"ue_steel_secondary") eq 0
+$endif.fixed_production
+                                                                            ) ..
   vm_cesIO(ttot,regi,"ue_steel_secondary")
   =l=
     ( vm_cesIO(ttot,regi,"ue_steel_primary")


### PR DESCRIPTION
restrict q37_limit_secondary_steel_share to periods/regions in which steel production is not fixed to avoid infeasibilities

- [x] Minor change (default scenarios show only small differences)

- [x] My code follows the coding etiquette
- [ ] I have performed a self-review of my own code
- [x] Changes are commented, particularly in hard-to-understand areas
- [ ] I have updated the in-code documentation
- [x] I have adjusted reporting where it was needed
- [x] The model compiles and runs successfully (`Rscript start.R -q`)
