### PR TITLE
shut up about package versions if the environment variable ignoreRenvUpdates is "TRUE"

### DIFF
--- a/scripts/start/submit.R
+++ b/scripts/start/submit.R
@@ -62,7 +62,8 @@ submit <- function(cfg, restart = FALSE, stopOnFolderCreateError = TRUE) {
 
         if (getOption("autoRenvUpdates", FALSE)) {
           source("scripts/utils/updateRenv.R")
-        } else if (!is.null(piamenv::showUpdates())) {
+        } else if (   'TRUE' != Sys.getenv('ignoreRenvUpdates')
+                   && !is.null(piamenv::showUpdates())) {
           message("Consider updating with `Rscript scripts/utils/updateRenv.R`.")
         }
       }
@@ -83,15 +84,15 @@ submit <- function(cfg, restart = FALSE, stopOnFolderCreateError = TRUE) {
                stdout = renvLogPath, stderr = "2>&1")
     }
 
-    # Save the cfg (with the updated name of the result folder) into the results folder. 
-    # Do not save the new name of the results folder to the .RData file in REMINDs main folder, because it 
+    # Save the cfg (with the updated name of the result folder) into the results folder.
+    # Do not save the new name of the results folder to the .RData file in REMINDs main folder, because it
     # might be needed to restart subsequent runs manually and should not contain the time stamp in this case.
     filename <- file.path(cfg$results_folder, "config.Rdata")
     cat("   Writing cfg to file", filename, "\n")
     # remember main folder
     cfg$remind_folder <- normalizePath(".")
     save(cfg, file = filename)
-    
+
     # Copy files required to configure and start a run
     filelist <- c("prepare_and_run.R" = "scripts/start/prepare_and_run.R",
                   ".Rprofile" = ".Rprofile")
@@ -103,8 +104,8 @@ submit <- function(cfg, restart = FALSE, stopOnFolderCreateError = TRUE) {
   on.exit(setwd(cfg$remind_folder))
   # Change to run folder
   setwd(cfg$results_folder)
-  
-  # send prepare_and_run.R to cluster 
+
+  # send prepare_and_run.R to cluster
   cat("   Executing prepare_and_run.R for",cfg$results_folder,"\n")
   if (grepl("^direct", cfg$slurmConfig)) {
     log <- format(Sys.time(), paste0(cfg$title,"-%Y-%H-%M-%S-%OS3.log"))
@@ -113,6 +114,6 @@ submit <- function(cfg, restart = FALSE, stopOnFolderCreateError = TRUE) {
     system(paste0("sbatch --job-name=",cfg$title," --output=log.txt --mail-type=END --comment=REMIND --wrap=\"Rscript prepare_and_run.R \" ",cfg$slurmConfig))
     Sys.sleep(1)
   }
-    
+
   return(cfg$results_folder)
 }

--- a/start.R
+++ b/start.R
@@ -230,7 +230,9 @@ if (requireNamespace("piamenv", quietly = TRUE) && packageVersion("piamenv") >= 
        "and re-run start.R in a fresh R session.")
 }
 
-if (!getOption("autoRenvUpdates", FALSE) && !is.null(piamenv::showUpdates())) {
+if (   'TRUE' != Sys.getenv('ignoreRenvUpdates')
+    && !getOption("autoRenvUpdates", FALSE)
+    && !is.null(piamenv::showUpdates())) {
   message("Consider updating with `Rscript scripts/utils/updateRenv.R`.")
   Sys.sleep(1)
 }


### PR DESCRIPTION
Allow users to not be bothered about package updates if they don't care.
Required package updates as indicated in `DESCRIPTION` are still performed.

- [x] New feature 

## Checklist:

- [x] My code follows the coding etiquette
- [ ] I have performed a self-review of my own code
- [x] Changes are commented, particularly in hard-to-understand areas
- [x] I have updated the in-code documentation
- [x] I have adjusted reporting where it was needed
- [x] All automated model tests compile successfully (`Rscript start.R -g config/scenario_config_AMT.csv`)
- [x] The model runs successfully (`Rscript start.R -q`)

