### PR TITLE
adapt ramp-up of substitution elasticities for fuel switching in buildings and industry to improve short-term behavior

### DIFF
--- a/modules/01_macro/singleSectorGr/postsolve.gms
+++ b/modules/01_macro/singleSectorGr/postsolve.gms
@@ -23,7 +23,8 @@ pm_consPC(tall,regi)$(tall.val gt 2150) = pm_consPC("2150",regi);
 *** output parameter for diagnostics
 
 *** Compute ppf prices from CES derivatives
-o01_CESderivatives(t,regi,cesOut2cesIn(out,in))$( vm_cesIO.l(t,regi,in) gt 0 )
+o01_CESderivatives(t,regi,cesOut2cesIn(out,in))$( vm_cesIO.l(t,regi,in) gt 1e-6 AND
+                                                  vm_cesIO.l(t,regi,out) gt 1e-6 )
   =
     pm_cesdata(t,regi,in,"xi")
   * pm_cesdata(t,regi,in,"eff")
@@ -51,7 +52,7 @@ loop ((cesLevel2cesIO(counter,in),cesOut2cesIn(in,in2),cesOut2cesIn2(in2,in3)),
 *** of in to generate the same economic value
 loop ((t,regi,cesOut2cesIn(out,ppfen(in)),cesOut2cesIn2(out,in2))$( 
                                         o01_CESderivatives(t,regi,"inco",in2) ),
-  o01_CESmrs(t,regi,in,in2)
+  o01_CESmrs(t,regi,in,in2)$(o01_CESderivatives(t,regi,"inco",in2) gt 0)
   = o01_CESderivatives(t,regi,"inco",in)
   / o01_CESderivatives(t,regi,"inco",in2)
   );

--- a/modules/36_buildings/simple/datainput.gms
+++ b/modules/36_buildings/simple/datainput.gms
@@ -16,14 +16,15 @@ Parameter
 ;
 pm_cesdata_sigma(ttot,in)$p36_cesdata_sigma(in) = p36_cesdata_sigma(in);
 
+*** increase elasticities of subsitution over time to account for ramp-up requirements of new technologies in the short-term
 pm_cesdata_sigma(ttot,in)$ (pm_ttot_val(ttot) le 2025  AND sameAs(in, "enb")) = 0.1;
 pm_cesdata_sigma(ttot,in)$ (pm_ttot_val(ttot) eq 2030  AND sameAs(in, "enb")) = 0.3;
 
-pm_cesdata_sigma(ttot,in)$ (pm_ttot_val(ttot) le 2025  AND sameAs(in, "enhb")) = 0.1;
-pm_cesdata_sigma(ttot,in)$ (pm_ttot_val(ttot) eq 2030  AND sameAs(in, "enhb")) = 0.3;
-pm_cesdata_sigma(ttot,in)$ (pm_ttot_val(ttot) eq 2035  AND sameAs(in, "enhb")) = 0.6;
-pm_cesdata_sigma(ttot,in)$ (pm_ttot_val(ttot) eq 2040  AND sameAs(in, "enhb")) = 1.3;
-pm_cesdata_sigma(ttot,in)$ (pm_ttot_val(ttot) eq 2045  AND sameAs(in, "enhb")) = 2.0;
+pm_cesdata_sigma(ttot,in)$ (pm_ttot_val(ttot) le 2025  AND sameAs(in, "enhb")) = 0.5;
+pm_cesdata_sigma(ttot,in)$ (pm_ttot_val(ttot) eq 2030  AND sameAs(in, "enhb")) = 0.7;
+pm_cesdata_sigma(ttot,in)$ (pm_ttot_val(ttot) eq 2035  AND sameAs(in, "enhb")) = 1.3;
+pm_cesdata_sigma(ttot,in)$ (pm_ttot_val(ttot) eq 2040  AND sameAs(in, "enhb")) = 2.0;
+pm_cesdata_sigma(ttot,in)$ (pm_ttot_val(ttot) eq 2045  AND sameAs(in, "enhb")) = 2.5;
 
 pm_cesdata_sigma(ttot,"enhgab")$ (ttot.val le 2020) = 0.1;
 pm_cesdata_sigma(ttot,"enhgab")$ (ttot.val eq 2025) = 0.6;

--- a/modules/37_industry/subsectors/datainput.gms
+++ b/modules/37_industry/subsectors/datainput.gms
@@ -74,6 +74,28 @@ Parameter
 ;
 pm_cesdata_sigma(ttot,in)$( p37_cesdata_sigma(in) ) = p37_cesdata_sigma(in);
 
+
+*** increase elasticities of subsitution over time to account for ramp-up requirements of new technologies in the short-term
+pm_cesdata_sigma(ttot,"en_cement_non_electric")$ (ttot.val le 2025) = 0.7;
+pm_cesdata_sigma(ttot,"en_cement_non_electric")$ (ttot.val eq 2030) = 1.3;
+pm_cesdata_sigma(ttot,"en_cement_non_electric")$ (ttot.val eq 2035) = 1.7;
+pm_cesdata_sigma(ttot,"en_cement_non_electric")$ (ttot.val eq 2040) = 2.0;
+
+pm_cesdata_sigma(ttot,"en_chemicals_fhth")$ (ttot.val le 2025) = 0.7;
+pm_cesdata_sigma(ttot,"en_chemicals_fhth")$ (ttot.val eq 2030) = 1.3;
+pm_cesdata_sigma(ttot,"en_chemicals_fhth")$ (ttot.val eq 2035) = 2.0;
+pm_cesdata_sigma(ttot,"en_chemicals_fhth")$ (ttot.val eq 2040) = 3.0;
+
+pm_cesdata_sigma(ttot,"en_steel_furnace")$ (ttot.val le 2025) = 0.5;
+pm_cesdata_sigma(ttot,"en_steel_furnace")$ (ttot.val eq 2030) = 0.7;
+pm_cesdata_sigma(ttot,"en_steel_furnace")$ (ttot.val eq 2035) = 1.3;
+pm_cesdata_sigma(ttot,"en_steel_furnace")$ (ttot.val eq 2040) = 2.0;
+
+pm_cesdata_sigma(ttot,"en_otherInd_hth")$ (ttot.val le 2025) = 0.7;
+pm_cesdata_sigma(ttot,"en_otherInd_hth")$ (ttot.val eq 2030) = 1.3;
+pm_cesdata_sigma(ttot,"en_otherInd_hth")$ (ttot.val eq 2035) = 1.7;
+pm_cesdata_sigma(ttot,"en_otherInd_hth")$ (ttot.val eq 2040) = 2.0;
+
 *** abatement parameters for industry CCS MACs
 $include "./modules/37_industry/fixed_shares/input/pm_abatparam_Ind.gms";
 


### PR DESCRIPTION
# Purpose of this PR

This alters substitution elasticities for fuel switching buildings and industry which gradually increase over time to account for inertia and technology development in the short-term on the end-use side. 

The industry elasticities have been used in the ARIADNE runs (see PDFs below). They increase 2030 co2 prices mainly by slowing down the solids phase-out in steel an cement. The buildings elasticity still need some testing, but the goal is to have higher elasticities than before to allow for some switch to heat pumps in 2030 relative to baseline. 

As the new elasticities sometimes lead to execution errors in the macro postsolve section, some conditionals were added. 

I am currently doing test runs together with #980 and will merge both with new calibration files once results look good. Alternatively, we could maybe time it with the next round of general calibration runs by @LaviniaBaumstark as I am not aware what else is in the pipeline. 

Finally, if somebody is unhappy with some (other) elasticities, it is a good moment to raise that as we don't wanna touch that too frequently, I think. 

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

 
- [x] medium change (should have some impact on buildings and industry up to 2030, increase short-term co2 prices)



## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [x] I have updated the in-code documentation
- [x] The model compiles and runs successfully (`Rscript start.R -q`)
- [x] complete test runs buildings elasticity


## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 


https://cloud.pik-potsdam.de/index.php/apps/files/?dir=/Shared/REMIND-EU_calibration/Results/ElecH2_2022_08_29&openfile=14414908
