### PR TITLE
delete outdated options for nucscen, keep only number 2 (default), 5 and 6 

### DIFF
--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -204,10 +204,10 @@ if (cm_startyear le 2020,   !! require the realization of at least 50% of the pl
    vm_deltaCap.lo("2020",regi,"tnrs","1") = 0.5 * pm_NuclearConstraint("2020",regi,"tnrs") / 5;
    vm_deltaCap.up("2020",regi,"tnrs","1") = pm_NuclearConstraint("2020",regi,"tnrs") / 5;
 );
-if (cm_startyear le 2025 AND cm_nucscen ge 2,   !! upper bound calculated in mrremind/R/calcCapacityNuclear.R: 50% of planned and 30% of proposed plants, plus extra for lifetime extension and newcomers
+if (cm_startyear le 2025,   !! upper bound calculated in mrremind/R/calcCapacityNuclear.R: 50% of planned and 30% of proposed plants, plus extra for lifetime extension and newcomers
    vm_deltaCap.up("2025",regi,"tnrs","1") = pm_NuclearConstraint("2025",regi,"tnrs") / 5;
 );
-if (cm_startyear le 2030 AND cm_nucscen ge 2,   !! upper bound calculated in mrremind/R/calcCapacityNuclear.R: 50% of planned and 70% of proposed plants, plus extra for lifetime extension and newcomers
+if (cm_startyear le 2030,   !! upper bound calculated in mrremind/R/calcCapacityNuclear.R: 50% of planned and 70% of proposed plants, plus extra for lifetime extension and newcomers
    vm_deltaCap.up("2030",regi,"tnrs","1") = pm_NuclearConstraint("2030",regi,"tnrs") / 5;
 );
 
@@ -216,28 +216,13 @@ display p_CapFixFromRWfix, p_deltaCapFromRWfix;
 *** ------------------------------------------------------------------------------------------
 *RP* implement switch for scenarios with different nuclear assumptions:
 *** ------------------------------------------------------------------------------------------
+vm_deltaCap.up(t,regi,"fnrs",rlf)$(t.val ge 2010)= 0;
+vm_cap.fx(t,regi,"fnrs",rlf)$(t.val ge 2010) = 0;
 
-** FS: swtich on fnrs only in nucscen 0 and 4, (2 is default)
-if (cm_nucscen gt 0 AND cm_nucscen ne 4,
-  vm_deltaCap.up(t,regi,"fnrs",rlf)$(t.val ge 2010)= 0;
-  vm_cap.fx(t,regi,"fnrs",rlf)$(t.val ge 2010) = 0;
-);
-
-*mh no tnrs:
-if (cm_nucscen eq 3,
-  vm_deltaCap.up(t,regi_nucscen,"tnrs",rlf)$(t.val ge 2010) = 0;
-  vm_cap.lo(t,regi_nucscen,"tnrs",rlf)$(t.val ge 2010)= 0;
-);
-
-* no new nuclear investments after 2020, until then all currently planned plants are built
+*** no new nuclear investments after 2020, until then all currently planned plants are built
 if (cm_nucscen eq 5,
   vm_deltaCap.up(t,regi_nucscen,"tnrs",rlf)$(t.val gt 2020)= 1e-6;
   vm_cap.lo(t,regi_nucscen,"tnrs",rlf)$(t.val gt 2015)  = 0;
-);
-
-*FS: nuclear phase-out by 2040
-if (cm_nucscen eq 7,
-  vm_prodSe.up(t,regi_nucscen,"peur","seel","tnrs")$(t.val ge 2040) = 0;
 );
 
 *** -------------------------------------------------------------
@@ -255,10 +240,6 @@ if(cm_1stgen_phaseout=1,
 if (cm_emiscen ne 1,
   if (c_solscen eq 3,
     vm_cap.up(t,regi,"spv",rlf)$(t.val ge 2010)  = p_boundtmp(t,regi,"spv",rlf);
-  );
-  if (cm_nucscen eq 4,
-    vm_cap.up(t,regi_nucscen,"tnrs",rlf)$(t.val ge 2010) = p_boundtmp(t,regi_nucscen,"tnrs",rlf);
-    vm_cap.up(t,regi_nucscen,"fnrs",rlf)$(t.val ge 2010) = p_boundtmp(t,regi_nucscen,"fnrs",rlf);
   );
 );
 

--- a/main.gms
+++ b/main.gms
@@ -512,10 +512,7 @@ parameter
   cm_nucscen                "nuclear option choice"
 ;
   cm_nucscen       = 2;        !! def = 2
-*'   (1): no fnrs, tnrs completely free after 2020
 *'   (2): no fnrs, tnrs with restricted new builds until 2030 (based on current data on plants under construction, planned or proposed)
-*'   (3): no tnrs no fnrs
-*'   (4): fix at bau level
 *'   (5): no new nuclear investments after 2020
 *'   (6): +33% investment costs (tnrs) & uranium resources increased by a factor of 10
 *'

--- a/modules/40_techpol/CombLowCandCoalPO/not_used.txt
+++ b/modules/40_techpol/CombLowCandCoalPO/not_used.txt
@@ -12,7 +12,6 @@ pm_pop,parameter,???
 pm_gdp,input,questionnaire
 vm_shUePeT,input,questionnaire
 pm_NuclearConstraint,input,questionnaire
-cm_nucscen,input,questionnaire
 vm_capEarlyReti,input,questionnaire
 pm_regiEarlyRetiRate,input,questionnaire
 pm_eta_conv,input,questionnaire

--- a/modules/40_techpol/EVmandates/not_used.txt
+++ b/modules/40_techpol/EVmandates/not_used.txt
@@ -14,7 +14,6 @@ pm_prodCouple,parameter,???
 pm_gdp,input,questionnaire
 vm_shUePeT,input,questionnaire
 pm_NuclearConstraint,input,questionnaire
-cm_nucscen,input,questionnaire
 vm_capEarlyReti,input,questionnaire
 pm_regiEarlyRetiRate,input,questionnaire
 pm_eta_conv,input,questionnaire

--- a/modules/40_techpol/NDC/bounds.gms
+++ b/modules/40_techpol/NDC/bounds.gms
@@ -13,11 +13,6 @@ vm_cap.lo(t,regi,"tnrs","1")$(t.val ge 2025) = p40_TechBound(t,regi,"tnrs")*0.00
 vm_cap.lo(t,regi,"hydro","1")$(t.val ge 2025) = p40_TechBound(t,regi,"hydro")*0.001;
 
 
-* FS: in case of a nuclear phase-out scenario (nucscen 7), nuclear lower bound from p40_techBound only up to 2025
-if(cm_nucscen eq 7,
-  vm_cap.lo(t,regi_nucscen,"tnrs","1")$((t.val gt 2025) and (t.val ge cm_startyear)) = 0;
-);
-
 *** FS: if cm_H2Targets on: include capacity targets for electrolysis following national Hydrogen Strategies
 *** multiply by conversion efficiency as targets are given in GW(electricity) but GW(H2) needed
 *** EU Hydrogen Strategy (2020): https://ec.europa.eu/energy/sites/ener/files/hydrogen_strategy.pdf
@@ -30,8 +25,6 @@ if(cm_H2targets eq 1,
 if(cm_nucscen eq 5,
   vm_cap.lo(t,regi_nucscen,"tnrs","1")$(t.val gt 2020) = 0;
 );
-
-
 
 $ifthen.complex_transport "%transport%" == "complex"
 

--- a/modules/40_techpol/NDC/bounds.gms
+++ b/modules/40_techpol/NDC/bounds.gms
@@ -21,11 +21,6 @@ if(cm_H2targets eq 1,
   vm_cap.lo(t,regi,"elh2","1")$(t.val ge cm_startyear) = p40_TechBound(t,regi,"elh2")*0.001*pm_eta_conv(t,regi,"elh2");
 );
 
-*RP in case nucscen = 5(no new builds after 2020), remove nuclear lower bound from p40_techBound 
-if(cm_nucscen eq 5,
-  vm_cap.lo(t,regi_nucscen,"tnrs","1")$(t.val gt 2020) = 0;
-);
-
 $ifthen.complex_transport "%transport%" == "complex"
 
 vm_cap.lo(t,regi,"apCarElT","1")$(t.val ge cm_startyear) = p40_TechBound(t,regi,"apCarElT");

--- a/modules/40_techpol/NDCplus/bounds.gms
+++ b/modules/40_techpol/NDCplus/bounds.gms
@@ -12,12 +12,6 @@ vm_cap.lo(t,regi,"tnrs","1")$(t.val lt 2031) = p40_TechBound(t,regi,"tnrs")*0.00
 vm_cap.lo(t,regi,"hydro","1")$(t.val lt 2031 AND t.val gt 2024) = p40_TechBound(t,regi,"hydro")*0.001;
 
 
-* FS: in case of a nuclear phase-out scenario (nucscen 7), nuclear lower bound from p40_techBound only up to 2025
-if(cm_nucscen eq 7,
-  vm_cap.lo(t,regi_nucscen,"tnrs","1")$(t.val gt 2025) = 0;
-);
-
-
 $ifthen.complex_transport "%transport%" == "complex"
 
 vm_cap.lo(t,regi,"apCarElT","1")$(t.val lt 2041 AND t.val gt 2024) = p40_TechBound(t,regi,"apCarElT");

--- a/modules/40_techpol/NDCplus/not_used.txt
+++ b/modules/40_techpol/NDCplus/not_used.txt
@@ -11,3 +11,4 @@ pm_eta_conv,input,questionnaire
 cm_startyear,input,questionnaire
 cm_bioprod_histlim,input,questionnaire
 cm_H2targets,input,questionnaire
+cm_nucscen,input,questionnaire

--- a/modules/40_techpol/NDCplus/not_used.txt
+++ b/modules/40_techpol/NDCplus/not_used.txt
@@ -11,4 +11,3 @@ pm_eta_conv,input,questionnaire
 cm_startyear,input,questionnaire
 cm_bioprod_histlim,input,questionnaire
 cm_H2targets,input,questionnaire
-cm_nucscen,input,questionnaire

--- a/modules/40_techpol/NPi2018/not_used.txt
+++ b/modules/40_techpol/NPi2018/not_used.txt
@@ -8,7 +8,6 @@ name,type,reason
 pm_ttot_val,parameter,???
 vm_deltaCap,input,questionnaire
 pm_NuclearConstraint,input,questionnaire
-cm_nucscen,input,questionnaire
 vm_capEarlyReti,input,questionnaire
 pm_regiEarlyRetiRate,input,questionnaire
 pm_eta_conv,input,questionnaire

--- a/modules/40_techpol/coalPhaseout/not_used.txt
+++ b/modules/40_techpol/coalPhaseout/not_used.txt
@@ -13,7 +13,6 @@ pm_pop,parameter,???
 pm_gdp,input,questionnaire
 vm_shUePeT,input,questionnaire
 pm_NuclearConstraint,input,questionnaire
-cm_nucscen,input,questionnaire
 vm_capEarlyReti,input,questionnaire
 pm_regiEarlyRetiRate,input,questionnaire
 pm_eta_conv,input,questionnaire

--- a/modules/40_techpol/coalPhaseoutRegional/not_used.txt
+++ b/modules/40_techpol/coalPhaseoutRegional/not_used.txt
@@ -12,7 +12,6 @@ pm_prodCouple,parameter,???
 pm_gdp,input,questionnaire
 vm_shUePeT,input,questionnaire
 pm_NuclearConstraint,input,questionnaire
-cm_nucscen,input,questionnaire
 vm_capEarlyReti,input,questionnaire
 pm_regiEarlyRetiRate,input,questionnaire
 pm_eta_conv,input,questionnaire

--- a/modules/40_techpol/lowCarbonPush/not_used.txt
+++ b/modules/40_techpol/lowCarbonPush/not_used.txt
@@ -14,7 +14,6 @@ pm_pop,parameter,???
 pm_gdp,input,questionnaire
 vm_shUePeT,input,questionnaire
 pm_NuclearConstraint,input,questionnaire
-cm_nucscen,input,questionnaire
 vm_capEarlyReti,input,questionnaire
 pm_regiEarlyRetiRate,input,questionnaire
 pm_eta_conv,input,questionnaire

--- a/modules/40_techpol/none/not_used.txt
+++ b/modules/40_techpol/none/not_used.txt
@@ -15,7 +15,6 @@ pm_pop,parameter,???
 pm_gdp,input,questionnaire
 vm_shUePeT,input,questionnaire
 pm_NuclearConstraint,input,questionnaire
-cm_nucscen,input,questionnaire
 vm_capEarlyReti,input,questionnaire
 pm_regiEarlyRetiRate,input,questionnaire
 pm_eta_conv,input,questionnaire


### PR DESCRIPTION
# Purpose of this PR
cleaning options of nucscen

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Refactoring


## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [x] I have updated the in-code documentation

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 


