### PR TITLE
Add to cfg an additional (optional) region mapping, so that those validation data can be loaded that contain the corresponding additional regions

### DIFF
--- a/config/21_regions_EU11/extramapping_EU27.csv
+++ b/config/21_regions_EU11/extramapping_EU27.csv
@@ -1,0 +1,250 @@
+X;CountryCode;EU27_map
+Afghanistan;AFG;restEU27
+Aland Islands;ALA;EU27
+Albania;ALB;restEU27
+Algeria;DZA;restEU27
+American Samoa;ASM;restEU27
+Andorra;AND;restEU27
+Angola;AGO;restEU27
+Anguilla;AIA;restEU27
+Antarctica;ATA;restEU27
+Antigua and Barbuda;ATG;restEU27
+Argentina;ARG;restEU27
+Armenia;ARM;restEU27
+Aruba;ABW;restEU27
+Australia;AUS;restEU27
+Austria;AUT;EU27
+Azerbaijan;AZE;restEU27
+Bahamas;BHS;restEU27
+Bahrain;BHR;restEU27
+Bangladesh;BGD;restEU27
+Barbados;BRB;restEU27
+Belarus;BLR;restEU27
+Belgium;BEL;EU27
+Belize;BLZ;restEU27
+Benin;BEN;restEU27
+Bermuda;BMU;restEU27
+Bhutan;BTN;restEU27
+Bolivia, Plurinational State of;BOL;restEU27
+Bonaire, Sint Eustatius and Saba;BES;restEU27
+Bosnia and Herzegovina;BIH;restEU27
+Botswana;BWA;restEU27
+Bouvet Island;BVT;restEU27
+Brazil;BRA;restEU27
+British Indian Ocean Territory;IOT;restEU27
+Brunei Darussalam;BRN;restEU27
+Bulgaria;BGR;EU27
+Burkina Faso;BFA;restEU27
+Burundi;BDI;restEU27
+Cambodia;KHM;restEU27
+Cameroon;CMR;restEU27
+Canada;CAN;restEU27
+Cape Verde;CPV;restEU27
+Cayman Islands;CYM;restEU27
+Central African Republic;CAF;restEU27
+Chad;TCD;restEU27
+Chile;CHL;restEU27
+China;CHN;restEU27
+Christmas Island;CXR;restEU27
+Cocos (Keeling) Islands;CCK;restEU27
+Colombia;COL;restEU27
+Comoros;COM;restEU27
+Congo;COG;restEU27
+Congo, the Democratic Republic of the;COD;restEU27
+Cook Islands;COK;restEU27
+Costa Rica;CRI;restEU27
+Cote d Ivoire;CIV;restEU27
+Croatia;HRV;EU27
+Cuba;CUB;restEU27
+Curacao;CUW;restEU27
+Cyprus;CYP;EU27
+Czech Republic;CZE;EU27
+Denmark;DNK;EU27
+Djibouti;DJI;restEU27
+Dominica;DMA;restEU27
+Dominican Republic;DOM;restEU27
+Ecuador;ECU;restEU27
+Egypt;EGY;restEU27
+El Salvador;SLV;restEU27
+Equatorial Guinea;GNQ;restEU27
+Eritrea;ERI;restEU27
+Estonia;EST;EU27
+Ethiopia;ETH;restEU27
+Falkland Islands (Malvinas);FLK;restEU27
+Faroe Islands;FRO;EU27
+Fiji;FJI;restEU27
+Finland;FIN;EU27
+France;FRA;EU27
+French Guiana;GUF;restEU27
+French Polynesia;PYF;restEU27
+French Southern Territories;ATF;restEU27
+Gabon;GAB;restEU27
+Gambia;GMB;restEU27
+Georgia;GEO;restEU27
+Germany;DEU;EU27
+Ghana;GHA;restEU27
+Gibraltar;GIB;restEU27
+Greece;GRC;EU27
+Greenland;GRL;restEU27
+Grenada;GRD;restEU27
+Guadeloupe;GLP;restEU27
+Guam;GUM;restEU27
+Guatemala;GTM;restEU27
+Guernsey;GGY;restEU27
+Guinea;GIN;restEU27
+Guinea-Bissau;GNB;restEU27
+Guyana;GUY;restEU27
+Haiti;HTI;restEU27
+Heard Island and McDonald Islands;HMD;restEU27
+Holy See (Vatican City State);VAT;restEU27
+Honduras;HND;restEU27
+Hong Kong;HKG;restEU27
+Hungary;HUN;EU27
+Iceland;ISL;restEU27
+India;IND;restEU27
+Indonesia;IDN;restEU27
+Iran, Islamic Republic of;IRN;restEU27
+Iraq;IRQ;restEU27
+Ireland;IRL;restEU27
+Isle of Man;IMN;restEU27
+Israel;ISR;restEU27
+Italy;ITA;EU27
+Jamaica;JAM;restEU27
+Japan;JPN;restEU27
+Jersey;JEY;restEU27
+Jordan;JOR;restEU27
+Kazakhstan;KAZ;restEU27
+Kenya;KEN;restEU27
+Kiribati;KIR;restEU27
+Korea, Democratic People's Republic of;PRK;restEU27
+Korea, Republic of;KOR;restEU27
+Kuwait;KWT;restEU27
+Kyrgyzstan;KGZ;restEU27
+Lao People's Democratic Republic;LAO;restEU27
+Latvia;LVA;EU27
+Lebanon;LBN;restEU27
+Lesotho;LSO;restEU27
+Liberia;LBR;restEU27
+Libya;LBY;restEU27
+Liechtenstein;LIE;restEU27
+Lithuania;LTU;EU27
+Luxembourg;LUX;EU27
+Macao;MAC;restEU27
+Macedonia, the former Yugoslav Republic of;MKD;restEU27
+Madagascar;MDG;restEU27
+Malawi;MWI;restEU27
+Malaysia;MYS;restEU27
+Maldives;MDV;restEU27
+Mali;MLI;restEU27
+Malta;MLT;EU27
+Marshall Islands;MHL;restEU27
+Martinique;MTQ;restEU27
+Mauritania;MRT;restEU27
+Mauritius;MUS;restEU27
+Mayotte;MYT;restEU27
+Mexico;MEX;restEU27
+Micronesia, Federated States of;FSM;restEU27
+Moldova, Republic of;MDA;restEU27
+Monaco;MCO;restEU27
+Mongolia;MNG;restEU27
+Montenegro;MNE;restEU27
+Montserrat;MSR;restEU27
+Morocco;MAR;restEU27
+Mozambique;MOZ;restEU27
+Myanmar;MMR;restEU27
+Namibia;NAM;restEU27
+Nauru;NRU;restEU27
+Nepal;NPL;restEU27
+Netherlands;NLD;EU27
+New Caledonia;NCL;restEU27
+New Zealand;NZL;restEU27
+Nicaragua;NIC;restEU27
+Niger;NER;restEU27
+Nigeria;NGA;restEU27
+Niue;NIU;restEU27
+Norfolk Island;NFK;restEU27
+Northern Mariana Islands;MNP;restEU27
+Norway;NOR;restEU27
+Oman;OMN;restEU27
+Pakistan;PAK;restEU27
+Palau;PLW;restEU27
+Palestine, State of;PSE;restEU27
+Panama;PAN;restEU27
+Papua New Guinea;PNG;restEU27
+Paraguay;PRY;restEU27
+Peru;PER;restEU27
+Philippines;PHL;restEU27
+Pitcairn;PCN;restEU27
+Poland;POL;EU27
+Portugal;PRT;EU27
+Puerto Rico;PRI;restEU27
+Qatar;QAT;restEU27
+Reunion;REU;restEU27
+Romania;ROU;EU27
+Russian Federation;RUS;restEU27
+Rwanda;RWA;restEU27
+Saint Barthelemy;BLM;restEU27
+Saint Helena, Ascension and Tristan da Cunha;SHN;restEU27
+Saint Kitts and Nevis;KNA;restEU27
+Saint Lucia;LCA;restEU27
+Saint Martin (French part);MAF;restEU27
+Saint Pierre and Miquelon;SPM;restEU27
+Saint Vincent and the Grenadines;VCT;restEU27
+Samoa;WSM;restEU27
+San Marino;SMR;restEU27
+Sao Tome and Principe;STP;restEU27
+Saudi Arabia;SAU;restEU27
+Senegal;SEN;restEU27
+Serbia;SRB;restEU27
+Seychelles;SYC;restEU27
+Sierra Leone;SLE;restEU27
+Singapore;SGP;restEU27
+Sint Maarten (Dutch part);SXM;restEU27
+Slovakia;SVK;EU27
+Slovenia;SVN;EU27
+Solomon Islands;SLB;restEU27
+Somalia;SOM;restEU27
+South Africa;ZAF;restEU27
+South Georgia and the South Sandwich Islands;SGS;restEU27
+South Sudan;SSD;restEU27
+Spain;ESP;EU27
+Sri Lanka;LKA;restEU27
+Sudan;SDN;restEU27
+Suriname;SUR;restEU27
+Svalbard and Jan Mayen;SJM;restEU27
+Swaziland;SWZ;restEU27
+Sweden;SWE;EU27
+Switzerland;CHE;restEU27
+Syrian Arab Republic;SYR;restEU27
+Taiwan, Province of China;TWN;restEU27
+Tajikistan;TJK;restEU27
+Tanzania, United Republic of;TZA;restEU27
+Thailand;THA;restEU27
+Timor-Leste;TLS;restEU27
+Togo;TGO;restEU27
+Tokelau;TKL;restEU27
+Tonga;TON;restEU27
+Trinidad and Tobago;TTO;restEU27
+Tunisia;TUN;restEU27
+Turkey;TUR;restEU27
+Turkmenistan;TKM;restEU27
+Turks and Caicos Islands;TCA;restEU27
+Tuvalu;TUV;restEU27
+Uganda;UGA;restEU27
+Ukraine;UKR;restEU27
+United Arab Emirates;ARE;restEU27
+United Kingdom;GBR;restEU27
+United States;USA;restEU27
+United States Minor Outlying Islands;UMI;restEU27
+Uruguay;URY;restEU27
+Uzbekistan;UZB;restEU27
+Vanuatu;VUT;restEU27
+Venezuela, Bolivarian Republic of;VEN;restEU27
+Viet Nam;VNM;restEU27
+Virgin Islands, British;VGB;restEU27
+Virgin Islands, U.S.;VIR;restEU27
+Wallis and Futuna;WLF;restEU27
+Western Sahara;ESH;restEU27
+Yemen;YEM;restEU27
+Zambia;ZMB;restEU27
+Zimbabwe;ZWE;restEU27

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -24,6 +24,9 @@ cfg$description <- "REMIND run with default settings"
 #### region settings ####
 cfg$regionmapping <- "config/regionmappingH12.csv"
 
+### Additional (optional) region mapping, so that those validation data can be loaded that contain the corresponding additional regions.
+cfg$extramappings_historic <- NULL
+
 #### Current input data revision (<mainrevision>.<subrevision>) ####
 cfg$inputRevision <- "6.316"
 

--- a/scripts/start/prepare_and_run.R
+++ b/scripts/start/prepare_and_run.R
@@ -431,7 +431,7 @@ prepare <- function() {
       input_old     <- "no_data"
   }
   input_new      <- c(paste0("rev",cfg$inputRevision,"_", regionscode(cfg$regionmapping),"_", tolower(cfg$model_name),".tgz"),
-                      paste0("rev",cfg$inputRevision,"_", regionscode(cfg$regionmapping),ifelse(is.null(cfg$extramappings_historic),"",paste0("-", regionscode(cfg$extramapping_historical))),"_", tolower(cfg$validationmodel_name),".tgz"),
+                      paste0("rev",cfg$inputRevision,"_", regionscode(cfg$regionmapping),ifelse(is.null(cfg$extramappings_historic),"",paste0("-", regionscode(cfg$extramappings_historic))),"_", tolower(cfg$validationmodel_name),".tgz"),
                       paste0("CESparametersAndGDX_",cfg$CESandGDXversion,".tgz"))
   # download and distribute needed data 
   if(!setequal(input_new, input_old) | cfg$force_download) {

--- a/scripts/start/prepare_and_run.R
+++ b/scripts/start/prepare_and_run.R
@@ -431,7 +431,7 @@ prepare <- function() {
       input_old     <- "no_data"
   }
   input_new      <- c(paste0("rev",cfg$inputRevision,"_", regionscode(cfg$regionmapping),"_", tolower(cfg$model_name),".tgz"),
-                      paste0("rev",cfg$inputRevision,"_", regionscode(cfg$regionmapping),"_", tolower(cfg$validationmodel_name),".tgz"),
+                      paste0("rev",cfg$inputRevision,"_", regionscode(cfg$regionmapping),ifelse(is.null(cfg$extramappings_historic),"",paste0("-", regionscode(cfg$extramapping_historical))),"_", tolower(cfg$validationmodel_name),".tgz"),
                       paste0("CESparametersAndGDX_",cfg$CESandGDXversion,".tgz"))
   # download and distribute needed data 
   if(!setequal(input_new, input_old) | cfg$force_download) {


### PR DESCRIPTION
# Purpose of this PR

Give the opportunity to load historical data for the validation pdf that contain regions that are *additional* to the regular regions.

## Type of change

- [ ] New feature 
- [ ] Minor change (default scenarios show only no differences)

## Checklist:

- [ ] My code follows the coding etiquette
- [ ] I have performed a self-review of my own code
- [ ] Changes are commented, particularly in hard-to-understand areas
- [ ] I have updated the in-code documentation
- [ ] I have adjusted reporting where it was needed
- [ ] The model compiles and runs successfully (`Rscript start.R -q`)
