### PR TITLE
Var list html

### DIFF
--- a/output.R
+++ b/output.R
@@ -118,7 +118,7 @@ if (comp %in% c("comparison", "export")) {
   }
 
   # choose the slurm options. If you use command line arguments, use slurmConfig=priority or standby
-  modules_using_slurmConfig <- c("compareScenarios2")
+  modules_using_slurmConfig <- c("compareScenarios2", "varListHtml")
   if (!exists("slurmConfig") && any(modules_using_slurmConfig %in% output)) {
     slurmConfig <- choose_slurmConfig_output()
   }

--- a/output.R
+++ b/output.R
@@ -118,7 +118,7 @@ if (comp %in% c("comparison", "export")) {
   }
 
   # choose the slurm options. If you use command line arguments, use slurmConfig=priority or standby
-  modules_using_slurmConfig <- c("compareScenarios2", "varListHtml")
+  modules_using_slurmConfig <- c("compareScenarios2")
   if (!exists("slurmConfig") && any(modules_using_slurmConfig %in% output)) {
     slurmConfig <- choose_slurmConfig_output()
   }

--- a/output.R
+++ b/output.R
@@ -108,7 +108,7 @@ if (! exists("outputdir")) {
 
 if (comp %in% c("comparison", "export")) {
   # ask for filename_prefix, if one of the modules that use it is selected
-  modules_using_filename_prefix <- c("compareScenarios2", "xlsx_IIASA")
+  modules_using_filename_prefix <- c("compareScenarios2", "xlsx_IIASA", "varListHtml")
   if (!exists("filename_prefix")) {
     if (any(modules_using_filename_prefix %in% output)) {
       filename_prefix <- choose_filename_prefix(modules = intersect(modules_using_filename_prefix, output))

--- a/scripts/output/comparison/varListHtml.R
+++ b/scripts/output/comparison/varListHtml.R
@@ -1,0 +1,53 @@
+# |  (C) 2006-2022 Potsdam Institute for Climate Impact Research (PIK)
+# |  authors, and contributors see CITATION.cff file. This file is part
+# |  of REMIND and licensed under AGPL-3.0-or-later. Under Section 7 of
+# |  AGPL-3.0, you are granted additional permissions described in the
+# |  REMIND License Exception, version 1.0 (see LICENSE file).
+# |  Contact: remind@pik-potsdam.de
+
+source("./scripts/utils/isSlurmAvailable.R")
+
+# This script expects a variable `outputdirs` and `slurmConfig` to be defined.
+# Variable `filename_prefix` is used if defined.
+if (!exists("outputdirs") || !exists("slurmConfig")) {
+  stop(
+    "Variable outputdirs or slurmConfig do not exist. ",
+    "Please call varListHtml.R via output.R, which defines outputdirs and slurmConfig.")
+}
+
+timeStamp <- format(Sys.time(), "%Y-%m-%d_%H.%M.%S")
+if (!exists("filename_prefix")) filename_prefix <- ""
+nameCore <- paste0(filename_prefix, ifelse(filename_prefix == "", "", "-"), timeStamp)
+fullName <- paste0("varList-", nameCore)
+
+mifs <- c(remind2::getMifScenPath(outputdirs), remind2::getMifHistPath(outputdirs[1]))
+
+command <- paste0(
+  "remind2::createVarListHtml(",
+  "x = c(\"", paste(mifs, collapse = "\",\""), "\"), ",
+  "outFileName = \"", fullName, ".html\"", ", ",
+  "title = \"", fullName, "\", ", 
+  "usePlus = FALSE, ",
+  "details = NULL",
+  ")"
+)
+
+if (isSlurmAvailable() && slurmConfig != "direct") {
+  clcom <- paste0(
+    "sbatch ", slurmConfig,
+    " --job-name=", fullName,
+    " --output=", fullName, ".out",
+    " --error=", fullName, ".out",
+    " --mail-type=END --time=200 --mem-per-cpu=8000",
+    r"( --wrap="R -e ')", command, r"('")")
+  cat(clcom, "\n")
+  system(clcom)
+} else {
+  tmpEnv <- new.env()
+  tmpError <- try(
+    eval(parse(text=command), envir = tmpEnv)
+  )
+  if (!is.null(tmpError))
+    warning("Script ", script, " was stopped by an error and not executed properly!")
+  rm(tmpEnv)
+}

--- a/scripts/output/comparison/varListHtml.R
+++ b/scripts/output/comparison/varListHtml.R
@@ -39,7 +39,7 @@ if (isSlurmAvailable() && slurmConfig != "direct") {
     " --output=", fullName, ".out",
     " --error=", fullName, ".out",
     " --mail-type=END --time=200 --mem-per-cpu=8000",
-    r"( --wrap="R -e ')", command, r"('")")
+    r"( --wrap="R -e ')", gsub("\"", "\\\"", command), r"('")")
   cat(clcom, "\n")
   system(clcom)
 } else {

--- a/scripts/output/comparison/varListHtml.R
+++ b/scripts/output/comparison/varListHtml.R
@@ -39,7 +39,7 @@ if (isSlurmAvailable() && slurmConfig != "direct") {
     " --output=", fullName, ".out",
     " --error=", fullName, ".out",
     " --mail-type=END --time=200 --mem-per-cpu=8000",
-    r"( --wrap="R -e ')", gsub("\"", "\\\"", command), r"('")")
+    r"( --wrap="R -e ')", gsub(r"(\")", r"(\\")", command), r"('")")
   cat(clcom, "\n")
   system(clcom)
 } else {

--- a/scripts/output/comparison/varListHtml.R
+++ b/scripts/output/comparison/varListHtml.R
@@ -17,6 +17,11 @@ timeStamp <- format(Sys.time(), "%Y-%m-%d_%H.%M.%S")
 if (!exists("filename_prefix")) filename_prefix <- ""
 nameCore <- paste0(filename_prefix, ifelse(filename_prefix == "", "", "-"), timeStamp)
 fullName <- paste0("varList-", nameCore)
+htmlBefore <- paste0(c(
+  "<ul>",
+  paste0("  <li>", outputdirs, "</li>"),
+  "</ul>"
+), collapse = "\n")
 
 mifs <- c(
   remind2::getMifScenPath(outputdirs), 
@@ -35,6 +40,7 @@ remind2::createVarListHtml(
   x = mifs,
   outFileName = paste0(fullName, ".html"),
   title = fullName,
+  htmlBefore = htmlBefore,
   usePlus = TRUE,
   details = details)
 

--- a/scripts/output/comparison/varListHtml.R
+++ b/scripts/output/comparison/varListHtml.R
@@ -5,8 +5,6 @@
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
 
-source("./scripts/utils/isSlurmAvailable.R")
-
 # This script expects a variable `outputdirs` to be defined.
 # Variable `filename_prefix` is used if defined.
 if (!exists("outputdirs")) {
@@ -20,7 +18,9 @@ if (!exists("filename_prefix")) filename_prefix <- ""
 nameCore <- paste0(filename_prefix, ifelse(filename_prefix == "", "", "-"), timeStamp)
 fullName <- paste0("varList-", nameCore)
 
-mifs <- c(remind2::getMifScenPath(outputdirs), remind2::getMifHistPath(outputdirs[1]))
+mifs <- c(
+  remind2::getMifScenPath(outputdirs), 
+  remind2::getMifHistPath(outputdirs[1]))
 
 details <- 
   readr::read_delim(

--- a/scripts/output/comparison/varListHtml.R
+++ b/scripts/output/comparison/varListHtml.R
@@ -28,7 +28,7 @@ details <-
     delim = ";",
     col_select = c(r21m42, Definition),
     col_types = "cc") |>
-  dplyr::rename(name = r21m42))
+  dplyr::rename(name = r21m42)
 
 remind2::createVarListHtml(
   x = mifs,

--- a/scripts/output/comparison/varListHtml.R
+++ b/scripts/output/comparison/varListHtml.R
@@ -27,7 +27,8 @@ details <-
     "https://raw.githubusercontent.com/pik-piam/project_interfaces/master/ar6/mapping_template_AR6.csv",
     delim = ";",
     col_select = c(r21m42, Definition),
-    col_types = "cc") |>
+    col_types = "cc"
+  ) |>
   dplyr::rename(name = r21m42)
 
 remind2::createVarListHtml(

--- a/scripts/output/comparison/varListHtml.R
+++ b/scripts/output/comparison/varListHtml.R
@@ -18,9 +18,11 @@ if (!exists("filename_prefix")) filename_prefix <- ""
 nameCore <- paste0(filename_prefix, ifelse(filename_prefix == "", "", "-"), timeStamp)
 fullName <- paste0("varList-", nameCore)
 htmlBefore <- paste0(c(
+  "<h2>Runs Used</h2>",
   "<ul>",
   paste0("  <li>", outputdirs, "</li>"),
-  "</ul>"
+  "</ul>",
+  "<h2>List of Variables</h2>"
 ), collapse = "\n")
 
 mifs <- c(


### PR DESCRIPTION
# Purpose of this PR

Add new output.R script to create an HTML containing a hierarchical list of all variable names in reported mif-files of runs or in the historical.mif.

Also use the getPath-methods added to remind2 here: https://github.com/pik-piam/remind2/pull/326

**Requires https://github.com/pik-piam/remind2/pull/326!**

## Type of change

- [x] Refactoring
- [x] New feature 

## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [x] Changes are commented, particularly in hard-to-understand areas
- [x] I have updated the in-code documentation
- [x] I have adjusted reporting where it was needed
- [X] The model compiles and runs successfully (`Rscript start.R -q`)

## Further information:

Example of `Rscript output.R -> comparision -> varListHtml` :
`/p/tmp/cschoetz/varListHtml/remind/varList-TEST-2022-08-22_17.40.05.html`
