### PR TITLE
output.R: Remove outdated path setting

### DIFF
--- a/output.R
+++ b/output.R
@@ -46,14 +46,6 @@ if (!exists("source_include")) {
   flags <- NULL
 }
 
-# Setting relevant paths
-if (file.exists("/iplex/01/landuse")) { # run is performed on the cluster
-  pythonpath <- "/iplex/01/landuse/bin/python/bin/"
-  latexpath <- "/iplex/01/sys/applications/texlive/bin/x86_64-linux/"
-} else {
-  pythonpath <- ""
-  latexpath <- NA
-}
 
 choose_slurmConfig_output <- function(slurmExceptions = NULL) {
   slurm_options <- c("--qos=priority", "--qos=short", "--qos=standby",


### PR DESCRIPTION
# Purpose of this PR

There was code in output.R which is most certainly outdated (it tried to access `/iplex` on the cluster, should be gone since at least 2015).

I didn't test anything, but `latexpath` and `pythonpath` are not used in the whole remind repo, so I think it is safe to not set them. But how would I smoke test `output.R`?

## Type of change

- [x] Refactoring

## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [x] Changes are commented, particularly in hard-to-understand areas
- [x] I have updated the in-code documentation
- [x] I have adjusted reporting where it was needed
- [ ] The model compiles and runs successfully (`Rscript start.R -q`)



