### PR TITLE
add DESCRIPTION, make renv install modelstats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ plotRuntimeDependencies/
 # main renv.lock should only be commited for releases
 /renv.lock
 /archive/
+/.Rbuildignore

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,4 +1,3 @@
-Package: remindmodel
 Title: REMIND - REgional Model of INvestments and Development
 Version: 0.1
 Date: 2022-08-31

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,0 +1,75 @@
+Package: remindmodel
+Title: REMIND - REgional Model of INvestments and Development
+Version: 0.1
+Date: 2022-08-31
+Description: This is not a package yet, the purpose of this file is to
+    document metadata, notably dependencies.
+License: file LICENSE
+URL: https://github.com/remindmodel/remind,
+    https://doi.org/10.5281/zenodo.6794920
+BugReports: https://github.com/remindmodel/remind/issues
+Depends:
+    R (>= 4.0.0)
+Imports:
+    callr,
+    colorspace,
+    crayon,
+    data.table,
+    devtools,
+    dplyr,
+    edgeTransport,
+    flexdashboard,
+    GDPuc,
+    gdx,
+    gdxdt,
+    gdxrrw,
+    ggplot2,
+    gms,
+    gridExtra,
+    gtools,
+    hdf5r,
+    here,
+    htmltools,
+    iamc,
+    kableExtra,
+    knitr,
+    lazyeval,
+    lpjclass,
+    lucode2,
+    luplot,
+    luscale,
+    lusweave,
+    magclass,
+    magpie4,
+    magpiesets,
+    mip,
+    modelstats,
+    mrremind,
+    mrvalidation,
+    ncdf4,
+    nleqslv,
+    optparse,
+    plotly,
+    purrr,
+    quitte,
+    R.utils,
+    raster,
+    readr,
+    readxl,
+    remind2,
+    renv,
+    reshape2,
+    rlang,
+    rmarkdown,
+    rmndt,
+    SPEI,
+    stringr,
+    terra,
+    tibble,
+    tidyr,
+    tidyverse,
+    withr,
+    writexl,
+    yaml,
+    zoo
+Encoding: UTF-8

--- a/scripts/cs2/run_compareScenarios2.R
+++ b/scripts/cs2/run_compareScenarios2.R
@@ -6,9 +6,6 @@
 # |  Contact: remind@pik-potsdam.de
 library(remind2)
 
-# optional dependency of remind2 "kableExtra" is used here, make explicit so renv installs it
-requireNamespace("kableExtra", quietly = TRUE)
-
 if (!exists("source_include")) {
   lucode2::readArgs("outputDirs", "outFileName", "profileName")
 }

--- a/scripts/utils/checkSetup.R
+++ b/scripts/utils/checkSetup.R
@@ -8,7 +8,8 @@ stopifnot(`pdflatex not found, check your LaTeX installation` = Sys.which("pdfla
 message("checking for pdflatex executable on your PATH - ok")
 
 message("checking if required R packages are installed")
-missingDeps <- Filter(function(x) !requireNamespace(x, quietly = TRUE), renv::dependencies(dev = TRUE)[, "Package"])
+missingDeps <- Filter(function(x) !requireNamespace(x, quietly = TRUE),
+                      renv::dependencies(dev = TRUE)[, "Package"])
 if (length(missingDeps) > 0) {
   stop("Some required R packages are missing, install them with `renv::install(",
        paste(capture.output(dput(missingDeps)), collapse = ""), ")`")


### PR DESCRIPTION
# Purpose of this PR
Add a DESCRIPTION file to document dependencies and other metadata in a standard way. Renv would not realize `modelstats` was a dependency (for rs2), so it is now listed explicitly as a dep in DESCRIPTION.

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix 

## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code