### PR TITLE
Fix output.R: object 'outputUsingDirect' not found

### DIFF
--- a/output.R
+++ b/output.R
@@ -148,10 +148,10 @@ if (comp %in% c("comparison", "export")) {
   }
 } else { # comp = single
   # define slurm class or direct execution
+  outputUsingDirect <- c("plotIterations")
   if (! exists("source_include")) {
     # for selected output scripts, only slurm configurations matching these regex are available
     slurmExceptions <- if ("reporting" %in% output) "--mem=[0-9]*[0-9]{3}" else NULL
-    outputUsingDirect <- c("plotIterations")
     if (all(output %in% outputUsingDirect)) slurmConfig <- "direct"
     # if this script is not being sourced by another script but called from the command line via Rscript let the user
     # choose the slurm options


### PR DESCRIPTION
# Purpose of this PR

output.R failed when sourced from another script with error message `object 'outputUsingDirect' not found`

This is solved by putting the definition of `outputUsingDirect` where it can also be seen when output.R is called directly and when it is sourced by another script.

## Type of change

- [X] Bug fix

## Checklist:

- [X] My code follows the coding etiquette
- [X] I have performed a self-review of my own code
- [X] Changes are commented, particularly in hard-to-understand areas
- [ ] I have updated the in-code documentation
- [X] I have adjusted reporting where it was needed
- [X] The model compiles and runs successfully (`Rscript start.R -q`)
