### PR TITLE
Use gms::getLine() instead of re-defining it everywhere

### DIFF
--- a/output.R
+++ b/output.R
@@ -41,19 +41,6 @@ if (file.exists("/iplex/01/landuse")) { # run is performed on the cluster
   latexpath <- NA
 }
 
-get_line <- function() {
-  # gets characters (line) from the terminal of from a connection
-  # and stores it in the return object
-  if (interactive()) {
-    s <- readline()
-  } else {
-    con <- file("stdin")
-    s <- readLines(con, 1, warn = FALSE)
-    on.exit(close(con))
-  }
-  return(s)
-}
-
 choose_folder <- function(folder, title = "Please choose a folder") {
   dirs <- NULL
 
@@ -72,7 +59,7 @@ choose_folder <- function(folder, title = "Please choose a folder") {
   cat(paste(seq_along(dirs), dirs, sep = ": "), sep = "\n")
   cat(paste(length(dirs) + 1, "Search by the pattern.\n", sep = ": "))
   cat("\nNumber: ")
-  identifier <- get_line()
+  identifier <- getLine()
   identifier <- strsplit(identifier, ",")[[1]]
   tmp <- NULL
   for (i in seq_along(identifier)) {
@@ -86,13 +73,13 @@ choose_folder <- function(folder, title = "Please choose a folder") {
   # PATTERN
   if (length(identifier) == 1 && identifier == (length(dirs) + 1)) {
     cat("\nInsert the search pattern or the regular expression: ")
-    pattern <- get_line()
+    pattern <- getLine()
     id <- grep(pattern = pattern, dirs[-1])
     # lists all chosen directories and ask for the confirmation of the made choice
     cat("\n\nYou have chosen the following directories:\n")
     cat(paste(seq_along(id), dirs[id + 1], sep = ": "), sep = "\n")
     cat("\nAre you sure these are the right directories?(y/n): ")
-    answer <- get_line()
+    answer <- getLine()
     if (answer == "y") {
       return(dirs[id + 1])
     } else {
@@ -112,7 +99,7 @@ choose_module <- function(Rfolder, title = "Please choose an outputmodule") {
   cat("\n\n", title, ":\n\n")
   cat(paste(seq_along(module), module, sep = ": "), sep = "\n")
   cat("\nNumber: ")
-  identifier <- get_line()
+  identifier <- getLine()
   identifier <- as.numeric(strsplit(identifier, ",")[[1]])
   if (any(!(identifier %in% seq_along(module)))) {
     stop("This choice (", identifier, ") is not possible. Please type in a number between 1 and ", length(module))
@@ -125,7 +112,7 @@ choose_mode <- function(title = "Please choose the output mode") {
   cat("\n\n", title, ":\n\n")
   cat(paste(seq_along(modes), modes, sep = ": "), sep = "\n")
   cat("\nNumber: ")
-  identifier <- get_line()
+  identifier <- getLine()
   identifier <- as.numeric(strsplit(identifier, ",")[[1]])
   if (identifier == 1) {
     comp <- FALSE
@@ -153,7 +140,7 @@ choose_slurmConfig_priority_standby <- function(title = "Please enter the slurm 
   cat("\n\n", title, ":\n\n")
   cat(paste(seq_along(slurm_options), gsub("qos=", "", gsub("--", "", slurm_options)), sep = ": "), sep = "\n")
   cat("\nNumber: ")
-  identifier <- get_line()
+  identifier <- getLine()
   if (identifier == "") {
     identifier <- 1
   }
@@ -166,7 +153,7 @@ choose_slurmConfig_priority_standby <- function(title = "Please enter the slurm 
 choose_filename_prefix <- function(modules, title = "") {
   cat(paste0("\n\n ", title, "Please choose a prefix for filenames of ", paste(modules, collapse=", "), ".\n"))
   cat(" For example compareScenarios2 uses it for the filenames: compScen-yourprefix-2022-….pdf.\n Use only A-Za-z0-9_-, or leave empty:\n\n")
-  filename_prefix <- get_line()
+  filename_prefix <- getLine()
   if(grepl("[^A-Za-z0-9_-]", filename_prefix)) {
     filename_prefix <- choose_filename_prefix(modules, title = paste("No, this contained special characters, try again.\n",title))
   }

--- a/scripts/output/comparison/compareScenarios2.R
+++ b/scripts/output/comparison/compareScenarios2.R
@@ -6,21 +6,6 @@
 # |  Contact: remind@pik-potsdam.de
 # ---- Define set of runs that will be compared ----
 
-
-# gets characters (line) from the terminal of from a connection
-# and stores it in the return object
-# same as get_line() in output.R, should eventually be extracted to package
-getLine <- function() {
-  if (interactive()) {
-    s <- readline()
-  } else {
-    con <- file("stdin")
-    s <- readLines(con, 1, warn = FALSE)
-    on.exit(close(con))
-  }
-  return(s)
-}
-
 # Ask user to select an element form a sequence.
 chooseFromSequence <- function(sequence, title, default) {
   cat(
@@ -29,7 +14,7 @@ chooseFromSequence <- function(sequence, title, default) {
     sep = "")
   cat(paste(seq_along(sequence), sequence, sep = ": "), sep = "\n")
   cat("\nNumbers, e.g., '1', '2,4', '3:5':\n")
-  input <- get_line()
+  input <- gms::getLine()
   ids <- as.numeric(eval(parse(text = paste("c(", input, ")"))))
   if (any(!ids %in% seq_along(sequence))) {
     stop("Choose numbers between 1 and ", length(sequence))

--- a/scripts/output/comparison/multiComparison.R
+++ b/scripts/output/comparison/multiComparison.R
@@ -40,7 +40,7 @@ compareScenTable <- function(listofruns){
 
       def_choice <- fls[length(fls)]
       cat(sprintf("Select the correct output directory (%s): ", def_choice))
-      n <- as.integer(get_line())
+      n <- as.integer(gms::getLine())
       if(is.na(n))
         choice <- def_choice
       else

--- a/scripts/output/comparison/plotRuntime.R
+++ b/scripts/output/comparison/plotRuntime.R
@@ -10,16 +10,6 @@ library(tidyr)
 library(ggplot2)
 library(magclass)
 
-getLine <- function() {
-  # gets and returns characters (line) from the terminal or from a connection
-  if (interactive()) {
-    s <- readline()
-  } else {
-    s <- readLines(withr::local_connection(file("stdin")), 1, warn = FALSE)
-  }
-  return(s)
-}
-
 if (!exists("source_include")) {
   ## Define arguments that can be read from command line
   lucode2::readArgs("outputdirs")
@@ -31,7 +21,7 @@ print(outputdirs)
 defaultFilenameKeywords <- "Base, NDC, PkBudg900"
 cat("Which filename keywords (case-insensitive regex) do you want to compare? Separate with commas. (default: ",
     defaultFilenameKeywords, ") ")
-filenameKeywords <- getLine()
+filenameKeywords <- gms::getLine()
 if (identical(filenameKeywords, "")) {
   filenameKeywords <- defaultFilenameKeywords
 }
@@ -39,7 +29,7 @@ filenameKeywords <- trimws(strsplit(filenameKeywords, ",", fixed = TRUE)[[1]])
 
 defaultComparisonProperty <- "config$gms$buildings"
 cat("Which property in runstatistics.rda do you want to compare? (default: ", defaultComparisonProperty, ") ")
-comparisonProperty <- getLine()
+comparisonProperty <- gms::getLine()
 if (identical(comparisonProperty, "")) {
   comparisonProperty <- defaultComparisonProperty
 }

--- a/scripts/output/comparison/policyCosts.R
+++ b/scripts/output/comparison/policyCosts.R
@@ -269,7 +269,7 @@ while (!happy_with_input) {
     message("Is that what you intended?")
     message("Type '",crayon::green("y"),"' to continue, '",crayon::blue("r"),"' to reselect output directories, '",crayon::red("n"),"' to abort: ")
 
-    user_input <- get_line()
+    user_input <- gms::getLine()
 
     if(user_input %in% c("y","Y","yes")) {
       happy_with_input <- TRUE
@@ -282,7 +282,7 @@ while (!happy_with_input) {
       message("3: Skip plot creation")
       message("4: Plot until 2150 in pdf")
       message("Type the number (or numbers seperated by a comma) to choose the special requests, or nothing to continue without any: ")
-      special_requests <- get_line() %>% str_split(",",simplify = TRUE) %>% as.vector()
+      special_requests <- gms::getLine() %>% str_split(",",simplify = TRUE) %>% as.vector()
 
     } else if (user_input %in% c("r","R","reselect")) {
       if (exists("choose_folder")) {

--- a/scripts/output/single/plotIterations.R
+++ b/scripts/output/single/plotIterations.R
@@ -19,18 +19,11 @@ if (!exists("source_include")) {
 outputdir <- normalizePath(outputdir)
 
 
-getLine <- function() {
-  # gets characters (line) from the terminal of from a connection
-  # and stores it in the return object
-  if (interactive()) {
-    s <- readline()
-  } else {
-    con <- file("stdin")
-    on.exit(close(con))
-    s <- readLines(con, 1, warn = FALSE)
-    if (identical(length(s), 0L)) {
-      s <- ""
-    }
+getLineCoerce <- function() {
+  # gets characters (line) from the user and always returns a string
+  s <- gms::getLine()
+  if (identical(length(s), 0L)) {
+    s <- ""
   }
   stopifnot(identical(length(s), 1L))
   return(s)
@@ -41,7 +34,7 @@ rmdPath <- file.path(outputdir, paste0("plotIterations_", now, ".Rmd"))
 
 # choose variables
 cat("\n\nWhich variables/parameters do you want to plot? Separate with comma. (default: ", symbolNames, ") ")
-answer <- getLine()
+answer <- getLineCoerce()
 if (!identical(trimws(answer), "")) {
   symbolNames <- answer
 }
@@ -52,7 +45,7 @@ symbolNames <- trimws(strsplit(symbolNames, ",")[[1]])
   for (s in symbolNames) {
   cat("\n\nHow do you want to map the dimensions of ", s, "in the plot?",
       "Unused aesthetics need to be set to NULL. Combine dimensions with +.\n(default: ", plotMappingDefault, ")\n")
-  answer <- getLine()
+  answer <- getLineCoerce()
   if (!identical(trimws(answer), "")) {
     pm <- answer
     if (grepl("\\+", pm)) {
@@ -156,7 +149,7 @@ writeLines(paste0(c(rmdHeader, vapply(symbolNames, rmdChunksForSymbol, character
 ), rmdPath)
 
 cat("Render plots to html? (default: ", generateHtml, ") ")
-answer <- getLine()
+answer <- getLineCoerce()
 if (!identical(trimws(answer), "")) {
   generateHtml <- tolower(answer)
 }

--- a/scripts/start/choose_slurmConfig.R
+++ b/scripts/start/choose_slurmConfig.R
@@ -8,18 +8,6 @@
 ############### Select slurm partitiion ###############################
 #######################################################################
 
-get_line <- function(){
-  # gets characters (line) from the terminal or from a connection
-  # and returns it
-  if(interactive()){
-    s <- readline()
-  } else {
-    con <- file("stdin")
-    s <- readLines(con, 1, warn=FALSE)
-    on.exit(close(con))
-  }
-  return(s);
-}
 
 choose_slurmConfig <- function(identifier = FALSE) {
 
@@ -57,7 +45,7 @@ choose_slurmConfig <- function(identifier = FALSE) {
       cat(modes,sep="\n")
       cat("=======================================================================\n")
       cat("Number: ")
-      identifier <- strsplit(get_line(), ",")[[1]]
+      identifier <- strsplit(gms::getLine(), ",")[[1]]
     }
     comp <- switch(as.integer(identifier),
                     "1" = "--qos=standby --nodes=1 --tasks-per-node=12"  , # SLURM standby  - task per node: 12 (nash H12) [recommended]

--- a/scripts/start/submit.R
+++ b/scripts/start/submit.R
@@ -69,7 +69,7 @@ submit <- function(cfg, restart = FALSE, stopOnFolderCreateError = TRUE) {
   
   # send prepare_and_run.R to cluster 
   cat("   Executing prepare_and_run.R for",cfg$results_folder,"\n")
-  if(cfg$slurmConfig=="direct") {
+  if (grepl("^direct", cfg$slurmConfig)) {
     log <- format(Sys.time(), paste0(cfg$title,"-%Y-%H-%M-%S-%OS3.log"))
     system("Rscript prepare_and_run.R")
   } else {

--- a/start.R
+++ b/start.R
@@ -50,21 +50,6 @@ helpText <- "
 source("scripts/start/submit.R")
 source("scripts/start/choose_slurmConfig.R")
 
-############## Define function: get_line ##############################
-
-get_line <- function(){
-    # gets characters (line) from the terminal or from a connection
-    # and stores it in the return object
-    if(interactive()){
-        s <- readline()
-    } else {
-        con <- file("stdin")
-        s <- readLines(con, 1, warn=FALSE)
-        on.exit(close(con))
-    }
-    return(s);
-}
-
 ############## Define function: chooseFromList #########################
 # thelist: list to be selected from
 # group: list with same dimension as thelist with group names to allow to select whole groups
@@ -93,7 +78,7 @@ chooseFromList <- function(thelist, type = "runs", returnboolean = FALSE, multip
   message(paste(paste(str_pad(1:length(thelist), nchar(length(thelist)), side = "left"), thelist, sep=": " ), collapse="\n"))
   message("\nNumber", ifelse(multiple,"s entered as 2,4:6,9",""),
           ifelse(allowempty, " or leave empty", ""), " (", type, "): ")
-  identifier <- strsplit(get_line(), ",")[[1]]
+  identifier <- strsplit(gms::getLine(), ",")[[1]]
   if (allowempty & length(identifier) == 0) return(NA)
   if (length(identifier) == 0 | ! all(grepl("^[0-9,:]*$", identifier))) {
     message("Try again, you have to choose some numbers.")
@@ -124,13 +109,13 @@ chooseFromList <- function(thelist, type = "runs", returnboolean = FALSE, multip
   # PATTERN
   if(multiple && length(identifier == 1) && identifier == length(thelist) ){
     message("\nInsert the search pattern or the regular expression: ")
-    pattern <- get_line()
+    pattern <- gms::getLine()
     id <- grep(pattern=pattern, originallist)
     # lists all chosen and ask for the confirmation of the made choice
     message("\n\nYou have chosen the following ", type, ":")
     if (length(id) > 0) message(paste(paste(1:length(id), originallist[id], sep=": "), collapse="\n"))
     message("\nAre you sure these are the right ", type, "? (y/n): ")
-    if(get_line() == "y"){
+    if(gms::getLine() == "y"){
       identifier <- id
       booleanlist[id] <- 1
     } else {
@@ -151,7 +136,7 @@ chooseFromList <- function(thelist, type = "runs", returnboolean = FALSE, multip
 select_testOneRegi_region <- function() {
   message("\nWhich region should testOneRegi use? Type it, or leave empty to keep settings:\n",
   "Examples are CAZ, CHA, EUR, IND, JPN, LAM, MEA, NEU, OAS, REF, SSA, USA.")
-  return(get_line())
+  return(gms::getLine())
 }
 
 ############## Define function: configure_cfg #########################
@@ -316,7 +301,7 @@ if ("--reset" %in% argv) {
 if (any(c("--testOneRegi", "--debug", "--quick") %in% argv) & "--restart" %in% argv & ! "--reprepare" %in% argv) {
   message("\nIt is impossible to combine --restart with --debug, --quick or --testOneRegi because full.gms has to be rewritten.\n",
   "If this is what you want, use --reprepare instead, or answer with y:")
-  if (get_line() %in% c("Y", "y")) argv <- c(argv, "--reprepare")
+  if (gms::getLine() %in% c("Y", "y")) argv <- c(argv, "--reprepare")
 }
 
 ignorederrors <- 0 # counts ignored errors in --test mode
@@ -341,7 +326,7 @@ if (any(c("--reprepare", "--restart") %in% argv)) {
   # possibledirs <- sub("./output/", "", lucode2::findIterations(runs, modelpath = "./output", latest = TRUE))
   outputdirs <- chooseFromList(sort(unique(possibledirs)), "runs to be restarted", returnboolean = FALSE)
   message("\nAlso restart subsequent runs? Enter y, else leave empty:")
-  restart_subsequent_runs <- get_line() %in% c("Y", "y")
+  restart_subsequent_runs <- gms::getLine() %in% c("Y", "y")
   if ("--testOneRegi" %in% argv) testOneRegi_region <- select_testOneRegi_region()
   if ("--reprepare" %in% argv) {
     message("\nBecause of the flag --reprepare, move full.gms -> full_old.gms and fulldata.gdx -> fulldata_old.gdx such that runs are newly prepared.\n")


### PR DESCRIPTION
# Purpose of this PR

Instead of defining `getLine` or variants of it in every script, use the version from `gms`. This is not a new dependency, we depend on `gms` anyway in REMIND. See discussion in #929.

## Type of change

- [x] Refactoring

## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [x] Changes are commented, particularly in hard-to-understand areas
- [x] I have updated the in-code documentation
- [x] I have adjusted reporting where it was needed
- [x] The model compiles and runs successfully (`Rscript start.R -q`)