### PR TITLE
fix start.R not running without scenario_config file

### DIFF
--- a/start.R
+++ b/start.R
@@ -169,8 +169,12 @@ flags <- lucode2::readArgs(.flags = acceptedFlags, .silent = TRUE)
 config.file <- NULL
 
 # load command-line arguments
-if(!exists("argv")) argv <- commandArgs(trailingOnly = TRUE)
-argv <- argv[! grepl("^-", argv) && ! grepl("=", argv)]
+if (!exists("argv"))
+  argv <- commandArgs(trailingOnly = TRUE)
+
+# filter "--switches" and "variable=assignments"
+argv <- grep('(^-|=)', argv, value = TRUE, invert = TRUE)
+
 # check if user provided any unknown arguments or config files that do not exist
 if (length(argv) > 0) {
   file_exists <- file.exists(argv)


### PR DESCRIPTION
- close #1082
- depends on #1081 for testing

- [x] Bug fix 

## Checklist:

- [x] My code follows the coding etiquette
- [ ] I have performed a self-review of my own code
- [x] Changes are commented, particularly in hard-to-understand areas
- [x] I have updated the in-code documentation
- [x] I have adjusted reporting where it was needed
- [ ] All automated model tests compile successfully (`Rscript start.R -g config/scenario_config_AMT.csv`)
- [ ] The model runs successfully (`Rscript start.R -q`)

