### PR TITLE
stop on missing input files, without trying to unpack them

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Imports:
     gdxdt,
     gdxrrw,
     ggplot2,
-    gms,
+    gms (>= 0.21.0),
     gridExtra,
     gtools,
     hdf5r,

--- a/scripts/start/prepare_and_run.R
+++ b/scripts/start/prepare_and_run.R
@@ -446,7 +446,8 @@ prepare <- function() {
       download_distribute(files        = input_new,
                           repositories = cfg$repositories, # defined in your local .Rprofile or on the cluster /p/projects/rd3mod/R/.Rprofile
                           modelfolder  = ".",
-                          debug        = FALSE)
+                          debug        = FALSE,
+			  stopOnMissing = TRUE)
   } else {
       message("No input data downloaded and distributed. To enable that, delete input/source_files.log or set cfg$force_download to TRUE.")
   }


### PR DESCRIPTION
See pik-piam/gms#40

- [x] New feature 

## Checklist:

- [x] My code follows the coding etiquette
- [x] I have adjusted reporting where it was needed
- [x] The model compiles and runs successfully (`Rscript start.R -q`)