### PR TITLE
Uniform carbon price

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -437,6 +437,7 @@ cfg$gms$cm_frac_CCS                     <- 10      # def <- 10
 cfg$gms$cm_frac_NetNegEmi               <- 0.5     # def <- 0.5
 cfg$gms$cm_regNetNegCO2                 <- "on"     # def <- "on"
 cfg$gms$cm_peakBudgYr                   <- 2050     # def <- 2050
+cfg$gms$cm_taxCO2inc_fix                <- "off"    # def <- "off"
 cfg$gms$cm_taxCO2inc_after_peakBudgYr   <- 3     # def <- 3
 cfg$gms$cm_CO2priceRegConvEndYr         <- 2050     # def <- 2050
 

--- a/main.gms
+++ b/main.gms
@@ -393,6 +393,7 @@ parameters
   cm_noReboundEffect      "Switch for allowing a rebound effect when closing the efficiency gap (cm_DiscRateScen)"
   cm_INNOPATHS_priceSensiBuild    "Price sensitivity of energy carrier choice in buildings"
   cm_peakBudgYr       "date of net-zero CO2 emissions for peak budget runs without overshoot"
+  cm_taxCO2inc_fix            "globally universal annual increase of CO2 price after cm_expoLinear_yearStart"
   cm_taxCO2inc_after_peakBudgYr "annual increase of CO2 price after the Peak Budget Year in $ per tCO2"
   cm_CO2priceRegConvEndYr      "Year at which regional CO2 prices converge in module 45 realization diffPhaseIn2LinFlex"
   c_regi_nucscen				"regions to apply nucscen to"
@@ -542,6 +543,7 @@ $setGlobal cm_regiCO2target  off   !! def = off
 cm_postTargetIncrease    = 2;      !! def = 2
 $setGlobal cm_quantity_regiCO2target  off !! def = off
 cm_peakBudgYr            = 2050;   !! def = 2050
+$setGlobal cm_taxCO2inc_fix off    !! def = off - if switched on you might want to set it to cm_taxCO2inc_after_peakBudgYr
 cm_taxCO2inc_after_peakBudgYr = 3; !! def = 3
 cm_CO2priceRegConvEndYr  = 2050;   !! def = 2050
 $setGlobal cm_emiMktETS  off       !! def = off

--- a/modules/45_carbonprice/expoLinear/datainput.gms
+++ b/modules/45_carbonprice/expoLinear/datainput.gms
@@ -13,8 +13,16 @@ pm_taxCO2eq("2020",regi)= cm_co2_tax_2020 * sm_DptCO2_2_TDpGtC;
 
 *LB* calculate tax path until cm_expoLinear_yearStart (defaults to 2060)
 pm_taxCO2eq(ttot,regi)$(ttot.val ge max(2020,cm_startyear) ) = pm_taxCO2eq("2020",regi)*cm_co2_tax_growth**(ttot.val-2020);
+
 *LB* use linear tax path from cm_expoLinear_yearStart on
+$ifthen %cm_taxCO2inc_fix% == "off"
+*** regional price increase before cm_expoLinear_yearStart
 p45_tau_co2_tax_inc(regi) = sum(ttot$(ttot.val eq cm_expoLinear_yearStart),((pm_taxCO2eq(ttot, regi) - pm_taxCO2eq(ttot - 1, regi)) / (pm_ttot_val(ttot) - pm_ttot_val(ttot - 1)))); 
+$else
+*RH* globally universal price increase
+p45_tau_co2_tax_inc(regi) = cm_taxCO2inc_fix * sm_DptCO2_2_TDpGtC;
+$endif
+
 pm_taxCO2eq(ttot,regi)$(ttot.val gt cm_expoLinear_yearStart) = sum(t$(t.val eq cm_expoLinear_yearStart), pm_taxCO2eq(t, regi) +  p45_tau_co2_tax_inc(regi) * (pm_ttot_val(ttot) - pm_ttot_val(t)))  ;
 *** set carbon price constant after 2110 to prevent huge carbon prices which lead to convergence problems
 pm_taxCO2eq(ttot,regi)$(ttot.val gt 2110) = pm_taxCO2eq("2110",regi);


### PR DESCRIPTION
# Purpose of this PR
With the `expoLinear` realisation of the carbon price module, you can now set a fix tax increase in $/(tCO2.yr). This should allow to have globally uniform carbon prices. The default of the new switch `cm_taxCO2inc_fix` is `off` maintaining the current model behavior.

## Type of change

- [x] New feature 

## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [x] Changes are commented, particularly in hard-to-understand areas
- [x] I have updated the in-code documentation
- [x] I have adjusted reporting where it was needed
- [x] The model compiles and runs successfully (`Rscript start.R -q`)

