### PR TITLE
cs2 profiles with interactive selection

### DIFF
--- a/scripts/cs2/profiles.csv
+++ b/scripts/cs2/profiles.csv
@@ -1,18 +1,18 @@
+# Profiles for cs2 (compareScenarios2);;;;;;;;;;;;;;;;;;;;
+# Lines that start with a hashtag are comments.;;;;;;;;;;;;;;;;;;;;
+# The column 'name' identifies the profile.;;;;;;;;;;;;;;;;;;;;
+# The other columns are arguments to remind2::compareScenarios2(). See the R help page of this function for the meaning of the arguments.;;;;;;;;;;;;;;;;;;;;
+# The values in the cells are evaluated as R-code. They are not quoted (no single or double quotes at beginning and end unless the value should be a string, in this case use single quotes). Make sure that this format is still valid after changing this file!;;;;;;;;;;;;;;;;;;;;
+# These R expressions may contain a variable named '.'. It refers to the default value of the variable as defined in scripts/utils/run_compareScenarios2.R.;;;;;;;;;;;;;;;;;;;;
+# Leave a cell empty to not change the corresponding argument.;;;;;;;;;;;;;;;;;;;;
 name;mifScen;mifHist;outputDir;outputFile;outputFormat;envir;cfgScen;cfgDefault;yearsScen;yearsHist;yearsBarPlot;yearRef;reg;modelsHistExclude;sections;userSectionPath;mainReg;figWidth;figHeight;warning
-# Profiles for cs2 (compareScenarios2)
-# Lines that start with a hashtag are comments.
-# The column name identifies the profile.
-# The other columns are arguments to remind2::compareScenarios2(). See the R help page of this function for the meaning of the arguments.
-# The values in the cells are evaluated as R-code. They are not quoted (no " at beginning and end unless the value should be a string). Make sure that this format is still valid after changing this file!
-# These R expressions may contain a variable named ".". It refers to the default value of the variable as defined in scripts/utils/run_compareScenarios2.R.
-# Leave a cell empty to not change the corresponding argument.
-# default: The default profile.
+# default: The default profile.;;;;;;;;;;;;;;;;;;;;
 default;;;;;;;;;;;;;;;;;;;;
-defaultHTML;;;;;"html";;;;;;;;;;;;;;;
-# short: The default profile but only until 2050.
+defaultHTML;;;;;'html';;;;;;;;;;;;;;;
+# short: The default profile but only until 2050.;;;;;;;;;;;;;;;;;;;;
 short;;;;;;;;;seq(2005, 2050, 5);c(seq(1990, 2020, 1), seq(2025, 2050, 5));c(2010, 2030, 2050);;;;;;;;;
-shortHTML;;;;;"html";;;;seq(2005, 2050, 5);c(seq(1990, 2020, 1), seq(2025, 2050, 5));c(2010, 2030, 2050);;;;;;;;;
-# AriadneDEU: years until 2050, DEU as main region
-AriadneDEU;;;;paste0(., "-Ariadne");;;;;seq(2005, 2050, 5);c(seq(1990, 2020, 1), seq(2025, 2050, 5));c(2010, 2030, 2050);;;c("IEA ETP B2DS", "IEA ETP 2DS", "IEA ETP RTS", "EDGE_SSP1", "EDGE_SSP2", "CEDS", "IRENA", "IEA WEO 2021 APS", "IEA WEO 2021 SDS", "IEA WEO 2021 SPS");;;"DEU";;;
-# summary: show only the summary chapter
-summary;;;;paste0(., "-Summary");;;;;;;;;;;c(0,1,99);;;;;
+shortHTML;;;;;'html';;;;seq(2005, 2050, 5);c(seq(1990, 2020, 1), seq(2025, 2050, 5));c(2010, 2030, 2050);;;;;;;;;
+# AriadneDEU: years until 2050, DEU as main region;;;;;;;;;;;;;;;;;;;;
+AriadneDEU;;;;paste0(., '-Ariadne');;;;;seq(2005, 2050, 5);c(seq(1990, 2020, 1), seq(2025, 2050, 5));c(2010, 2030, 2050);;;c('IEA ETP B2DS', 'IEA ETP 2DS', 'IEA ETP RTS', 'EDGE_SSP1', 'EDGE_SSP2', 'CEDS', 'IRENA', 'IEA WEO 2021 APS', 'IEA WEO 2021 SDS', 'IEA WEO 2021 SPS');;;'DEU';;;
+# summary: show only the summary chapter;;;;;;;;;;;;;;;;;;;;
+summary;;;;paste0(., '-Summary');;;;;;;;;;;c(0,1,99);;;;;

--- a/scripts/cs2/profiles.csv
+++ b/scripts/cs2/profiles.csv
@@ -1,0 +1,4 @@
+name;mifScen;mifHist;outputDir;outputFile;outputFormat;envir;cfgScen;cfgDefault;yearsScen;yearsHist;yearsBarPlot;yearRef;reg;modelsHistExclude;sections;userSectionPath;mainReg;figWidth;figHeight;warning
+default;;;;;;;;;;;;;;;;;;;;
+short;;;;;;;;;seq(2005, 2050, 5);c(seq(1990, 2020, 1), seq(2025, 2050, 5));c(2010, 2030, 2050);;;;;;;;;
+AriadneDEU;;;;"paste0(., ""-"", ""Ariadne"")";;;;;seq(2005, 2050, 5);c(seq(1990, 2020, 1), seq(2025, 2050, 5));c(2010, 2030, 2050);;;"c(""IEA ETP B2DS"", ""IEA ETP 2DS"", ""IEA ETP RTS"", ""EDGE_SSP1"", ""EDGE_SSP2"", ""CEDS"", ""IRENA"", ""IEA WEO 2021 APS"", ""IEA WEO 2021 SDS"", ""IEA WEO 2021 SPS"")";;;DEU;;;

--- a/scripts/cs2/profiles.csv
+++ b/scripts/cs2/profiles.csv
@@ -1,4 +1,16 @@
 name;mifScen;mifHist;outputDir;outputFile;outputFormat;envir;cfgScen;cfgDefault;yearsScen;yearsHist;yearsBarPlot;yearRef;reg;modelsHistExclude;sections;userSectionPath;mainReg;figWidth;figHeight;warning
+# Profiles for cs2 (compareScenarios2)
+# Lines that start with a hashtag are comments.
+# The column name identifies the profile.
+# The other columns are arguments to remind2::compareScenarios2(). See the R help page of this function for the meaning of the arguments.
+# The values in the cells are evaluated as R-code. They are not quoted (no " at beginning and end unless the value should be a string). Make sure that this format is still valid after changing this file!
+# These R expressions may contain a variable named ".". It refers to the default value of the variable as defined in scripts/utils/run_compareScenarios2.R.
+# Leave a cell empty to not change the corresponding argument.
+# default: The default profile.
 default;;;;;;;;;;;;;;;;;;;;
+# short: The default profile but only until 2050.
 short;;;;;;;;;seq(2005, 2050, 5);c(seq(1990, 2020, 1), seq(2025, 2050, 5));c(2010, 2030, 2050);;;;;;;;;
-AriadneDEU;;;;"paste0(., ""-"", ""Ariadne"")";;;;;seq(2005, 2050, 5);c(seq(1990, 2020, 1), seq(2025, 2050, 5));c(2010, 2030, 2050);;;"c(""IEA ETP B2DS"", ""IEA ETP 2DS"", ""IEA ETP RTS"", ""EDGE_SSP1"", ""EDGE_SSP2"", ""CEDS"", ""IRENA"", ""IEA WEO 2021 APS"", ""IEA WEO 2021 SDS"", ""IEA WEO 2021 SPS"")";;;DEU;;;
+# AriadneDEU: years until 2050, DEU as main region
+AriadneDEU;;;;paste0(., "-", "Ariadne");;;;;seq(2005, 2050, 5);c(seq(1990, 2020, 1), seq(2025, 2050, 5));c(2010, 2030, 2050);;;c("IEA ETP B2DS", "IEA ETP 2DS", "IEA ETP RTS", "EDGE_SSP1", "EDGE_SSP2", "CEDS", "IRENA", "IEA WEO 2021 APS", "IEA WEO 2021 SDS", "IEA WEO 2021 SPS");;;DEU;;;
+# summary: show only the summary chapter
+summary;;;;paste0(., "-", "Summary");;;;;;;;;;;c(0,1,99);;;;;

--- a/scripts/cs2/profiles.csv
+++ b/scripts/cs2/profiles.csv
@@ -13,6 +13,6 @@ defaultHTML;;;;;'html';;;;;;;;;;;;;;;
 short;;;;;;;;;seq(2005, 2050, 5);c(seq(1990, 2020, 1), seq(2025, 2050, 5));c(2010, 2030, 2050);;;;;;;;;
 shortHTML;;;;;'html';;;;seq(2005, 2050, 5);c(seq(1990, 2020, 1), seq(2025, 2050, 5));c(2010, 2030, 2050);;;;;;;;;
 # AriadneDEU: years until 2050, DEU as main region;;;;;;;;;;;;;;;;;;;;
-AriadneDEU;;;;paste0(., '-Ariadne');;;;;seq(2005, 2050, 5);c(seq(1990, 2020, 1), seq(2025, 2050, 5));c(2010, 2030, 2050);;;c('IEA ETP B2DS', 'IEA ETP 2DS', 'IEA ETP RTS', 'EDGE_SSP1', 'EDGE_SSP2', 'CEDS', 'IRENA', 'IEA WEO 2021 APS', 'IEA WEO 2021 SDS', 'IEA WEO 2021 SPS');;;'DEU';;;
+AriadneDEU;;;;;;;;;seq(2005, 2050, 5);c(seq(1990, 2020, 1), seq(2025, 2050, 5));c(2010, 2030, 2050);;;c('IEA ETP B2DS', 'IEA ETP 2DS', 'IEA ETP RTS', 'EDGE_SSP1', 'EDGE_SSP2', 'CEDS', 'IRENA', 'IEA WEO 2021 APS', 'IEA WEO 2021 SDS', 'IEA WEO 2021 SPS');;;'DEU';;;
 # summary: show only the summary chapter;;;;;;;;;;;;;;;;;;;;
-summary;;;;paste0(., '-Summary');;;;;;;;;;;c(0,1,99);;;;;
+summary;;;;;;;;;;;;;;;c(0,1,99);;;;;

--- a/scripts/cs2/profiles.csv
+++ b/scripts/cs2/profiles.csv
@@ -8,9 +8,11 @@ name;mifScen;mifHist;outputDir;outputFile;outputFormat;envir;cfgScen;cfgDefault;
 # Leave a cell empty to not change the corresponding argument.
 # default: The default profile.
 default;;;;;;;;;;;;;;;;;;;;
+defaultHTML;;;;;"html";;;;;;;;;;;;;;;
 # short: The default profile but only until 2050.
 short;;;;;;;;;seq(2005, 2050, 5);c(seq(1990, 2020, 1), seq(2025, 2050, 5));c(2010, 2030, 2050);;;;;;;;;
+shortHTML;;;;;"html";;;;seq(2005, 2050, 5);c(seq(1990, 2020, 1), seq(2025, 2050, 5));c(2010, 2030, 2050);;;;;;;;;
 # AriadneDEU: years until 2050, DEU as main region
-AriadneDEU;;;;paste0(., "-", "Ariadne");;;;;seq(2005, 2050, 5);c(seq(1990, 2020, 1), seq(2025, 2050, 5));c(2010, 2030, 2050);;;c("IEA ETP B2DS", "IEA ETP 2DS", "IEA ETP RTS", "EDGE_SSP1", "EDGE_SSP2", "CEDS", "IRENA", "IEA WEO 2021 APS", "IEA WEO 2021 SDS", "IEA WEO 2021 SPS");;;DEU;;;
+AriadneDEU;;;;paste0(., "-Ariadne");;;;;seq(2005, 2050, 5);c(seq(1990, 2020, 1), seq(2025, 2050, 5));c(2010, 2030, 2050);;;c("IEA ETP B2DS", "IEA ETP 2DS", "IEA ETP RTS", "EDGE_SSP1", "EDGE_SSP2", "CEDS", "IRENA", "IEA WEO 2021 APS", "IEA WEO 2021 SDS", "IEA WEO 2021 SPS");;;DEU;;;
 # summary: show only the summary chapter
-summary;;;;paste0(., "-", "Summary");;;;;;;;;;;c(0,1,99);;;;;
+summary;;;;paste0(., "-Summary");;;;;;;;;;;c(0,1,99);;;;;

--- a/scripts/cs2/profiles.csv
+++ b/scripts/cs2/profiles.csv
@@ -13,6 +13,6 @@ defaultHTML;;;;;"html";;;;;;;;;;;;;;;
 short;;;;;;;;;seq(2005, 2050, 5);c(seq(1990, 2020, 1), seq(2025, 2050, 5));c(2010, 2030, 2050);;;;;;;;;
 shortHTML;;;;;"html";;;;seq(2005, 2050, 5);c(seq(1990, 2020, 1), seq(2025, 2050, 5));c(2010, 2030, 2050);;;;;;;;;
 # AriadneDEU: years until 2050, DEU as main region
-AriadneDEU;;;;paste0(., "-Ariadne");;;;;seq(2005, 2050, 5);c(seq(1990, 2020, 1), seq(2025, 2050, 5));c(2010, 2030, 2050);;;c("IEA ETP B2DS", "IEA ETP 2DS", "IEA ETP RTS", "EDGE_SSP1", "EDGE_SSP2", "CEDS", "IRENA", "IEA WEO 2021 APS", "IEA WEO 2021 SDS", "IEA WEO 2021 SPS");;;DEU;;;
+AriadneDEU;;;;paste0(., "-Ariadne");;;;;seq(2005, 2050, 5);c(seq(1990, 2020, 1), seq(2025, 2050, 5));c(2010, 2030, 2050);;;c("IEA ETP B2DS", "IEA ETP 2DS", "IEA ETP RTS", "EDGE_SSP1", "EDGE_SSP2", "CEDS", "IRENA", "IEA WEO 2021 APS", "IEA WEO 2021 SDS", "IEA WEO 2021 SPS");;;"DEU";;;
 # summary: show only the summary chapter
 summary;;;;paste0(., "-Summary");;;;;;;;;;;c(0,1,99);;;;;

--- a/scripts/output/comparison/compareScenarios2.R
+++ b/scripts/output/comparison/compareScenarios2.R
@@ -10,7 +10,7 @@
 chooseFromSequence <- function(sequence, title, default) {
   cat(
     "\n\n", title, 
-    "Leave empty for: ", paste(default, collapse=", "), ".\n\n", 
+    "\nLeave empty for: ", paste(default, collapse=", "), ".\n\n", 
     sep = "")
   cat(paste(seq_along(sequence), sequence, sep = ": "), sep = "\n")
   cat("\nNumbers, e.g, '1', '2,4', '3:5', ...:\n")

--- a/scripts/output/comparison/compareScenarios2.R
+++ b/scripts/output/comparison/compareScenarios2.R
@@ -25,7 +25,7 @@ chooseFromSequence <- function(sequence, title, default) {
 profileNamesDefault <- c("short", "default")
 profilesFilePath <- normalizePath("./scripts/cs2/profiles.csv")
 profiles <- read.delim(
-  profilesFilePath, 
+  text = readLines(profilesFilePath, warn = FALSE), 
   header = TRUE, 
   sep = ";",
   colClasses = "character",

--- a/scripts/output/comparison/compareScenarios2.R
+++ b/scripts/output/comparison/compareScenarios2.R
@@ -6,14 +6,14 @@
 # |  Contact: remind@pik-potsdam.de
 # ---- Define set of runs that will be compared ----
 
-# Ask user to select an element form a sequence.
+# Ask user to select an element from a sequence.
 chooseFromSequence <- function(sequence, title, default) {
   cat(
     "\n\n", title, 
     "\nLeave empty for: ", paste(default, collapse=", "), ".\n\n", 
     sep = "")
   cat(paste(seq_along(sequence), sequence, sep = ": "), sep = "\n")
-  cat("\nNumbers, e.g, '1', '2,4', '3:5', ...:\n")
+  cat("\nNumbers, e.g., '1', '2,4', '3:5':\n")
   input <- get_line()
   ids <- as.numeric(eval(parse(text = paste("c(", input, ")"))))
   if (any(!ids %in% seq_along(sequence))) {

--- a/scripts/output/comparison/compareScenarios2.R
+++ b/scripts/output/comparison/compareScenarios2.R
@@ -71,7 +71,8 @@ start_comp <- function(outputdirs,
                        outfilename,
                        regionList,
                        mainReg,
-                       modelsHistExclude=c()) {
+                       modelsHistExclude = c(),
+                       profile = "") {
   if (!exists("slurmConfig")) {
     slurmConfig <- "--qos=standby"
   }
@@ -93,6 +94,7 @@ start_comp <- function(outputdirs,
     " --wrap=\"Rscript ", script,
     " outputdirs=", paste(outputdirs, collapse = ","),
     " shortTerm=", shortTerm,
+    " profile=", profile,
     " outfilename=", jobname,
     " regionList=", paste(regionList, collapse = ","),
     " mainRegName=", mainReg,
@@ -136,9 +138,21 @@ for (r in listofruns) {
     else
       mainRegName <- reg
     if (r$period == "short" | r$period == "both")
-      start_comp(outputdirs=r$dirs, shortTerm=TRUE, outfilename=fileName, regionList=regionList, mainReg=mainRegName)
+      start_comp(
+        outputdirs = r$dirs, 
+        shortTerm = TRUE, 
+        outfilename = fileName, 
+        regionList = regionList, 
+        mainReg = mainRegName,
+        profile = "short")
     if (r$period == "long" | r$period == "both")
-      start_comp(outputdirs=r$dirs, shortTerm=FALSE, outfilename=fileName, regionList=regionList, mainReg=mainRegName)
+      start_comp(
+        outputdirs = r$dirs, 
+        shortTerm = FALSE, 
+        outfilename = fileName, 
+        regionList = regionList, 
+        mainReg = mainRegName,
+        profile = "default")
 
     # plot additional pdf with Germany as focus region and exclusion of non-meaningful references in that context
     if (reg == "EUR") {
@@ -151,7 +165,14 @@ for (r in listofruns) {
         paste0("'", x, "'")
       }, USE.NAMES = F)
       fileName <- paste0(filename_prefix, ifelse(filename_prefix == "", "", "-"), r$set, "-DEU")
-      start_comp(outputdirs = r$dirs, shortTerm = TRUE, outfilename = paste0(fileName, "-", "Ariadne"), regionList = regionList, mainReg = "DEU", modelsHistExclude = ref.exclude)
+      start_comp(
+        outputdirs = r$dirs, 
+        shortTerm = TRUE, 
+        outfilename = paste0(fileName, "-", "Ariadne"), 
+        regionList = regionList, 
+        mainReg = "DEU", 
+        modelsHistExclude = ref.exclude,
+        profile = "AriadneDEU")
     }
 
   }

--- a/scripts/output/comparison/compareScenarios2.R
+++ b/scripts/output/comparison/compareScenarios2.R
@@ -13,14 +13,14 @@ chooseFromSequence <- function(sequence, title, default) {
     "Leave empty for: ", paste(default, collapse=", "), ".\n\n", 
     sep = "")
   cat(paste(seq_along(sequence), sequence, sep = ": "), sep = "\n")
-  cat("\nNumbers, e.g, '1', '2,4', '3:5', ...\n: ")
+  cat("\nNumbers, e.g, '1', '2,4', '3:5', ...:\n")
   input <- get_line()
   ids <- as.numeric(eval(parse(text = paste("c(", input, ")"))))
   if (any(!ids %in% seq_along(sequence))) {
     stop("Choose numbers between 1 and ", length(sequence))
   }
   chosenElements <- if (length(ids) == 0) default else sequence[ids]
-  cat("\nchosen elements:\n", paste(chosenElements, collapse="\n"), "\n\n")
+  cat("\nchosen elements:\n  ", paste(chosenElements, collapse="\n  "), "\n\n")
   return(chosenElements)
 }
 

--- a/scripts/output/comparison/compareScenarios2.R
+++ b/scripts/output/comparison/compareScenarios2.R
@@ -11,7 +11,7 @@ chooseFromSequence <- function(sequence, title, default) {
   cat("\n\n", title, "\n\n")
   cat(paste(seq_along(sequence), sequence, sep = ": "), sep = "\n")
   cat("\nNumber: ")
-  input <- readline()
+  input <- get_line()
   ids <- as.numeric(eval(parse(text = paste("c(", input, ")"))))
   if (any(!ids %in% seq_along(sequence))) {
     stop("Choose numbers between 1 and ", length(sequence))

--- a/scripts/output/comparison/compareScenarios2.R
+++ b/scripts/output/comparison/compareScenarios2.R
@@ -16,10 +16,9 @@ chooseFromSequence <- function(sequence, title, default) {
   if (any(!ids %in% seq_along(sequence))) {
     stop("Choose numbers between 1 and ", length(sequence))
   }
-  if (length(ids) == 0) {
-    return(default)
-  }
-  return(sequence[ids])
+  chosenElements <- if (length(ids) == 0) default else sequence[ids]
+  cat("\nchosen elements:", paste(chosenElements, collapse=", "))
+  return(chosenElements)
 }
 
 # cs2 profiles

--- a/scripts/output/comparison/compareScenarios2.R
+++ b/scripts/output/comparison/compareScenarios2.R
@@ -8,16 +8,19 @@
 
 # Ask user to select an element form a sequence.
 chooseFromSequence <- function(sequence, title, default) {
-  cat("\n\n", title, "\n\n")
+  cat(
+    "\n\n", title, 
+    "Leave empty for: ", paste(default, collapse=", "), ".\n\n", 
+    sep = "")
   cat(paste(seq_along(sequence), sequence, sep = ": "), sep = "\n")
-  cat("\nNumber: ")
+  cat("\nNumbers, e.g, '1', '2,4', '3:5', ...\n: ")
   input <- get_line()
   ids <- as.numeric(eval(parse(text = paste("c(", input, ")"))))
   if (any(!ids %in% seq_along(sequence))) {
     stop("Choose numbers between 1 and ", length(sequence))
   }
   chosenElements <- if (length(ids) == 0) default else sequence[ids]
-  cat("\nchosen elements:", paste(chosenElements, collapse=", "), "\n\n")
+  cat("\nchosen elements:\n", paste(chosenElements, collapse="\n"), "\n\n")
   return(chosenElements)
 }
 
@@ -39,9 +42,7 @@ if (exists("outputdirs")) {
   
   profileNames <- chooseFromSequence(
     profiles$name, 
-    paste0(
-      "Choose profiles for cs2. ",
-      "Leave empty for ", paste(profileNamesDefault, collapse=", ")),
+    "Choose profiles for cs2.",
     profileNamesDefault)
   
   listofruns <- list(list(

--- a/scripts/output/comparison/compareScenarios2.R
+++ b/scripts/output/comparison/compareScenarios2.R
@@ -17,7 +17,7 @@ chooseFromSequence <- function(sequence, title, default) {
     stop("Choose numbers between 1 and ", length(sequence))
   }
   chosenElements <- if (length(ids) == 0) default else sequence[ids]
-  cat("\nchosen elements:", paste(chosenElements, collapse=", "))
+  cat("\nchosen elements:", paste(chosenElements, collapse=", "), "\n\n")
   return(chosenElements)
 }
 

--- a/scripts/output/comparison/compareScenarios2.R
+++ b/scripts/output/comparison/compareScenarios2.R
@@ -12,7 +12,7 @@ chooseFromSequence <- function(sequence, title, default) {
   cat(paste(seq_along(sequence), sequence, sep = ": "), sep = "\n")
   cat("\nNumber: ")
   input <- readline()
-  ids <- as.numeric(eval(parse(paste("c(", input, ")"))))
+  ids <- as.numeric(eval(parse(text = paste("c(", input, ")"))))
   if (any(!ids %in% seq_along(sequence))) {
     stop("Choose numbers between 1 and ", length(sequence))
   }

--- a/scripts/output/comparison/compareScenarios2.R
+++ b/scripts/output/comparison/compareScenarios2.R
@@ -6,13 +6,52 @@
 # |  Contact: remind@pik-potsdam.de
 # ---- Define set of runs that will be compared ----
 
+# Ask user to select an element form a sequence.
+chooseFromSequence <- function(sequence, title, default) {
+  cat("\n\n", title, "\n\n")
+  cat(paste(seq_along(sequence), sequence, sep = ": "), sep = "\n")
+  cat("\nNumber: ")
+  input <- readline()
+  ids <- as.numeric(eval(parse(paste("c(", input, ")"))))
+  if (any(!ids %in% seq_along(sequence))) {
+    stop("Choose numbers between 1 and ", length(sequence))
+  }
+  if (length(ids) == 0) {
+    return(default)
+  }
+  return(sequence[ids])
+}
+
+# cs2 profiles
+profileNamesDefault <- c("short", "default")
+profilesFilePath <- normalizePath("./scripts/cs2/profiles.csv")
+profiles <- read.delim(
+  profilesFilePath, 
+  header = TRUE, 
+  sep = ";",
+  colClasses = "character",
+  comment.char = "#",
+  quote = "")
+profileNames <- profileNamesDefault
+
+
 if (exists("outputdirs")) {
   # This is the case if this script was called via Rscript output.R
+  
+  profileNames <- chooseFromSequence(
+    profiles$name, 
+    paste0(
+      "Choose profiles for cs2. ",
+      "Leave empty for ", paste(profileNamesDefault, collapse=", ")),
+    profileNamesDefault)
+  
   listofruns <- list(list(
     period = "both",
     set = format(Sys.time(), "%Y-%m-%d_%H.%M.%S"),
     dirs = outputdirs))
+  
 } else {
+  
   # This is the case if this script was called directly via Rscript
   listofruns <- list(
     list(
@@ -51,6 +90,7 @@ if (exists("outputdirs")) {
       period = "both",
       set = "cpl-SSP5",
       dirs = c("C_SSP5-Base-rem-5","C_SSP5-NPi-rem-5","C_SSP5-PkBudg1300-rem-5","C_SSP5-PkBudg1100-rem-5","C_SSP5-PkBudg900-rem-5")))
+  
 }
 
 # remove the NULL element
@@ -66,21 +106,20 @@ for (i in 1:length(listofruns)) {
 
 # ---- Start compareScenarios either on the cluster or locally ----
 
-start_comp <- function(outputdirs,
-                       shortTerm,
-                       outfilename,
-                       regionList,
-                       mainReg,
-                       modelsHistExclude = c(),
-                       profile = "") {
+start_comp <- function(
+  outputdirs,
+  outfilename,
+  regionList,
+  mainReg,
+  profileName
+) {
   if (!exists("slurmConfig")) {
     slurmConfig <- "--qos=standby"
   }
   jobname <- paste0(
       "compScen",
-      ifelse(outfilename == "", "", "-"),
-      outfilename,
-      ifelse(shortTerm, "-shortTerm", "")
+      ifelse(outfilename == "", "", "-"), outfilename,
+      "-", profileName
     )
   cat("Starting ", jobname, "\n")
   on_cluster <- file.exists("/p/projects/")
@@ -93,12 +132,10 @@ start_comp <- function(outputdirs,
     " --mail-type=END --time=200 --mem-per-cpu=8000",
     " --wrap=\"Rscript ", script,
     " outputdirs=", paste(outputdirs, collapse = ","),
-    " shortTerm=", shortTerm,
-    " profile=", profile,
+    " profileName=", profileName,
     " outfilename=", jobname,
     " regionList=", paste(regionList, collapse = ","),
     " mainRegName=", mainReg,
-    " modelsHistExclude=", paste(modelsHistExclude, collapse = ","),
     "\"")
   cat(clcom, "\n")
   if (on_cluster) {
@@ -137,42 +174,23 @@ for (r in listofruns) {
       mainRegName <- "World"
     else
       mainRegName <- reg
-    if (r$period == "short" | r$period == "both")
+    for (profileName in profileNames) {
       start_comp(
         outputdirs = r$dirs, 
-        shortTerm = TRUE, 
         outfilename = fileName, 
         regionList = regionList, 
         mainReg = mainRegName,
-        profile = "short")
-    if (r$period == "long" | r$period == "both")
-      start_comp(
-        outputdirs = r$dirs, 
-        shortTerm = FALSE, 
-        outfilename = fileName, 
-        regionList = regionList, 
-        mainReg = mainRegName,
-        profile = "default")
+        profileName = profileName)
+    }
 
     # plot additional pdf with Germany as focus region and exclusion of non-meaningful references in that context
     if (reg == "EUR") {
-      ref.exclude <- c(
-        "IEA ETP B2DS", "IEA ETP 2DS", "IEA ETP RTS",
-        "EDGE_SSP1", "EDGE_SSP2", "CEDS", "IRENA",
-        "IEA WEO 2021 APS", "IEA WEO 2021 SDS", "IEA WEO 2021 SPS"
-      )
-      ref.exclude <- sapply(ref.exclude, function(x) {
-        paste0("'", x, "'")
-      }, USE.NAMES = F)
       fileName <- paste0(filename_prefix, ifelse(filename_prefix == "", "", "-"), r$set, "-DEU")
       start_comp(
         outputdirs = r$dirs, 
-        shortTerm = TRUE, 
-        outfilename = paste0(fileName, "-", "Ariadne"), 
+        outfilename = fileName, 
         regionList = regionList, 
-        mainReg = "DEU", 
-        modelsHistExclude = ref.exclude,
-        profile = "AriadneDEU")
+        profileName = "AriadneDEU")
     }
 
   }

--- a/scripts/output/comparison/compareScenarios2.R
+++ b/scripts/output/comparison/compareScenarios2.R
@@ -20,7 +20,7 @@ chooseFromSequence <- function(sequence, title, default) {
     stop("Choose numbers between 1 and ", length(sequence))
   }
   chosenElements <- if (length(ids) == 0) default else sequence[ids]
-  cat("\nchosen elements:\n  ", paste(chosenElements, collapse="\n  "), "\n\n")
+  cat("\nchosen elements:\n  ", paste(chosenElements, collapse="\n  "), "\n\n", sep="")
   return(chosenElements)
 }
 

--- a/scripts/utils/run_compareScenarios2.R
+++ b/scripts/utils/run_compareScenarios2.R
@@ -8,8 +8,6 @@ library(lucode2) # getScenNames
 library(remind2)
 
 if (!exists("source_include")) {
-  modelsHistExclude <- c()
-  profile <- ""
   readArgs("outputdirs", "outfilename", "regionList", "mainRegName", "profileName")
 }
 
@@ -23,7 +21,7 @@ run_compareScenarios2 <- function(
 
   profilesFilePath <- normalizePath("./scripts/cs2/profiles.csv")
   profiles <- read.delim(
-    profilesFilePath, 
+    text = readLines(profilesFilePath, warn = FALSE), 
     header = TRUE, 
     sep = ";",
     colClasses = "character",

--- a/scripts/utils/run_compareScenarios2.R
+++ b/scripts/utils/run_compareScenarios2.R
@@ -94,9 +94,9 @@ run_compareScenarios2 <- function(
   }
   
   # move pdf / html file out of temporary folder and remove temporary folder
-  on.exit(system(paste0("mv ", outfilename, ".* ..")))
+  on.exit(system(paste0("mv ", args$outputFile, ".* ..")))
   on.exit(setwd(wd), add = TRUE)
-  on.exit(system(paste0("rm -rf ", outfilename)), add = TRUE)
+  on.exit(system(paste0("rm -rf ", args$outputDir)), add = TRUE)
   
   try(do.call(compareScenarios2, args))
 }

--- a/scripts/utils/run_compareScenarios2.R
+++ b/scripts/utils/run_compareScenarios2.R
@@ -72,8 +72,7 @@ run_compareScenarios2 <- function(
     outputFile = outfilename,
     outputFormat = "PDF",
     reg = regionList,
-    mainReg = mainRegName,
-    modelsHistExclude = modelsHistExclude
+    mainReg = mainRegName
   )
   
   # If profile is a single non-empty string, load cs2 profile and change args. 

--- a/scripts/utils/run_compareScenarios2.R
+++ b/scripts/utils/run_compareScenarios2.R
@@ -48,8 +48,8 @@ run_compareScenarios2 <- function(
   wd <- getwd()
 
   setwd(outfilepath)
-  # remove temporary folder
-  on.exit(system(paste0("mv ", outfilename, ".pdf ..")))
+  # move pdf / html file out of temporary folder and remove temporary folder
+  on.exit(system(paste0("mv ", outfilename, ".* ..")))
   on.exit(setwd(wd), add = TRUE)
   on.exit(system(paste0("rm -rf ", outfilename)), add = TRUE)
 

--- a/scripts/utils/run_compareScenarios2.R
+++ b/scripts/utils/run_compareScenarios2.R
@@ -46,13 +46,8 @@ run_compareScenarios2 <- function(
   system(paste0("mkdir ", outfilename))
   outfilepath <- normalizePath(outfilename) # Make path absolute.
   wd <- getwd()
-
   setwd(outfilepath)
-  # move pdf / html file out of temporary folder and remove temporary folder
-  on.exit(system(paste0("mv ", outfilename, ".* ..")))
-  on.exit(setwd(wd), add = TRUE)
-  on.exit(system(paste0("rm -rf ", outfilename)), add = TRUE)
-
+  
   # Use adjustedPolicyCosts mif, if available
   mif_path <- ifelse(file.exists(mif_path_polCosts), mif_path_polCosts, mif_path)
 
@@ -97,6 +92,11 @@ run_compareScenarios2 <- function(
   } else {
     message("using default profile")
   }
+  
+  # move pdf / html file out of temporary folder and remove temporary folder
+  on.exit(system(paste0("mv ", outfilename, ".* ..")))
+  on.exit(setwd(wd), add = TRUE)
+  on.exit(system(paste0("rm -rf ", outfilename)), add = TRUE)
   
   try(do.call(compareScenarios2, args))
 }

--- a/scripts/utils/run_compareScenarios2.R
+++ b/scripts/utils/run_compareScenarios2.R
@@ -70,7 +70,7 @@ run_compareScenarios2 <- function(
     mainReg = mainRegName
   )
   
-  # If profile is a single non-empty string, load cs2 profile and change args. 
+  # If profileName is a single non-empty string, load cs2 profile and change args. 
   if (
     length(profileName) == 1 && 
     is.character(profileName) && 


### PR DESCRIPTION
# Purpose of this PR

Allow to choose different *profiles* (sets of options) when calling compareScenarios2 via `Rscript output.R`.

The file `scripts/cs2/profiles.csv` is added. It contains a table, in which each row defines a set of options for calling `remind2::compareScenarios2()`, called a (cs2-) **profile**. E.g., the long term (until 2100) and short term (until 2050) cs2-reports, which were previously produced by default, are now defined as such profiles (see the rows with values `default` and `short` in the `name` column). Furthermore, `default` and `short` are available in HTML versions, see profiles `defaultHTML` and `shortHTML`. Also the Ariadne cs2-report with DEU as main region is now realized as a profile (name `AriadneDEU`).

When calling `compareScenarios2` via `Rscript output.R`, there is an additional prompt for the user, asking which profiles to run. Just hitting enter will run `default` and `short`, i.e., the previously standard cs2-reports.

By adding rows to the file  `scripts/cs2/profiles.csv` one can easily add further profiles. In particular, one may add a path to an Rmd-file in the `userSectionPath` column to be able to run a fully customized compareScenarios2 (which will be demonstrated in a later PR).

## Type of change

- [X] New feature 

## Checklist:

- [X] My code follows the coding etiquette
- [X] I have performed a self-review of my own code
- [X] Changes are commented, particularly in hard-to-understand areas
- [X] I have updated the in-code documentation
- [X] I have adjusted reporting where it was needed
- [X] The model compiles and runs successfully (`Rscript start.R -q`)
