### PR TITLE
new input data and CES parameters and .gdx files for SSP1, SSP2EU, SD…

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -27,10 +27,10 @@ cfg$regionmapping <- "config/regionmappingH12.csv"
 ### Additional (optional) region mapping, so that those validation data can be loaded that contain the corresponding additional regions.
 cfg$extramappings_historic <- NULL
 #### Current input data revision (<mainrevision>.<subrevision>) ####
-cfg$inputRevision <- "6.316"
+cfg$inputRevision <- "6.322"
 
 #### Current CES parameter and GDX revision (commit hash) ####
-cfg$CESandGDXversion <- "346023c22fb098052539fbbfdda2041b5114d82c"
+cfg$CESandGDXversion <- "1074017d964fa8747e484215b9b3783a15e051e8"
 
 #### Force the model to download new input data ####
 cfg$force_download <- FALSE


### PR DESCRIPTION
…P, SDP_EI, SDP_MC, SDP_RC, SSP5, and EU21reg

# Purpose of this PR
provide new input data and CES parameters generated by Michaja

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Minor change (default scenarios show only small differences)



## Checklist:

- [x] The model compiles and runs successfully (`Rscript start.R -q`)

## Further information (optional):

* Test runs are here: /p/tmp/lavinia/REMIND/REMIND_forkLav_2022_10_18/remind/output
* Comparison of results (what changes by this PR?): 


