### PR TITLE
Fall-back to ggplots in plotIterations

### DIFF
--- a/scripts/output/single/plotIterations.R
+++ b/scripts/output/single/plotIterations.R
@@ -6,8 +6,10 @@
 # |  Contact: remind@pik-potsdam.de
 
 symbolNames <- paste("pm_FEPrice_iter")
-plotMapping <- 'xAxis = "year", color = "iteration", facets = "region", slider = "all_enty"'
+plotMappingDefault <- 'xAxis = "year", color = "iteration", facets = "region", slider = NULL'
+plotMapping <- list()
 generateHtml <- "y"
+combineDims <- list()
 
 if (!exists("source_include")) {
   outputdir <- file.path("output", "B-putty_SSP2-NDC_restartWithAllIterationResults")
@@ -45,55 +47,94 @@ if (!identical(trimws(answer), "")) {
 }
 symbolNames <- trimws(strsplit(symbolNames, ",")[[1]])
 
+
 # choose plot mapping
-cat("\n\nHow do you want to map the variable dimensions in the plot?",
-    "Unused aesthetics need to be set to NULL. \n(default: ", plotMapping, ")\n")
-answer <- getLine()
-if (!identical(trimws(answer), "")) {
-  plotMapping <- answer
+  for (s in symbolNames) {
+  cat("\n\nHow do you want to map the dimensions of ", s, "in the plot?",
+      "Unused aesthetics need to be set to NULL. Combine dimensions with +.\n(default: ", plotMappingDefault, ")\n")
+  answer <- getLine()
+  if (!identical(trimws(answer), "")) {
+    pm <- answer
+    if (grepl("\\+", pm)) {
+      cd <- strsplit(pm, ",")[[1]]
+      cd <- cd[grepl("\\+", cd)]
+      cd <- gsub(" |\"|\'", "", cd)
+      cd <- setNames(gsub(".*=", "", cd),
+                              gsub("=.*", "", cd))
+      cd <- lapply(cd, function(x) strsplit(x, "\\+")[[1]])
+      for (i in seq_along(cd)) {
+        pm <- gsub(
+          paste0("[\"\']", paste(cd[i][[1]], collapse = ".*"), "[\"\']"),
+          paste0("\"", names(cd)[i], "\""),
+          pm)
+      }
+      for (i in seq_along(cd)) {
+        cd[i] <- paste0(s, 'Clean <- tidyr::unite(', s, 'Clean, "',
+                        names(cd)[i], '", "',
+                        paste0(cd[i][[1]], collapse = "\", \""),
+                        '", sep = ".")\n')
+      }
+      cd <- paste0(
+        '\n# Combine dimensions\n',
+        paste0(cd, collapse = '\n')
+      )
+      combineDims[[s]] <- cd
+      plotMapping[[s]] <- pm
+    }
+  } else {
+    plotMapping[[s]] <- plotMappingDefault
+    combineDims[[s]] <- ""
+  }
 }
 
 rmdHeader <- paste0(
   "---\n",
-  "output: html_document\n",
+  "output:\n",
+  "  html_document:\n",
+  "    toc: true\n",
+  "    toc_float: true\n",
   "title: plotIterations - ", paste(symbolNames, collapse = ", "), "\n",
   "---\n",
   "\n",
   "## Setup\n",
-  "```{r}\n",
+  "```{r setup}\n",
   'runPath <- "', gsub("\\", "\\\\", outputdir, fixed = TRUE), '"\n',
   "```"
 )
 
 rmdChunksForSymbol <- function(symbolName) {
+
   # BEGIN TEMPLATE -------------------------
   return(paste0('
 ## ', symbolName, '
 
 ### Read Data from gdx
-```{r}
+```{r ', symbolName,'___READ}
 ', symbolName, 'Raw <- mip::getPlotData("', symbolName, '", runPath)
 str(', symbolName, 'Raw)
 ```
 
 ### Clean Data
-```{r}
+```{r ', symbolName,'___CLEAN}
 ', symbolName, 'Clean <- ', symbolName, 'Raw
+', 
+combineDims[[symbolName]],
+'
 # filter and fix data here if needed
 str(', symbolName, 'Clean)
 ```
 
 ### Create Plots
-```{r, results = "asis"}
+```{r ', symbolName,'___PLOT, results = "asis"}
 ', symbolName, 'Plots <- mip::mipIterations(
   plotData = ', symbolName, 'Clean, returnGgplots = TRUE,
-  ', plotMapping, '
+  ', plotMapping[[symbolName]], '
 )
 
 # customize plots here if needed
 
-# convert up to 10 plots via plotly::ggplotly and render
-htmltools::tagList(lapply(head(', symbolName, 'Plots, 10), plotly::ggplotly))
+# convert up to 20 plots via plotly::ggplotly and render
+lapply(head(', symbolName, 'Plots, 20), print)
 ```'))
   # END TEMPLATE -------------------------
 }
@@ -102,7 +143,7 @@ rmdFooter <- if (length(symbolNames) >= 2) {
   paste0(
     "\n",
     "## Show Plots side-by-side for Comparison\n",
-    '```{r, results = "asis"}\n',
+    '```{r ', symbolNames[[1]], '_VS_', symbolNames[[2]], ', results = "asis"}\n',
     "mip::sideBySidePlots(list(", symbolNames[[1]], "Plots[[1]], ", symbolNames[[2]], "Plots[[1]]))\n",
     "```"
   )


### PR DESCRIPTION
This is a quick fix to the plotIterations function. None of this affects the functionality of REMIND and this function is currently not 
commonly used. I removed the conversion of ggplots to plotly plots for now, as this conversion is highly inefficient and caused outOfMemory errors. With this, the silder should not be mapped, as it doesen't exist in ggplot. Usually, the default mapping should work fine. I will change the `mip::plotIterations` function in the future to directly produce plotly plots to avoid the conversion and have the benefit of dynamic plots.

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix 
- [ ] Refactoring
- [ ] New feature 
- [ ] Minor change (default scenarios show only small differences)
- [ ] Fundamental change
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [ ] Changes are commented, particularly in hard-to-understand areas
- [x] I have updated the in-code documentation
- [x] I have adjusted reporting where it was needed
- [ ] The model compiles and runs successfully (`Rscript start.R -q`) `-> n.a.`