### PR TITLE
Update VRE integration costs

### DIFF
--- a/modules/32_power/IntC/datainput.gms
+++ b/modules/32_power/IntC/datainput.gms
@@ -73,6 +73,16 @@ $ENDIF.WindOff
 p32_storageCap(te,char) = f32_storageCap(char,te);
 display p32_storageCap;
 
+*** set thresholds above which total VRE share additional integration challenges arise: 
+p32_AddIntCostThreshold(t)$(t.val < 2030) = 50;
+p32_AddIntCostThreshold("2030") = 60;
+p32_AddIntCostThreshold("2035") = 70;
+p32_AddIntCostThreshold("2040") = 80;
+p32_AddIntCostThreshold("2045") = 90;
+p32_AddIntCostThreshold(t)$(t.val > 2045) = 95;
+
+p32_shAddIntCostTotVREFactor = 1.5;
+
 $ontext
 parameter p32_flex_maxdiscount(all_regi,all_te) "maximum electricity price discount for flexible technologies reached at high VRE shares"
 /

--- a/modules/32_power/IntC/datainput.gms
+++ b/modules/32_power/IntC/datainput.gms
@@ -74,12 +74,11 @@ p32_storageCap(te,char) = f32_storageCap(char,te);
 display p32_storageCap;
 
 *** set thresholds above which total VRE share additional integration challenges arise: 
-p32_AddIntCostThreshold(t)$(t.val < 2030) = 50;
-p32_AddIntCostThreshold("2030") = 60;
-p32_AddIntCostThreshold("2035") = 70;
-p32_AddIntCostThreshold("2040") = 80;
-p32_AddIntCostThreshold("2045") = 90;
-p32_AddIntCostThreshold(t)$(t.val > 2045) = 95;
+p32_shAddIntCostTotVREThreshold(t)$(t.val < 2030) = 50;
+p32_shAddIntCostTotVREThreshold("2030") = 60;
+p32_shAddIntCostTotVREThreshold("2035") = 70;
+p32_shAddIntCostTotVREThreshold("2040") = 80;
+p32_shAddIntCostTotVREThreshold(t)$(t.val > 2040) = 90;
 
 p32_shAddIntCostTotVREFactor = 1.5;
 

--- a/modules/32_power/IntC/declarations.gms
+++ b/modules/32_power/IntC/declarations.gms
@@ -53,9 +53,8 @@ equations
     q32_flexPriceShare(tall,all_regi,all_te)        "calculate share of average electricity price that flexible technologies see"
     q32_flexPriceBalance(tall,all_regi)             "constraint such that flexible electricity prices balanance to average electricity price"
     q32_TotVREshare(ttot,all_regi)                  "calculate total VRE share"
-    q32_AddIntCost(ttot,all_regi)                   "calculate how much total VRE share is above threshold value"
+    q32_shAddIntCostTotVRE(ttot,all_regi)                   "calculate how much total VRE share is above threshold value"
     q32_shIntegAll(ttot,all_regi,all_te)            "calculate share of seel production from a VRE te that needs to be stored, based on this te and all other VRE"
-
 ;
 
 variables

--- a/modules/32_power/IntC/declarations.gms
+++ b/modules/32_power/IntC/declarations.gms
@@ -16,7 +16,8 @@ parameters
     p32_storageCap(all_te,char)                     "multiplicative factor between dummy seel<-->h2 technologies and storXXX technologies"
     p32_PriceDurSlope(all_regi,all_te)              "slope of price duration curve used for calculation of electricity price for flexible technologies, determines how fast electricity price declines at lower capacity factors"
     o32_dispatchDownPe2se(ttot,all_regi,all_te)           "output parameter to check by how much a pe2se te reduced its output below the normal, in % of the normal output."
-
+    p32_shAddIntCostTotVREThreshold(ttot)           "Total VRE share above which additional integration costs arise. Increases with time as eg in 2030, there is still little experience with managing systems with 80% VRE share. Unit: Percent"
+    p32_shAddIntCostTotVREFactor                    "Multiplicative factor that influences how much the total VRE share increases integration challenges"
 ;
 
 scalars
@@ -24,10 +25,12 @@ s32_storlink                                        "how strong is the influence
 ;
 
 positive variables
-    v32_shStor(ttot,all_regi,all_te)         		"share of seel production from renewables that needs to be stored, range 0..1 [0,1]"
+    v32_shStor(ttot,all_regi,all_te)         		"share of seel production from a VRE te that needs to be stored based on this te's share. Unit: ~Percent"
     v32_storloss(ttot,all_regi,all_te)         		"total energy loss from storage for a given technology [TWa]"
     v32_shSeEl(ttot,all_regi,all_te)				"new share of electricity production in % [%]"
     v32_testdemSeShare(ttot,all_regi,all_te)        "test variable for tech share of SE electricity demand"
+    v32_shAddIntCostTotVRE(ttot,all_regi)           "Share to calculate additional integation costs due to total VRE share. How much is TotVREshare above the threshold"
+    v32_shStorAll(ttot,all_regi,all_te)             "share of seel production from a VRE te that needs to be stored, based on this te and all other VRE"
 ;
 
 equations
@@ -48,6 +51,10 @@ equations
     q32_flexPriceShareMin                           "calculatae miniumum share of average electricity that flexible technologies can see"
     q32_flexPriceShare(tall,all_regi,all_te)        "calculate share of average electricity price that flexible technologies see"
     q32_flexPriceBalance(tall,all_regi)             "constraint such that flexible electricity prices balanance to average electricity price"
+    q32_TotVREshare(ttot,all_regi)                  "calculate total VRE share"
+    q32_AddIntCost(ttot,all_regi)                   "calculate how much total VRE share is above threshold value"
+    q32_shIntegAll(ttot,all_regi,all_te)            "calculate share of seel production from a VRE te that needs to be stored, based on this te and all other VRE"
+
 ;
 
 variables

--- a/modules/32_power/IntC/declarations.gms
+++ b/modules/32_power/IntC/declarations.gms
@@ -29,6 +29,7 @@ positive variables
     v32_storloss(ttot,all_regi,all_te)         		"total energy loss from storage for a given technology [TWa]"
     v32_shSeEl(ttot,all_regi,all_te)				"new share of electricity production in % [%]"
     v32_testdemSeShare(ttot,all_regi,all_te)        "test variable for tech share of SE electricity demand"
+    v32_TotVREshare(ttot,all_regi)                  "Total VRE share as calculated by summing shSeEl. Unit: Percent"
     v32_shAddIntCostTotVRE(ttot,all_regi)           "Share to calculate additional integation costs due to total VRE share. How much is TotVREshare above the threshold"
     v32_shStorAll(ttot,all_regi,all_te)             "share of seel production from a VRE te that needs to be stored, based on this te and all other VRE"
 ;

--- a/modules/32_power/IntC/equations.gms
+++ b/modules/32_power/IntC/equations.gms
@@ -139,10 +139,31 @@ q32_shStor(t,regi,teVRE)$(t.val ge 2015)..
 q32_storloss(t,regi,teVRE)$(t.val ge 2020)..
 	v32_storloss(t,regi,teVRE)
 	=e=
-	v32_shStor(t,regi,teVRE) / 93    !! corrects for the 7%-shift in v32_shStor: at 100% the value is correct again
+	v32_shStorAll(t,regi,teVRE) / 100    
 	* sum(VRE2teStor(teVRE,teStor), (1 - pm_eta_conv(t,regi,teStor) ) /  pm_eta_conv(t,regi,teStor) )
 	* vm_usableSeTe(t,regi,"seel",teVRE)
 ;
+
+q32_TotVREshare(t,regi)..
+  v32_TotVREshare(t,regi)
+  =e=
+  sum(teVRE, v32_shSeEl(t,regi,teVRE) )
+;
+
+q32_shAddIntCostTotVRE(t,regi)..
+  v32_shAddIntCostTotVRE(t,regi)
+  =g=
+  v32_TotVREshare(t,regi)
+  - p32_shAddIntCostTotVREThreshold(t)
+;
+
+q32_shIntegAll(t,regi,teVRE)..
+  v32_shStorAll(t,regi,teVRE) / 100
+  =e=
+  v32_shStor(t,regi,teVRE) / 93  !! corrects for the 7%-shift in v32_shStor: at 100% the value is correct again
+  + p32_shAddIntCostTotVREFactor * v32_shAddIntCostTotVRE(t,regi) / 100 
+;
+
 
 ***---------------------------------------------------------------------------
 *** Operating reserve constraint


### PR DESCRIPTION
# Purpose of this PR

Improve VRE integration costs by representing that a) getting VRE to >90% will likely be more challenging, and that b) very high VRE shares in the short term will be more challenging than in the long term as there is still limited experience and knowledge about balancing very high VRE share grids. 

## Type of change

- [x ] Minor change (default scenarios show only small differences)

## Checklist:

- [x] My code follows the coding etiquette
- [x ] I have performed a self-review of my own code
- [x ] Changes are commented, particularly in hard-to-understand areas
- [ ] I have updated the in-code documentation
- [x ] I have adjusted reporting where it was needed
- [x ] The model compiles and runs successfully (`Rscript start.R -q`)

## Further information (optional):

* Test runs are here: 


* Comparison of results (what changes by this PR?): 
very fast transformation to high VRE shares is a bit slowed in very stringent scenarios, as VRE integration costs increase when total VRE share goes above: 
50% in 2025
60% in 2030
70% in 2035
80% in 2040
90% after 2040



