### PR TITLE
introduce constraint of maximum biomass use per industry subsector

### DIFF
--- a/modules/37_industry/subsectors/datainput.gms
+++ b/modules/37_industry/subsectors/datainput.gms
@@ -438,4 +438,10 @@ execute_load "input_ref.gdx", vm_demFEsector;
     );
 );
 
+
+
+*** FS: maximum share of biomass use in industry subsector
+*** set to prevent too fast or technically unrealistic switch to biomass in industry subsectors
+p37_BioShareMaxSubsec(t,regi,entyFe,secInd37)=1;
+
 *** EOF ./modules/37_industry/subsectors/datainput.gms

--- a/modules/37_industry/subsectors/datainput.gms
+++ b/modules/37_industry/subsectors/datainput.gms
@@ -442,6 +442,18 @@ execute_load "input_ref.gdx", vm_demFEsector;
 
 *** FS: maximum share of biomass use in industry subsector
 *** set to prevent too fast or technically unrealistic switch to biomass in industry subsectors
-p37_BioShareMaxSubsec(t,regi,entyFe,secInd37)=1;
+
+*** initialize maximum biomass share in all industry subsectors at 100%
+p37_BioShareMaxSubsec(t,regi,entyFeCC37,secInd37)=1;
+
+
+*** for steel set maximum biomass share in solids to 30% until 2025 and linearly increase up to 80% in 2050
+p37_BioShareMaxSubsec(t,regi,"fesos","steel")$(t.val le 2025)=0.3;
+p37_BioShareMaxSubsec(t,regi,"fesos","steel")$(t.val gt 2025 AND t.val le 2050)= 0.3 + (t.val - 2025) * 0.02;
+p37_BioShareMaxSubsec(t,regi,"fesos","steel")$(t.val gt 2050)=p37_BioShareMaxSubsec("2050",regi,"fesos","steel");
+
+*** for Germany set maximum biomass share of solids in steel to 10% at all times
+p37_BioShareMaxSubsec(t,regi,"fesos","steel")$(t.val ge 2020 AND sameas(regi,"DEU"))=0.1;
+
 
 *** EOF ./modules/37_industry/subsectors/datainput.gms

--- a/modules/37_industry/subsectors/datainput.gms
+++ b/modules/37_industry/subsectors/datainput.gms
@@ -448,7 +448,7 @@ p37_BioShareMaxSubsec(t,regi,entyFeCC37,secInd37)=1;
 
 
 *** for steel set maximum biomass share in solids to 30% until 2025 and linearly increase up to 80% in 2050
-p37_BioShareMaxSubsec(t,regi,"fesos","steel")$(t.val le 2025)=0.3;
+p37_BioShareMaxSubsec(t,regi,"fesos","steel")$(t.val gt 2015 AND t.val le 2025)=0.3;
 p37_BioShareMaxSubsec(t,regi,"fesos","steel")$(t.val gt 2025 AND t.val le 2050)= 0.3 + (t.val - 2025) * 0.02;
 p37_BioShareMaxSubsec(t,regi,"fesos","steel")$(t.val gt 2050)=p37_BioShareMaxSubsec("2050",regi,"fesos","steel");
 

--- a/modules/37_industry/subsectors/declarations.gms
+++ b/modules/37_industry/subsectors/declarations.gms
@@ -76,21 +76,23 @@ $endif.no_calibration
 
 
 *** process-based implementation
-Parameters
+
 $ifthen.process_based_steel "%cm_process_based_steel%" == "on"                 !! cm_process_based_steel
+Parameters
 **p37_specMatsDem(mats,all_te,opModes)                                         "Specific materials demand of a production technology and operation mode [t_input/t_output]"
 **p37_specFeDem(all_enty,all_te,opModes)                                       "Specific final-energy demand of a production technology and operation mode [MWh/t_output]"
-$endif.process_based_steel
 ;
+$endif.process_based_steel
 
-Equations
+
 $ifthen.process_based_steel "%cm_process_based_steel%" == "on"                 !! cm_process_based_steel
+Equations
   q37_balMats(tall,all_regi,all_enty)                     "Balance of materials in material-flow model"
   q37_limitCapMat(tall,all_regi,all_enty,all_te)          "Material-flow conversion is limited by capacities"
   q37_demMatsProc(tall,all_regi,all_enty)                 "Demand of process materials"
   q37_demFEMats(tall,all_regi,all_enty,all_emiMkt)        "Final-energy demand of materail-flow model"
-$endif.process_based_steel
 ;
+$endif.process_based_steel
 
 *** EOF ./modules/37_industry/subsectors/declarations.gms
 

--- a/modules/37_industry/subsectors/declarations.gms
+++ b/modules/37_industry/subsectors/declarations.gms
@@ -22,10 +22,7 @@ Parameters
   p37_steel_secondary_max_share(tall,all_regi)                                 "maximum share of secondary steel production"
   p37_BAU_industry_ETS_solids(tall,all_regi)                                   "industry solids demand in baseline scenario"
   p37_cesIO_baseline(tall,all_regi,all_in)                                     "vm_cesIO from the baseline scenario"
-$ifthen.process_based_steel "%cm_process_based_steel%" == "on"                 !! cm_process_based_steel
-**p37_specMatsDem(mats,all_te,opModes)                                         "Specific materials demand of a production technology and operation mode [t_input/t_output]"
-**p37_specFeDem(all_enty,all_te,opModes)                                       "Specific final-energy demand of a production technology and operation mode [MWh/t_output]"
-$endif.process_based_steel
+  p37_BioShareMaxSubsec(ttot,all_regi,all_enty,secInd37)                       "maximum biomass share in industry subsector per energy carrier"
 
 *** output parameters only for reporting
   o37_emiInd(ttot,all_regi,all_enty,secInd37,all_enty)                   "industry CCS emissions [GtC/a]"                                                                                
@@ -59,6 +56,8 @@ $ifthen.process_based_steel "%cm_process_based_steel%" == "on"                 !
 $endif.process_based_steel
 ;
 
+
+
 Equations
 $ifthen.no_calibration "%CES_parameters%" == "load"   !! CES_parameters
   q37_energy_limits(ttot,all_regi,all_in)                 "thermodynamic/technical limit of energy use"
@@ -71,7 +70,20 @@ $endif.no_calibration
   q37_IndCCSCost                                          "Calculate industry CCS costs"
   q37_demFeIndst(ttot,all_regi,all_enty,all_emiMkt)       "industry final energy demand (per emission market)"
   q37_costCESmarkup(ttot,all_regi,all_in)                 "calculation of additional CES markup cost to represent demand-side technology cost of end-use transformation, for example, cost of heat pumps etc."
+  q37_BioLimitSubsec(ttot,all_regi,all_enty,all_emiMkt)   "limits of switching to biomass use in industry subsectors"
+;
 
+
+
+*** process-based implementation
+Parameters
+$ifthen.process_based_steel "%cm_process_based_steel%" == "on"                 !! cm_process_based_steel
+**p37_specMatsDem(mats,all_te,opModes)                                         "Specific materials demand of a production technology and operation mode [t_input/t_output]"
+**p37_specFeDem(all_enty,all_te,opModes)                                       "Specific final-energy demand of a production technology and operation mode [MWh/t_output]"
+$endif.process_based_steel
+;
+
+Equations
 $ifthen.process_based_steel "%cm_process_based_steel%" == "on"                 !! cm_process_based_steel
   q37_balMats(tall,all_regi,all_enty)                     "Balance of materials in material-flow model"
   q37_limitCapMat(tall,all_regi,all_enty,all_te)          "Material-flow conversion is limited by capacities"

--- a/modules/37_industry/subsectors/equations.gms
+++ b/modules/37_industry/subsectors/equations.gms
@@ -205,4 +205,19 @@ q37_costCESmarkup(t,regi,in)$(ppfen_industry_dyn37(in))..
   * (vm_cesIO(t,regi,in) + pm_cesdata(t,regi,in,"offset_quantity"))
 ;
 
+*** limits of switching to biomass use in industry subsectors
+q37_BioLimitSubsec(t,regi,entyFe,emiMkt)..
+  sum( se2fe(entySeBio,entyFe,te),
+    vm_demFEsector(t,regi,entySeBio,entyFE,"indst",emiMkt)
+  )
+  =l=
+  sum(secInd37_emiMkt(secInd37,emiMkt),
+      p37_BioShareMaxSubsec(t,regi,entyFe,secInd37)
+      * sum( (secInd37_2_pf(secInd37,in),
+              fe2ppfen37(entyFe,in)),
+          vm_cesIO(t,regi,in))
+  )
+;
+
+
 *** EOF ./modules/37_industry/subsectors/equations.gms


### PR DESCRIPTION
# Purpose of this PR

This introduces a constraint which allows limiting the maximum biomass use for solids/liquids/gases in the industry subsectors. This was added in the ARIADNE branch to prevent too fast switch of industry solids from coal to biomass (50% of solids going into steel were biomass in Ger by 2030, see PDF below) which we found unrealistic. 

Currently, I set the limits to

* 30% biomass in steel in 2025 going to 80% in 2050
* 10% biomass in steel in Germany (as this option is not talked about afaik, but please correct me)
* all other sectors (cement, chemicals, otherIndustry) have 100%, so no limit in switching to biomass

The numbers may need to revising from people who know industrial processes better than I do. A quick google search tells me that biomass in BFs is considered in the literature, e.g.

https://www.sciencedirect.com/science/article/abs/pii/S0196890415003556

https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&ved=2ahUKEwixyenfqcb6AhW7hP0HHfPTDrwQFnoECAgQAQ&url=https%3A%2F%2Fwww.mdpi.com%2F2075-163X%2F11%2F2%2F157%2Fpdf&usg=AOvVaw3DwqBAynDTOuDwueGvy1k6


I would suggest going for a pragmatic solution now with a wide range in the long-term and consider refining later. This change is mainly motivated to get the short-term behavior until 2030 right. 


## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)


- [x] Minor to medium change (default scenarios show only small differences)


## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [x] Changes are commented, particularly in hard-to-understand areas
- [x] I have updated the in-code documentation
- [x] The model compiles and runs successfully (`Rscript start.R -q`)
- [ ] review default values for steel limits

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

ARIADNE runs without biomass limits (check out SE solids mix and FE steel mix in 2030): 

https://cloud.pik-potsdam.de/index.php/apps/files/?dir=/Shared/REMIND-EU_calibration/Results/Ariadne_2022_6_21_solstice&openfile=13687371

ARIADNE runs including biomass limits: 

https://cloud.pik-potsdam.de/index.php/apps/files/?dir=/Shared/REMIND-EU_calibration/Results/Ariadne_2022_6_21_solstice&openfile=13687371


