### PR TITLE
if many infes occur, tell the user in log.txt that the error that stopped GAMS is probably not the actual reason

### DIFF
--- a/scripts/start/prepare_and_run.R
+++ b/scripts/start/prepare_and_run.R
@@ -1050,11 +1050,13 @@ run <- function(start_subsequent_runs = TRUE) {
   if (identical(cfg$gms$optimization, "nash") && file.exists("full.lst")) {
     message("\nInfeasibilities extracted from full.lst with nashstat -F:")
     command <- paste(
-      "li=$(nashstat -F | wc -l); cat",
+      "li=$(nashstat -F | wc -l); cat",   # li-1 = #infes
       "<(if (($li < 2)); then echo no infeasibilities found; fi)",
       "<(if (($li > 1)); then nashstat -F | head -n 2 | sed -r 's/\\x1B\\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g'; fi)",
-      "<(if (($li > 4)); then echo ... $(($li - 3)) infeasibilities omitted, show all with nashstat -a ...; fi)",
-      "<(if (($li > 2)); then nashstat -F | tail -n 1 | sed -r 's/\\x1B\\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g'; fi)")
+      "<(if (($li > 4)); then echo ... $(($li - 3)) infeasibilities omitted, show all with 'nashstat -a' ...; fi)",
+      "<(if (($li > 2)); then nashstat -F | tail -n 1 | sed -r 's/\\x1B\\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g'; fi)",
+      "<(if (($li > 3)); then echo If infeasibilities appear some iterations before GAMS failed, check 'nashstat -a' carefully.; fi)",
+      "<(if (($li > 3)); then echo The error that stopped GAMS is probably not the actual reason to fail.; fi)")
     nashstatres <- try(system2("/bin/bash", args = c("-c", shQuote(command))))
     if (nashstatres != 0) message("nashstat not found, search for p80_repy in full.lst yourself.")
   }


### PR DESCRIPTION
## Purpose of this PR

often, infeasibilities occur early and the error message of GAMS is useless. After this PR, it will tell the reader about it in the log file (the last two lines are new):

```
itr   region   solvestat              modelstat            resusd     objval
  5   REF      NORMAL COMPLETION   LOCALLY INFEASIBLE   1826.088    14.4513552835815   F
  ... 126 infeasibilities omitted, show all with nashstat -a ...
 45   USA      NORMAL COMPLETION   LOCALLY INFEASIBLE     1231.7    48.7879269029275   F
If infeasibilities appear some iterations before GAMS failed, check nashstat -a carefully.
The error that stopped GAMS is probably not the actual reason to fail.
```

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Minor change (no impact on scenarios)

## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [x] Changes are commented, particularly in hard-to-understand areas
- [x] The model compiles and runs successfully (`Rscript start.R -q`)
