### PR TITLE
checkSetup.R: Do not depend on non-existing R package

### DIFF
--- a/scripts/utils/checkSetup.R
+++ b/scripts/utils/checkSetup.R
@@ -8,7 +8,10 @@ stopifnot(`pdflatex not found, check your LaTeX installation` = Sys.which("pdfla
 message("checking for pdflatex executable on your PATH - ok")
 
 message("checking if required R packages are installed")
-missingDeps <- Filter(function(x) !requireNamespace(x, quietly = TRUE),
+filter_func <- function(x) {
+  return(!requireNamespace(x, quietly = TRUE) && x != "R")
+}
+missingDeps <- Filter(filter_func,
                       renv::dependencies(dev = TRUE)[, "Package"])
 if (length(missingDeps) > 0) {
   stop("Some required R packages are missing, install them with `renv::install(",

--- a/scripts/utils/checkSetup.R
+++ b/scripts/utils/checkSetup.R
@@ -8,11 +8,8 @@ stopifnot(`pdflatex not found, check your LaTeX installation` = Sys.which("pdfla
 message("checking for pdflatex executable on your PATH - ok")
 
 message("checking if required R packages are installed")
-filter_func <- function(x) {
-  return(!requireNamespace(x, quietly = TRUE) && x != "R")
-}
-missingDeps <- Filter(filter_func,
-                      renv::dependencies(dev = TRUE)[, "Package"])
+missingDeps <- Filter(function(x) !requireNamespace(x, quietly = TRUE),
+                      setdiff(renv::dependencies(dev = TRUE)[, "Package"], "R"))
 if (length(missingDeps) > 0) {
   stop("Some required R packages are missing, install them with `renv::install(",
        paste(capture.output(dput(missingDeps)), collapse = ""), ")`")


### PR DESCRIPTION
# Purpose of this PR

In some circumstances (notably, when using renv on the cluster), `checkSetup.R` detects `"R"` as a package dependency. But "R" is not an R package, and therefore it ends with the nonsensical recommendation to run `renv::install("R")`. With this PR, this is explicitly filtered out.

## Type of change

- [x] Bug fix 
- [x] Minor change


## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [x] Changes are commented, particularly in hard-to-understand areas
- [ ] I have updated the in-code documentation
- [ ] The model compiles and runs successfully (`Rscript start.R -q`)

## Further information (optional):

No change in model, only in the util R script, so I didn't check any modelruns.


