### PR TITLE
new CES parameters and gdx files for SSP2EU, SSP2EU_lowEn, SSP1 for 6.324

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -27,10 +27,10 @@ cfg$regionmapping <- "config/regionmappingH12.csv"
 ### Additional (optional) region mapping, so that those validation data can be loaded that contain the corresponding additional regions.
 cfg$extramappings_historic <- ""
 #### Current input data revision (<mainrevision>.<subrevision>) ####
-cfg$inputRevision <- "6.316"
+cfg$inputRevision <- "6.324"
 
 #### Current CES parameter and GDX revision (commit hash) ####
-cfg$CESandGDXversion <- "b577e6de076abd3c12ca0385002af599db370c2c"
+cfg$CESandGDXversion <- "34a93aa9d54616d1c3b302aa3002ec161da24a94"
 
 #### Force the model to download new input data ####
 cfg$force_download <- FALSE


### PR DESCRIPTION

# Purpose of this PR
new CES parameters and gdx files for SSP2EU, SSP2EU_lowEn and SSP1 for input data revision 6.324. calibration runs: /p/tmp/lavinia/REMIND/REMIND_calibration_2022_11_24/remind/output

## Type of change


- [x] New feature 


## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 


