### PR TITLE
bugfixes for emission tax initialization values

### DIFF
--- a/main.gms
+++ b/main.gms
@@ -1222,6 +1222,7 @@ $setGlobal cm_regiExoPrice  off    !! def = off
 ***     cm_emiMktTarget = '2020.2050.EU27_regi.all.budget.netGHG_noBunkers 72, 2020.2050.DEU.all.year.netGHG_noBunkers 0.1'
 ***     sets a 72 GtCO2eq budget target for European 27 countries (EU27_regi), for all GHG emissions excluding bunkers between 2020 and 2050; and a 100 MtCO2 CO2eq emission target for the year 2050, for Germany"
 ***     Requires regiCarbonPrice realization in regipol module
+***   Important: If you set multiple yearly targets to the same region, it is highly recommended to enable the switch cm_prioRescaleFactor to avoid conflicts between the targets priorities.
 $setGlobal cm_emiMktTarget  off    !! def = off
 *** cm_prioRescaleFactor "factor applied to carbon tax rescale factor to prioritize short term targets in the initial 15 iterations (and vice versa latter) [0..1].
 ***   Example on how to use:

--- a/modules/47_regipol/regiCarbonPrice/datainput.gms
+++ b/modules/47_regipol/regiCarbonPrice/datainput.gms
@@ -53,8 +53,8 @@ loop(regi$regi_groupExt("EUR_regi",regi),
 ***    p47_taxemiMkt_init("2020",regi,"other")= 30*sm_DptCO2_2_TDpGtC;
   );
 
-*** intialize EUR price trajectory after 2020 by a yearly increase of 1$/tCO2 when no price is available.
-  p47_taxemiMkt_init(t,regi,emiMkt)$(not(p47_taxemiMkt_init(t,regi,emiMkt)) and (t.val gt 2020)) = p47_taxemiMkt_init("2020",regi,emiMkt) + (1*sm_DptCO2_2_TDpGtC)*(t.val-2020);
+*** intialize EUR price trajectory after 2020 with a yearly increase of 1$/tCO2 from a base value of 30$/tCO2 when no price is available.
+  p47_taxemiMkt_init(t,regi,emiMkt)$(not(p47_taxemiMkt_init(t,regi,emiMkt)) and (t.val gt 2020)) = (30*sm_DptCO2_2_TDpGtC) + (1*sm_DptCO2_2_TDpGtC)*(t.val-2020);
 );
 
 *** Auxiliar parameters based on emission targets information 


### PR DESCRIPTION
# Purpose of this PR

- bug fix to avoid distinct emission market taxes if you chose the `all` option in the `cm_emiMktTarget` switch.
- improved error handling to avoid division by zero in emission target scale calculation.
- comment added to underline the importance of using the switch `cm_prioRescaleFactor` in scenarios that set multiple targets for the same region

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
