### PR TITLE
fix bug in combine_slurmConfig

### DIFF
--- a/scripts/start/choose_slurmConfig.R
+++ b/scripts/start/choose_slurmConfig.R
@@ -107,7 +107,7 @@ combine_slurmConfig <- function (original, update_with) {
   names(v_original) <- gsub("--(.*)=.*","\\1",unlist(strsplit(original,split=" ")))
 
   # remove elements from "original" that are existing in "update_with"
-  v_original <- v_original[!names(v_original) %in% "qos"]
+  v_original <- v_original[!names(v_original) %in% names(v_update_with)]
 
   combined <- c(v_update_with,v_original)
 


### PR DESCRIPTION
## Purpose of this PR

``` R
slurmOld <- "--qos=standby --nodes=1 --tasks-per-node=12"
slurmNew <- "--qos=medium --nodes=5 --mem=8000"
combine_slurmConfig(slurmOld, slurmNew)
```
currently yields:
``` R
"--qos=medium --nodes=5 --mem=8000 --nodes=1 --tasks-per-node=12"
```
I don't think this is intended. After this PR, it returns:
``` R
"--qos=medium --nodes=5 --mem=8000 --tasks-per-node=12"
```
This is also how I understand the comment above the code.

Tagging @dklein-pik who [introduced this function](https://github.com/remindmodel/remind/commit/b69f943c55bd0011288fb40994a2c0f1e0fb3b2a)