### PR TITLE
report run statistics also for failed runs

### DIFF
--- a/scripts/start/prepare_and_run.R
+++ b/scripts/start/prepare_and_run.R
@@ -1062,11 +1062,6 @@ run <- function(start_subsequent_runs = TRUE) {
   }
   message("")
 
-  if (stoprun) {
-    stop("GAMS did not complete its run, so stopping here:\n       No output is generated, no subsequent runs are started.\n",
-         "       See the debugging tutorial at https://github.com/remindmodel/remind/blob/develop/tutorials/10_DebuggingREMIND.md")
-  }
-
   message("\nCollect and submit run statistics to central data base.")
   lucode2::runstatistics(file       = "runstatistics.rda",
                          modelstat  = modelstat,
@@ -1074,6 +1069,11 @@ run <- function(start_subsequent_runs = TRUE) {
                          runtime    = gams_runtime,
                          setup_info = lucode2::setup_info(),
                          submit     = cfg$runstatistics)
+
+  if (stoprun) {
+    stop("GAMS did not complete its run, so stopping here:\n       No output is generated, no subsequent runs are started.\n",
+         "       See the debugging tutorial at https://github.com/remindmodel/remind/blob/develop/tutorials/10_DebuggingREMIND.md")
+  }
 
   # Compress files with the fixing-information
   if (cfg$gms$cm_startyear > 2005)


### PR DESCRIPTION
# Purpose of this PR

If the GAMS part of a REMIND run fails, run statistics (like e.g. model runtime) were not reported. This PR fixes that.

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] The model compiles and runs successfully (`Rscript start.R -q`)



