### PR TITLE
Use R exclusively in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,15 @@
 .PHONY: help docs update-renv update-all-renv check check-fix
 .DEFAULT_GOAL := help
 
+# extracts the help text and formats it nicely
+HELP_PARSING = 'm <- readLines("Makefile");\
+				m <- grep("\#\#", m, value=TRUE);\
+				command <- sub("^([^ ]*) *\#\#(.*)", "\\1", m);\
+				help <- sub("^([^ ]*) *\#\#(.*)", "\\2", m);\
+				cat(sprintf("%-18s%s", command, help), sep="\n")'
+
 help:           ## Show this help.
-	@sed -e '/##/ !d' -e '/sed/ d' -e 's/^\([^ ]*\) *##\(.*\)/\1^\2/' \
-		$(MAKEFILE_LIST) | column -ts '^'
+	@Rscript -e $(HELP_PARSING)
 
 docs:           ## Generate/update model HTML documentation in the doc/ folder
 	Rscript -e 'goxygen::goxygen(unitPattern = c("\\[","\\]"), includeCore=T, max_num_edge_labels="adjust", max_num_nodes_for_edge_labels = 15)'


### PR DESCRIPTION
# Purpose of this PR

`sed` and `column` are typically not available on windows. To make it easier to use the Makefile also on windows, re-implement the help text parsing in the Makefile in R so that we have fewer dependencies.

## Type of change

- [x] Refactoring

## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [x] Changes are commented, particularly in hard-to-understand areas
- [x] I have updated the in-code documentation
- [ ] I have adjusted reporting where it was needed
- [ ] All automated model tests compile successfully (`Rscript start.R -g config/scenario_config_AMT.csv`)
- [ ] The model runs successfully (`Rscript start.R -q`)
