### PR TITLE
Use quitte's write.mif to append EDGE-T vars to the report.

### DIFF
--- a/scripts/output/single/reporting.R
+++ b/scripts/output/single/reporting.R
@@ -11,6 +11,7 @@ library(lucode2)
 library(gms)
 library(methods)
 library(edgeTransport)
+library(quitte)
 ############################# BASIC CONFIGURATION #############################
 gdx_name     <- "fulldata.gdx"             # name of the gdx
 gdx_ref_name <- "input_refpolicycost.gdx"  # name of the reference gdx (for policy cost calculation)
@@ -76,7 +77,7 @@ message("start generation of EDGE-T reporting")
                                   scenario_title = scenario, model_name = "REMIND",
                                   gdx = paste0(outputdir,"/fulldata.gdx"))
 
-  writeMIF(EDGET_output, remind_reporting_file, append=T)
+  write.mif(EDGET_output, remind_reporting_file, append=T)
   deletePlus(remind_reporting_file, writemif=T)
 
 message("end generation of EDGE-T reporting")


### PR DESCRIPTION
# Purpose of this PR
Bugfix. Use correct package/function when appending the EDGE-T reporting vars to the full MIF file.

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix 


## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [ ] Changes are commented, particularly in hard-to-understand areas
- [ ] I have updated the in-code documentation
- [ ] I have adjusted reporting where it was needed
- [ ] The model compiles and runs successfully (`Rscript start.R -q`)

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 


