### PR TITLE
new CES parameters and gdx files for SSP5, SDP, SSP1, SSP2EU, SDP_EI …

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -28,7 +28,7 @@ cfg$regionmapping <- "config/regionmappingH12.csv"
 cfg$inputRevision <- "6.316"
 
 #### Current CES parameter and GDX revision (commit hash) ####
-cfg$CESandGDXversion <- "1319573f58117b8e641981561543bc613ebc0aa6"
+cfg$CESandGDXversion <- "705399ba7aa85e038eb5b0762285ea2a069f8450"
 
 #### Force the model to download new input data ####
 cfg$force_download <- FALSE


### PR DESCRIPTION
…and SDP_RC

# Purpose of this PR
new CES parameters and gdx files were necessary to run REMIND without infes

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix 


## Checklist:

- [x] I have performed a self-review of my own code

## Further information (optional):

* based on following calibration runs: /p/tmp/lavinia/REMIND/REMIND_calibration_2022_08_26/remind/output


