### PR TITLE
add deletePlus to polCost calculation

### DIFF
--- a/scripts/output/comparison/policyCosts.R
+++ b/scripts/output/comparison/policyCosts.R
@@ -136,6 +136,7 @@ write_new_reporting <- function(mif_path,
   my_data <- magclass::add_dimension(my_data, dim=3.1, add = "scenario", nm = scen_name)
 
   magclass::write.report(my_data, file = new_mif_path, ndigit = 7)
+  remind2::deletePlus(new_mif_path, writemif=TRUE)
 
   return(new_mif_path)
 }
@@ -202,7 +203,8 @@ report_transfers <- function(pol_mif, ref_mif) {
     magclass::add_dimension(dim=3.1,add = "scenario",nm = sc)
   
   magclass::write.report(pol_run, file = pol_mif, ndigit = 7, skipempty = FALSE)
-  
+  remind2::deletePlus(pol_mif, writemif = TRUE)
+
   return(my_transfers)
 }
 # ###### END FUNCTION DEFINITONS ########################################

--- a/tutorials/4_RunningREMINDandMAgPIE.md
+++ b/tutorials/4_RunningREMINDandMAgPIE.md
@@ -49,7 +49,7 @@ bash /p/projects/rd3mod/R/libraries/Scripts/create_snapshot_with_day.sh
 
 ### Activate snapshot for REMIND and MAgPIE
 
-Direct the models to the snapshot you just created above by editing [`.Rprofile`](../.Rprofile) in both REMIND's main folder. This file will be copied to the MAgPIE main folder automatically. Uncomment these line by deleting `#` and change the date to today (the `_R4` is necessary if you run `R 4.0` or later):
+Direct the models to the snapshot you just created above by editing [`.Rprofile`](../.Rprofile) in REMIND's main folder. This file will be copied to the MAgPIE main folder automatically. Uncomment these line by deleting `#` and change the date to today (the `_R4` is necessary if you run `R 4.0` or later):
 
 ```bash
 # snapshot <- "/p/projects/rd3mod/R/libraries/snapshots/2022_05_17_R4"
@@ -73,7 +73,7 @@ Here's an example of a simple case. If you start a new coupled run with the scen
 
 This process will continue until for as many iterations as set in `max_iterations` in `start_bundle_coupled.R` (see Check the Convergence below). The last iteration will run REMIND only, so REMIND will have run `max_iterations` times and MAgPIE wil have run `max_iterations - 1` times. So, if `max_iterations` is 5, the last REMIND run in this case will be `C_SSP2-Base-rem-5` and the last MAgPIE iteration will be `C_SSP2-Base-mag-4`.
 
-The output of both models can be analyzed normally from these two runs. However, at the end of a successful coupled run the coupling script will automatically merge the reports of the last runs of both models in a `.mif` file located in the root of REMIND's output folder. In our example, that file will be `path_remind/output/C_SSP-Base.mif`.
+The output of both models can be analyzed normally from these two runs. The REMIND .mif file contains also the MAgPIE variables. Additionally, at the end of a successful coupled run the coupling script will automatically merge the reports of the last runs of both models in a `.mif` file located in the root of REMIND's output folder, using the joint model name "REMIND-MAgPIE". In our example, that file will be `path_remind/output/C_SSP-Base.mif`.
 
 So, in the end of the coupled run in this example, you should have a directory structure like:
 
@@ -139,7 +139,7 @@ Other, optional columns allow you to make a run start only after another has fin
       - If you set any of these `path_gdx…` columns (or `path_mif_ghgprice_land`, below) with a scenario name such as `SSP2-Base`, the coupling script will not start any runs that depend on an unfinished run, and automatically start them when that run finishes. So, in the example above, you can set `start` to `1` in both `SSP2-Base` and `SSP2-NDC`, `SSP2-NDC` will only start *after* `SSP2-Base` is finished. In "parallel" mode, `SSP2-NDC-rem-1` will start after `SSP2-Base-rem-1` is finished, while in "serial" mode, it waits for `SSP2-Base-rem-5`.
       - If you set any of these settings with a scenario name, the script will automatically try to detect whether the required "parent" run including the reporting is already finished and uses the appropriate `fulldata.gdx` then. In "serial" mode, if for some reason you changed `max_iterations` between the "parent" run and the current one, it's safer to specify a full path to a `fulldata.gdx` in these settings, otherwise the script may look for the wrong iteration of the "parent" scenario.
       - You can also set it to `C_SSP2-Base-rem-3` if for some reason, you want the results of a specific iteration.
-   - `path_mif_ghgprice_land`: This setting allows MAgPIE to be run using an exogenous, fixed GHG price path, regardless of the GHG price in the REMIND coupling. This can be useful if you want to simulate different GHG pricing policies in the land-use sector. It's timing is also controlled by `no_ghgprices_land_until`.
+   - `path_mif_ghgprice_land`: This setting allows MAgPIE to be run using an exogenous, fixed GHG price path, regardless of the GHG price in the REMIND coupling. This can be useful if you want to simulate different GHG pricing policies in the land-use sector. Its timing is also controlled by `no_ghgprices_land_until`.
       - As with the `path_gdx*` settings, this can be set both to the full path of a REMIND `.mif` reporting file (*not* a `.gdx`) or to the name of another scenario. If set to the name of another scenario, it will also wait for that run to finish before starting the dependent run as described.
    - `oldrun`: This setting can be used to continue a coupled run that had a different name and/or is in a different folder. It works in almost the same way as `path_gdx`, but it is used only if no REMIND run has been finished for this scenario. It will look in the path set in `start_bundle_coupled.R`'s `path_remind_oldruns`. This can be useful when continuing a previous experiment that was made in another REMIND copy, or after changing scenario names.
    - `cm_nash_autoconverge_lastrun`: can be used to specify `cm_nash_autoconverge`, but only for the last REMIND run, for example to increase precision there by setting it to `2`.


### PR DESCRIPTION
## Purpose of this PR

In PR https://github.com/remindmodel/remind/pull/881 we decided to overwrite the mif file with the new policyCosts, but we forgot the one without the `|++|` notation. This PR fixes that.

Additionally, I fixed some typos in the tutorial.

## Type of change

- [x] Bug fix, affecting only the ex-post policyCost calculation

## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code: `./output.R 
- [x] The model compiles and runs successfully (`Rscript start.R -q`)

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 


