### PR TITLE
Hotfix: do not subtract baseline bioenergy n2o emissions

### DIFF
--- a/core/preloop.gms
+++ b/core/preloop.gms
@@ -148,8 +148,7 @@ pm_macBaseMagpie(t,regi,enty)$(emiMac2sector(enty,"agriculture","process","ch4")
 *** Hotfix: Disable the subtraction of baseline bioenergy N2O emissions, since somehow this
 *** may lead to negative values.
 *** pm_macBaseMagpie(t,regi,"n2ofertin") = pm_macBaseMagpie(t,regi,"n2ofertin") - (p_efFossilFuelExtr(regi,"pebiolc","n2obio") * pm_pebiolc_demandmag(t,regi));
-pm_macBaseMagpie(t,regi,"n2ofertin") = pm_macBaseMagpie(t,regi,"n2ofertin");
-display pm_macBaseMagpie;
+display pm_macBaseMagpie, pm_pebiolc_demandmag;
 
 $IFTHEN.out "%cm_debug_preloop%" == "on" 
 option limrow = 70;

--- a/core/preloop.gms
+++ b/core/preloop.gms
@@ -148,7 +148,7 @@ pm_macBaseMagpie(t,regi,enty)$(emiMac2sector(enty,"agriculture","process","ch4")
 *** Hotfix: Disable the subtraction of baseline bioenergy N2O emissions, since somehow this
 *** may lead to negative values.
 *** pm_macBaseMagpie(t,regi,"n2ofertin") = pm_macBaseMagpie(t,regi,"n2ofertin") - (p_efFossilFuelExtr(regi,"pebiolc","n2obio") * pm_pebiolc_demandmag(t,regi));
-pm_macBaseMagpie(t,regi,"n2ofertin") = pm_macBaseMagpie(t,regi,"n2ofertin")
+pm_macBaseMagpie(t,regi,"n2ofertin") = pm_macBaseMagpie(t,regi,"n2ofertin");
 display pm_macBaseMagpie;
 
 $IFTHEN.out "%cm_debug_preloop%" == "on" 

--- a/core/preloop.gms
+++ b/core/preloop.gms
@@ -148,6 +148,7 @@ pm_macBaseMagpie(t,regi,enty)$(emiMac2sector(enty,"agriculture","process","ch4")
 *** Hotfix: Disable the subtraction of baseline bioenergy N2O emissions, since somehow this
 *** may lead to negative values.
 *** pm_macBaseMagpie(t,regi,"n2ofertin") = pm_macBaseMagpie(t,regi,"n2ofertin") - (p_efFossilFuelExtr(regi,"pebiolc","n2obio") * pm_pebiolc_demandmag(t,regi));
+pm_macBaseMagpie(t,regi,"n2ofertin") = pm_macBaseMagpie(t,regi,"n2ofertin")
 display pm_macBaseMagpie;
 
 $IFTHEN.out "%cm_debug_preloop%" == "on" 

--- a/core/preloop.gms
+++ b/core/preloop.gms
@@ -145,7 +145,9 @@ pm_macBaseMagpie(t,regi,enty)$(emiMac2sector(enty,"agriculture","process","ch4")
 *** includes the N2O emissions from biomass. In q_macBase in core/equations.gms the N2O 
 *** emissions resulting from the actual biomass demand in REMIND are then added again. 
 
-pm_macBaseMagpie(t,regi,"n2ofertin") = pm_macBaseMagpie(t,regi,"n2ofertin") - (p_efFossilFuelExtr(regi,"pebiolc","n2obio") * pm_pebiolc_demandmag(t,regi));
+*** Hotfix: Disable the subtraction of baseline bioenergy N2O emissions, since somehow this
+*** may lead to negative values.
+*** pm_macBaseMagpie(t,regi,"n2ofertin") = pm_macBaseMagpie(t,regi,"n2ofertin") - (p_efFossilFuelExtr(regi,"pebiolc","n2obio") * pm_pebiolc_demandmag(t,regi));
 display pm_macBaseMagpie;
 
 $IFTHEN.out "%cm_debug_preloop%" == "on" 


### PR DESCRIPTION
# Purpose of this PR
This PR is a hotfix related to [PR885](https://github.com/remindmodel/remind/pull/885).
It disables the subtraction of baseline N2O emissions related to bioenergy production that is already accounted for in the baseline run.
Thus, there is now (again) some double accounting of bioenergy N2O emissions.
This was necessary because there are cases, in which the subtraction led to negative emissions, which broke REMIND.

## Type of change

- [x] Bug fix 


## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [x] Changes are commented, particularly in hard-to-understand areas
- [x] I have updated the in-code documentation
- [x] I have adjusted reporting where it was needed
- [x] The model compiles and runs successfully (`Rscript start.R -q`)

## Further information (optional):

* Test runs:
The infeasible run is here: /p/projects/piam/SHAPE_runs/coupled_2022-07-12/remind/output/SDP_EI-Base_2022-07-14_13.50.32
The exact same run with the fix is here: /p/tmp/merfort/bugfixing/n2ofertin_negative/remind/output/SDP_EI-Base_2022-07-14_13.50.32


