### PR TITLE
include pm_BAU_reg_emi_wo_LU_bunkers.cs4r only if it exists, to enable gamscompile testing

### DIFF
--- a/modules/45_carbonprice/NDC/datainput.gms
+++ b/modules/45_carbonprice/NDC/datainput.gms
@@ -74,7 +74,9 @@ display p45_histShare;
 Parameter p45_BAU_reg_emi_wo_LU_bunkers(ttot,all_regi) "regional GHG emissions (without LU and bunkers) in BAU scenario"
   /
 $ondelim
+$ifthen exist "./modules/45_carbonprice/NDC/input/pm_BAU_reg_emi_wo_LU_bunkers.cs4r"
 $include "./modules/45_carbonprice/NDC/input/pm_BAU_reg_emi_wo_LU_bunkers.cs4r"
+$endif
 $offdelim
   /             ;
 

--- a/modules/46_carbonpriceRegi/NDC/datainput.gms
+++ b/modules/46_carbonpriceRegi/NDC/datainput.gms
@@ -55,7 +55,9 @@ display p46_histShare;
 Parameter p46_BAU_reg_emi_wo_LU_bunkers(ttot,all_regi) "regional GHG emissions (without LU and bunkers) in BAU scenario"
   /
 $ondelim
+$ifthen exist "./modules/46_carbonpriceRegi/NDC/input/pm_BAU_reg_emi_wo_LU_bunkers.cs4r"
 $include "./modules/46_carbonpriceRegi/NDC/input/pm_BAU_reg_emi_wo_LU_bunkers.cs4r"
+$endif
 $offdelim
   /;
 


### PR DESCRIPTION
- in NDC runs, pm_BAU_reg_emi_wo_LU_bunkers.cs4r is written by ./scripts/input/prepare_NDC.R and generally not available
- make the inclusion conditional on existance allows for compiling, while not interfering with gms::singleGAMSfile()
- close #1089

- [x] Bug fix 

## Checklist:

- [x] My code follows the coding etiquette
- [ ] I have performed a self-review of my own code
- [ ] Changes are commented, particularly in hard-to-understand areas
- [ ] I have updated the in-code documentation
- [x] I have adjusted reporting where it was needed
- [x] All automated model tests compile successfully (`Rscript start.R -g config/scenario_config_AMT.csv`)
- [x] The model runs successfully (`Rscript start.R -q`)