### PR TITLE
avoid that 11_exoGAINS overwrites fulldata.gdx, improve restart message

### DIFF
--- a/modules/11_aerosols/exoGAINS/postsolve.gms
+++ b/modules/11_aerosols/exoGAINS/postsolve.gms
@@ -13,8 +13,10 @@
 *** run exoGAINS from iteration 2 onwards to avoid incomplete GDX files when running it in the first iteration
 if (iteration.val ge 2,
 
-*** write data to file
-Execute_Unload 'fulldata_exoGAINS';
+*** write data to file if an optimal solution was found
+if((o_modelstat le 2),
+    Execute_Unload 'fulldata_exoGAINS';
+);
 
 *** Calculate AP emissions
 Execute "Rscript exoGAINSAirpollutants.R";

--- a/modules/11_aerosols/exoGAINS/postsolve.gms
+++ b/modules/11_aerosols/exoGAINS/postsolve.gms
@@ -12,16 +12,11 @@
 
 *** run exoGAINS from iteration 2 onwards to avoid incomplete GDX files when running it in the first iteration
 if (iteration.val ge 2,
-*** write the fulldata.gdx file after each optimal iteration
-***AJS* in Nash status 7 is considered optimal in that respect (see definition of o_modelstat in solve.gms)
-if((o_modelstat le 2),
-    Execute_Unload 'fulldata';
-  );  
-if((o_modelstat gt 2),
-    Execute_Unload 'non_optimal';
-  );
 
-*** Calcualte AP emissions
+*** write data to file
+Execute_Unload 'fulldata_exoGAINS';
+
+*** Calculate AP emissions
 Execute "Rscript exoGAINSAirpollutants.R";
 
 *** Read input ref results for tall with following dimensions: pm_emiAPexsolve(tall,all_regi,all_sectorEmi,emiRCP)

--- a/scripts/input/exoGAINSAirpollutants.R
+++ b/scripts/input/exoGAINSAirpollutants.R
@@ -29,13 +29,13 @@ invisible(getConfig(option = NULL, verbose = firstIteration))
 load("config.Rdata")
 ssp_scenario <- cfg$gms$cm_APscen
 
-# read in REMIND avtivities, use the fulldata_post.gdx and then the input.gdx if the fulldata.gdx is not available
-if (file.exists("fulldata.gdx")){gdx <- "fulldata.gdx"} else {if (file.exists("fulldata_post.gdx")){gdx <- "fulldata_post.gdx"} else {gdx <- "input.gdx"}}
+# read in REMIND avtivities, use input.gdx if the fulldata_exoGAINS.gdx is not available
+gdx <- if (file.exists("fulldata_exoGAINS.gdx")) "fulldata_exoGAINS.gdx" else "input.gdx"
 
-
+iterationNumber <- as.numeric(readGDX(gdx = gdx, "o_iterationNumber", format = "simplest"))
 t <- c(seq(2005,2060,5),seq(2070,2110,10),2130,2150)
 rem_in_mo <- NULL
-message("exoGAINSAirpollutants.R calls remind2::reportMacroEconomy ", appendLF = FALSE)
+message("Iteration ", iterationNumber, ": exoGAINSAirpollutants.R calls remind2::reportMacroEconomy ", appendLF = FALSE)
 rem_in_mo <- mbind(rem_in_mo,reportMacroEconomy(gdx)[,t,])
 message("- reportPE ", appendLF = FALSE)
 rem_in_mo <- mbind(rem_in_mo,reportPE(gdx)[,t,])
@@ -227,6 +227,8 @@ writeGDX(out,file="pm_emiAPexsolve.gdx",period_with_y = FALSE)
 # CEDS16 <- add_columns(CEDS16,addnm = getNames(avi_E,dim=1)) # filled with NA
 # CEDS16[,,getNames(avi_E,dim=1)] <- 0 # replace NA with zero
 # CEDS16["GLO",,getNames(avi_E[,,ssp_scenario])] <- avi_E[,,ssp_scenario] # data only contains BC and NOx emissions from aircraft
+
+unlink("fulldata_exoGAINS.gdx")
 
 if(firstIteration){
   cat("\nExoGAINS - end of first iteration.\n\n")

--- a/scripts/input/exoGAINSAirpollutants.R
+++ b/scripts/input/exoGAINSAirpollutants.R
@@ -228,8 +228,6 @@ writeGDX(out,file="pm_emiAPexsolve.gdx",period_with_y = FALSE)
 # CEDS16[,,getNames(avi_E,dim=1)] <- 0 # replace NA with zero
 # CEDS16["GLO",,getNames(avi_E[,,ssp_scenario])] <- avi_E[,,ssp_scenario] # data only contains BC and NOx emissions from aircraft
 
-unlink("fulldata_exoGAINS.gdx")
-
 if(firstIteration){
   cat("\nExoGAINS - end of first iteration.\n\n")
 }

--- a/scripts/start/prepare_and_run.R
+++ b/scripts/start/prepare_and_run.R
@@ -442,7 +442,9 @@ prepare <- function() {
                       paste0("CESparametersAndGDX_",cfg$CESandGDXversion,".tgz"))
   # download and distribute needed data 
   if(!setequal(input_new, input_old) | cfg$force_download) {
-      message("Your input data are outdated or in a different regional resolution. New data are downloaded and distributed.")
+      message(if (cfg$force_download) "You set 'cfg$force_download = TRUE'"
+              else "Your input data are outdated or in a different regional resolution",
+              ". New input data are downloaded and distributed.")
       download_distribute(files        = input_new,
                           repositories = cfg$repositories, # defined in your local .Rprofile or on the cluster /p/projects/rd3mod/R/.Rprofile
                           modelfolder  = ".",
@@ -1270,6 +1272,7 @@ if (!file.exists("full.gms")) {
 } else {
   # If "full.gms" exists, the script assumes that a full.gms has been generated before and you want
   # to restart REMIND in the same folder using the gdx that it eventually previously produced.
+  message("\nRestarting REMIND, find old log in 'log_beforeRestart.txt'.")
   if(file.exists("fulldata.gdx")) file.copy("fulldata.gdx", "input.gdx", overwrite = TRUE)
   start_subsequent_runs <- FALSE
 }

--- a/scripts/start/submit.R
+++ b/scripts/start/submit.R
@@ -23,20 +23,20 @@ submit <- function(cfg, restart = FALSE, stopOnFolderCreateError = TRUE) {
     cfg$results_folder <- gsub(":date:", date, cfg$results_folder, fixed = TRUE)
     cfg$results_folder <- gsub(":title:", cfg$title, cfg$results_folder, fixed = TRUE)
     # Create output folder
-    cat("   Creating results folder",cfg$results_folder,"\n")
     if (!file.exists(cfg$results_folder)) {
+      message("   Creating results folder", cfg$results_folder)
       dir.create(cfg$results_folder, recursive = TRUE, showWarnings = FALSE)
     } else if (!cfg$force_replace) {
-      couldnotdelete <- paste0("Results folder ",cfg$results_folder," could not be created because it already exists")
+      couldnotdelete <- paste0("Results folder ",cfg$results_folder," already exists")
       if (stopOnFolderCreateError) {
         stop(couldnotdelete, ".")
       } else if (! all(grepl("^log*.txt", list.files(cfg$results_folder)))) {
         stop(couldnotdelete, " and it contains not only log files.")
       } else {
-        message(couldnotdelete, " but it contains only log files.")
+        message(couldnotdelete, " containing only log files as expected for coupled runs.")
       }
     } else {
-      cat("    Deleting results folder because it already exists:",cfg$results_folder,"\n")
+      message("    Results folder already exists, deleting and re-creating it: ",cfg$results_folder,"\n")
       unlink(cfg$results_folder, recursive = TRUE)
       dir.create(cfg$results_folder, recursive = TRUE, showWarnings = FALSE)
     }

--- a/start.R
+++ b/start.R
@@ -234,12 +234,16 @@ if (any(c("--reprepare", "--restart") %in% flags)) {
   # runs <- lucode2::findCoupledruns("./output/")
   # possibledirs <- sub("./output/", "", lucode2::findIterations(runs, modelpath = "./output", latest = TRUE))
   outputdirs <- gms::chooseFromList(sort(unique(possibledirs)), returnBoolean = FALSE,
-                           type = paste0("runs to be re ", ifelse("--reprepare" %in% argv, "prepared", "started")))
+                           type = paste0("runs to be re", ifelse("--reprepare" %in% flags, "prepared", "started")))
   message("\nAlso restart subsequent runs? Enter y, else leave empty:")
   restart_subsequent_runs <- gms::getLine() %in% c("Y", "y")
   if ("--testOneRegi" %in% flags) testOneRegi_region <- select_testOneRegi_region()
-  filestomove <- c("abort.gdx" = "abort_beforeRestart.gdx", "non_optimal.gdx" = "non_optimal_beforeRestart.gdx",
-                  c("full.gms" = "full_beforeRestart.gms", "fulldata.gdx" = "fulldata_beforeRestart.gdx")["--reprepare" %in% argv])
+  filestomove <- c("abort.gdx" = "abort_beforeRestart.gdx",
+                   "non_optimal.gdx" = "non_optimal_beforeRestart.gdx",
+                   "log.txt" = "log_beforeRestart.txt",
+     if ("--reprepare" %in% flags) c("full.gms" = "full_beforeRestart.gms",
+                                     "fulldata.gdx" = "fulldata_beforeRestart.gdx")
+                  )
   message("\n", paste(names(filestomove), collapse = ", "), " will be moved and get a postfix '_beforeRestart'.\n")
   if(! exists("slurmConfig")) slurmConfig <- choose_slurmConfig()
   if ("--quick" %in% flags) slurmConfig <- paste(slurmConfig, "--time=60")


### PR DESCRIPTION
## Purpose of this PR
- Fixes two issues with 11_exoGAINS: first, that it overwrites `fulldata.gdx` in the middle of an iteration, causing some mess on restarts sometimes. #918. Second, that after non-optimal solve in early iterations, no fulldata.gdx is found and it crashes. Solution is to write an own gdx file that is only used by exoGAINS and later deleted
- improve some logging, preserve `log.txt` as `log_beforeRestart.txt` if runs are restarted and tell the user about it

## Type of change

- [x] Bug fix 
- [x] No change in scenario results

## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [x] The model compiles and runs successfully (see `/p/tmp/oliverr/remind/output/default_2022-10-06_17.35.04`)