### PR TITLE
improve the reporting on Industry FE price scaling during calibration

### DIFF
--- a/modules/29_CES_parameters/calibrate/preloop.gms
+++ b/modules/29_CES_parameters/calibrate/preloop.gms
@@ -1370,8 +1370,16 @@ loop ((t,regi_dyn29(regi),ue_industry_dyn37(out)),
   if (sm_tmp ne 1,
     loop (ue_industry_2_pf(out,ppfen_industry_dyn37(in)),
       put pm_cesdata.tn(t,regi,in,"price"),
-          @60 pm_cesdata(t,regi,in,"price"), " x ",
-          sm_tmp, " = ";
+          @60 pm_cesdata(t,regi,in,"price"), " x ";
+      if (abs(sm_tmp - 1) lt 1e-2,
+        if (sm_tmp gt 1,
+          put "(1 + ", (sm_tmp - 1), ") = ";
+        else
+          put "(1 - ", (1 - sm_tmp), ") = ";
+        );
+      else
+        put "     ", sm_tmp, "  = ";
+      );
 
       pm_cesdata(t,regi,in,"price")
       = pm_cesdata(t,regi,in,"price")


### PR DESCRIPTION
Lots of very small scaling differences caused hard-to-understand output.
Sample of new output:
```
pm_cesdata('2015','EUR','fehe_otherInd','price')            5.851E+00 x (1 +  2.220E-16) =  5.851E+00
pm_cesdata('2015','EUR','feelhth_otherInd','price')         3.263E+01 x (1 +  2.220E-16) =  3.263E+01
pm_cesdata('2015','EUR','feelwlth_otherInd','price')        1.233E+01 x (1 +  2.220E-16) =  1.233E+01
pm_cesdata('2020','EUR','feso_cement','price')              3.629E+00 x       9.875E-01  =  3.584E+00
pm_cesdata('2020','EUR','feli_cement','price')              1.364E+01 x       9.875E-01  =  1.347E+01
pm_cesdata('2020','EUR','fega_cement','price')              5.760E+00 x       9.875E-01  =  5.688E+00
pm_cesdata('2020','EUR','feh2_cement','price')              2.116E+01 x       9.875E-01  =  2.090E+01
pm_cesdata('2020','EUR','feel_cement','price')              8.253E+00 x       9.875E-01  =  8.150E+00
pm_cesdata('2020','EUR','feso_chemicals','price')           4.626E-01 x (1 -  1.237E-03) =  4.620E-01
pm_cesdata('2020','EUR','feli_chemicals','price')           1.738E+00 x (1 -  1.237E-03) =  1.736E+00
```

- [x] New feature 

## Checklist:

- [x] My code follows the coding etiquette
- [ ] I have performed a self-review of my own code
- [x] Changes are commented, particularly in hard-to-understand areas
- [ ] I have updated the in-code documentation
- [x] I have adjusted reporting where it was needed
- [x] The model compiles and runs successfully (`Rscript start.R -q`)

