### PR TITLE
Remove .Rprofile in github action

### DIFF
--- a/.github/workflows/test-code.yaml
+++ b/.github/workflows/test-code.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Remove .Rprofile
-        shell: rm .Rprofile
+        run: rm .Rprofile
 
       - uses: r-lib/actions/setup-r@v1
 

--- a/.github/workflows/test-code.yaml
+++ b/.github/workflows/test-code.yaml
@@ -20,6 +20,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Remove .Rprofile
+        shell: rm .Rprofile
+
       - uses: r-lib/actions/setup-r@v1
 
       - name: Query dependencies

--- a/.github/workflows/test-code.yaml
+++ b/.github/workflows/test-code.yaml
@@ -14,7 +14,7 @@ name: check
 
 jobs:
   check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -23,27 +23,17 @@ jobs:
       - name: Remove .Rprofile
         run: rm .Rprofile
 
-      - uses: r-lib/actions/setup-r@v1
-
-      - name: Query dependencies
-        run: |
-          saveRDS("gms", ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
-
-      - name: Cache R packages
-        uses: actions/cache@v2
+      - uses: r-lib/actions/setup-r@v2
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+          extra-repositories:
+            - https://cloud.r-project.org
+            - https://rse.pik-potsdam.de/r/packages/
 
       - name: Install R dependencies
-        run: |
-          repos <- c("https://cloud.r-project.org","https://rse.pik-potsdam.de/r/packages/")
-          install.packages(c("remotes"), repos=repos)
-          remotes::install_cran("gms", repos=repos)
-        shell: Rscript {0}
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          packages: gms
+          extra-packages: gms
         
       - name: codeCheck
         run: null <- gms::codeCheck(strict=TRUE)

--- a/.github/workflows/test-code.yaml
+++ b/.github/workflows/test-code.yaml
@@ -25,9 +25,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r@v2
         with:
-          extra-repositories:
-            - https://cloud.r-project.org
-            - https://rse.pik-potsdam.de/r/packages/
+          extra-repositories: https://cloud.r-project.org https://rse.pik-potsdam.de/r/packages/
 
       - name: Install R dependencies
         uses: r-lib/actions/setup-r-dependencies@v2


### PR DESCRIPTION
# Purpose of this PR

The `.Rprofile`, which is meant to be used to run REMIND and sets up the renv automatically, was used by the github action automatically. Unfortunately, setting up the renv takes a long time, and is ultimately useless because we don't need everything to run REMIND in the github action, we only need `gms`, which the github action already installs.

Additionally, I refactored the github actions to use the latest r-lib/actions, which do caching automatically, needing less weird hacks from our side.

## Type of change

- [x] Bug fix 
- [x] Minor change (default scenarios show only small differences)

## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [ ] Changes are commented, particularly in hard-to-understand areas
- [ ] I have updated the in-code documentation
- [x] I have adjusted reporting where it was needed
- [ ] The model compiles and runs successfully (`Rscript start.R -q`)

## Further information:

No change to the model itself, so no test runs.


