### PR TITLE
Bugfix - initialize pm_taxCO2eq_iterationdiff parameters

### DIFF
--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -25,6 +25,9 @@ pm_temperatureImpulseResponseCO2(tall,tall) = 0;
 vm_demFeForEs.L(t,regi,entyFe,esty,teEs) = 0;
 vm_demFeForEs.L(t,regi,fe2es(entyFe,esty,teEs)) = 0.1;
 
+pm_taxCO2eq_iterationdiff(t,regi) = 0;
+pm_taxCO2eq_iterationdiff_tmp(t,regi) = 0;
+
 *------------------------------------------------------------------------------------
 ***                        calculations based on sets
 *------------------------------------------------------------------------------------


### PR DESCRIPTION
# Purpose of this PR

`pm_taxCO2eq_iterationdiff` and `pm_taxCO2eq_iterationdiff_tmp` only have values if cm_emiscen=9. Nevertheless, there is a display call for them in the nash postsolve code. 
If your gdx does not contain these parameters from a previous policy run, REMIND would error out. 

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
