### PR TITLE
adding support for additional REMIND 21 calibration files

### DIFF
--- a/config/gdx-files/files
+++ b/config/gdx-files/files
@@ -9,4 +9,5 @@ indu_subsectors-buil_simple-tran_edge_esm-POP_pop_SDP_RC-GDP_gdp_SDP_RC-En_gdp_S
 indu_subsectors-buil_simple-tran_edge_esm-POP_pop_SDP_EI-GDP_gdp_SDP_EI-En_gdp_SDP_EI-Kap_debt_limit-Reg_62eff8f7.gdx
 indu_subsectors-buil_simple-tran_edge_esm-POP_pop_SSP5-GDP_gdp_SSP5-En_gdp_SSP5-Kap_debt_limit-Reg_62eff8f7.gdx
 indu_subsectors-buil_simple-tran_edge_esm-POP_pop_SSP2EU-GDP_gdp_SSP2EU-En_gdp_SSP2EU-Kap_debt_limit-Reg_2b1450bc.gdx
+indu_fixed_shares-buil_simple-tran_complex-POP_pop_SSP2EU-GDP_gdp_SSP2EU-En_gdp_SSP2EU-Kap_debt_limit-FE_med-Reg_2b1450bc.gdx
 

--- a/modules/29_CES_parameters/load/input/files
+++ b/modules/29_CES_parameters/load/input/files
@@ -9,5 +9,6 @@ indu_subsectors-buil_simple-tran_edge_esm-POP_pop_SDP_EI-GDP_gdp_SDP_EI-En_gdp_S
 indu_subsectors-buil_simple-tran_edge_esm-POP_pop_SSP5-GDP_gdp_SSP5-En_gdp_SSP5-Kap_debt_limit-Reg_62eff8f7.inc
 indu_subsectors-buil_simple-tran_edge_esm-POP_pop_SSP2EU-GDP_gdp_SSP2EU-En_gdp_SSP2EU-Kap_debt_limit-Reg_2b1450bc.inc
 indu_subsectors-buil_simple-tran_complex-POP_pop_SSP2-GDP_gdp_SSP2-Kap_perfect-Reg_62eff8f7.inc
+indu_fixed_shares-buil_simple-tran_complex-POP_pop_SSP2EU-GDP_gdp_SSP2EU-En_gdp_SSP2EU-Kap_debt_limit-FE_med-Reg_2b1450bc.inc
 
 


### PR DESCRIPTION
# Purpose of this PR
* adding support for additional REMIND 21 calibration files, using alternative module realizations.

## Type of change
- [x] Minor change 

## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code

