### PR TITLE
new CES parameters and gdx files for EU21_SSP2EU, add inputdataInfo.log

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -30,7 +30,7 @@ cfg$extramappings_historic <- ""
 cfg$inputRevision <- "6.324"
 
 #### Current CES parameter and GDX revision (commit hash) ####
-cfg$CESandGDXversion <- "34a93aa9d54616d1c3b302aa3002ec161da24a94"
+cfg$CESandGDXversion <- "9039ba72aaf2be2727afea5d12948ae0b1747fb4"
 
 #### Force the model to download new input data ####
 cfg$force_download <- FALSE

--- a/tutorials/06_Advanced_ChangeInputs.md
+++ b/tutorials/06_Advanced_ChangeInputs.md
@@ -47,7 +47,7 @@ The .log file lists the progress and potential errors. This process might take a
 
 4. If the process terminates without errors, do a test run with the new input data. To do this, clone the REMIND repo and update the data input version `cfg$revision` in `config/default.cfg` using your recently created data revision number file and run one scenario (e.g. SSP2EU-Base).
 
-4.a ATTENTION: If your new input data change FE pathways, polulation, GDP trajectories or substantial behaviour of REMIND, you need to rerun CES parameter calibration (see tutorial 12_Calibrating_CES_Parameters) and adjust input data revision togehter with updated CES parameters.
+4.a ATTENTION: If your new input data change FE pathways, population, GDP trajectories or substantial behaviour of REMIND, you need to rerun the CES parameter calibration (see tutorial 12_Calibrating_CES_Parameters) and adjust the input data revision together with the updated CES parameters.
 
 5. If the test run completes without errors, add the change in `config/default.cfg` and the update of the input data revision in `main.gms` that was automatically performed by the REMIND run to a commit in your REMIND clone. This can be best done by using
 ```bash

--- a/tutorials/06_Advanced_ChangeInputs.md
+++ b/tutorials/06_Advanced_ChangeInputs.md
@@ -47,6 +47,8 @@ The .log file lists the progress and potential errors. This process might take a
 
 4. If the process terminates without errors, do a test run with the new input data. To do this, clone the REMIND repo and update the data input version `cfg$revision` in `config/default.cfg` using your recently created data revision number file and run one scenario (e.g. SSP2EU-Base).
 
+4.a ATTENTION: If your new input data change FE pathways, polulation, GDP trajectories or substantial behaviour of REMIND, you need to rerun CES parameter calibration (see tutorial 12_Calibrating_CES_Parameters) and adjust input data revision togehter with updated CES parameters.
+
 5. If the test run completes without errors, add the change in `config/default.cfg` and the update of the input data revision in `main.gms` that was automatically performed by the REMIND run to a commit in your REMIND clone. This can be best done by using
 ```bash
 git add -p config/default.cfg main.gms


### PR DESCRIPTION
# Purpose of this PR
new CES parameters and gdx files for EU21_SSP2EU for input data revision 6.324 and also added inputdataInfo.log to the CES parameter folder containing information on input data revision the CES calibration is based on. This info will be downloaded together with the CES parameters. Adjusted tutorial 06_Advanced_ChangeInputs and https://redmine.pik-potsdam.de/projects/remind-r/wiki/GDX_and_CES_parameter_Handling accordingly

## Type of change

- [x] Refactoring
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [x] The model runs successfully (`Rscript start.R -q`)

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 


