### PR TITLE
append MAgPIE results in reporting.R, not in start_coupled.R

### DIFF
--- a/scripts/output/single/reporting.R
+++ b/scripts/output/single/reporting.R
@@ -25,7 +25,7 @@ if(!exists("source_include")) {
 
 gdx      <- file.path(outputdir,gdx_name)
 gdx_ref  <- file.path(outputdir,gdx_ref_name)
-if(!file.exists(gdx_ref)) { gdx_ref <- NULL }
+if (!file.exists(gdx_ref)) { gdx_ref <- NULL }
 scenario <- getScenNames(outputdir)
 ###############################################################################
 # paths of the reporting files
@@ -77,10 +77,29 @@ message("start generation of EDGE-T reporting")
                                   scenario_title = scenario, model_name = "REMIND",
                                   gdx = paste0(outputdir,"/fulldata.gdx"))
 
-  write.mif(EDGET_output, remind_reporting_file, append=T)
-  deletePlus(remind_reporting_file, writemif=T)
+  write.mif(EDGET_output, remind_reporting_file, append = TRUE)
+  deletePlus(remind_reporting_file, writemif = TRUE)
 
 message("end generation of EDGE-T reporting")
+}
+
+configfile <- file.path(outputdir, "config.Rdata")
+envir <- new.env()
+load(configfile, envir = envir)
+magpie_reporting_file <- envir$cfg$pathToMagpieReport
+if (! is.null(magpie_reporting_file) && file.exists(magpie_reporting_file)) {
+  message("add MAgPIE reporting from ", magpie_reporting_file)
+  tmp_rem <- read.report(remind_reporting_file, as.list=FALSE)
+  tmp_mag <- read.report(magpie_reporting_file, as.list=FALSE)[, getYears(tmp_rem), ]
+  # harmonize scenario name from -mag-xx to -rem-xx
+  getNames(tmp_mag, dim = 1) <- paste0(scenario)
+  tmp_rem_mag <- mbind(tmp_rem, tmp_mag)
+  if (any(getNames(tmp_rem_mag[, , "REMIND"], dim = 3) %in% getNames(tmp_rem_mag[, , "MAgPIE"], dim = 3))) {
+    message("Cannot produce common REMIND-MAgPIE reporting because there are identical variable names in both models!")
+  } else {
+    write.report(tmp_rem_mag, file = remind_reporting_file, ndigit = 7)
+    deletePlus(remind_reporting_file, writemif = TRUE)
+  }
 }
 
 message("### end generation of mif files at ", Sys.time())

--- a/scripts/start/prepare_and_run.R
+++ b/scripts/start/prepare_and_run.R
@@ -92,7 +92,7 @@ getReportData <- function(path_to_report,inputpath_mag="magpie",inputpath_acc="c
       map <- rbind(map,data.frame(emimag="Emissions|CH4|Land|Agriculture|+|Rice (Mt CH4/yr)",                                              emirem="ch4rice",   factor_mag2rem=1,stringsAsFactors=FALSE))
       map <- rbind(map,data.frame(emimag="Emissions|CH4|Land|Agriculture|+|Animal waste management (Mt CH4/yr)",                           emirem="ch4anmlwst",factor_mag2rem=1,stringsAsFactors=FALSE))
       map <- rbind(map,data.frame(emimag="Emissions|CH4|Land|Agriculture|+|Enteric fermentation (Mt CH4/yr)",                              emirem="ch4animals",factor_mag2rem=1,stringsAsFactors=FALSE))
-    } else {
+    } else if("Emissions|CO2|Land Use (Mt CO2/yr)" %in% getNames(mag)) {
       # MAgPIE 3
       map <- rbind(map,data.frame(emimag="Emissions|CO2|Land Use (Mt CO2/yr)",                                                        emirem="co2luc",    factor_mag2rem=1/1000*12/44,stringsAsFactors=FALSE))
       map <- rbind(map,data.frame(emimag="Emissions|N2O|Land Use|Agriculture|AWM (kt N2O/yr)",                                        emirem="n2oanwstm", factor_mag2rem=1/1000*28/44,stringsAsFactors=FALSE))
@@ -111,6 +111,8 @@ getReportData <- function(path_to_report,inputpath_mag="magpie",inputpath_acc="c
       map <- rbind(map,data.frame(emimag="Emissions|CH4|Land Use|Biomass Burning|Forest Burning (Mt CH4/yr)",                         emirem="ch4forest", factor_mag2rem=1,stringsAsFactors=FALSE))
       map <- rbind(map,data.frame(emimag="Emissions|CH4|Land Use|Biomass Burning|Savannah Burning (Mt CH4/yr)",                       emirem="ch4savan",  factor_mag2rem=1,stringsAsFactors=FALSE))
       map <- rbind(map,data.frame(emimag="Emissions|CH4|Land Use|Biomass Burning|Agricultural Waste Burning (Mt CH4/yr)",             emirem="ch4agwaste",factor_mag2rem=1,stringsAsFactors=FALSE))
+    } else {
+      stop("Emission data not found in MAgPIE report. Check MAgPIE reporting file.")
     }
 
     # Read data from MAgPIE report and convert to REMIND data, collect in 'out' object

--- a/start_coupled.R
+++ b/start_coupled.R
@@ -198,29 +198,14 @@ start_coupled <- function(path_remind, path_magpie, cfg_rem, cfg_mag, runname, m
         stop("### COUPLING ### REMIND didn't produce any gdx. Coupling iteration stopped!")
       }
       # combine REMIND and MAgPIE reports of last coupling iteration (and REMIND water reporting if existing)
-      report_rem <- paste0(path_remind,outfolder_rem,"/REMIND_generic_",cfg_rem$title,".mif")
-      if (exists("mag_report_keep_in_mind") && file.exists(mag_report_keep_in_mind)) {
-        message("\n### Joining to a common reporting file:\n    ", report_rem, "\n    ", mag_report_keep_in_mind)
-        tmp1 <- read.report(report_rem, as.list=FALSE)
-        tmp2 <- read.report(mag_report_keep_in_mind, as.list=FALSE)[, getYears(tmp1), ]
-        tmp3 <- mbind(tmp1,tmp2)
-        getNames(tmp3, dim=1) <- gsub("-(rem|mag)-[0-9]{1,2}","",getNames(tmp3,dim=1)) # remove -rem-xx and mag-xx from scenario names
-        # only harmonize model names to REMIND-MAgPIE, if there are no variable names that are identical across the models
-        if (any(getNames(tmp3[,,"REMIND"],dim=3) %in% getNames(tmp3[,,"MAgPIE"],dim=3))) {
-          msg <- "Cannot produce common REMIND-MAgPIE reporting because there are identical variable names in both models!\n"
-          message(msg)
-          warning(msg)
-        } else {
-          write.report(tmp3, file = report_rem, ndigit = 7)
-          remind2::deletePlus(report_rem, writemif = TRUE)
-          message(" -> ", report_rem, " now contains also MAgPIE results.")
-          if (i == max_iterations) {
-            # Replace REMIND and MAgPIE with REMIND-MAgPIE and write directly to output folder
-            getNames(tmp3,dim=2) <- gsub("REMIND|MAgPIE","REMIND-MAgPIE",getNames(tmp3,dim=2))
-            write.report(tmp3, file = paste0("output/",runname,".mif"), ndigit = 7)
-            message(" -> output/", runname, ".mif uses REMIND-MAgPIE as model name.")
-          }
-        }
+      report_rem <- paste0(path_remind, outfolder_rem, "/REMIND_generic_", cfg_rem$title,".mif")
+      if (i == max_iterations) {
+        # Replace REMIND and MAgPIE with REMIND-MAgPIE and write directly to output folder
+        tmp_rem_mag <- read.report(report_rem, as.list=FALSE)
+        getNames(tmp_rem_mag, dim=2) <- gsub("REMIND|MAgPIE", "REMIND-MAgPIE", getNames(tmp_rem_mag, dim=2))
+        getNames(tmp_rem_mag, dim=1) <- runname
+        write.report(tmp_rem_mag, file = paste0("output/",runname,".mif"), ndigit = 7)
+        message("\n### output/", runname, ".mif written: model='REMIND-MAgPIE', scenario='", runname, "'.")
       }
     }
 


### PR DESCRIPTION
## Purpose of this PR
- fixes https://github.com/remindmodel/remind/issues/988
- moves concatenating MAgPIE results to REMIND mif from `start_coupled.R` to `reporting.R`
- improve error message if `magpie4::reportEmissions()` failed for some reason

## Type of change

- [x] Bug fix 
- [x] Refactoring

## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [x] Changes are commented, particularly in hard-to-understand areas
- [x] The model compiles and runs successfully: see `/p/tmp/oliverr/remind-smallfix/output/test_*` folders with coupled runs, also starting `reporting` via `output.R` worked for both coupled and non-coupled run.
