### PR TITLE
Setting default of cm_abortOnConsecFail to 5.

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -298,7 +298,7 @@ cfg$gms$codePerformance <- "off"        # def = off
 #                          SWITCHES
 #-----------------------------------------------------------------------------
 cfg$gms$cm_iteration_max          <- 1       # def <- 1
-cfg$gms$cm_abortOnConsecFail      <- 0       # def <- 0
+cfg$gms$cm_abortOnConsecFail      <- 5       # def <- 5
 cfg$gms$c_solver_try_max          <- 2       # def <- 2
 cfg$gms$c_keep_iteration_gdxes    <- 0       # def <- 0
 cfg$gms$cm_keep_presolve_gdxes    <- 0       # def <- 0

--- a/main.gms
+++ b/main.gms
@@ -362,7 +362,7 @@ parameters
 *** --------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 cm_iteration_max       = 1;     !! def = 1
-cm_abortOnConsecFail   = 0;     !! def = 0
+cm_abortOnConsecFail   = 5;     !! def = 5
 c_solver_try_max       = 2;     !! def = 2
 c_keep_iteration_gdxes = 0;     !! def = 0
 cm_keep_presolve_gdxes  = 0;     !! def = 0


### PR DESCRIPTION
# Purpose of this PR
As discussed many times within the group, we would like to turn this switch on by default so that newbies don't constantly run into arbitrary REMIND errors due to a series of consecutive INFES early in the REMIND iteration.

## Type of change

- [x] New feature 