### PR TITLE
prevent updating renv package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,7 @@ update-renv:    ## Upgrade all pik-piam packages in your renv to the respective
 
 update-all-renv: ## Upgrade all packages (including CRAN packages) in your renv
                  ## to the respective latest release, make new snapshot
-	Rscript -e 'renv::update()'
-	Rscript -e 'renv::install()'
+	Rscript -e 'renv::update(exclude = "renv")'
 	Rscript -e 'renv::snapshot()'
 
 check:          ## Check if the GAMS code follows the coding etiquette

--- a/scripts/utils/updateRenv.R
+++ b/scripts/utils/updateRenv.R
@@ -10,8 +10,5 @@ local({
   # update pik-piam packages only
   renv::update(intersect(utils::installed.packages()[, "Package"], pikPiamPackages), prompt = FALSE)
 
-  # install new dependencies
-  renv::install(prompt = FALSE)
-
   source(here::here("scripts", "utils", "archiveRenv.R"))
 })


### PR DESCRIPTION
# Purpose of this PR
`make update-all-renv` would also update the renv package itself, resulting in changes to e.g. `renv/activate.R`. We discussed [here](https://github.com/remindmodel/remind/pull/965) that the renv package should not be updated unless there is a good reason, so this PR prevents updating renv via `make update-all-renv`. New dependencies will now no longer be installed with that command (because it's tricky to prevent updating renv in the process), but https://github.com/remindmodel/remind/pull/1030 will add checks and probably a convenient way to install new dependencies anyway.

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix 

## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code