### PR TITLE
BugFix for H12 runs that use regipol switches 

### DIFF
--- a/modules/47_regipol/regiCarbonPrice/datainput.gms
+++ b/modules/47_regipol/regiCarbonPrice/datainput.gms
@@ -9,6 +9,11 @@
 *** initialize regipol target deviation parameter
 pm_emiMktTarget_dev(ttot,ttot2,ext_regi,emiMktExt) = 0;
 
+*** RR this should be replaced as soon as non-energy is treated endogenously in the model
+*** EUR in 2030 =~ 90Mtoe (90 * 10^6 toe -> 90 * 10^6 toe * 41.868 GJ/toe -> 3768.12 * 10^6 GJ * 10^-9 EJ/GJ -> 3.76812 EJ * 1 TWa/31.536 EJ -> 0.1194863 TWa) EU27 =~ 92% EU28"
+p47_nonEnergyUse("2030",ext_regi)$(sameas(ext_regi, "EUR_regi")) = 0.1194863;
+p47_nonEnergyUse("2030",ext_regi)$(sameas(ext_regi, "EU27_regi")) = 0.11;
+
 ***--------------------------------------------------
 *** Emission markets (EU Emission trading system and Effort Sharing)
 ***--------------------------------------------------

--- a/modules/47_regipol/regiCarbonPrice/declarations.gms
+++ b/modules/47_regipol/regiCarbonPrice/declarations.gms
@@ -16,8 +16,8 @@ Parameter
   p47_LULUCFEmi_GrassiShift(ttot,all_regi)           "difference between Magpie land-use change emissions and UNFCCC emissions in 2015 to correct for national accounting in emissions targets"
   pm_emiMktTarget_dev(ttot,ttot2,ext_regi,emiMktExt) "deviation of emissions of current iteration from target emissions, for budget target this is the difference normalized by target emissions, while for year targets this is the difference normalized by 2005 emissions [%]"
 
-*** RR this should be replaced as soon as non-energy is treated endoegenously in the model
-  p47_nonEnergyUse(ttot,ext_regi)                  "non-energy use: EUR in 2030 =~ 90Mtoe (90 * 10^6 toe -> 90 * 10^6 toe * 41.868 GJ/toe -> 3768.12 * 10^6 GJ * 10^-9 EJ/GJ -> 3.76812 EJ * 1 TWa/31.536 EJ -> 0.1194863 TWa) EU27 =~ 92% EU28" / 2030.EUR_regi 0.1194863, 2030.EU27_regi 0.11 /
+*** RR this should be replaced as soon as non-energy is treated endogenously in the model
+  p47_nonEnergyUse(ttot,ext_regi)                  "non-energy use"
 ;
 
 *** parameters to track regipol emissions calculation


### PR DESCRIPTION
# Purpose of this PR
* Chris found a bug with H12 runs using the regipol module that is fixed by this PR.
* additional improvements in quantity target convergence report.

## Type of change

- [x] Bug fix 
- [x] Minor change (default scenarios show only small differences)

## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [x] Changes are commented, particularly in hard-to-understand areas
- [x] I have updated the in-code documentation
- [x] I have adjusted reporting where it was needed
- [x] The model compiles and runs successfully (`Rscript start.R -q`)

