### PR TITLE
Fixing bug with tradbio phaseout switch.

### DIFF
--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -66,7 +66,7 @@ vm_deltaCap.up(t,regi,"fnrs",rlf) = 0;
 *** Note: make sure that this matches with the settings for residues in modules/05_initialCap/on/preloop.gms
 
 *BS/DK* Developed regions phase out quickly (no new capacities)
-vm_deltaCap.up(t,regi,"biotr",rlf)$(t.val gt 2005) = 0;
+vm_deltaCap.fx(t,regi,"biotr",rlf)$(t.val gt 2005) = 0;
 *BS/DK* Developing regions (defined by GDP PPP threshold) phase out more slowly ( + varied by SSP)
 loop(regi,
   if ( (pm_gdp("2005",regi)/pm_pop("2005",regi) / pm_shPPPMER(regi)) lt 4,


### PR DESCRIPTION
The following error occurs when the switch `cm_tradbio_phaseout` is changed from `default` to `fast` only (!) in a policy run:

```
**** Matrix error - lower bound > upper bound
vm_deltaCap(2025,SSA,biotr,1)   (.LO, .L, .UP = 0.00666013227861135, 0.00666013227861133, 0)
```

The problem seems to arise in these lines `core/bounds.gms`:

```
*BS/DK* Developed regions phase out quickly (no new capacities)
vm_deltaCap.up(t,regi,"biotr",rlf)$(t.val gt 2005) = 0;
*BS/DK* Developing regions (defined by GDP PPP threshold) phase out more slowly ( + varied by SSP)
loop(regi,
  if ( (pm_gdp("2005",regi)/pm_pop("2005",regi) / pm_shPPPMER(regi)) lt 4,
    vm_deltaCap.fx("2010",regi,"biotr","1") = 1.3  * vm_deltaCap.lo("2005",regi,"biotr","1");
    vm_deltaCap.fx("2015",regi,"biotr","1") = 0.9  * vm_deltaCap.lo("2005",regi,"biotr","1");
    vm_deltaCap.fx("2020",regi,"biotr","1") = 0.7  * vm_deltaCap.lo("2005",regi,"biotr","1");
$ifthen NOT %cm_tradbio_phaseout% == "fast"   !! cm_tradbio_phaseout
    vm_deltaCap.fx("2025",regi,"biotr","1") = 0.5  * vm_deltaCap.lo("2005",regi,"biotr","1");
    vm_deltaCap.fx("2030",regi,"biotr","1") = 0.4  * vm_deltaCap.lo("2005",regi,"biotr","1");
    vm_deltaCap.fx("2035",regi,"biotr","1") = 0.3  * vm_deltaCap.lo("2005",regi,"biotr","1");
    vm_deltaCap.fx("2040",regi,"biotr","1") = 0.2  * vm_deltaCap.lo("2005",regi,"biotr","1");
    vm_deltaCap.fx("2045",regi,"biotr","1") = 0.15 * vm_deltaCap.lo("2005",regi,"biotr","1");
    vm_deltaCap.fx("2050",regi,"biotr","1") = 0.1  * vm_deltaCap.lo("2005",regi,"biotr","1");
    vm_deltaCap.fx("2055",regi,"biotr","1") = 0.1  * vm_deltaCap.lo("2005",regi,"biotr","1");
$endif
  );
);
```

This is my understanding of how the error occurs:
* baseline run (`cm_tradbio_phaseout` set to `default`) sets `vm_deltaCap.fx` in 2025
* policy run (`cm_tradbio_phaseout` set to `fast`) loads `.l`, `.lo` and `.up` from baseline run in 2025 (via `Execute_Loadpoint`)
* policy run sets `.up` to zero but does not set `.fx` to undo the `.lo`
* you end up with a conflicting `.lo` and `.up`

This commit simply changes

```
- vm_deltaCap.up(t,regi,"biotr",rlf)$(t.val gt 2005) = 0;
+ vm_deltaCap.fx(t,regi,"biotr",rlf)$(t.val gt 2005) = 0;
```

as suggested by Michaja.