### PR TITLE
increase adjustment cost for geohe (central heat pumps) to prevent too fast scale-up

### DIFF
--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -997,6 +997,7 @@ loop(ttot$(ttot.val ge 2005),
   p_adj_seed_te(ttot,regi,'apCarDiEffT')     = 0.50;
   p_adj_seed_te(ttot,regi,'apCarDiEffH2T')   = 0.50;
   p_adj_seed_te(ttot,regi,'dac')             = 0.25;
+  p_adj_seed_te(ttot,regi,'geohe')           = 0.33;
 
 $IFTHEN.WindOff %cm_wind_offshore% == "1"
   p_adj_seed_te(ttot,regi,"windoff") = 0.5; 
@@ -1020,6 +1021,7 @@ $ENDIF.WindOff
   p_adj_coeff(ttot,regi,"coalftcrec")      = 0.8;
   p_adj_coeff(ttot,regi,"spv")             = 0.08;
   p_adj_coeff(ttot,regi,"wind")            = 0.15;
+  p_adj_coeff(ttot,regi,"geohe")            = 0.6;
 
 $IFTHEN.WindOff %cm_wind_offshore% == "1"
 


### PR DESCRIPTION

# Purpose of this PR

Increase adjustment cost as ramp-up can be too fast with high co2 prices. 

See

https://cloud.pik-potsdam.de/index.php/apps/files/?dir=/Shared/REMIND-EU_calibration/Results/Ariadne_2022_7_12_FORECAST_fix&openfile=13863804

for Ariadne runs without adjustment cost increase (see -> Energy Supply -> Secondary Energy Mixes -> SE|Heat) and

https://cloud.pik-potsdam.de/index.php/apps/files/?dir=/Shared/REMIND-EU_calibration/Results/Ariadne_2022_9_23&openfile=14277271

for Ariadne runs with this increase in adjustment cost. 



## Type of change



- [x] Minor change (default scenarios show only small differences)



## Checklist:

- [x] My code follows the coding etiquette
- [x] Changes are commented, particularly in hard-to-understand areas
- [x] All automated model tests compile successfully (`Rscript start.R -g config/scenario_config_AMT.csv`)
- [x] The model runs successfully (`Rscript start.R -q`)

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 


