### PR TITLE
add specific energy demand limits in industry also for chemicals and other industry sector to prevent too fast energy efficiency gains in those sectors

### DIFF
--- a/modules/37_industry/subsectors/datainput.gms
+++ b/modules/37_industry/subsectors/datainput.gms
@@ -126,6 +126,7 @@ sm_tmp2 = 0.75;   !! maximum "efficiency gain", from 2015 baseline value to
                   !! thermodynamic limit
 sm_tmp  = 2050;   !! period in which closing could be achieved
 
+*** Specific energy demand limits for steel and cement relative to thermodynamic limit from input data
 loop (industry_ue_calibration_target_dyn37(out)$( pm_energy_limit(out) ),
   p37_energy_limit_slope(ttot,regi,out)$( ttot.val ge 2015 )
   = ( ( sum(ces_eff_target_dyn37(out,in), p37_cesIO_baseline("2015",regi,in))
@@ -149,6 +150,35 @@ loop (industry_ue_calibration_target_dyn37(out)$( pm_energy_limit(out) ),
       )
     );
 );
+
+*** Specific energy demand limits for other industry and chemicals in TWa/trUSD
+*** exponential decrease of minimum specific energy demand per value added up to 90% by 2100
+sm_tmp2 = 0.9;   !! maximum "efficiency gain" relative to 2015 baseline value 
+sm_tmp  = 2100;   !! period in which closing could be achieved
+
+loop (industry_ue_calibration_target_dyn37(out)$( sameas(out,"ue_chemicals") OR  sameas(out,"ue_otherInd")),
+  p37_energy_limit_slope(ttot,regi,out)$( ttot.val ge 2015 )
+  = ( ( sum(ces_eff_target_dyn37(out,in), p37_cesIO_baseline("2015",regi,in))
+      / p37_cesIO_baseline("2015",regi,out)
+      )
+    )
+  * exp((2015 - ttot.val) / ((2015 - sm_tmp) / log(1 - sm_tmp2)));
+
+  !! To account for strong 2015-20 drops due to imperfect 2020 energy data,
+  !! use the lower of the calculated curve, or 95 % of the baseline specific
+  !! energy demand
+  p37_energy_limit_slope(ttot,regi,out)$( ttot.val ge 2015 )
+  = min(
+      p37_energy_limit_slope(ttot,regi,out),
+      ( 0.95
+      * ( sum(ces_eff_target_dyn37(out,in), p37_cesIO_baseline(ttot,regi,in))
+        / p37_cesIO_baseline(ttot,regi,out)
+	)
+      )
+    );
+);
+
+display p37_energy_limit_slope;
 $endif.no_calibration
 
 *** CCS for industry is off by default


### PR DESCRIPTION


# Purpose of this PR

Adds specific energy limits as used in ARIADNE project for Germany. SEC can still go down by ~50% in most regions within the next 20 years which is about double what regions of the Global North had in the last 20 years but lower than India and China (they had ~80%). Implementation could be fine-tuned per region in the future. 



## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)


- [x] Minor change (default scenarios show only small differences)




## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [x] Changes are commented, particularly in hard-to-understand areas
- [x] I have updated the in-code documentation
- [x] The model compiles and runs successfully (`Rscript start.R -q`)

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

Compare specific energy in Ariadne runs

without limits: https://cloud.pik-potsdam.de/index.php/apps/files/?dir=/Shared/REMIND-EU_calibration/Results/Ariadne_2022_6_21_solstice&openfile=13645430

with limits: https://cloud.pik-potsdam.de/index.php/apps/files/?dir=/Shared/REMIND-EU_calibration/Results/Ariadne_2022_7_26&openfile=13905646


