### PR TITLE
Use empty string instead of NULL to indicate that no extramappings_h…

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -25,7 +25,7 @@ cfg$description <- "REMIND run with default settings"
 cfg$regionmapping <- "config/regionmappingH12.csv"
 
 ### Additional (optional) region mapping, so that those validation data can be loaded that contain the corresponding additional regions.
-cfg$extramappings_historic <- NULL
+cfg$extramappings_historic <- ""
 #### Current input data revision (<mainrevision>.<subrevision>) ####
 cfg$inputRevision <- "6.316"
 

--- a/scripts/start/prepare_and_run.R
+++ b/scripts/start/prepare_and_run.R
@@ -438,7 +438,7 @@ prepare <- function() {
       input_old     <- "no_data"
   }
   input_new      <- c(paste0("rev",cfg$inputRevision,"_", regionscode(cfg$regionmapping),"_", tolower(cfg$model_name),".tgz"),
-                      paste0("rev",cfg$inputRevision,"_", regionscode(cfg$regionmapping),ifelse(is.null(cfg$extramappings_historic),"",paste0("-", regionscode(cfg$extramappings_historic))),"_", tolower(cfg$validationmodel_name),".tgz"),
+                      paste0("rev",cfg$inputRevision,"_", regionscode(cfg$regionmapping),ifelse(cfg$extramappings_historic == "","",paste0("-", regionscode(cfg$extramappings_historic))),"_", tolower(cfg$validationmodel_name),".tgz"),
                       paste0("CESparametersAndGDX_",cfg$CESandGDXversion,".tgz"))
   # download and distribute needed data
   if(!setequal(input_new, input_old) | cfg$force_download) {


### PR DESCRIPTION
…istoric exist. Using NULL removes the element from the list and makes it inaccessible for later use. Closes #1042 

# Purpose of this PR


## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix 

## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [x] Changes are commented, particularly in hard-to-understand areas
- [ ] I have updated the in-code documentation
- [ ] I have adjusted reporting where it was needed
- [x] The model compiles and runs successfully (`Rscript start.R -q`)

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 


