### PR TITLE
correct initialization of learning parameters for electrolysis following Adrian's paper and improve initialization procedure by2025

### DIFF
--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -271,6 +271,8 @@ if (cm_emiscen ne 1,
 
 *nr* cumulated capacity never falls below initial cumulated capacity:
 vm_capCum.lo(ttot,regi,teLearn)$(ttot.val ge cm_startyear) = pm_data(regi,"ccap0",teLearn);
+*** exception for tech_stat 4 technologies whose ccap0 refers to 2025 as these technologies don't exist in 2005
+vm_capCum.lo(ttot,regi,teLearn)$(pm_data(regi,"tech_stat",teLearn) eq 4 AND ttot.val le 2020) = pm_data(regi,"ccap0",teLearn);
 
 *nr: floor costs represent the lower bound of learning technologies investment costs
 vm_costTeCapital.lo(t,regi,teLearn) = pm_data(regi,"floorcost",teLearn);
@@ -354,6 +356,12 @@ loop(regi,
 
 *** no technologies with tech_stat 4 before 2025
 vm_cap.fx(t,regi,te,rlf)$(t.val le 2020 AND pm_data(regi,"tech_stat",te) eq 4)=0;
+*** initialize cumulative capacity of tech_stat 4 technologies at 0 
+*** (not at ccap0 from generisdata_tech.prn which gives the cucmulative capacity
+***  at the initial investment cost of the first year in which the technology can be built)
+vm_capCum.fx(t0,regi,teLearn)$(pm_data(regi,"tech_stat",teLearn) eq 4) = 0;
+*** tech_stat 4 technologies don't learn before 2025, so capital cost should be fixed
+vm_costTeCapital.fx(t,regi,teLearn)$(t.val le 2020 AND pm_data(regi,"tech_stat",teLearn) eq 4)=fm_dataglob("inco0",teLearn);
 
 
 *CB 2012024 -----------------------------------------------------

--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -272,7 +272,7 @@ if (cm_emiscen ne 1,
 *nr* cumulated capacity never falls below initial cumulated capacity:
 vm_capCum.lo(ttot,regi,teLearn)$(ttot.val ge cm_startyear) = pm_data(regi,"ccap0",teLearn);
 *** exception for tech_stat 4 technologies whose ccap0 refers to 2025 as these technologies don't exist in 2005
-vm_capCum.lo(ttot,regi,teLearn)$(pm_data(regi,"tech_stat",teLearn) eq 4 AND ttot.val le 2020) = pm_data(regi,"ccap0",teLearn);
+vm_capCum.lo(ttot,regi,teLearn)$(pm_data(regi,"tech_stat",teLearn) eq 4 AND ttot.val le 2020) = 0;
 
 *nr: floor costs represent the lower bound of learning technologies investment costs
 vm_costTeCapital.lo(t,regi,teLearn) = pm_data(regi,"floorcost",teLearn);

--- a/core/equations.gms
+++ b/core/equations.gms
@@ -381,8 +381,9 @@ qm_deltaCapCumNet(ttot,regi,teLearn)$(ord(ttot) lt card(ttot) AND pm_ttot_val(tt
 
 ***---------------------------------------------------------------------------
 *' Initial values for cumulated capacities (learning technologies only):
+*' (except for tech_stat 4 technologies that have no standing capacities in 2005 and ccap0 refers to another year)
 ***---------------------------------------------------------------------------
-q_capCumNet(t0,regi,teLearn)..
+q_capCumNet(t0,regi,teLearn)$(NOT (pm_data(regi,"tech_stat",teLearn) eq 4))..
   vm_capCum(t0,regi,teLearn)
   =e=
   pm_data(regi,"ccap0",teLearn);
@@ -417,7 +418,8 @@ q_limitGeopot(t,regi,peReComp(enty),rlf)..
   sum(te$teReComp2pe(enty,te,rlf), (vm_capDistr(t,regi,te,rlf) / (pm_data(regi,"luse",te)/1000)));
 
 ***  learning curve for investment costs
-q_costTeCapital(t,regi,teLearn) .. 
+***  deactivate learning for tech_stat 4 technologies before 2025 as they are not built before
+q_costTeCapital(t,regi,teLearn)$(NOT (pm_data(regi,"tech_stat",teLearn) AND t.val le 2020)) .. 
   vm_costTeCapital(t,regi,teLearn)
   =e=
 ***  special treatment for first time steps: using global estimates better

--- a/core/equations.gms
+++ b/core/equations.gms
@@ -419,7 +419,7 @@ q_limitGeopot(t,regi,peReComp(enty),rlf)..
 
 ***  learning curve for investment costs
 ***  deactivate learning for tech_stat 4 technologies before 2025 as they are not built before
-q_costTeCapital(t,regi,teLearn)$(NOT (pm_data(regi,"tech_stat",teLearn) AND t.val le 2020)) .. 
+q_costTeCapital(t,regi,teLearn)$(NOT (pm_data(regi,"tech_stat",teLearn) eq 4 AND t.val le 2020)) .. 
   vm_costTeCapital(t,regi,teLearn)
   =e=
 ***  special treatment for first time steps: using global estimates better

--- a/core/input/generisdata_tech.prn
+++ b/core/input/generisdata_tech.prn
@@ -84,15 +84,15 @@ luse                                                                            
 
 +                  elh2         dot         dhp       h2turb      h2curt       h2turbVRE  elh2VRE      h22ch4      MeOH
 tech_stat            4                                    2                                               3          3  
-inco0               2000         480         360         600         700          0.1      0.1          700        800
+inco0               1500         480         360         600         700          0.1      0.1          700        800
 constrTme            2            2           1           2           2            1        1            2          2
 mix0                                                                                                                    
 eta                 0.73        0.30        0.80        0.40        0.62         0.40      0.73         0.8        0.7
 omf                 0.05        0.03        0.03        0.03        0.05         0.00      0.00         0.03       0.03
 omv                    3          12          12          24           0                                 3           12
 lifetime              30          25          25          30          30          30        30            30          30
-incolearn           1500
-ccap0              0.013 
+incolearn           1350
+ccap0             0.0065 
 learn               0.15  
 
 
@@ -197,14 +197,13 @@ Explanations:
  
 Electrolysis - elh2
 learning parameterization:
-Assume that 20 GW(el) electrolysis installed globally at 1200 EUR/GW(el) in 2025 
-(Ueckerdt et al. (2021), https://doi.org/10.1038/s41558-021-01032-7, Fig. S3,
- Odenweller et al. (2022), https://doi.org/10.1038/s41560-022-01097-4, Fig. 1d ).
-
-20 GW(el) * 0.65 (elh2 efficiency) * 1e-3 ~ 0.013 TW(H2) = ccap0
-1200 EUR/GW(el) / 0.65 (elh2 efficiency) * 1.1 (EUR to USD, 2015) ~ 2000 USD/kW(H2) = inco0
-Assume floor cost: 350 EUR/GW(el)
-350 EUR/GW(el) / 0.75 (long-term elh2 efficiency) * 1.1 (EUR to USD, 2015) ~ 500 USD/kW(H2) -> incolearn = 1500
+Assume that 10 GW(el) electrolysis installed globally and CAPEX of 900 EUR/kW(el) in 2025 
+(Odenweller et al. (2022), https://doi.org/10.1038/s41560-022-01097-4,
+Ueckerdt et al. (2021), https://doi.org/10.1038/s41558-021-01032-7, Fig. S3).
+10 GW(el) * 0.65 (elh2 efficiency) * 1e-3 ~ 0.0065 TW(H2) = ccap0
+900 EUR/kW(el) / 0.65 (elh2 efficiency) * 1.1 (EUR to USD, 2015) ~ 1500 USD/kW(H2) = inco0
+Assume floor cost: 100 EUR/kW(el)
+100 EUR/kW(el) / 0.75 (long-term elh2 efficiency) * 1.1 (EUR to USD, 2015) ~ 150 USD/kW(H2) -> incolearn = 1350
 
 Direct Air Capture - dac
 learning parameterization:

--- a/core/input/generisdata_tech.prn
+++ b/core/input/generisdata_tech.prn
@@ -84,14 +84,14 @@ luse                                                                            
 
 +                  elh2         dot         dhp       h2turb      h2curt       h2turbVRE  elh2VRE      h22ch4      MeOH
 tech_stat            4                                    2                                               3          3  
-inco0               1500         480         360         600         700          0.1      0.1          700        800
+inco0               1350         480         360         600         700          0.1      0.1          700        800
 constrTme            2            2           1           2           2            1        1            2          2
 mix0                                                                                                                    
 eta                 0.73        0.30        0.80        0.40        0.62         0.40      0.73         0.8        0.7
 omf                 0.05        0.03        0.03        0.03        0.05         0.00      0.00         0.03       0.03
 omv                    3          12          12          24           0                                 3           12
 lifetime              30          25          25          30          30          30        30            30          30
-incolearn           1350
+incolearn           1200
 ccap0             0.0065 
 learn               0.15  
 
@@ -197,14 +197,14 @@ Explanations:
  
 Electrolysis - elh2
 learning parameterization:
-Assume that 10 GW(el) electrolysis installed globally and CAPEX of 900 EUR/kW(el) in 2025
+Assume that 10 GW(el) electrolysis installed globally and CAPEX of 800 EUR/kW(el) in 2025
 (slightly optimistic due to recent policies, e.g. EU Hydrogen Bank and US Inflation Reduction Act)
 (Odenweller et al. (2022), https://doi.org/10.1038/s41560-022-01097-4,
 Ueckerdt et al. (2021), https://doi.org/10.1038/s41558-021-01032-7, Fig. S3).
 10 GW(el) * 0.65 (elh2 efficiency) * 1e-3 ~ 0.0065 TW(H2) = ccap0
-900 EUR/kW(el) / 0.65 (elh2 efficiency) * 1.1 (EUR to USD, 2015) ~ 1500 USD/kW(H2) = inco0
+800 EUR/kW(el) / 0.65 (elh2 efficiency) * 1.1 (EUR to USD, 2015) ~ 1350 USD/kW(H2) = inco0
 Assume floor cost: 100 EUR/kW(el)
-100 EUR/kW(el) / 0.75 (long-term elh2 efficiency) * 1.1 (EUR to USD, 2015) ~ 150 USD/kW(H2) -> incolearn = 1350
+100 EUR/kW(el) / 0.75 (long-term elh2 efficiency) * 1.1 (EUR to USD, 2015) ~ 150 USD/kW(H2) -> incolearn = 1200
 
 Direct Air Capture - dac
 learning parameterization:

--- a/core/input/generisdata_tech.prn
+++ b/core/input/generisdata_tech.prn
@@ -197,7 +197,8 @@ Explanations:
  
 Electrolysis - elh2
 learning parameterization:
-Assume that 10 GW(el) electrolysis installed globally and CAPEX of 900 EUR/kW(el) in 2025 
+Assume that 10 GW(el) electrolysis installed globally and CAPEX of 900 EUR/kW(el) in 2025
+(slightly optimistic due to recent policies, e.g. EU Hydrogen Bank and US Inflation Reduction Act)
 (Odenweller et al. (2022), https://doi.org/10.1038/s41560-022-01097-4,
 Ueckerdt et al. (2021), https://doi.org/10.1038/s41558-021-01032-7, Fig. S3).
 10 GW(el) * 0.65 (elh2 efficiency) * 1e-3 ~ 0.0065 TW(H2) = ccap0


### PR DESCRIPTION
# Purpose of this PR

This corrects learning parameters for electrolysis once more (follow-up to #997) and improves the initialization procedure to hit the desired capital cost values in 2025.  

See results and description of open points in this [Issue](https://github.com/remindmodel/development_issues/issues/163). 

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)


- [x] Minor change (default scenarios show only small differences)


## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [x] Changes are commented, particularly in hard-to-understand areas
- [x] I have updated the in-code documentation
- [x] The model compiles and runs successfully (`Rscript start.R -q`)
- [x]  check learning initialization in test runs

## Further information (optional):

* Test runs are here: 

/p/tmp/schreyer/Modeling/remind/Current/output/Base_Learn_2022-11-18_11.51.57

/p/tmp/schreyer/Modeling/remind/Current/output/NDC_Learn_2022-11-18_16.39.53


/p/tmp/schreyer/Modeling/remind/Current/output/PkBudg500_Learn_2022-11-19_01.27.07

* Comparison of results (what changes by this PR?): 

See plots in Issue. 


