### PR TITLE
let start_bundle_coupled.R fail transparently if no scenario selected

### DIFF
--- a/start_bundle_coupled.R
+++ b/start_bundle_coupled.R
@@ -182,7 +182,7 @@ if (!identical(common,character(0))) {
   message("The following ", length(common), " scenarios will be started:")
   message("  ", paste(common, collapse = ", "))
 } else {
-  message("No scenario selected.")
+  stop("No scenario found with start=", startnow, " in ", basename(path_settings_coupled), ".")
 }
 message("")
 


### PR DESCRIPTION
## Purpose of this PR

if no scenario is selected, fail instead of failing somewhat later

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix 