### PR TITLE
watch versions of packages lucode2 and magpie4 instead of lucode and magpie in log

### DIFF
--- a/scripts/start/prepare_and_run.R
+++ b/scripts/start/prepare_and_run.R
@@ -227,7 +227,7 @@ prepare <- function() {
         tribble(
             ~Package, "data.table", "devtools", "dplyr", "edgeTransport",
             "flexdashboard", "gdx", "gdxdt", "gdxrrw", "ggplot2", "gtools",
-            "lucode", "luplot", "luscale", "magclass", "magpie", "methods",
+            "lucode2", "luplot", "luscale", "magclass", "magpie4", "methods",
             "mip", "mrremind", "mrvalidation", "optparse", "parallel",
             "plotly", "remind", "remind2", "rlang", "rmndt", "tidyverse",
             "tools"),


### PR DESCRIPTION
watch versions of packages lucode2 and magpie4 instead of lucode and magpie in log

- [x] Bug fix 

## Checklist:

- [x] My code follows the coding etiquette
- [ ] I have performed a self-review of my own code
- [ ] Changes are commented, particularly in hard-to-understand areas
- [ ] I have updated the in-code documentation
- [x] I have adjusted reporting where it was needed
- [x] The model compiles and runs successfully (`Rscript start.R -q`)