### PR TITLE
add missing unloading of abort.gdx

### DIFF
--- a/modules/29_CES_parameters/calibrate/preloop.gms
+++ b/modules/29_CES_parameters/calibrate/preloop.gms
@@ -1202,6 +1202,7 @@ if (0 gt sm_tmp,
     );
   );
   putclose logfile, " " /;
+  execute_unload "abort.gdx";
   abort "assertion EEK value < subsector output quantity failed. See log for details.";
 );
 


### PR DESCRIPTION
add missing unloading of abort.gdx to #939

- [x] Bug fix 

## Checklist:

- [x] My code follows the coding etiquette
- [ ] I have performed a self-review of my own code
- [ ] Changes are commented, particularly in hard-to-understand areas
- [ ] I have updated the in-code documentation
- [x] I have adjusted reporting where it was needed
- [x] The model compiles and runs successfully (`Rscript start.R -q`)