### PR TITLE
add output script to compare calibration targets across runs

### DIFF
--- a/scripts/output/comparison/compareCalibrationTargets.R
+++ b/scripts/output/comparison/compareCalibrationTargets.R
@@ -1,0 +1,23 @@
+# |  (C) 2006-2022 Potsdam Institute for Climate Impact Research (PIK)
+# |  authors, and contributors see CITATION.cff file. This file is part
+# |  of REMIND and licensed under AGPL-3.0-or-later. Under Section 7 of
+# |  AGPL-3.0, you are granted additional permissions described in the
+# |  REMIND License Exception, version 1.0 (see LICENSE file).
+# |  Contact: remind@pik-potsdam.de
+library(lucode2)
+library(remind2)
+
+if (!exists("outputdirs")) {
+  #Define arguments that can be read from command line
+  readArgs("outputdirs")
+}
+
+gdx_name <- "fulldata.gdx"
+gdxPaths <- file.path(outputdirs, gdx_name)
+outputFile <- paste0("compareCalibrationTargets-",
+                     format(Sys.time(), "%Y-%m-%d_%H.%M.%S"),".html")
+
+remind2::compareCalibrationTargets(
+  gdxPaths = gdxPaths,
+  outputFile = outputFile
+)


### PR DESCRIPTION
# Purpose of this PR

Add an output script that compares calibration targets across runs

## Type of change

- [ ] New feature 
- [ ] Minor change (default scenarios show only small differences)

## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [x] Changes are commented, particularly in hard-to-understand areas
- [x] I have updated the in-code documentation
- [x] I have adjusted reporting where it was needed
- [x] All automated model tests compile successfully (`Rscript start.R -g config/scenario_config_AMT.csv`)
- [x] The model runs successfully (`Rscript start.R -q`)
