### PR TITLE
Fix call signature for edget reporting.

### DIFF
--- a/scripts/output/single/reporting.R
+++ b/scripts/output/single/reporting.R
@@ -68,12 +68,13 @@ if (0 == nchar(Sys.getenv('MAGICC_BINARY'))) {
 ## the reporting is appended to REMIND_generic_<scenario>.MIF
 ## REMIND_generic_<scenario>_withoutPlus.MIF is replaced.
 
-if(file.exists(file.path(outputdir, "EDGE-T"))){
+edgetOutputDir <- file.path(outputdir, "EDGE-T")
+if(file.exists(edgetOutputDir)) {
 message("start generation of EDGE-T reporting")
-  EDGET_output <- toolReportEDGET(outputdir, sub_folder = "EDGE-T",
-                                            extendedReporting = FALSE,
-                                            scenario_title = scenario, model_name = "REMIND",
-                                            gdx = paste0(outputdir,"/fulldata.gdx"))
+  EDGET_output <- toolReportEDGET(edgetOutputDir,
+                                  extendedReporting = FALSE,
+                                  scenario_title = scenario, model_name = "REMIND",
+                                  gdx = paste0(outputdir,"/fulldata.gdx"))
 
   writeMIF(EDGET_output, remind_reporting_file, append=T)
   deletePlus(remind_reporting_file, writemif=T)


### PR DESCRIPTION
# Purpose of this PR
Fix the calling signature of the edgeTransport reporting script. The sub_folder parameter is deprecated.

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix 


## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [ ] Changes are commented, particularly in hard-to-understand areas
- [ ] I have updated the in-code documentation
- [ ] I have adjusted reporting where it was needed
- [ ] The model compiles and runs successfully (`Rscript start.R -q`)

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 


