### PR TITLE
create joint REMIND and MAgPIE reporting for every coupling round

### DIFF
--- a/scripts/output/comparison/plot_compare_iterations.R
+++ b/scripts/output/comparison/plot_compare_iterations.R
@@ -227,8 +227,10 @@ plot_iterations <- function(runname) {
   report_path <- report_path[!grepl("with|adj",report_path)]
 
   tmp <- NULL
-  for (r in report_path) tmp <- mbind(tmp, read.report(r,as.list=FALSE))
-  tmp <- tmp[,,"Price|Carbon (US$2005/t CO2)"]
+  for (r in report_path) {
+    tmp1 <- read.report(r, as.list=FALSE)
+    tmp <- mbind(tmp, tmp1[,,"Price|Carbon (US$2005/t CO2)"])
+  }
   getNames(tmp) <- gsub(".*rem-","",getNames(tmp))
 
   v  <- paste(runname,"Price|Carbon (US$2005/t CO2)",sep="\n")

--- a/start_coupled.R
+++ b/start_coupled.R
@@ -211,10 +211,35 @@ start_coupled <- function(path_remind, path_magpie, cfg_rem, cfg_mag, runname, m
       } else {
         stop("### COUPLING ### REMIND didn't produce any gdx. Coupling iteration stopped!")
       }
+      # combine REMIND and MAgPIE reports of last coupling iteration (and REMIND water reporting if existing)
+      report_rem <- paste0(path_remind,outfolder_rem,"/REMIND_generic_",cfg_rem$title,".mif")
+      if (exists("mag_report_keep_in_mind") && file.exists(mag_report_keep_in_mind)) {
+        message("\n### Joining to a common reporting file:\n    ", report_rem, "\n    ", mag_report_keep_in_mind)
+        tmp1 <- read.report(report_rem, as.list=FALSE)
+        tmp2 <- read.report(mag_report_keep_in_mind, as.list=FALSE)[, getYears(tmp1), ]
+        tmp3 <- mbind(tmp1,tmp2)
+        getNames(tmp3, dim=1) <- gsub("-(rem|mag)-[0-9]{1,2}","",getNames(tmp3,dim=1)) # remove -rem-xx and mag-xx from scenario names
+        # only harmonize model names to REMIND-MAgPIE, if there are no variable names that are identical across the models
+        if (any(getNames(tmp3[,,"REMIND"],dim=3) %in% getNames(tmp3[,,"MAgPIE"],dim=3))) {
+          msg <- "Cannot produce common REMIND-MAgPIE reporting because there are identical variable names in both models!\n"
+          message(msg)
+          warning(msg)
+        } else {
+          write.report(tmp3, file = report_rem, ndigit = 7)
+          remind2::deletePlus(report_rem, writemif = TRUE)
+          message(" -> ", report_rem, " now contains also MAgPIE results.")
+          if (i == max_iterations) {
+            # Replace REMIND and MAgPIE with REMIND-MAgPIE and write directly to output folder
+            getNames(tmp3,dim=2) <- gsub("REMIND|MAgPIE","REMIND-MAgPIE",getNames(tmp3,dim=2))
+            write.report(tmp3, file = paste0("output/",runname,".mif"), ndigit = 7)
+            message(" -> output/", runname, ".mif uses REMIND-MAgPIE as model name.")
+          }
+        }
+      }
     }
 
     if (!file.exists(report)) stop(paste0("### COUPLING ### Could not find report: ", report,"\n"))
-    
+
     # If in the last iteration don't run MAgPIE
     if (i == max_iterations) {
       report_mag <- mag_report_keep_in_mind
@@ -351,32 +376,6 @@ start_coupled <- function(path_remind, path_magpie, cfg_rem, cfg_mag, runname, m
     ret  <- findIterations(runs, modelpath = c(remindpath, magpiepath), latest = FALSE)
     readRuntime(ret, plot=TRUE, coupled=TRUE)
     unlink(c("runtime.log", "runtime.out", "runtime.rda"))
-
-    # combine REMIND and MAgPIE reports of last coupling iteration (and REMIND water reporting if existing)
-    report_rem <- paste0(path_remind,outfolder_rem,"/REMIND_generic_",cfg_rem$title,".mif")
-    if (exists("outfolder_mag")) {
-      # If MAgPIE has run use its regular outputfolder
-      report_mag <- paste0(path_magpie, outfolder_mag, "/report.mif")
-    } else {
-      # If MAgPIE did not run, because coupling has been restarted with the last REMIND iteration,
-      # use the path to the MAgPIE report REMIND has been restarted with.
-      report_mag <- mag_report_keep_in_mind
-    }
-    message("Joining to a common reporting file:\n    ", report_rem, "\n    ", report_mag)
-    tmp1 <- read.report(report_rem, as.list=FALSE)
-    tmp2 <- read.report(report_mag, as.list=FALSE)[, getYears(tmp1), ]
-    tmp3 <- mbind(tmp1,tmp2)
-    getNames(tmp3, dim=1) <- gsub("-(rem|mag)-[0-9]{1,2}","",getNames(tmp3,dim=1)) # remove -rem-xx and mag-xx from scenario names
-    # only harmonize model names to REMIND-MAgPIE, if there are no variable names that are identical across the models
-    if (any(getNames(tmp3[,,"REMIND"],dim=3) %in% getNames(tmp3[,,"MAgPIE"],dim=3))) {
-      msg <- "Cannot produce common REMIND-MAgPIE reporting because there are identical variable names in both models!\n"
-      message(msg)
-      warning(msg)
-    } else {
-      # Replace REMIND and MAgPIE with REMIND-MAgPIE
-      #getNames(tmp3,dim=2) <- gsub("REMIND|MAgPIE","REMIND-MAGPIE",getNames(tmp3,dim=2))
-      write.report(tmp3,file=paste0("output/",runname,".mif"))
-    }
 
     if (max_iterations > 1) {
       # set required variables and execute script to create convergence plots


### PR DESCRIPTION
## Purpose of this PR

- until now, `start_coupled.R` produces a joint reporting `./output/C_SSP2-Base.mif` after the final -rem- run (say: -rem-5).
- after this PR, a joint mif file is created after every coupling round (if a MAgPIE report exists), so for -rem-2 with -mag-1, for -rem-3 with -mag-2 etc. The model names are kept to `REMIND` and `MAgPIE` to make it distinguishable
- this file can then be used to plot MAgPIE variables also in compareScenarios2
- the `./output/C_SSP2-Base.mif` will still be written after the last iteration, containing a joint reporting with `REMIND-MAgPIE` as model name
- I moved it before the starting of subsequent runs to avoid that the mif file is rewritten while read by some other script (should not happen, though, as subsequent runs read only gdx files, as far as I know)
- I also adapted the code a bit in plot_compare_iterations because the mbind command took very long if one run had the MAgPIE part in the mif and the other not.
- you can have a look at `/p/tmp/oliverr/remind-smallfix/output/C_o_1p5c_bIT.mif`, also the corresponding -rem- folders, and `compScen-rem-1-5_C_o_1p5c_bIT.pdf`

## Type of change

- [x] New feature 
- [x] Minor change (no impact on scenarios)

## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [x] Changes are commented, particularly in hard-to-understand areas
- [x] I have updated the in-code documentation
- [x] The model compiles and runs successfully (`Rscript start.R -q`)
- [x] I tested the NGFS scenarios using [this quick setup](https://github.com/pik-piam/discussions/discussions/28) and it works well. Also cs2 worked.
