### PR TITLE
move non_optimal.gdx and abort.gdx for calib and restarts, cleanup

### DIFF
--- a/scripts/input/prepare_NDC.R
+++ b/scripts/input/prepare_NDC.R
@@ -36,6 +36,9 @@ prepare_NDC<-function(gdx, cfg){
   }
 
   getNames(pm_BAU_reg_emi_wo_LU_bunkers) <- NULL
-  write.magpie(pm_BAU_reg_emi_wo_LU_bunkers, "./modules/45_carbonprice/NDC/input/pm_BAU_reg_emi_wo_LU_bunkers.cs4r", comment="** description: Regional GHG emi (excl. LU and bunkers) in BAU scenario \n*** unit: Mt CO2eq/yr \n*** file created with scripts/input/prepare_NDC.R")
-  write.magpie(pm_BAU_reg_emi_wo_LU_bunkers, "./modules/46_carbonpriceRegi/NDC/input/pm_BAU_reg_emi_wo_LU_bunkers.cs4r", comment="** description: Regional GHG emi (excl. LU and bunkers) in BAU scenario \n*** unit: Mt CO2eq/yr \n*** file created with scripts/input/prepare_NDC.R")
+  write.magpie(pm_BAU_reg_emi_wo_LU_bunkers, "./modules/45_carbonprice/NDC/input/pm_BAU_reg_emi_wo_LU_bunkers.cs4r",
+               comment = "description: Regional GHG emi (excl. LU and bunkers) in BAU scenario \nunit: Mt CO2eq/yr \nfile created with scripts/input/prepare_NDC.R",
+               comment.char="*** ")
+  file.copy("./modules/45_carbonprice/NDC/input/pm_BAU_reg_emi_wo_LU_bunkers.cs4r",
+            "./modules/46_carbonpriceRegi/NDC/input/pm_BAU_reg_emi_wo_LU_bunkers.cs4r")
 }

--- a/scripts/start/prepare_and_run.R
+++ b/scripts/start/prepare_and_run.R
@@ -959,6 +959,9 @@ run <- function(start_subsequent_runs = TRUE) {
         file.copy("fulldata.gdx", paste0(cfg$gms$cm_CES_configuration,".gdx"), overwrite = TRUE)
         file.copy("fulldata.gdx", sprintf("input_%02i.gdx", cal_itr),
                   overwrite = TRUE)
+        if (file.exists("non_optimal.gdx")) {
+          file.rename("non_optimal.gdx", sprintf("non_optimal_%02i.gdx", cal_itr))
+        }
 
         # Update file modification time
         fulldata_m_time <- file.info("fulldata.gdx")$mtime

--- a/scripts/start/prepare_and_run.R
+++ b/scripts/start/prepare_and_run.R
@@ -953,19 +953,20 @@ run <- function(start_subsequent_runs = TRUE) {
         getLoadFile()
 
         # Store all the interesting output
-        file.copy("full.lst", sprintf("full_%02i.lst", cal_itr), overwrite = TRUE)
-        file.copy("full.log", sprintf("full_%02i.log", cal_itr), overwrite = TRUE)
+        interestingOutput <- c("full.lst", "full.log", "fulldata.gdx", "non_optimal.gdx", "abort.gdx")
+        file.copy(from = interestingOutput,
+                  to = sub("^(.*)(\\.[^\\.]+)$", sprintf("\\1_%02i\\2", cal_itr), interestingOutput), overwrite = TRUE)
         file.copy("fulldata.gdx", "input.gdx", overwrite = TRUE)
-        file.copy("fulldata.gdx", paste0(cfg$gms$cm_CES_configuration,".gdx"), overwrite = TRUE)
-        file.copy("fulldata.gdx", sprintf("input_%02i.gdx", cal_itr),
-                  overwrite = TRUE)
-        if (file.exists("non_optimal.gdx")) {
-          file.rename("non_optimal.gdx", sprintf("non_optimal_%02i.gdx", cal_itr))
+        if (cal_itr < cfg$gms$c_CES_calibration_iterations) {
+          unlink(c("abort.gdx", "non_optimal.gdx"))
+        } else { # calibration was successful
+          file.copy("fulldata.gdx", paste0(cfg$gms$cm_CES_configuration, ".gdx"))
+          file.copy(from = paste0(cfg$gms$cm_CES_configuration, "_ITERATION_", cal_itr, ".inc"),
+                    to = paste0(cfg$gms$cm_CES_configuration, ".inc"))
         }
 
         # Update file modification time
         fulldata_m_time <- file.info("fulldata.gdx")$mtime
-
       } else {
         break
       }

--- a/tutorials/10_DebuggingREMIND.md
+++ b/tutorials/10_DebuggingREMIND.md
@@ -142,7 +142,7 @@ To restart a run in "debug" mode, run
 ```bash
 Rscript start.R --debug --reprepare
 ```
-in the REMIND main folder and select the runs to be restarted (the shortcut is `Rscript start.R -dR`). This will recreate move `full.gms` and `fulldata.gdx` to filenames with an appended `_old` and restart the input preparation and the model run.
+in the REMIND main folder and select the runs to be restarted (the shortcut is `Rscript start.R -dR`). This will move `full.gms` and `fulldata.gdx` to filenames with an appended `_beforeRestart` and restart the input preparation and the model run.
 
 If you only want to look at a specific region that created the infeasibility, you can either specify `c_testOneRegi_region` in `scenario_config_XYZ.csv`:
 ```bash


### PR DESCRIPTION
## Purpose of this PR

- if a run writes a non_optimal.gdx or abort.gdx, this file remains there also for the next calibration iteration or if the run is restarted, confusing not only a variety of scripts from rs2 to the model summary in log.txt, but also potentially the user. With this PR, the files are moved once the model is restarted to `non_optimal_beforeRestart.gdx` etc., and once a calibration iteration (say: 5) is over, to `non_optimal_05.gdx` etc.. This way, they are clearly marked as outdated.
- <s>I don't particularly like the `system(mv…)` call, but there seems to be no native `file.move` in R. Corrections welcome.</s> `file.rename` is it…
- I haven't tested the part in the calibration iteration in a full run as I don't do calibrations, but I guess it should be safe.
- fix minor comment confusion issue created by this bugfix, namely now having `****` which looks like an error in `full.lst`: https://github.com/pik-piam/magclass/pull/125

## Type of change

- [x] Bug fix 
- [x] Minor change

## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [x] The model compiles and runs successfully (`Rscript start.R -q`)
