### PR TITLE
make sure recent remind2 version is used

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,7 +58,7 @@ Imports:
     raster,
     readr,
     readxl,
-    remind2,
+    remind2 (>= 1.103.11),
     renv,
     reshape2,
     rlang,


### PR DESCRIPTION
## Purpose of this PR
Current remind2 version is required, if not, REMIND fails in iteration 2: https://github.com/pik-piam/remind2/pull/347

## Type of change

- [x] Bug fix 
