### PR TITLE
Fix type in scenario name

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -25,7 +25,7 @@ cfg$description <- "REMIND run with default settings"
 cfg$regionmapping <- "config/regionmappingH12.csv"
 
 #### Current input data revision (<mainrevision>.<subrevision>) ####
-cfg$inputRevision <- 6.3120025
+cfg$inputRevision <- 6.316
 
 #### Current CES parameter and GDX revision (commit hash) ####
 cfg$CESandGDXversion <- "cf70acb4f81647aeda6826b350475de51875c70a"

--- a/core/sets.gms
+++ b/core/sets.gms
@@ -70,7 +70,7 @@ gdp_SSP2_lowEn  "SSP2 with low energy"
 gdp_SSP2EU_NAV_ele "NAVIGATE demand scenarios: Electrification and fuel shift"
 gdp_SSP2EU_NAV_act "NAVIGATE demand scenarios: Activity reduction and activity shift"
 gdp_SSP2EU_NAV_all "NAVIGATE demand scenarios: All measures."
-gdp_SSP2EU_NAV_tech "NAVIGATE demand scenarios: Technological improvements - energy efficiency"
+gdp_SSP2EU_NAV_tec "NAVIGATE demand scenarios: Technological improvements - energy efficiency"
 /
 
 all_GDPpcScen    "all possible GDP per capita scenarios (GDP and Population from the same SSP-scenario"


### PR DESCRIPTION
# Purpose of this PR
Fix a typo in the Navigate scenario name and increase the input data revision to new data with the respective scenarios and correct naming.

## Type of change

Bug fix 


## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [ ] Changes are commented, particularly in hard-to-understand areas
- [ ] I have updated the in-code documentation
- [ ] I have adjusted reporting where it was needed
- [x] The model compiles and runs successfully (`Rscript start.R -q`)

## Further information (optional):

* Change does not affect existing scenarios

