### PR TITLE
if EDGE-T files are missing, regenerate them in reporting.R

### DIFF
--- a/scripts/output/single/reporting.R
+++ b/scripts/output/single/reporting.R
@@ -18,9 +18,9 @@ gdx_ref_name <- "input_refpolicycost.gdx"  # name of the reference gdx (for poli
 
 
 if(!exists("source_include")) {
-  #Define arguments that can be read from command line
-   outputdir <- "output/R17IH_SSP2_postIIASA-26_2016-12-23_16.03.23"     # path to the output folder
-   readArgs("outputdir","gdx_name","gdx_ref_name")
+   # Define arguments that can be read from command line
+   outputdir <- "."
+   readArgs("outputdir", "gdx_name", "gdx_ref_name")
 }
 
 gdx      <- file.path(outputdir,gdx_name)
@@ -71,16 +71,24 @@ if (0 == nchar(Sys.getenv('MAGICC_BINARY'))) {
 
 edgetOutputDir <- file.path(outputdir, "EDGE-T")
 if(file.exists(edgetOutputDir)) {
-message("start generation of EDGE-T reporting")
+  if (! file.exists(file.path(edgetOutputDir, "demandF_plot_pkm.RDS"))) {
+    message("EDGE-T reporting files are missing, probably because the run was killed.")
+    message("Rerunning toolIterativeEDGETransport(reporting = TRUE).")
+    savewd <- getwd()
+    setwd(outputdir)
+    edgeTransport::toolIterativeEDGETransport(reporting = TRUE)
+    setwd(savewd)
+  }
+  message("start generation of EDGE-T reporting")
   EDGET_output <- toolReportEDGET(edgetOutputDir,
                                   extendedReporting = FALSE,
                                   scenario_title = scenario, model_name = "REMIND",
-                                  gdx = paste0(outputdir,"/fulldata.gdx"))
+                                  gdx = file.path(outputdir, "fulldata.gdx"))
 
   write.mif(EDGET_output, remind_reporting_file, append = TRUE)
   deletePlus(remind_reporting_file, writemif = TRUE)
 
-message("end generation of EDGE-T reporting")
+  message("end generation of EDGE-T reporting")
 }
 
 configfile <- file.path(outputdir, "config.Rdata")
@@ -117,3 +125,5 @@ if(file.exists(file.path(outputdir, DIETERGDX))){
   remind2::reportDIETER(DIETERGDX,outputdir)
   message("end generation of DIETER reporting")
 }
+
+message("### reporting finished.")


### PR DESCRIPTION
## Purpose of this PR

- if the run runs into a cluster time-out, one may still want to use the fulldata.gdx and run a reporting, but some EDGE-T files such as `demandF_plot_pkm.RDS` are missing that are produced by [this function call in edge_esm/output.gms](https://github.com/remindmodel/remind/blob/develop/modules/35_transport/edge_esm/output.gms#L10)
- if `demandF_plot_pkm.RDS` does not exist, rerun this iterative EDGE-T reporting before starting the final EDGE-T reporting
- as long as https://github.com/pik-piam/edgeTransport/pull/205 is not merged, you have to run reporting twice to work, because the `quit` there ends the R session

## Type of change

- [x] Bug fix, no impact on any scenario

## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- not tested, because is no gms change. All automated model tests compile successfully (`Rscript start.R -g config/scenario_config_AMT.csv`)
- [x] The model runs successfully (`Rscript start.R -q`). I switched `output` on to check.

## Further information (optional):

* Test runs are here: `/p/tmp/oliverr/NGFS_v3_tests/2022-11-16/remind/output/d_delfrag_bIT_47_2022-11-19_01.47.23/log_reporting.txt`

