### PR TITLE
add lock to --gamscompile, cleanup

### DIFF
--- a/modules/01_macro/singleSectorGr/equations.gms
+++ b/modules/01_macro/singleSectorGr/equations.gms
@@ -125,7 +125,7 @@ q01_prodCompl(t,regi,in,in2) $ (complements_ref(in,in2) AND (( NOT in_putty(in2)
 
 
 ***---------------------------------------------------------------------------    
-*' The capital stock is claculated recursively. Its amount in the previous time
+*' The capital stock is calculated recursively. Its amount in the previous time
 *' step is devaluated by an annual depreciation factor and enlarged by investments. 
 *' Both depreciation and investments are expressed as annual values,
 *' so the time step length is taken into account.

--- a/scripts/start/prepare_and_run.R
+++ b/scripts/start/prepare_and_run.R
@@ -281,8 +281,8 @@ prepare <- function() {
 
   if (file.exists(cfg$magicc_template)) {
       cat("Copying MAGICC files from",cfg$magicc_template,"to results folder\n")
-      system(paste0("cp -rp ",cfg$magicc_template," ",cfg$results_folder))
-      system(paste0("cp -rp core/magicc/* ",cfg$results_folder,"/magicc/"))
+      system(paste0("cp -nrp ",cfg$magicc_template," ",cfg$results_folder))
+      system(paste0("cp -nrp core/magicc/* ",cfg$results_folder,"/magicc/"))
     } else {
       cat("Could not copy",cfg$magicc_template,"because it does not exist\n")
     }

--- a/start_bundle_coupled.R
+++ b/start_bundle_coupled.R
@@ -107,7 +107,7 @@ if ("--parallel" %in% flags) {
 }
 
 # load arguments from command line
-argv <- argv[! grepl("^-", argv)]
+argv <- grep('(^-|=|^test$)', argv, value = TRUE, invert = TRUE)
 if (length(argv) > 0) {
   file_exists <- file.exists(argv)
   if (sum(file_exists) > 1) stop("Enter only a scenario_config_coupled* file via command line or set all files manually in start_bundle_coupled.R")


### PR DESCRIPTION
## Purpose of this PR

- Running `./start.R --gamscompile` now locks the model so that no run tinkers around with the files in the meantime as suggested by @mikapfl
- rename `verboseGamsCompile` to `interactive` because it is not only verbose, but also interactive :)
- better help message
- `prepare_and_run.R` isn't angry anymore that it cannot copy the magicc files if an existing run is started with `--reprepare`. @mikapfl: You suggested `-n`, but is it a problem that is [may not be compatible to all platforms](https://www.unix.com/unix-for-beginners-questions-and-answers/279031-cp-n-command.html)?
- in `start_bundle_config.R`, kick out all the `variable=whatever` stuff and `test` before searching for config files in the command line arguments

## Type of change

- [x] Bug fix 
- [x] no impact on scenarios

## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [x] All automated model tests compile successfully (`Rscript start.R -g config/scenario_config_AMT.csv`)
- [x] The model runs successfully (`Rscript start.R -q`)
