### PR TITLE
remove cm_SlowConvergence, not used anymore

### DIFF
--- a/main.gms
+++ b/main.gms
@@ -1539,9 +1539,6 @@ $setGlobal cm_FEtax_trajectory_rel  off !! def = off
 *** cm_wind_offshore  1, wind energy is represented by "wind" and "windoff", where "wind" means wind onshore. Later this will be the default and the name "wind" will be made to change to windon
 *** cm_wind_offshore  0, means wind energy is only represented by "wind", which is a mixture of both wind onshore and wind offshore
 $setglobal cm_wind_offshore  1      !! def = 1
-*** *RP* Turn on a slower convergence scheme where each conopt file is used twice, thus conopt1 is used for itr 1+2, conopt.op2 for itr 3+4, conopt.op3 for itr 5+6, conopt.op4 for itr 7+8, conopt.op5 from itr 9 on.
-*** *RP* from my own experience, this improves convergence and actually decreases total runtime, even if you start from a gdx with good convergence. But, as always, feelings about REMIND runtimes can be misleading :-)
-$setglobal cm_SlowConvergence  off        !! def = off
 *** *RP* Flag to allow the model to not extract oil, even though the eq_fuelex_dec would force it to extract.
 $setGlobal cm_OILRETIRE  on        !! def = on
 ***  cm_INCONV_PENALTY  on     !! def = on

--- a/modules/80_optimization/negishi/solve.gms
+++ b/modules/80_optimization/negishi/solve.gms
@@ -33,17 +33,6 @@ IF(o_modelstat eq 2,
     if (ord(iteration) eq 2, s80_cnptfile = 3); !! rtredg = 1.d-7
     if (ord(iteration) eq 3, s80_cnptfile = 3); !! rtredg = 1.d-7
     if (ord(iteration) eq 4, s80_cnptfile = 3); !! rtredg = 1.d-7
-*RP* Slower convergence scheme
-$IFTHEN.cm_SlowConvergence %cm_SlowConvergence% == "on"
-    if (ord(iteration) eq 1, s80_cnptfile = 1); !! rtredg = 1.d-5
-    if (ord(iteration) eq 2, s80_cnptfile = 2); !! rtredg = 1.d-6
-    if (ord(iteration) eq 3, s80_cnptfile = 2); !! rtredg = 1.d-6
-    if (ord(iteration) eq 4, s80_cnptfile = 3); !! rtredg = 1.d-7
-    if (ord(iteration) eq 5, s80_cnptfile = 3); !! rtredg = 1.d-7
-    if (ord(iteration) eq 6, s80_cnptfile = 3); !! rtredg = 1.d-7
-    if (ord(iteration) eq 7, s80_cnptfile = 3); !! rtredg = 1.d-7
-    if (ord(iteration) eq 8, s80_cnptfile = 3); !! rtredg = 1.d-7
-$ENDIF.cm_SlowConvergence
 );
 *** EOF ./modules/80_optimization/negishi/solve.gms
 


### PR DESCRIPTION
# Purpose of this PR

`cm_SlowConvergence` was not used any more for a long time, so we decided to remove it.

## Type of change

- [x] Minor change (default scenarios show only small differences)

## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [x] Changes are commented, particularly in hard-to-understand areas
- [x] I have updated the in-code documentation
- [x] The model compiles and runs successfully (`Rscript start.R -q`)

