### PR TITLE
Add Makefile for long / hard to remember commands

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,6 +24,7 @@ Imports:
     gdxrrw,
     ggplot2,
     gms,
+    goxygen,
     gridExtra,
     gtools,
     hdf5r,

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: help docs update-renv
+.DEFAULT_GOAL := help
+
+help:           ## Show this help.
+	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'
+
+docs:           ## Generate/update model HTML documentation in the doc/ folder
+	Rscript -e 'goxygen::goxygen(unitPattern = c("\\[","\\]"), includeCore=T, max_num_edge_labels="adjust", max_num_nodes_for_edge_labels = 15)'
+	echo -e 'Open\ndoc/html/index.htm\nin your browser to view the generated documentation.'
+
+update-renv:    ## Upgrade all packages in your renv to the respective latest release, make new snapshot
+	Rscript -e 'renv::update()'
+	Rscript -e 'renv::snapshot()'

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ docs:           ## Generate/update model HTML documentation in the doc/ folder
 	Rscript -e 'goxygen::goxygen(unitPattern = c("\\[","\\]"), includeCore=T, max_num_edge_labels="adjust", max_num_nodes_for_edge_labels = 15)'
 	echo -e 'Open\ndoc/html/index.htm\nin your browser to view the generated documentation.'
 
-update-renv:    ## Upgrade all packages in your renv to the respective latest release, make new snapshot
+update-renv:    ## Upgrade all pik-piam packages in your renv to the respective latest release, make new snapshot
+	Rscript scripts/utils/updateRenv.R
+
+update-all-renv: ## Upgrade all packages (including CRAN packages) in your renv to the respective latest release, make new snapshot
 	Rscript -e 'renv::update()'
 	Rscript -e 'renv::snapshot()'

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help docs update-renv
+.PHONY: help docs update-renv update-all-renv check
 .DEFAULT_GOAL := help
 
 help:           ## Show this help.
@@ -7,7 +7,7 @@ help:           ## Show this help.
 
 docs:           ## Generate/update model HTML documentation in the doc/ folder
 	Rscript -e 'goxygen::goxygen(unitPattern = c("\\[","\\]"), includeCore=T, max_num_edge_labels="adjust", max_num_nodes_for_edge_labels = 15)'
-	echo -e 'Open\ndoc/html/index.htm\nin your browser to view the generated documentation.'
+	@echo -e '\nOpen\ndoc/html/index.htm\nin your browser to view the generated documentation.'
 
 update-renv:    ## Upgrade all pik-piam packages in your renv to the respective
                 ## latest release, make new snapshot
@@ -17,3 +17,7 @@ update-all-renv: ## Upgrade all packages (including CRAN packages) in your renv
                  ## to the respective latest release, make new snapshot
 	Rscript -e 'renv::update()'
 	Rscript -e 'renv::snapshot()'
+
+check:          ## Check if the GAMS code follows the coding etiquette
+                ## using gms::codeCheck
+	Rscript -e 'invisible(gms::codeCheck(strict = TRUE))'

--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,18 @@
 .DEFAULT_GOAL := help
 
 help:           ## Show this help.
-	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'
+	@sed -e '/##/ !d' -e '/sed/ d' -e 's/^\([^ ]*\) *##\(.*\)/\1^\2/' \
+		$(MAKEFILE_LIST) | column -ts '^'
 
 docs:           ## Generate/update model HTML documentation in the doc/ folder
 	Rscript -e 'goxygen::goxygen(unitPattern = c("\\[","\\]"), includeCore=T, max_num_edge_labels="adjust", max_num_nodes_for_edge_labels = 15)'
 	echo -e 'Open\ndoc/html/index.htm\nin your browser to view the generated documentation.'
 
-update-renv:    ## Upgrade all pik-piam packages in your renv to the respective latest release, make new snapshot
+update-renv:    ## Upgrade all pik-piam packages in your renv to the respective
+                ## latest release, make new snapshot
 	Rscript scripts/utils/updateRenv.R
 
-update-all-renv: ## Upgrade all packages (including CRAN packages) in your renv to the respective latest release, make new snapshot
+update-all-renv: ## Upgrade all packages (including CRAN packages) in your renv
+                 ## to the respective latest release, make new snapshot
 	Rscript -e 'renv::update()'
 	Rscript -e 'renv::snapshot()'

--- a/README.md
+++ b/README.md
@@ -19,15 +19,16 @@ The model documentation for version 3.0.0 can be found at https://rse.pik-potsda
 
 The most recent version of the documentation can also be extracted from the
 model source code via the R package goxygen
-(https://github.com/pik-piam/goxygen). To extract the documentation, install the
-package and run the main function `(goxygen(unitPattern = c("\\[","\\]"), includeCore=T, max_num_edge_labels="adjust", max_num_nodes_for_edge_labels = 15))`
+(https://github.com/pik-piam/goxygen). To extract the documentation, run `make docs`
 in the main folder of the model.
-The resulting documentation can be found in the folder "doc".
+The resulting documentation can be found in the folder `doc/`.
 
 Please pay attention to the REMIND Coding Etiquette when you modify the code
 (if you plan on contributing to the REMIND official repository).
 The Coding Etiquette is found in the documentation section of the file main.gms.
 It explains also the used name conventions and other structural characteristics.
+To automatically check if some aspects of the coding etiquette, you can run
+`make check` in the main folder of the model.
 
 ## TUTORIALS
 


### PR DESCRIPTION
# Purpose of this PR

I always forget how to build our docs and similar "house-keeping" stuff. Putting these kinds of commands in a Makefile, I just have to remember `make docs` or even just `make help`.

## Type of change

- [x] Minor change (default scenarios show only small differences)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [x] Changes are commented, particularly in hard-to-understand areas
- [x] I have updated the in-code documentation
- [ ] I have adjusted reporting where it was needed
- [ ] The model compiles and runs successfully (`Rscript start.R -q`)

## Further information:

For now, I added the following commands:
```
help:            Show this help.
docs:            Generate/update model HTML documentation in the doc/ folder
update-renv:     Upgrade all pik-piam packages in your renv to the respective latest release, make new snapshot
update-all-renv:  Upgrade all packages (including CRAN packages) in your renv to the respective latest release, make new snapshot
```

I can also think of other commands, e.g. codeCheck, but I'd like to get feedback first if you think this approach is useful.