### PR TITLE
Fix magpie ch4/n2o emission rescaling and correction

### DIFF
--- a/core/declarations.gms
+++ b/core/declarations.gms
@@ -130,6 +130,8 @@ p_aux_capToDistr(all_regi,all_te)                           "aux. param. to calc
 s_aux_cap_remaining                                         "aux. param. to calculate p_avCapFac2015; countdown parameter"
 p_aux_capThisGrade(all_regi,all_te,rlf)                     "aux. param. to calculate p_avCapFac2015; How the historic 2015 capacity is distributed among grades"
 p_aux_capacityFactorHistOverREMIND(all_regi,all_te)         "aux. param. to calculate capacity factors correction (wind and spv): the ratio of historic over REMIND CapFac in 2015"
+p_aux_scaleEmiHistorical_n2o(all_regi)                      "aux. param. to rescale MAgPIE n2o emissions to historical values"
+p_aux_scaleEmiHistorical_ch4(all_regi)                      "aux. param. to rescale MAgPIE ch4 emissions to historical values"
 
 $IFTHEN.WindOff %cm_wind_offshore% == "1"
 p_shareWindPotentialOff2On(all_regi)                 "ratio of technical potential of windoff to windon"

--- a/core/preloop.gms
+++ b/core/preloop.gms
@@ -92,31 +92,55 @@ if(cm_iterative_target_adj eq 9,
 
 display p_taxCO2eq_until2150, pm_taxCO2eq;
 
+
+*** The N2O emissions generated during biomass production in agriculture (in MAgPIE)
+*** are represented in REMIND by applying the n2obio emission factor (zero in coupled runs)
+*** in q_macBase. In standaolne runs the resulting emissions need to be subtracted (see below)
+*** from the exogenous emission baseline read from MAgPIE, since the baseline already implicitly 
+*** includes the N2O emissions from biomass. In q_macBase in core/equations.gms the N2O 
+*** emissions resulting from the actual biomass demand in REMIND are then added again. 
+*** In case some inconsistencies between pm_pebiolc_demandmag and pm_macBaseMagpie lead to
+*** negative values, set the value to 0 instead, since negative values may lead to 
+*** infeasibilities.
+display pm_macBaseMagpie;
+pm_macBaseMagpie(t,regi,"n2ofertin") = max(0, pm_macBaseMagpie(t,regi,"n2ofertin") - (p_efFossilFuelExtr(regi,"pebiolc","n2obio") * pm_pebiolc_demandmag(t,regi)));
+display pm_macBaseMagpie;
+
+
 $IFTHEN.scaleEmiHist %c_scaleEmiHistorical% == "on"
+*** Re-scale MAgPie reference CH4 and N2O emissions to be inline with eurostat
+*** data (MagPie overestimates non-CO2 GHG emissions by a factor of 50% more).
+*** This involves different emission variables in pm_macBaseMagpie and
+*** additionall agwaste variables from p_macBaseExo
+display p_macBaseExo;
 
-*re-scale MAgPie reference emissions to be inline with eurostat data (MagPie overestimates non-CO2 GHG emissions by a factor of 50% more)
-display pm_macBaseMagpie;
-loop(enty$(sameas(enty,"ch4rice") OR sameas(enty,"ch4animals") OR sameas(enty,"ch4anmlwst")),
-  pm_macBaseMagpie(ttot,regi,enty)$(p_histEmiSector("2005",regi,"ch4","agriculture","process") AND (ttot.val ge 2005)) =
-   pm_macBaseMagpie(ttot,regi,enty) *
-    ( (p_histEmiSector("2005",regi,"ch4","agriculture","process")+p_histEmiSector("2005",regi,"ch4","lulucf","process")) !!no rescaling needed - REMIND-internal unit is Mt CH4
-      /
-      (sum(enty2$(sameas(enty2,"ch4rice") OR sameas(enty2,"ch4animals") OR sameas(enty2,"ch4anmlwst")), pm_macBaseMagpie("2005",regi,enty2)) + p_macBaseExo("2005",regi,"ch4agwaste"))
-    )
-  ;
-);
-loop(enty$(sameas(enty,"n2ofertin") OR sameas(enty,"n2ofertcr") OR sameas(enty,"n2oanwstc") OR sameas(enty,"n2oanwstm") OR sameas(enty,"n2oanwstp")),
-  pm_macBaseMagpie(ttot,regi,enty)$(p_histEmiSector("2005",regi,"n2o","agriculture","process") AND (ttot.val ge 2005)) =
-    pm_macBaseMagpie(ttot,regi,enty) *
-    ( p_histEmiSector("2005",regi,"n2o","agriculture","process")/( 44 / 28) !! rescaling to Mt N (internal unit for N2O emissions)
-* eurostat uses 298 to convert N2O to CO2eq
-      /
-      (sum(enty2$(sameas(enty,"n2ofertin") OR sameas(enty2,"n2ofertcr") OR sameas(enty2,"n2oanwstc") OR sameas(enty2,"n2oanwstm") OR sameas(enty2,"n2oanwstp")), pm_macBaseMagpie("2005",regi,enty2)) + p_macBaseExo("2005",regi,"n2oagwaste"))
-    )
-  ;
-);
-display pm_macBaseMagpie;
+*** Define rescale factor for MAgPIE CH4 emissions
+p_aux_scaleEmiHistorical_ch4(regi)$p_histEmiSector("2005",regi,"ch4","agriculture","process") =
+  (p_histEmiSector("2005",regi,"ch4","agriculture","process")+p_histEmiSector("2005",regi,"ch4","lulucf","process")) !!no rescaling needed - REMIND-internal unit is Mt CH4
+    /
+  (sum(enty$emiMacMagpieCH4(enty), pm_macBaseMagpie("2005",regi,enty)) + p_macBaseExo("2005",regi,"ch4agwaste"));
+*** Rescale CH4 emissions so that all subtypes add up to the historic values
+*** pm_macBaseMagpie
+pm_macBaseMagpie(ttot,regi,enty)$((ttot.val ge 2005) AND p_aux_scaleEmiHistorical_ch4(regi) AND emiMacMagpieCH4(enty)) =
+  pm_macBaseMagpie(ttot,regi,enty) * p_aux_scaleEmiHistorical_ch4(regi);
+*** p_macBaseExo
+p_macBaseExo(ttot,regi,"ch4agwaste")$((ttot.val ge 2005) AND p_aux_scaleEmiHistorical_ch4(regi)) =
+  p_macBaseExo(ttot,regi,"ch4agwaste") * p_aux_scaleEmiHistorical_ch4(regi);
 
+*** Define rescale factor for MAgPIE N2O emissions
+p_aux_scaleEmiHistorical_n2o(regi)$p_histEmiSector("2005",regi,"n2o","agriculture","process") =
+  p_histEmiSector("2005",regi,"n2o","agriculture","process")/( 44 / 28) !! rescaling to Mt N (internal unit for N2O emissions), since eurostat uses 298 to convert N2O to CO2eq
+    /
+  (sum(enty$emiMacMagpieN2O(enty), pm_macBaseMagpie("2005",regi,enty)) + p_macBaseExo("2005",regi,"n2oagwaste"));
+*** Rescale N2O emissions so that all subtypes add up to the historic values
+*** pm_macBaseMagpie
+pm_macBaseMagpie(ttot,regi,enty)$((ttot.val ge 2005) AND p_aux_scaleEmiHistorical_n2o(regi) AND emiMacMagpieN2O(enty)) =
+  pm_macBaseMagpie(ttot,regi,enty) * p_aux_scaleEmiHistorical_n2o(regi);
+*** p_macBaseExo
+p_macBaseExo(ttot,regi,"n2oagwaste")$((ttot.val ge 2005) AND p_aux_scaleEmiHistorical_n2o(regi)) =
+  p_macBaseExo(ttot,regi,"n2oagwaste") * p_aux_scaleEmiHistorical_n2o(regi);
+
+display pm_macBaseMagpie;
 $ENDIF.scaleEmiHist
 
 *** FS: calculate total bioenregy primary energy demand from last iteration
@@ -138,17 +162,6 @@ p_agriEmiPhaseOut(t)$(t.val ge 2040) = 1;
 pm_macBaseMagpie(t,regi,enty)$(emiMac2sector(enty,"agriculture","process","ch4") OR emiMac2sector(enty,"agriculture","process","n2o"))
   = (1-p_agriEmiPhaseOut(t)*c_BaselineAgriEmiRed)*pm_macBaseMagpie(t,regi,enty);
   
-*** The N2O emissions generated during biomass production in agriculture (in MAgPIE)
-*** are represented in REMIND by applying the n2obio emission factor (zero in coupled runs)
-*** in q_macBase. In standaolne runs the resulting emissions need to be subtracted (see below)
-*** from the exogenous emission baseline read from MAgPIE, since the baseline already implicitly 
-*** includes the N2O emissions from biomass. In q_macBase in core/equations.gms the N2O 
-*** emissions resulting from the actual biomass demand in REMIND are then added again. 
-
-*** Hotfix: Disable the subtraction of baseline bioenergy N2O emissions, since somehow this
-*** may lead to negative values.
-*** pm_macBaseMagpie(t,regi,"n2ofertin") = pm_macBaseMagpie(t,regi,"n2ofertin") - (p_efFossilFuelExtr(regi,"pebiolc","n2obio") * pm_pebiolc_demandmag(t,regi));
-display pm_macBaseMagpie, pm_pebiolc_demandmag;
 
 $IFTHEN.out "%cm_debug_preloop%" == "on" 
 option limrow = 70;

--- a/core/preloop.gms
+++ b/core/preloop.gms
@@ -109,9 +109,9 @@ display pm_macBaseMagpie;
 
 $IFTHEN.scaleEmiHist %c_scaleEmiHistorical% == "on"
 *** Re-scale MAgPie reference CH4 and N2O emissions to be inline with eurostat
-*** data (MagPie overestimates non-CO2 GHG emissions by a factor of 50% more).
-*** This involves different emission variables in pm_macBaseMagpie and
-*** additionall agwaste variables from p_macBaseExo
+*** data (depending on the region MAgPIE non-CO2 GHG emissions can be up to 
+*** twice as high as historic emissions). This involves different emission variables in
+*** pm_macBaseMagpie and additionall agwaste variables from p_macBaseExo
 display p_macBaseExo;
 
 *** Define rescale factor for MAgPIE CH4 emissions

--- a/core/sets.gms
+++ b/core/sets.gms
@@ -1920,7 +1920,6 @@ emiMacMagpieN2O(all_enty)  "types of climate-relevant non-energy N2O emissions w
         n2ofertcr  "n2o emissions from decay of crop residues (resid_n2o)"
         n2ofertsom "n2o emissions from soil organic matter loss (som_n2o)"
         n2oanwstc  "n2o emissions from manure applied to croplands (man_crop_n2o)"
-        ch4peatland "ch4 emissions from peatlands (peatland_ch4)"        
         n2oanwstm  "n2o emissions from animal waste management (awms_n2o)"
         n2opeatland "n2o emissions from peatlands (no MAC available)"        
         n2oanwstp  "n2o emissions from manure excreted on pasture (man_past_n2o)"


### PR DESCRIPTION
# Purpose of this PR
This PR fixes a few issues regarding the accounting and rescaling to historic values of land-use N2O and CH4 emissions from MAgPIE within REMIND. 

1. There was a bug in the rescaling mechanism of N2O and CH4 emissions that is applied in order to match historic emissions. This bug led in particular to wrong N2O emissions in `EUR` and `NEU`, leading to much too low values for inorganic fertilizers (`n2ofertin`), while the rescaling (wrongly) had almost no effect on other N2O emission types. For CH4 emissions in particular the rescaling of animal waste management (`ch4anmlwst`) was wrong. These bugs thus had the effect that the rescaling did a) messed up the relative shares between emission types and b) led to wrong total numbers, i.e. the sum of all rescaled emissions did not add up to historic values (which is what the rescaling should do), both for CH4 and N2O. 
These bugs are fixed now and the whole code is refactored a bit. Two new variables were added for the regionalized rescaling factors, which are helpful for diagnostics. Remark: While CH4 emissions are rescaled in all regions, N2O emissions are (as of yet) only rescaled in `EUR` and `NEU`, since there is no historic data for other regions in the model so far.
2. There are new emission variables added to the rescaling process that were so far not part of it. 
For N2O emissions the rescaling now affects all types of emissions that are part of `emiMacMagpieN2O` and emissions from Burning of Crop Residues (`n2oagwaste` from `p_macBaseExo`). This adds in particular Soil Organic Matter Loss (`n2ofertsom`) and Peatland (`n2opeatland`). However, in REMIND standalone runs this has no effect so far, since these are rather new variables and the look-up tables from MAgPIE are outdated, so they are not part of the input data yet. Furthermore the exogenous emissions from Burning of Crop Residues (`n2oagwaste`) are now also being rescaled. 
For CH4 emissions now also the exogenous emissions `ch4agwaste` from `p_macBaseExo` are rescaled.
3. There was a bug in the accounting of bioenergy-induced N2O emissions from fertilizer use. This bug was fixed in [PR885](https://github.com/remindmodel/remind/pull/885). However, the fix caused infeasibilties due to negative N2O emissions induced by the bug in the rescaling, therefore parts of it had to be revealed in [PR903](https://github.com/remindmodel/remind/pull/903) as a hot fix. Since the rescaling is working now, this PR fixes the accounting again, by subtracting bioenergy related N2O emissions from baseline N2O emissions (`n2ofertin`). It furthermore makes sure that if the subtraction induces negative values of `n2ofertin`, the emissions are set to zero instead.
4. The set `emiMacMagpieN2O` wrongly contained `ch4peatland`. This is removed now.

## Type of change

- [x] Bug fix 
- [x] Refactoring

## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [x] Changes are commented, particularly in hard-to-understand areas
- [x] I have updated the in-code documentation
- [x] I have adjusted reporting where it was needed
- [x] The model compiles and runs successfully (`Rscript start.R -q`)

## Further information:

* Test runs (Baseline for the different SSPs) once for the original version (no suffix), the version with the fixed rescaling (suffix `new_resc`) and the version with fixed rescaling and bioenergy correction (suffix `new_resc_subtract_bio`) are here:
/p/tmp/merfort/bugfixing/n2ofertin_negative/remind_fix/output
* Comparison of results (what changes by this PR?):
Compare scenarios for each SSP: 
/p/tmp/merfort/bugfixing/n2ofertin_negative/remind_fix/compScen-SDP-2022-07-20_11.37.59-H12.pdf
/p/tmp/merfort/bugfixing/n2ofertin_negative/remind_fix/compScen-SSP1-2022-07-20_11.38.23-H12.pdf
/p/tmp/merfort/bugfixing/n2ofertin_negative/remind_fix/compScen-SSP2EU-2022-07-20_11.38.59-H12.pdf
/p/tmp/merfort/bugfixing/n2ofertin_negative/remind_fix/compScen-SSP5-2022-07-20_11.39.28-H12.pdf

Here is a comparison of emissions between **input** (as imported from MAgPIE), **old_rescale** (as emissions were rescaled and before the PR), **new_rescale** (as emissions are rescaled now, but without the correction of bioenergy N2O emissions) and **new_rescale_cor_bio** (as emissions are rescaled now including the correction of bioenergy N2O emissions) for N2O and CH4 emissions for the different SSPs:
**CH4**
![emi_ch4_SDP-Base](https://user-images.githubusercontent.com/58845874/179998910-e8e1cc88-375c-4cbc-8caf-9854f62cc25a.png)
![emi_ch4_SSP1-Base](https://user-images.githubusercontent.com/58845874/179998918-b37194d4-4650-4911-90df-8a9729fa9348.png)
![emi_ch4_SSP2EU-Base](https://user-images.githubusercontent.com/58845874/179998929-eda644e5-19f2-4bb7-a286-80742a5311a8.png)
![emi_ch4_SSP5-Base](https://user-images.githubusercontent.com/58845874/179998977-cd544402-78cd-4f16-83c4-b1f8289c570a.png)
**N2O**
![emi_n2oSDP-Base](https://user-images.githubusercontent.com/58845874/179999025-fbf5d564-ff9c-4b6a-9cf3-a5f2869e2f05.png)
![emi_n2oSSP1-Base](https://user-images.githubusercontent.com/58845874/179999051-032c11c0-d189-4f9a-ad6b-3b51ac71d8a8.png)
![emi_n2oSSP2EU-Base](https://user-images.githubusercontent.com/58845874/179999095-eed059cf-08ce-45f4-9676-c00b6d166fe4.png)
![emi_n2oSSP5-Base](https://user-images.githubusercontent.com/58845874/179999112-5f52d717-69ad-490a-8af2-053ac008d8bc.png)

* The current rescaling factors:
`p_aux_scaleEmiHistorical_n2o`
EUR  0.743879224614325
NEU  0.64341875
`p_aux_scaleEmiHistorical_ch4`
LAM  0.886725609018387
OAS  0.895444030943405
SSA  0.61096130640195
EUR  0.635230351971992
NEU  0.881513529393413
MEA  0.605258579563769
REF  0.853090165466584
CAZ  1.04691918725229
CHA  0.544705770521807
IND  1.09930735810518
JPN  0.535901681422513
USA  0.751169800851561

