### PR TITLE
deactivate q37_energy_limits for calibration runs

### DIFF
--- a/modules/37_industry/subsectors/equations.gms
+++ b/modules/37_industry/subsectors/equations.gms
@@ -23,7 +23,13 @@ q37_demFeIndst(ttot,regi,entyFe,emiMkt)$(    ttot.val ge cm_startyear
 *' Thermodynamic limits on subsector energy demand
 q37_energy_limits(ttot,regi,industry_ue_calibration_target_dyn37(out))$(
                                       ttot.val gt 2020
-				  AND p37_energy_limit_slope(ttot,regi,out) ) ..
+				  AND p37_energy_limit_slope(ttot,regi,out) 
+!! deactivate energy limits for calibration, since they would be essentially
+!! random
+$ifthen.calibration "%CES_parameters%" == "calibrate"   !! CES_parameters
+                                  AND NO
+$endif.calibration
+				                                            ) ..
   sum(ces_eff_target_dyn37(out,in), vm_cesIO(ttot,regi,in))
   =g=
     vm_cesIO(ttot,regi,out)


### PR DESCRIPTION
deactivate q37_energy_limits for calibration runs as it might turn infes based on essentially random data in the input gdx

- [x] Bug fix 

- [x] My code follows the coding etiquette
- [ ] I have performed a self-review of my own code
- [x] Changes are commented, particularly in hard-to-understand areas
- [ ] I have updated the in-code documentation
- [x] I have adjusted reporting where it was needed
- [x] The model compiles and runs successfully (`Rscript start.R -q`)
