### PR TITLE
don't compute o01_CESmrs should that entail a division by zero

### DIFF
--- a/modules/01_macro/singleSectorGr/postsolve.gms
+++ b/modules/01_macro/singleSectorGr/postsolve.gms
@@ -46,13 +46,14 @@ loop ((cesLevel2cesIO(counter,in),cesOut2cesIn(in,in2),cesOut2cesIn2(in2,in3)),
 );
 
 
-*** compute marginal rate of substitution between primary production factors as ratio of CES prices
-*** provides the amount of in2 needed to subsitute one unit of in to generate the same economic value
-loop((cesOut2cesIn(out,in),cesOut2cesIn2(out,in2))$(ppfen(in)),
+*** compute marginal rate of substitution between primary production factors as
+*** ratio of CES prices provides the amount of in2 needed to subsitute one unit
+*** of in to generate the same economic value
+loop ((t,regi,cesOut2cesIn(out,ppfen(in)),cesOut2cesIn2(out,in2))$( 
+                                        o01_CESderivatives(t,regi,"inco",in2) ),
   o01_CESmrs(t,regi,in,in2)
-  =
-  o01_CESderivatives(t,regi,"inco",in) /
-  o01_CESderivatives(t,regi,"inco",in2)
+  = o01_CESderivatives(t,regi,"inco",in)
+  / o01_CESderivatives(t,regi,"inco",in2)
   );
 
 *** total CES efficiency as diagnostic output parameter


### PR DESCRIPTION
# Purpose of this PR

- Prevent division by zero and entailing execution errors.
- Follow the [coding etiquette](https://github.com/remindmodel/remind/blob/055e952bc7e130cc1b1b03afb65a11e8b916f657/tutorials/7_Advanced_ChangeCode.md#equations).

- [x] Bug fix 

## Checklist:

- [x] My code follows the coding etiquette
- [ ] I have performed a self-review of my own code
- [x] Changes are commented, particularly in hard-to-understand areas
- [ ] I have updated the in-code documentation
- [x] I have adjusted reporting where it was needed
- [x] The model compiles and runs successfully (`Rscript start.R -q`)