### PR TITLE
delete switches that are defined twice from main.gms

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -143,9 +143,6 @@ cfg$files2export$start <- c("config/conopt3.opt",
 # Files that should be copied after the REMIND run is finished
 cfg$files2export$end <- NULL
 
-# There is the converted data located?
-cfg$converted_input_folder <- "config"
-
 # placeholder for storing information on subsequent runs that need input from this run
 cfg$RunsUsingTHISgdxAsInput <- character(0)
 

--- a/main.gms
+++ b/main.gms
@@ -1322,7 +1322,6 @@ $setGlobal cm_VREminShare    off !! def = off
 ***     amount of Carbon Capture and Storage (including DACCS and BECCS) is limited to a maximum of 2GtCO2 per yr globally, and 250 Mt CO2 per yr in EU28. 
 ***   This switch only works for model native regions. If you want to apply it to a group region use cm_implicitQttyTarget instead.
 $setGlobal cm_CCSmaxBound    off  !! def = off
-$setglobal cm_CES_configuration   indu_subsectors-buil_simple-tran_edge_esm-POP_pop_SSP2EU-GDP_gdp_SSP2EU-En_gdp_SSP2EU-Kap_debt_limit-Reg_62eff8f7   !! this will be changed by start_run()
 *** c_CES_calibration_new_structure      <-   0        switch to 1 if you want to calibrate a CES structure different from input gdx
 $setglobal c_CES_calibration_new_structure  0     !!  def  =  0
 *** c_CES_calibration_write_prices       <-   0       switch to 1 if you want to generate price file, you can use this as new p29_cesdata_price.cs4r price input file
@@ -1601,17 +1600,6 @@ $setglobal cm_process_based_steel   off  !! off
 *** c_CO2priceDependent_AdjCosts
 ***    default on changes adjustment costs for advanced vehicles in dependence of CO2 prices
 $setglobal c_CO2priceDependent_AdjCosts    on   !! def = on
-*** cm_dispatchSetyDown <- "off", if set to some value, this allows dispatching of pe2se technologies, 
-***  i.e. the capacity factors can be varied by REMIND and are not fixed. The value of this switch gives the percentage points by how much the lower bound of capacity factors should be lowered.
-***  Example: if set to 10, then the CF of all pe2se technologies can be decreased by up to 10% from the default value
-***  Setting capacity factors free is numerically expensive but can be helpful to see if negative prices disappear in historic years as the model is allowed to dispatch.
-$setGlobal cm_dispatchSetyDown  off   !! def = off  The amount that te producing any sety can dispatch less (in percent) - so setting "20" in a cm_dispatchSetyDown column in scenario_config will allow the model to reduce the output of this te by 20% 
-*** cm_dispatchSeelDown <- "off", same as cm_dispatchSetyDown but only provides range to capacity factors of electricity generation technologies
-***  cm_steel_secondary_max_share_scenario
-***  defines maximum secondary steel share per region
-***  Share is faded in from cm_startyear or 2020 to the denoted level by region/year.
-***  Example: "2040.EUR 0.6" will cap the share of secondary steel production at 60 % in EUR from 2040 onwards
-$setGlobal cm_dispatchSeelDown  off   !! def = off  The amount that te producing seel can dispatch less (in percent) (overrides cm_dispatchSetyDown for te producing seel)
 *** set conopt version. Warning: conopt4 is in beta
 $setGlobal cm_conoptv  conopt3    !! def = conopt3
 


### PR DESCRIPTION
## Purpose of this PR
cleanup.
- `cfg$converted_input_folder` seems to be some legacy, reposearch shows it is never used somewhere
- cm_CES_configuration, cm_dispatchSetyDown and cm_dispatchSeelDown were defined twice in main.gms, one occurence is deleted.

## Type of change

- [x] cleanup