### PR TITLE
showUpdates in start.R

### DIFF
--- a/start.R
+++ b/start.R
@@ -224,6 +224,7 @@ if (packageVersion("lucode2") >= "0.34.0") {
 
 if (!getOption("autoRenvUpdates", FALSE) && !is.null(lucode2::showUpdates())) {
   message("Consider updating with `Rscript scripts/utils/updateRenv.R`.")
+  Sys.sleep(1)
 }
 
 ignorederrors <- 0 # counts ignored errors in --test mode

--- a/start.R
+++ b/start.R
@@ -222,6 +222,10 @@ if (packageVersion("lucode2") >= "0.34.0") {
        "and re-run start.R in a fresh R session.")
 }
 
+if (!getOption("autoRenvUpdates", FALSE) && !is.null(lucode2::showUpdates())) {
+  message("Consider updating with `Rscript scripts/utils/updateRenv.R`.")
+}
+
 ignorederrors <- 0 # counts ignored errors in --test mode
 startedRuns <- 0
 waitingRuns <- 0


### PR DESCRIPTION
# Purpose of this PR
The info which piam packages could be updated comes unnecessarily late. With this PR the update check is already done in start.R. The update check is additionally also done in the `submit` function, because there might be cases where submit is called directly, without sourcing/Rscripting `start.R` first (if this is not actually true we could just remove the check in submit).

## Type of change

- [x] Refactoring


## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
