### PR TITLE
use custom renv snapshot filter to include all of, but only those packages required by REMIND in the lock file

### DIFF
--- a/renv/settings.dcf
+++ b/renv/settings.dcf
@@ -3,7 +3,7 @@ external.libraries:
 ignored.packages:
 package.dependency.fields: Imports, Depends, LinkingTo
 r.version:
-snapshot.type: all
+snapshot.type: implicit
 use.cache: TRUE
 vcs.ignore.cellar: TRUE
 vcs.ignore.library: TRUE


### PR DESCRIPTION
otherwise, REMIND breaks on renv being unable to install packages for which it can't determine upstream package sources (development packages, packages on repositories requiring access tokens)

- [x] Bug fix 

- [x] My code follows the coding etiquette
- [ ] I have performed a self-review of my own code
- [x] Changes are commented, particularly in hard-to-understand areas
- [x] I have updated the in-code documentation
- [x] I have adjusted reporting where it was needed
- [x] The model compiles and runs successfully (`Rscript start.R -q`)