### PR TITLE
apply sector CO2 tax markup only for >= cm_startyear

### DIFF
--- a/modules/21_tax/on/datainput.gms
+++ b/modules/21_tax/on/datainput.gms
@@ -232,10 +232,10 @@ Parameter
   p21_extRegiCO2TaxSectorMarkup(ext_regi,emi_sectors) "CO2 tax markup in building, industry or transport sector (extended regions)" / %cm_CO2TaxSectorMarkup% /
 ;
   loop((ext_regi,emi_sectors)$p21_extRegiCO2TaxSectorMarkup(ext_regi,emi_sectors),
-    p21_CO2TaxSectorMarkup(regi,emi_sectors)$(regi_group(ext_regi,regi)) = p21_extRegiCO2TaxSectorMarkup(ext_regi,emi_sectors);
+    p21_CO2TaxSectorMarkup(ttot,regi,emi_sectors)$(regi_group(ext_regi,regi) AND ttot.val ge cm_startyear) = p21_extRegiCO2TaxSectorMarkup(ext_regi,emi_sectors);
   );
 $else.cm_CO2TaxSectorMarkup
-  p21_CO2TaxSectorMarkup(regi,emi_sectors) = 0;
+  p21_CO2TaxSectorMarkup(ttot,regi,emi_sectors)$(ttot.val ge cm_startyear) = 0;
 ;
 $endIf.cm_CO2TaxSectorMarkup
 

--- a/modules/21_tax/on/declarations.gms
+++ b/modules/21_tax/on/declarations.gms
@@ -57,7 +57,7 @@ p21_implicitDiscRate_iter(iteration,ttot,all_regi)         "reference level valu
 p21_taxrevFlex_iter(iteration,ttot,all_regi)               "reference level value of flexibility tax revenue"
 p21_taxrevBioImport_iter(iteration,ttot,all_regi)          "reference level value of bioenergy import tax"
 
-p21_CO2TaxSectorMarkup(all_regi,emi_sectors)            "CO2 tax markup in building, industry or transport sector"
+p21_CO2TaxSectorMarkup(ttot,all_regi,emi_sectors)          "CO2 tax markup in building, industry or transport sector"
 
 p21_deltarev(iteration,all_regi)             "convergence criteria for iteration on tax revenue recycling"
 

--- a/modules/21_tax/on/equations.gms
+++ b/modules/21_tax/on/equations.gms
@@ -75,7 +75,7 @@ v21_taxrevGHG(t,regi) =e= pm_taxCO2eqSum(t,regi) * (vm_co2eq(t,regi) - vm_emiMac
 ***---------------------------------------------------------------------------
 
 q21_taxrevCO2Sector(t,regi,emi_sectors)$(t.val ge max(2010,cm_startyear))..
-v21_taxrevCO2Sector(t,regi,emi_sectors) =e= p21_CO2TaxSectorMarkup(regi,emi_sectors) * pm_taxCO2eqSum(t,regi) * vm_emiCO2Sector(t,regi,emi_sectors)
+v21_taxrevCO2Sector(t,regi,emi_sectors) =e= p21_CO2TaxSectorMarkup(t,regi,emi_sectors) * pm_taxCO2eqSum(t,regi) * vm_emiCO2Sector(t,regi,emi_sectors)
                              - pm_taxrevCO2Sector0(t,regi,emi_sectors);
 
 ***---------------------------------------------------------------------------

--- a/modules/21_tax/on/postsolve.gms
+++ b/modules/21_tax/on/postsolve.gms
@@ -22,7 +22,7 @@ pm_taxCO2eqSum(ttot,regi) = pm_taxCO2eq(ttot,regi) + pm_taxCO2eqRegi(ttot,regi) 
 *JH* !!Warning!! The same allocation block exists in presolve.gms.
 ***                Do not forget to update the other file.
 pm_taxrevGHG0(ttot,regi) = pm_taxCO2eqSum(ttot,regi) * (vm_co2eq.l(ttot,regi) - vm_emiMacSector.l(ttot,regi,"co2luc")$(cm_multigasscen ne 3));
-pm_taxrevCO2Sector0(ttot,regi,emi_sectors) = p21_CO2TaxSectorMarkup(regi,emi_sectors) * pm_taxCO2eqSum(ttot,regi) * vm_emiCO2Sector.l(ttot,regi,emi_sectors);
+pm_taxrevCO2Sector0(ttot,regi,emi_sectors) = p21_CO2TaxSectorMarkup(ttot,regi,emi_sectors) * pm_taxCO2eqSum(ttot,regi) * vm_emiCO2Sector.l(ttot,regi,emi_sectors);
 pm_taxrevCO2LUC0(ttot,regi) = pm_taxCO2eqSum(ttot,regi) * vm_emiMacSector.l(ttot,regi,"co2luc")$(cm_multigasscen ne 3);
 p21_taxrevCCS0(ttot,regi) = cm_frac_CCS * pm_data(regi,"omf","ccsinje") * pm_inco0_t(ttot,regi,"ccsinje") 
                             * ( sum(teCCS2rlf(te,rlf), sum(ccs2te(ccsCO2(enty),enty2,te), vm_co2CCS.l(ttot,regi,enty,enty2,te,rlf) ) ) )

--- a/modules/21_tax/on/presolve.gms
+++ b/modules/21_tax/on/presolve.gms
@@ -20,7 +20,7 @@ pm_taxCO2eqSum(ttot,regi) = pm_taxCO2eq(ttot,regi) + pm_taxCO2eqRegi(ttot,regi) 
 ***                Do not forget to update the other file.
 *** save level value of all taxes
 pm_taxrevGHG0(ttot,regi) = pm_taxCO2eqSum(ttot,regi) * (vm_co2eq.l(ttot,regi) - vm_emiMacSector.l(ttot,regi,"co2luc")$(cm_multigasscen ne 3));
-pm_taxrevCO2Sector0(ttot,regi,emi_sectors) = p21_CO2TaxSectorMarkup(regi,emi_sectors) * pm_taxCO2eqSum(ttot,regi) * vm_emiCO2Sector.l(ttot,regi,emi_sectors);
+pm_taxrevCO2Sector0(ttot,regi,emi_sectors) = p21_CO2TaxSectorMarkup(ttot,regi,emi_sectors) * pm_taxCO2eqSum(ttot,regi) * vm_emiCO2Sector.l(ttot,regi,emi_sectors);
 pm_taxrevCO2LUC0(ttot,regi) = pm_taxCO2eqSum(ttot,regi) * vm_emiMacSector.l(ttot,regi,"co2luc")$(cm_multigasscen ne 3);
 p21_taxrevCCS0(ttot,regi) = cm_frac_CCS * pm_data(regi,"omf","ccsinje") * pm_inco0_t(ttot,regi,"ccsinje") 
                             * ( sum(teCCS2rlf(te,rlf), sum(ccs2te(ccsCO2(enty),enty2,te), vm_co2CCS.l(ttot,regi,enty,enty2,te,rlf) ) ) )

--- a/scripts/start/prepare_and_run.R
+++ b/scripts/start/prepare_and_run.R
@@ -617,7 +617,7 @@ prepare <- function() {
                               list(c("q41_emitrade_restr_mp.M", "!!q41_emitrade_restr_mp.M")),
                               list(c("q41_emitrade_restr_mp2.M", "!!q41_emitrade_restr_mp2.M")))
 
-    #AJS this symbol is not known and crashes the run - is it depreciated? TODO
+    #AJS this symbol is not known and crashes the run - is it deprecated? TODO
     levs_manipulateThis <- c(levs_manipulateThis,
                              list(c("vm_pebiolc_price_base.L", "!!vm_pebiolc_price_base.L")))
 
@@ -821,16 +821,19 @@ prepare <- function() {
       fixings_manipulateThis <- c(fixings_manipulateThis, list(c("q35_transGDPshare.M", "!! q35_transGDPshare.M")))
     }
 
-    # renamed because of https://github.com/remindmodel/remind/pull/848
+    # renamed because of https://github.com/remindmodel/remind/pull/848, 1066
     levs_manipulateThis <- c(levs_manipulateThis,
+                             list(c("vm_forcOs.L", "!!vm_forcOs.L")),
                              list(c("vm_emiTeMkt.L", "!!vm_emiTeMkt.L")),
                              list(c("v32_shSeEl.L", "!!v32_shSeEl.L")))
     margs_manipulateThis <- c(margs_manipulateThis,
+                             list(c("vm_forcOs.M", "!!vm_forcOs.M")),
                              list(c("vm_emiTeMkt.M", "!!vm_emiTeMkt.M")),
                              list(c("v32_shSeEl.M", "!!v32_shSeEl.M")))
     fixings_manipulateThis <- c(fixings_manipulateThis,
-                            list(c("vm_emiTeMkt.FX", "!!vm_emiTeMkt.FX")),
-                            list(c("v32_shSeEl.FX", "!!v32_shSeEl.FX")))
+                             list(c("vm_forcOs.FX", "!!vm_forcOs.FX")),
+                             list(c("vm_emiTeMkt.FX", "!!vm_emiTeMkt.FX")),
+                             list(c("v32_shSeEl.FX", "!!v32_shSeEl.FX")))
 
     #filter out deprecated regipol items
     levs_manipulateThis <- c(levs_manipulateThis,


### PR DESCRIPTION
## Purpose of this PR
- apply sector CO2 tax markup only for >= cm_startyear
- needs https://github.com/pik-piam/remind2/pull/348
- delete `vm_forcOs` from levs, margins, fixings to avoid model fails after this PR: https://github.com/remindmodel/remind/pull/1066

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [x] I have adjusted reporting where it was needed: https://github.com/pik-piam/remind2/pull/348
- [x] The model compiles and runs successfully (`Rscript start.R -q`)

## Further information (optional):

* Test runs are here: in preparation: `/p/tmp/oliverr/NGFS_v3_tests/2022-11-10/remind/output/d_rap_bIT_2022-11-14_14.53.08`
