### PR TITLE
convert compile-time `c_CES_calibration_iteration` to run-time scalar

### DIFF
--- a/core/declarations.gms
+++ b/core/declarations.gms
@@ -600,6 +600,8 @@ sm_globalBudget_dev                                   "actual level of global cu
 
 sm_eps                                                "small number: 1e-9 "  /1e-9/
 
+sm_CES_calibration_iteration                          "current calibration iteration number, updated from R" /1/
+
 ***----------------------------------------------------------------------------------------
 ***----------------------------------------------trade module------------------------------
 ;

--- a/main.gms
+++ b/main.gms
@@ -1594,7 +1594,6 @@ $setGLobal cm_debug_preloop  off    !! def = off
 $setGlobal cm_APscen  SSP2          !! def = SSP2
 $setglobal cm_CES_configuration  indu_subsectors-buil_simple-tran_edge_esm-POP_pop_SSP2EU-GDP_gdp_SSP2EU-En_gdp_SSP2EU-Kap_debt_limit-Reg_62eff8f7   !! this will be changed by start_run()
 $setglobal c_CES_calibration_iterations  10     !!  def  =  10
-$setglobal c_CES_calibration_iteration  1     !!  def  =  1
 $setglobal c_CES_calibration_industry_FE_target  1
 $setglobal c_testOneRegi_region  EUR       !! def = EUR
 $setglobal cm_fixCO2price  off !! def = off

--- a/modules/29_CES_parameters/calibrate/bounds.gms
+++ b/modules/29_CES_parameters/calibrate/bounds.gms
@@ -43,13 +43,13 @@ sm_tmp = 5;  !! last iteration with bounds on industry
 loop (pf_industry_relaxed_bounds_dyn37(in),
   vm_cesIO.lo(t_29(t),regi_dyn29(regi),in)
   = pm_cesdata(t,regi,in,"quantity")
-  * max(1e-12, 0.95 + min(0, (1 - %c_CES_calibration_iteration%) / sm_tmp));
+  * max(1e-12, 0.95 + min(0, (1 - sm_CES_calibration_iteration) / sm_tmp));
 
   vm_cesIO.up(t,regi_dyn29(regi),in)
   = ( pm_cesdata(t,regi,in,"quantity")
-    * (1.05 + max(0, (%c_CES_calibration_iteration% - 1) / sm_tmp))
-    )$( %c_CES_calibration_iteration% le sm_tmp )
-  + INF$( %c_CES_calibration_iteration% gt sm_tmp );
+    * (1.05 + max(0, (sm_CES_calibration_iteration - 1) / sm_tmp))
+    )$( sm_CES_calibration_iteration le sm_tmp )
+  + INF$( sm_CES_calibration_iteration gt sm_tmp );
 );
 
 *** EOF ./modules/29_CES_parameters/calibrate/bounds.gms

--- a/modules/29_CES_parameters/calibrate/datainput.gms
+++ b/modules/29_CES_parameters/calibrate/datainput.gms
@@ -345,7 +345,7 @@ Execute_Loadpoint 'input'  p29_cesIO_load = vm_cesIO.l, p29_effGr = vm_effGr.l;
 
 *** Load putty-clay quantities if relevant (initialise to 0 in case it is not)
 p29_cesIOdelta_load(t,regi,in) = 0;
-if ( (%c_CES_calibration_iteration% gt 1 OR %c_CES_calibration_new_structure% eq 0) AND (card(in_putty) gt 0),
+if ( (sm_CES_calibration_iteration gt 1 OR s29_CES_calibration_new_structure eq 0) AND (card(in_putty) gt 0),
 Execute_Loadpoint 'input'  p29_cesIOdelta_load = vm_cesIOdelta.l;
 );
 
@@ -461,7 +461,7 @@ loop((t,regi,in)$(    (ppf(in) OR ppf_29(in))
 p29_capitalPrice(t,regi) = 0.12;
 
 *** Load capital price assumption for the first iteration, otherwise take it from gdx prices
-if( %c_CES_calibration_iteration% = 1 AND %c_CES_calibration_new_structure% = 1,  pm_cesdata(t,regi,"kap","price") = p29_capitalPrice(t,regi));
+if( sm_CES_calibration_iteration eq 1 AND s29_CES_calibration_new_structure eq 1,  pm_cesdata(t,regi,"kap","price") = p29_capitalPrice(t,regi));
 
 *** In case there is one capital variable together with an energy variable in a same CES, give them the same efficiency growth pathways
 

--- a/modules/29_CES_parameters/calibrate/declarations.gms
+++ b/modules/29_CES_parameters/calibrate/declarations.gms
@@ -6,6 +6,10 @@
 *** |  Contact: remind@pik-potsdam.de
 *** SOF ./modules/29_CES_parameters/calibrate/declarations.gms
 
+Scalars
+  s29_CES_calibration_new_structure    "CES structure differs from input.gdx"  /%c_CES_calibration_new_structure%/
+;
+
 Parameters
   p29_CESderivative(tall,all_regi,all_in,all_in)   "derivative of the CES function for calculating prices"
 
@@ -75,7 +79,7 @@ file_CES_calibration.nd =     3;   !! three decimal places
 file_CES_calibration.nw =    10;   !! number width: +0.000e+00
 file_CES_calibration.pw = 32767;   !! page width
 
-if (%c_CES_calibration_iteration% eq 1,   !! c_CES_calibration_iteration
+if (sm_CES_calibration_iteration eq 1,
   !! print a comment header giving the order of production factors in the CES
   !! tree so that they can be displayed in a meaningful order in calibration
   !! reports
@@ -141,7 +145,7 @@ capital_unit.lw =  0;
 capital_unit.nw = 15;
 capital_unit.nd =  9;
 
-if (%c_CES_calibration_iteration% eq 1,
+if (sm_CES_calibration_iteration eq 1,
 put capital_unit;
 put "iteration","index","period","variable", "parameter","region","value" /;
 putclose;

--- a/modules/29_CES_parameters/calibrate/output.gms
+++ b/modules/29_CES_parameters/calibrate/output.gms
@@ -46,14 +46,14 @@ loop ((t,regi_dyn29(regi),in)$(   ppf_29(in)
                                OR ppf_beyondcalib_29(in) 
                                OR sameas(in,"inco")
                                OR ppf_putty(in)          ),
-  put "%c_expname%", sm_CES_calibration_iteration, t.tl, regi.tl;
+  put "%c_expname%", sm_CES_calibration_iteration:0:0, t.tl, regi.tl;
   put "efficiency", in.tl;
   put (pm_cesdata("2005",regi,in,"eff") * vm_effGr.l(t,regi,in)) /;
 
-  put "%c_expname%", sm_CES_calibration_iteration, t.tl, regi.tl;
+  put "%c_expname%", sm_CES_calibration_iteration:0:0, t.tl, regi.tl;
   put "efficiency growth", in.tl, vm_effGr.l(t,regi,in) /;
 
-  put "%c_expname%", sm_CES_calibration_iteration, t.tl, regi.tl, "xi";
+  put "%c_expname%", sm_CES_calibration_iteration:0:0, t.tl, regi.tl, "xi";
   put in.tl, pm_cesdata(t,regi,in,"xi") /;
 );
 
@@ -61,13 +61,13 @@ loop ((t,regi_dyn29(regi),in)$(    NOT in_putty(in)
                                AND (   ppf_29(in) 
                                     OR ppf_beyondcalib_29(in) 
                                     OR sameas(in,"inco"))     ),
-  put "%c_expname%", sm_CES_calibration_iteration, t.tl, regi.tl; 
+  put "%c_expname%", sm_CES_calibration_iteration:0:0, t.tl, regi.tl; 
   put "quantity", in.tl, vm_cesIO.l(t,regi,in) /;
     
-  put "%c_expname%", sm_CES_calibration_iteration, t.tl, regi.tl, "price";
+  put "%c_expname%", sm_CES_calibration_iteration:0:0, t.tl, regi.tl, "price";
   put in.tl, pm_cesdata(t,regi,in,"price") /;
     
-  put "%c_expname%", sm_CES_calibration_iteration, t.tl, regi.tl; 
+  put "%c_expname%", sm_CES_calibration_iteration:0:0, t.tl, regi.tl; 
   put "total efficiency", in.tl;
   put sum(cesOut2cesIn(out,in), 
         pm_cesdata(t,regi,in,"xi")
@@ -83,13 +83,13 @@ loop ((t,regi_dyn29(regi),in)$(     in_putty(in)
                                     OR ppf_beyondcalib_29(in) 
                                     OR sameas(in,"inco"))
                                OR ppf_putty(in)               ),
-  put "%c_expname%", sm_CES_calibration_iteration, t.tl, regi.tl; 
+  put "%c_expname%", sm_CES_calibration_iteration:0:0, t.tl, regi.tl; 
   put "quantity_putty", in.tl, vm_cesIOdelta.l(t,regi,in) /;
     
-  put "%c_expname%", sm_CES_calibration_iteration, t.tl, regi.tl, "price_putty";
+  put "%c_expname%", sm_CES_calibration_iteration:0:0, t.tl, regi.tl, "price_putty";
   put in.tl, pm_cesdata(t,regi,in,"price") /;
     
-  put "%c_expname%", sm_CES_calibration_iteration, t.tl, regi.tl; 
+  put "%c_expname%", sm_CES_calibration_iteration:0:0, t.tl, regi.tl; 
   put "total efficiency putty", in.tl;
   put sum(cesOut2cesIn(out,in), 
         pm_cesdata(t,regi,in,"xi")
@@ -101,19 +101,19 @@ loop ((t,regi_dyn29(regi),in)$(     in_putty(in)
 );
 
 loop ((ttot,regi_dyn29(regi),te_29_report),
-  put "%c_expname%", sm_CES_calibration_iteration, ttot.tl, regi.tl;
+  put "%c_expname%", sm_CES_calibration_iteration:0:0, ttot.tl, regi.tl;
   put "vm_deltaCap", te_29_report.tl;
   put sum(rlf,vm_deltacap.L(ttot,regi,te_29_report,rlf)) /;
 );
 
 loop ((t,regi_dyn29(regi),in),
   if (vm_cesIO.lo(t,regi,in) ne 0,
-    put "%c_expname%", sm_CES_calibration_iteration, t.tl, regi.tl;
+    put "%c_expname%", sm_CES_calibration_iteration:0:0, t.tl, regi.tl;
     put "lower bound", in.tl, vm_cesIO.lo(t,regi,in) /;
   );
 
   if (vm_cesIO.up(t,regi,in) ne INF,
-    put "%c_expname%", sm_CES_calibration_iteration, t.tl, regi.tl;
+    put "%c_expname%", sm_CES_calibration_iteration:0:0, t.tl, regi.tl;
     put "upper bound", in.tl, vm_cesIO.up(t,regi,in) /;
   );
 );

--- a/modules/29_CES_parameters/calibrate/output.gms
+++ b/modules/29_CES_parameters/calibrate/output.gms
@@ -46,14 +46,14 @@ loop ((t,regi_dyn29(regi),in)$(   ppf_29(in)
                                OR ppf_beyondcalib_29(in) 
                                OR sameas(in,"inco")
                                OR ppf_putty(in)          ),
-  put "%c_expname%", "%c_CES_calibration_iteration%", t.tl, regi.tl;
+  put "%c_expname%", sm_CES_calibration_iteration, t.tl, regi.tl;
   put "efficiency", in.tl;
   put (pm_cesdata("2005",regi,in,"eff") * vm_effGr.l(t,regi,in)) /;
 
-  put "%c_expname%", "%c_CES_calibration_iteration%", t.tl, regi.tl;
+  put "%c_expname%", sm_CES_calibration_iteration, t.tl, regi.tl;
   put "efficiency growth", in.tl, vm_effGr.l(t,regi,in) /;
 
-  put "%c_expname%", "%c_CES_calibration_iteration%", t.tl, regi.tl, "xi";
+  put "%c_expname%", sm_CES_calibration_iteration, t.tl, regi.tl, "xi";
   put in.tl, pm_cesdata(t,regi,in,"xi") /;
 );
 
@@ -61,13 +61,13 @@ loop ((t,regi_dyn29(regi),in)$(    NOT in_putty(in)
                                AND (   ppf_29(in) 
                                     OR ppf_beyondcalib_29(in) 
                                     OR sameas(in,"inco"))     ),
-  put "%c_expname%", "%c_CES_calibration_iteration%", t.tl, regi.tl; 
+  put "%c_expname%", sm_CES_calibration_iteration, t.tl, regi.tl; 
   put "quantity", in.tl, vm_cesIO.l(t,regi,in) /;
     
-  put "%c_expname%", "%c_CES_calibration_iteration%", t.tl, regi.tl, "price";
+  put "%c_expname%", sm_CES_calibration_iteration, t.tl, regi.tl, "price";
   put in.tl, pm_cesdata(t,regi,in,"price") /;
     
-  put "%c_expname%", "%c_CES_calibration_iteration%", t.tl, regi.tl; 
+  put "%c_expname%", sm_CES_calibration_iteration, t.tl, regi.tl; 
   put "total efficiency", in.tl;
   put sum(cesOut2cesIn(out,in), 
         pm_cesdata(t,regi,in,"xi")
@@ -83,13 +83,13 @@ loop ((t,regi_dyn29(regi),in)$(     in_putty(in)
                                     OR ppf_beyondcalib_29(in) 
                                     OR sameas(in,"inco"))
                                OR ppf_putty(in)               ),
-  put "%c_expname%", "%c_CES_calibration_iteration%", t.tl, regi.tl; 
+  put "%c_expname%", sm_CES_calibration_iteration, t.tl, regi.tl; 
   put "quantity_putty", in.tl, vm_cesIOdelta.l(t,regi,in) /;
     
-  put "%c_expname%", "%c_CES_calibration_iteration%", t.tl, regi.tl, "price_putty";
+  put "%c_expname%", sm_CES_calibration_iteration, t.tl, regi.tl, "price_putty";
   put in.tl, pm_cesdata(t,regi,in,"price") /;
     
-  put "%c_expname%", "%c_CES_calibration_iteration%", t.tl, regi.tl; 
+  put "%c_expname%", sm_CES_calibration_iteration, t.tl, regi.tl; 
   put "total efficiency putty", in.tl;
   put sum(cesOut2cesIn(out,in), 
         pm_cesdata(t,regi,in,"xi")
@@ -101,19 +101,19 @@ loop ((t,regi_dyn29(regi),in)$(     in_putty(in)
 );
 
 loop ((ttot,regi_dyn29(regi),te_29_report),
-  put "%c_expname%", "%c_CES_calibration_iteration%", ttot.tl, regi.tl;
+  put "%c_expname%", sm_CES_calibration_iteration, ttot.tl, regi.tl;
   put "vm_deltaCap", te_29_report.tl;
   put sum(rlf,vm_deltacap.L(ttot,regi,te_29_report,rlf)) /;
 );
 
 loop ((t,regi_dyn29(regi),in),
   if (vm_cesIO.lo(t,regi,in) ne 0,
-    put "%c_expname%", "%c_CES_calibration_iteration%", t.tl, regi.tl;
+    put "%c_expname%", sm_CES_calibration_iteration, t.tl, regi.tl;
     put "lower bound", in.tl, vm_cesIO.lo(t,regi,in) /;
   );
 
   if (vm_cesIO.up(t,regi,in) ne INF,
-    put "%c_expname%", "%c_CES_calibration_iteration%", t.tl, regi.tl;
+    put "%c_expname%", sm_CES_calibration_iteration, t.tl, regi.tl;
     put "upper bound", in.tl, vm_cesIO.up(t,regi,in) /;
   );
 );

--- a/modules/29_CES_parameters/calibrate/preloop.gms
+++ b/modules/29_CES_parameters/calibrate/preloop.gms
@@ -971,14 +971,14 @@ $endif.subsectors
                         AND pm_cesdata_sigma(t,out) eq -1                     ),
 
     if (sm_CES_calibration_iteration eq 1 and s29_CES_calibration_new_structure eq 1,
-      put sm_CES_calibration_iteration, "remind", t.tl, in.tl ;
+      put sm_CES_calibration_iteration:0:0, "remind", t.tl, in.tl ;
       put "price_Noscale", regi.tl, pm_cesdata(t,regi,in,"price") /;
-      put sm_CES_calibration_iteration, "remind", t.tl, in2.tl;
+      put sm_CES_calibration_iteration:0:0, "remind", t.tl, in2.tl;
       put "price_Noscale", regi.tl, pm_cesdata(t,regi,in2,"price") /;
     else
-      put sm_CES_calibration_iteration, "remind", t.tl, in.tl;
+      put sm_CES_calibration_iteration:0:0, "remind", t.tl, in.tl;
       put "price_Noscale", regi.tl, p29_CESderivative(t,regi,"inco",in) /;
-      put sm_CES_calibration_iteration, "remind", t.tl, in2.tl;
+      put sm_CES_calibration_iteration:0:0, "remind", t.tl, in2.tl;
       put "price_Noscale", regi.tl, p29_CESderivative(t,regi,"inco",in2) /;
     );
   );
@@ -1466,30 +1466,30 @@ loop ((out,in,in2,t)$((pm_cesdata_sigma(t,out) eq -1)
                                     AND (sameAs(t, "2015") OR sameAs(t, "2050") OR sameAs(t, "2100"))) ,
 
        if ( sameAs(t,"2015"),
-           put sm_CES_calibration_iteration, "remind" ,"2015", out.tl   , "output_scale", regi.tl, p29_output_estimation(regi,out) /;
+           put sm_CES_calibration_iteration:0:0, "remind" ,"2015", out.tl   , "output_scale", regi.tl, p29_output_estimation(regi,out) /;
        );
 
-       put sm_CES_calibration_iteration, "remind" , t.tl, out.tl   , "quantity", regi.tl, ( pm_cesdata(t,regi,out,"quantity") $ ( NOT ipf_putty(out)) + pm_cesdata_putty(t,regi,out,"quantity") $ ( ipf_putty(out))) /;
-       put sm_CES_calibration_iteration, "remind" , t.tl, in.tl , "quantity", regi.tl, ( pm_cesdata(t,regi,in,"quantity") $ ( NOT ipf_putty(out)) + pm_cesdata_putty(t,regi,in,"quantity") $ ( ipf_putty(out))) /;
-       put sm_CES_calibration_iteration, "remind" , t.tl, in2.tl  , "quantity", regi.tl, ( pm_cesdata(t,regi,in2,"quantity") $ ( NOT ipf_putty(out)) + pm_cesdata_putty(t,regi,in2,"quantity") $ ( ipf_putty(out))) /;
+       put sm_CES_calibration_iteration:0:0, "remind" , t.tl, out.tl   , "quantity", regi.tl, ( pm_cesdata(t,regi,out,"quantity") $ ( NOT ipf_putty(out)) + pm_cesdata_putty(t,regi,out,"quantity") $ ( ipf_putty(out))) /;
+       put sm_CES_calibration_iteration:0:0, "remind" , t.tl, in.tl , "quantity", regi.tl, ( pm_cesdata(t,regi,in,"quantity") $ ( NOT ipf_putty(out)) + pm_cesdata_putty(t,regi,in,"quantity") $ ( ipf_putty(out))) /;
+       put sm_CES_calibration_iteration:0:0, "remind" , t.tl, in2.tl  , "quantity", regi.tl, ( pm_cesdata(t,regi,in2,"quantity") $ ( NOT ipf_putty(out)) + pm_cesdata_putty(t,regi,in2,"quantity") $ ( ipf_putty(out))) /;
 
-       put sm_CES_calibration_iteration,"remind" , t.tl, in.tl , "eff", regi.tl, pm_cesdata(t,regi,in,"eff") /;
-       put sm_CES_calibration_iteration,"remind" , t.tl, in2.tl  , "eff", regi.tl, pm_cesdata(t,regi,in2,"eff") /;
+       put sm_CES_calibration_iteration:0:0,"remind" , t.tl, in.tl , "eff", regi.tl, pm_cesdata(t,regi,in,"eff") /;
+       put sm_CES_calibration_iteration:0:0,"remind" , t.tl, in2.tl  , "eff", regi.tl, pm_cesdata(t,regi,in2,"eff") /;
 
-       put sm_CES_calibration_iteration,"remind" , t.tl, in.tl , "effGr", regi.tl, pm_cesdata(t,regi,in,"effGr") /;
-       put sm_CES_calibration_iteration,"remind" , t.tl, in2.tl  , "effGr", regi.tl, pm_cesdata(t,regi,in2,"effGr") /;
+       put sm_CES_calibration_iteration:0:0,"remind" , t.tl, in.tl , "effGr", regi.tl, pm_cesdata(t,regi,in,"effGr") /;
+       put sm_CES_calibration_iteration:0:0,"remind" , t.tl, in2.tl  , "effGr", regi.tl, pm_cesdata(t,regi,in2,"effGr") /;
 
-       put sm_CES_calibration_iteration,"remind" , t.tl, in.tl , "xi", regi.tl, pm_cesdata(t,regi,in,"xi") /;
-       put sm_CES_calibration_iteration,"remind" , t.tl, in2.tl  , "xi", regi.tl, pm_cesdata(t,regi,in2,"xi") /;
+       put sm_CES_calibration_iteration:0:0,"remind" , t.tl, in.tl , "xi", regi.tl, pm_cesdata(t,regi,in,"xi") /;
+       put sm_CES_calibration_iteration:0:0,"remind" , t.tl, in2.tl  , "xi", regi.tl, pm_cesdata(t,regi,in2,"xi") /;
 
-       put sm_CES_calibration_iteration,"remind" , t.tl, in.tl , "price", regi.tl, pm_cesdata(t,regi,in,"price") /;
-       put sm_CES_calibration_iteration,"remind" , t.tl, in2.tl  , "price", regi.tl, pm_cesdata(t,regi,in2,"price") /;
+       put sm_CES_calibration_iteration:0:0,"remind" , t.tl, in.tl , "price", regi.tl, pm_cesdata(t,regi,in,"price") /;
+       put sm_CES_calibration_iteration:0:0,"remind" , t.tl, in2.tl  , "price", regi.tl, pm_cesdata(t,regi,in2,"price") /;
 
-       put sm_CES_calibration_iteration,"remind" , t.tl,out.tl  , "rho", regi.tl, pm_cesdata(t,regi,out,"rho") /;
+       put sm_CES_calibration_iteration:0:0,"remind" , t.tl,out.tl  , "rho", regi.tl, pm_cesdata(t,regi,out,"rho") /;
        );
 
        loop ((index_Nr,in)$p29_capitalUnitProjections(regi, in, index_Nr),
-       put sm_CES_calibration_iteration,index_Nr.tl, "2015", in.tl , "quantity", regi.tl,  p29_capitalUnitProjections(regi,in,index_Nr) /;
+       put sm_CES_calibration_iteration:0:0,index_Nr.tl, "2015", in.tl , "quantity", regi.tl,  p29_capitalUnitProjections(regi,in,index_Nr) /;
        );
 );
 putclose;

--- a/modules/29_CES_parameters/calibrate/preloop.gms
+++ b/modules/29_CES_parameters/calibrate/preloop.gms
@@ -872,7 +872,7 @@ if (card(ppf_beyondcalib_29) >= 1,
   Display "  before computing xi in beyond", pm_cesdata;
 
   !! if prices haven't already been loaded
-  if (sm_CES_calibration_iteration > 1 or s29_CES_calibration_new_structure eq 1,
+  if (sm_CES_calibration_iteration > 1 or s29_CES_calibration_new_structure eq 0,
 
     !! Compute ppf prices from CES derivatives of previous run
     p29_CESderivative(t,regi_dyn29(regi),cesOut2cesIn(out,in))$(

--- a/modules/29_CES_parameters/calibrate/preloop.gms
+++ b/modules/29_CES_parameters/calibrate/preloop.gms
@@ -35,130 +35,117 @@ if (sm_tmp,
 $endif.check_structure
 
 
-*** Determine if prices should be derived or loaded
-$set c_CES_calibration_prices "derive"
-$ifthen.new_structure   %c_CES_calibration_new_structure% == "1"
-$ifthen.first_iteration %c_CES_calibration_iteration%     == "1"
-$set c_CES_calibration_prices "load"
-$endif.first_iteration
-$endif.new_structure
-
-
 *** In the first iteration with a changed CES structure, load ppf prices
-$ifthen.get_prices %c_CES_calibration_prices% == "load"
-
-*** Set CES prices to the value specified by cm_CES_calibration_default_prices
-*** and abort if cm_CES_calibration_default_prices == 0
+if( sm_CES_calibration_iteration eq 1 and s29_CES_calibration_new_structure eq 1,
+  !! Set CES prices to the value specified by cm_CES_calibration_default_prices
+  !! and abort if cm_CES_calibration_default_prices == 0
 $ifthen.default_prices %cm_CES_calibration_default_prices% == "0"
-   abort "Please set cm_CES_calibration_default_prices > 0 to get the calibration started";
+    abort "Please set cm_CES_calibration_default_prices > 0 to get the calibration started";
 $endif.default_prices
-pm_cesdata(t,regi,all_in,"price") = %cm_CES_calibration_default_prices%;
+  pm_cesdata(t,regi,all_in,"price") = %cm_CES_calibration_default_prices%;
 
-pm_cesdata(t,regi,ipf_29,"price")
-  = 1;
-pm_cesdata(t,regi,in_complements(in),"price") = 1;
+  pm_cesdata(t,regi,ipf_29,"price") = 1;
+  pm_cesdata(t,regi,in_complements(in),"price") = 1;
 
+  pm_cesdata(t,regi,industry_ue_calibration_target_dyn37(in),"price")$(
+                                            pm_cesdata(t,regi,in,"price") eq 1 )
+    = %cm_CES_calibration_default_prices%;
 
-pm_cesdata(t,regi,industry_ue_calibration_target_dyn37(in),"price")$(
-                                          pm_cesdata(t,regi,in,"price") eq 1 )
-  = %cm_CES_calibration_default_prices%;
+else
+  !! If not first iteration or known CES structure, compute ppf prices
 
+  !! Compute ppf prices from CES derivatives of previous run
+  p29_CESderivative(t,regi_dyn29(regi),ces_29(out,in))$(
+                                                      p29_cesIO_load(t,regi,in))
+    = p29_cesdata_load(t,regi,in,"xi")
+    * p29_cesdata_load(t,regi,in,"eff")
+    * p29_effGr(t,regi,in)
 
-*** If not first iteration or known CES structure, compute ppf prices
-$else.get_prices
+    * ( p29_cesIO_load(t,regi,out)$( NOT ipf_putty(out))
+      + p29_cesIOdelta_load(t,regi,out)$( ipf_putty(out))
+      )
+    ** (1 - p29_cesdata_load(t,regi,out,"rho"))
 
-*** Compute ppf prices from CES derivatives of previous run
-p29_CESderivative(t,regi_dyn29(regi),ces_29(out,in))$(
-                                                     p29_cesIO_load(t,regi,in))
-  = p29_cesdata_load(t,regi,in,"xi")
-  * p29_cesdata_load(t,regi,in,"eff")
-  * p29_effGr(t,regi,in)
+    * exp(
+      log(
+      p29_cesdata_load(t,regi,in,"eff")
+      * p29_effGr(t,regi,in)
+      * ( p29_cesIO_load(t,regi,in)$( NOT ipf_putty(out))
+        + p29_cesIOdelta_load(t,regi,in)$( ipf_putty(out)))
+      )
+      * (p29_cesdata_load(t,regi,out,"rho") - 1));
 
-  * ( p29_cesIO_load(t,regi,out)$( NOT ipf_putty(out))
-    + p29_cesIOdelta_load(t,regi,out)$( ipf_putty(out))
-    )
- ** (1 - p29_cesdata_load(t,regi,out,"rho"))
-
-  * exp(
-	  log(
-		p29_cesdata_load(t,regi,in,"eff")
-		* p29_effGr(t,regi,in)
-		* ( p29_cesIO_load(t,regi,in)$( NOT ipf_putty(out))
-			+ p29_cesIOdelta_load(t,regi,in)$( ipf_putty(out)))
-		)
-		* (p29_cesdata_load(t,regi,out,"rho") - 1));
-
-*** Propagate price down the CES tree
-loop ((cesLevel2cesIO(counter,in),ces_29(in,in2),ces2_29(in2,in3)),
-    p29_CESderivative(t,regi_dyn29(regi),"inco",in3)
-    = p29_CESderivative(t,regi,"inco",in2)
-    * p29_CESderivative(t,regi,in2,in3);
-);
-
-
-*** Prices of intermediate production factors are all 1, except on the level 
-*** above the perfect substitutes if they are ppf_29.
-loop ( cesOut2cesIn(in2,in) $ (
-                    NOT ( ppf_29(in) AND in_complements(in))
-                    ),
-  p29_CESderivative(t,regi_dyn29(regi),out,ipf_29(in2))$(
-                                             p29_CESderivative(t,regi,out,in2) )
-  = 1;
-);
-
-*** Prices of perfect substitutes factors are all 1
-p29_CESderivative(t,regi_dyn29(regi),out,ppf_29(in2))$(
-                     p29_CESderivative(t,regi,out,in2) AND in_complements(in2) )
-  = 1;
-*** Price of inco is 1, too
-p29_cesdata_load(t,regi_dyn29(regi),"inco","price") = 1;   !! unit price
-
-*** Transfer prices
-
-pm_cesdata(t,regi_dyn29(regi), in, "price") =
- p29_CESderivative(t,regi,"inco",in);
-
-option
-  p29_CESderivative:3:3:1
-  pm_cesdata:3:3:1
-;
-
-*** The calibration of elasticities of substitution takes
-*** much longer to converge if it starts from a high elasticity of
-*** substitution. To avoid this situation, the price of the capital stock
-*** is increased
-if (%c_CES_calibration_iteration% eq 1,
- loop (cesOut2cesIn(out,in)$(pm_cesdata_sigma("2015",out) eq -1 AND ppfKap(in) AND in_29(in)),
-       pm_cesdata(t,regi,in,"price") = pm_cesdata(t,regi,in,"price") *1.3;
-       );
-);
-
-display "derivatives", p29_CESderivative, p29_effGr, p29_cesIO_load;
-
-*** Write prices to file and abort, to use them in calibration with differing
-*** CES structure
-$ifthen.write_prices %c_CES_calibration_write_prices% == "1"
-file file_pm_cesdata_price /"pm_cesdata_price"/;
-
-file_pm_cesdata_price.lw =  0;
-file_pm_cesdata_price.nw = 20;
-file_pm_cesdata_price.nd = 15;
-
-put file_pm_cesdata_price;
-
-loop ((ttot,regi_dyn29(regi),ppf_29(in)),
-  if (ttot.val ge 2005 AND p29_cesdata_load(ttot,regi,in,"price") gt 0,
-    put p29_cesdata_load.tn(ttot,regi,in,"price"), " = ";
-    put p29_cesdata_load(ttot,regi,in,"price"), ";" /;
+  !! Propagate price down the CES tree
+  loop ((cesLevel2cesIO(counter,in),ces_29(in,in2),ces2_29(in2,in3)),
+      p29_CESderivative(t,regi_dyn29(regi),"inco",in3)
+      = p29_CESderivative(t,regi,"inco",in2)
+      * p29_CESderivative(t,regi,in2,in3);
   );
-);
 
-putclose file_pm_cesdata_price;
 
-abort "wrote pm_cesdata_price as by c_CES_calibration_write_prices setting" ;
+  !! Prices of intermediate production factors are all 1, except on the level 
+  !! above the perfect substitutes if they are ppf_29.
+  loop ( cesOut2cesIn(in2,in) $ (
+                      NOT ( ppf_29(in) AND in_complements(in))
+                      ),
+    p29_CESderivative(t,regi_dyn29(regi),out,ipf_29(in2))$(
+                                              p29_CESderivative(t,regi,out,in2) )
+    = 1;
+  );
+
+  !! Prices of perfect substitutes factors are all 1
+  p29_CESderivative(t,regi_dyn29(regi),out,ppf_29(in2))$(
+                      p29_CESderivative(t,regi,out,in2) AND in_complements(in2) )
+    = 1;
+  !! Price of inco is 1, too
+  p29_cesdata_load(t,regi_dyn29(regi),"inco","price") = 1;   !! unit price
+
+  !! Transfer prices
+
+  pm_cesdata(t,regi_dyn29(regi), in, "price") =
+  p29_CESderivative(t,regi,"inco",in);
+
+  option
+    p29_CESderivative:3:3:1
+    pm_cesdata:3:3:1
+  ;
+
+  !! The calibration of elasticities of substitution takes
+  !! much longer to converge if it starts from a high elasticity of
+  !! substitution. To avoid this situation, the price of the capital stock
+  !! is increased
+  if (sm_CES_calibration_iteration eq 1,
+    loop (cesOut2cesIn(out,in)$(pm_cesdata_sigma("2015",out) eq -1 AND ppfKap(in) AND in_29(in)),
+        pm_cesdata(t,regi,in,"price") = pm_cesdata(t,regi,in,"price") *1.3;
+    );
+  );
+
+  display "derivatives", p29_CESderivative, p29_effGr, p29_cesIO_load;
+
+  !! Write prices to file and abort, to use them in calibration with differing
+  !! CES structure
+$ifthen.write_prices %c_CES_calibration_write_prices% == "1"
+  file file_pm_cesdata_price /"pm_cesdata_price"/;
+
+  file_pm_cesdata_price.lw =  0;
+  file_pm_cesdata_price.nw = 20;
+  file_pm_cesdata_price.nd = 15;
+
+  put file_pm_cesdata_price;
+
+  loop ((ttot,regi_dyn29(regi),ppf_29(in)),
+    if (ttot.val ge 2005 AND p29_cesdata_load(ttot,regi,in,"price") gt 0,
+      put p29_cesdata_load.tn(ttot,regi,in,"price"), " = ";
+      put p29_cesdata_load(ttot,regi,in,"price"), ";" /;
+    );
+  );
+
+  putclose file_pm_cesdata_price;
+
+  abort "wrote pm_cesdata_price as by c_CES_calibration_write_prices setting" ;
 $endif.write_prices
 
-$endif.get_prices
+)
 
 *** Check if all ppf prices are > 0
 if (smin((t,regi_dyn29(regi),ppf_29(in)), pm_cesdata(t,regi,in,"price")) le 0,
@@ -172,7 +159,7 @@ if (smin((t,regi_dyn29(regi),ppf_29(in)), pm_cesdata(t,regi,in,"price")) le 0,
 
 
 
-if (%c_CES_calibration_iteration% eq 1, !! first CES calibration iteration
+if (sm_CES_calibration_iteration eq 1, !! first CES calibration iteration
   put file_CES_calibration;
 
   loop ((t,regi_dyn29(regi),in)$(    ppf_29(in) 
@@ -467,7 +454,7 @@ pm_cesdata(t_29,regi_dyn29(regi),in,"quantity") $ putty_compute_in(in)
 
 
 
-if (%c_CES_calibration_iteration% eq 1, !! first CES calibration iteration
+if (sm_CES_calibration_iteration eq 1, !! first CES calibration iteration
   put file_CES_calibration;
 
   loop ((t,regi_dyn29(regi),in)$(    ppf_29(in) 
@@ -884,92 +871,91 @@ display " end consistency", pm_cesdata;
 if (card(ppf_beyondcalib_29) >= 1,
   Display "  before computing xi in beyond", pm_cesdata;
 
-!! if "load", prices have already been loaded
-$ifthen.prices_beyond NOT %c_CES_calibration_prices% == "load"
+  !! if prices haven't already been loaded
+  if (sm_CES_calibration_iteration > 1 or s29_CES_calibration_new_structure eq 1,
 
-  !! Compute ppf prices from CES derivatives of previous run
-  p29_CESderivative(t,regi_dyn29(regi),cesOut2cesIn(out,in))$(
-                                                     p29_cesIO_load(t,regi,in) )
-    = p29_cesdata_load(t,regi,in,"xi")
-    * p29_cesdata_load(t,regi,in,"eff")
-    * p29_effGr(t,regi,in)
+    !! Compute ppf prices from CES derivatives of previous run
+    p29_CESderivative(t,regi_dyn29(regi),cesOut2cesIn(out,in))$(
+                                                      p29_cesIO_load(t,regi,in) )
+      = p29_cesdata_load(t,regi,in,"xi")
+      * p29_cesdata_load(t,regi,in,"eff")
+      * p29_effGr(t,regi,in)
 
-    * ( p29_cesIO_load(t,regi,out)$( NOT ipf_putty(out) )
-      + p29_cesIOdelta_load(t,regi,out)$( ipf_putty(out) )
-      )
-   ** (1 - p29_cesdata_load(t,regi,out,"rho"))
+      * ( p29_cesIO_load(t,regi,out)$( NOT ipf_putty(out) )
+        + p29_cesIOdelta_load(t,regi,out)$( ipf_putty(out) )
+        )
+      ** (1 - p29_cesdata_load(t,regi,out,"rho"))
 
-   * exp(
-	  log(
-		p29_cesdata_load(t,regi,in,"eff")
-		* p29_effGr(t,regi,in)
-		* ( p29_cesIO_load(t,regi,in)$( NOT ipf_putty(out))
-			+ p29_cesIOdelta_load(t,regi,in)$( ipf_putty(out))
-		  )
-		)
-		* (p29_cesdata_load(t,regi,out,"rho") - 1));
+      * exp(
+        log(
+        p29_cesdata_load(t,regi,in,"eff")
+        * p29_effGr(t,regi,in)
+        * ( p29_cesIO_load(t,regi,in)$( NOT ipf_putty(out))
+          + p29_cesIOdelta_load(t,regi,in)$( ipf_putty(out))
+          )
+        )
+        * (p29_cesdata_load(t,regi,out,"rho") - 1));
 
-  !! Propagate price down the CES tree
-  loop ((cesLevel2cesIO(counter,in),cesOut2cesIn(in,in2),cesOut2cesIn2(in2,in3)),
-    p29_CESderivative(t,regi_dyn29(regi),"inco",in3)
-    = p29_CESderivative(t,regi,"inco",in2)
-    * p29_CESderivative(t,regi,in2,in3);
-  );
+    !! Propagate price down the CES tree
+    loop ((cesLevel2cesIO(counter,in),cesOut2cesIn(in,in2),cesOut2cesIn2(in2,in3)),
+      p29_CESderivative(t,regi_dyn29(regi),"inco",in3)
+      = p29_CESderivative(t,regi,"inco",in2)
+      * p29_CESderivative(t,regi,in2,in3);
+    );
 
-  
-  !! Prices of intermediate production factors are all 1, except on the level
-  !! above the perfect substitutes if they are ppf_29
-  loop (cesOut2cesIn(in2,in)$(
-                          NOT (ppf_beyondcalib_29(in) AND in_complements(in)) ),
-    p29_CESderivative(t,regi_dyn29(regi),out,ipf_beyond_29_excludeRoot(in2))$(
-                                             p29_CESderivative(t,regi,out,in2) )
+    
+    !! Prices of intermediate production factors are all 1, except on the level
+    !! above the perfect substitutes if they are ppf_29
+    loop (cesOut2cesIn(in2,in)$(
+                            NOT (ppf_beyondcalib_29(in) AND in_complements(in)) ),
+      p29_CESderivative(t,regi_dyn29(regi),out,ipf_beyond_29_excludeRoot(in2))$(
+                                              p29_CESderivative(t,regi,out,in2) )
+      = 1;
+    );
+
+    !!  Prices of perfect substitutes factors are all 1
+    p29_CESderivative(t,regi_dyn29(regi),out,ppf_beyondcalib_29(in2))$(
+                      p29_CESderivative(t,regi,out,in2) AND in_complements(in2) )
     = 1;
-  );
 
-  !!  Prices of perfect substitutes factors are all 1
-  p29_CESderivative(t,regi_dyn29(regi),out,ppf_beyondcalib_29(in2))$(
-                     p29_CESderivative(t,regi,out,in2) AND in_complements(in2) )
-  = 1;
+    display "check p29_CESderivative", p29_CESderivative;
 
-  display "check p29_CESderivative", p29_CESderivative;
-
-  loop ((regi_dyn29(regi),
-         cesOut2cesIn(out,in_beyond_calib_29_excludeRoot(in))),
-    pm_cesdata(t,regi,in,"price")
-    = p29_CESderivative(t,regi,out,in);
-  );
+    loop ((regi_dyn29(regi),
+          cesOut2cesIn(out,in_beyond_calib_29_excludeRoot(in))),
+      pm_cesdata(t,regi,in,"price")
+      = p29_CESderivative(t,regi,out,in);
+    );
 
 $ifthen.subsectors "%industry%" == "subsectors"
 $ifthen.FE_target "%c_CES_calibration_industry_FE_target%" == "1" !! c_CES_calibration_industry_FE_target
-  !! set minimum price on ppf_industry
-  pm_cesdata(t,regi_dyn29(regi),ppf_industry_dyn37(in),"price")
-  = max(pm_cesdata(t,regi,in,"price"), 1e-5);
+    !! set minimum price on ppf_industry
+    pm_cesdata(t,regi_dyn29(regi),ppf_industry_dyn37(in),"price")
+    = max(pm_cesdata(t,regi,in,"price"), 1e-5);
 $endif.FE_target
 $endif.subsectors
 
-  !! smooth historical prices
-  pm_cesdata(t_29hist(t),regi_dyn29(regi),in,"price")$(
-                                            in_beyond_calib_29_excludeRoot(in) )
-  = (0.25 * pm_cesdata(t,regi,in,"price"))
-  + ( 0.75
-    * sum(t_29hist2(t2), pm_cesdata(t2,regi,in,"price"))
-    / card(t_29hist2)
-    );
+    !! smooth historical prices
+    pm_cesdata(t_29hist(t),regi_dyn29(regi),in,"price")$(
+                                              in_beyond_calib_29_excludeRoot(in) )
+    = (0.25 * pm_cesdata(t,regi,in,"price"))
+    + ( 0.75
+      * sum(t_29hist2(t2), pm_cesdata(t2,regi,in,"price"))
+      / card(t_29hist2)
+      );
 
-$else.prices_beyond
+  else
+    !! complements are not treated in the first iteration
+    pm_cesdata(t,regi,ipf_beyond_29(in),"price")$( NOT ue_industry_dyn37(in) )
+    = 1;
 
-  pm_cesdata(t,regi,ipf_beyond_29(in),"price")$( NOT ue_industry_dyn37(in) )
-  = 1;
-  !! complements are not treated in the first iteration
-
-$endif.prices_beyond
+  );
 
   !! The calibration of elasticities of substitution takes much longer to 
   !! converge if it starts from a high elasticity of substitution. To avoid
   !! this situation, the price of the capital stock is increased.
-  if (%c_CES_calibration_iteration% eq 1,
+  if (sm_CES_calibration_iteration eq 1,
     loop (cesOut2cesIn(out,in_beyond_calib_29_excludeRoot(ppfKap(in)))$(
-                                           pm_cesdata_sigma("2015",out) eq -1 ),
+                                            pm_cesdata_sigma("2015",out) eq -1 ),
       pm_cesdata(t,regi,in,"price")
       = pm_cesdata(t,regi,in,"price")
       * 5;
@@ -984,17 +970,17 @@ $endif.prices_beyond
                         AND (t.val eq 2005 OR t.val eq 2050 OR t.val eq 2100)
                         AND pm_cesdata_sigma(t,out) eq -1                     ),
 
-$ifthen.repEsubs  %c_CES_calibration_prices% == "load"
-    put "%c_CES_calibration_iteration%", "remind", t.tl, in.tl ;
-    put "price_Noscale", regi.tl, pm_cesdata(t,regi,in,"price") /;
-    put "%c_CES_calibration_iteration%", "remind", t.tl, in2.tl;
-    put "price_Noscale", regi.tl, pm_cesdata(t,regi,in2,"price") /;
-$else.repEsubs
-    put "%c_CES_calibration_iteration%", "remind", t.tl, in.tl;
-    put "price_Noscale", regi.tl, p29_CESderivative(t,regi,"inco",in) /;
-    put "%c_CES_calibration_iteration%", "remind", t.tl, in2.tl;
-    put "price_Noscale", regi.tl, p29_CESderivative(t,regi,"inco",in2) /;
-$endif.repEsubs
+    if (sm_CES_calibration_iteration eq 1 and s29_CES_calibration_new_structure eq 1,
+      put sm_CES_calibration_iteration, "remind", t.tl, in.tl ;
+      put "price_Noscale", regi.tl, pm_cesdata(t,regi,in,"price") /;
+      put sm_CES_calibration_iteration, "remind", t.tl, in2.tl;
+      put "price_Noscale", regi.tl, pm_cesdata(t,regi,in2,"price") /;
+    else
+      put sm_CES_calibration_iteration, "remind", t.tl, in.tl;
+      put "price_Noscale", regi.tl, p29_CESderivative(t,regi,"inco",in) /;
+      put sm_CES_calibration_iteration, "remind", t.tl, in2.tl;
+      put "price_Noscale", regi.tl, p29_CESderivative(t,regi,"inco",in2) /;
+    );
   );
   putclose;
 
@@ -1480,30 +1466,30 @@ loop ((out,in,in2,t)$((pm_cesdata_sigma(t,out) eq -1)
                                     AND (sameAs(t, "2015") OR sameAs(t, "2050") OR sameAs(t, "2100"))) ,
 
        if ( sameAs(t,"2015"),
-           put "%c_CES_calibration_iteration%", "remind" ,"2015", out.tl   , "output_scale", regi.tl, p29_output_estimation(regi,out) /;
+           put sm_CES_calibration_iteration, "remind" ,"2015", out.tl   , "output_scale", regi.tl, p29_output_estimation(regi,out) /;
        );
 
-       put "%c_CES_calibration_iteration%", "remind" , t.tl, out.tl   , "quantity", regi.tl, ( pm_cesdata(t,regi,out,"quantity") $ ( NOT ipf_putty(out)) + pm_cesdata_putty(t,regi,out,"quantity") $ ( ipf_putty(out))) /;
-       put "%c_CES_calibration_iteration%", "remind" , t.tl, in.tl , "quantity", regi.tl, ( pm_cesdata(t,regi,in,"quantity") $ ( NOT ipf_putty(out)) + pm_cesdata_putty(t,regi,in,"quantity") $ ( ipf_putty(out))) /;
-       put "%c_CES_calibration_iteration%", "remind" , t.tl, in2.tl  , "quantity", regi.tl, ( pm_cesdata(t,regi,in2,"quantity") $ ( NOT ipf_putty(out)) + pm_cesdata_putty(t,regi,in2,"quantity") $ ( ipf_putty(out))) /;
+       put sm_CES_calibration_iteration, "remind" , t.tl, out.tl   , "quantity", regi.tl, ( pm_cesdata(t,regi,out,"quantity") $ ( NOT ipf_putty(out)) + pm_cesdata_putty(t,regi,out,"quantity") $ ( ipf_putty(out))) /;
+       put sm_CES_calibration_iteration, "remind" , t.tl, in.tl , "quantity", regi.tl, ( pm_cesdata(t,regi,in,"quantity") $ ( NOT ipf_putty(out)) + pm_cesdata_putty(t,regi,in,"quantity") $ ( ipf_putty(out))) /;
+       put sm_CES_calibration_iteration, "remind" , t.tl, in2.tl  , "quantity", regi.tl, ( pm_cesdata(t,regi,in2,"quantity") $ ( NOT ipf_putty(out)) + pm_cesdata_putty(t,regi,in2,"quantity") $ ( ipf_putty(out))) /;
 
-       put "%c_CES_calibration_iteration%","remind" , t.tl, in.tl , "eff", regi.tl, pm_cesdata(t,regi,in,"eff") /;
-       put "%c_CES_calibration_iteration%","remind" , t.tl, in2.tl  , "eff", regi.tl, pm_cesdata(t,regi,in2,"eff") /;
+       put sm_CES_calibration_iteration,"remind" , t.tl, in.tl , "eff", regi.tl, pm_cesdata(t,regi,in,"eff") /;
+       put sm_CES_calibration_iteration,"remind" , t.tl, in2.tl  , "eff", regi.tl, pm_cesdata(t,regi,in2,"eff") /;
 
-       put "%c_CES_calibration_iteration%","remind" , t.tl, in.tl , "effGr", regi.tl, pm_cesdata(t,regi,in,"effGr") /;
-       put "%c_CES_calibration_iteration%","remind" , t.tl, in2.tl  , "effGr", regi.tl, pm_cesdata(t,regi,in2,"effGr") /;
+       put sm_CES_calibration_iteration,"remind" , t.tl, in.tl , "effGr", regi.tl, pm_cesdata(t,regi,in,"effGr") /;
+       put sm_CES_calibration_iteration,"remind" , t.tl, in2.tl  , "effGr", regi.tl, pm_cesdata(t,regi,in2,"effGr") /;
 
-       put "%c_CES_calibration_iteration%","remind" , t.tl, in.tl , "xi", regi.tl, pm_cesdata(t,regi,in,"xi") /;
-       put "%c_CES_calibration_iteration%","remind" , t.tl, in2.tl  , "xi", regi.tl, pm_cesdata(t,regi,in2,"xi") /;
+       put sm_CES_calibration_iteration,"remind" , t.tl, in.tl , "xi", regi.tl, pm_cesdata(t,regi,in,"xi") /;
+       put sm_CES_calibration_iteration,"remind" , t.tl, in2.tl  , "xi", regi.tl, pm_cesdata(t,regi,in2,"xi") /;
 
-       put "%c_CES_calibration_iteration%","remind" , t.tl, in.tl , "price", regi.tl, pm_cesdata(t,regi,in,"price") /;
-       put "%c_CES_calibration_iteration%","remind" , t.tl, in2.tl  , "price", regi.tl, pm_cesdata(t,regi,in2,"price") /;
+       put sm_CES_calibration_iteration,"remind" , t.tl, in.tl , "price", regi.tl, pm_cesdata(t,regi,in,"price") /;
+       put sm_CES_calibration_iteration,"remind" , t.tl, in2.tl  , "price", regi.tl, pm_cesdata(t,regi,in2,"price") /;
 
-       put "%c_CES_calibration_iteration%","remind" , t.tl,out.tl  , "rho", regi.tl, pm_cesdata(t,regi,out,"rho") /;
+       put sm_CES_calibration_iteration,"remind" , t.tl,out.tl  , "rho", regi.tl, pm_cesdata(t,regi,out,"rho") /;
        );
 
        loop ((index_Nr,in)$p29_capitalUnitProjections(regi, in, index_Nr),
-       put "%c_CES_calibration_iteration%",index_Nr.tl, "2015", in.tl , "quantity", regi.tl,  p29_capitalUnitProjections(regi,in,index_Nr) /;
+       put sm_CES_calibration_iteration,index_Nr.tl, "2015", in.tl , "quantity", regi.tl,  p29_capitalUnitProjections(regi,in,index_Nr) /;
        );
 );
 putclose;
@@ -1745,7 +1731,7 @@ putclose logfile;
 ***_____________________________ END OF CONSISTENCY CHECKS ________________________________________
 
 *** Add information on ppf_putty quantities which are not in ppf_29
-if (%c_CES_calibration_iteration% eq 1, !! first CES calibration iteration
+if (sm_CES_calibration_iteration eq 1,
   put file_CES_calibration;
 
   loop ((t,regi_dyn29(regi),in)$(( NOT ppf_29(in)) AND ppf_putty(in)),

--- a/modules/29_CES_parameters/load/not_used.txt
+++ b/modules/29_CES_parameters/load/not_used.txt
@@ -29,4 +29,4 @@ pm_ue_eff_target,parameter,not needed
 pm_calibrate_eff_scale,parameter,not needed
 pm_fedemand,parameter,not needed
 pm_energy_limit
-
+sm_CES_calibration_iteration,scalar,only applicable during calibration

--- a/modules/80_optimization/nash/solve.gms
+++ b/modules/80_optimization/nash/solve.gms
@@ -38,7 +38,7 @@ if (cm_keep_presolve_gdxes eq 1,
   logfile.nr = 1;
   logfile.nd = 0;
   put_utility logfile, "shell" /
-    "mv presolve_nash.gdx presolve_nash_" all_regi.tl "_CES-%c_CES_calibration_iteration%_Nash-" iteration.val "_Sol-" sol_itr.val ".gdx";
+    "mv presolve_nash.gdx presolve_nash_" all_regi.tl "_CES-" sm_CES_calibration_iteration "_Nash-" iteration.val "_Sol-" sol_itr.val ".gdx";
   logfile.nr = sm_tmp;
   logfile.nd = sm_tmp2;
 );

--- a/modules/80_optimization/negishi/not_used.txt
+++ b/modules/80_optimization/negishi/not_used.txt
@@ -58,3 +58,4 @@ vm_emiTe,                          variable,    ??
 vm_fuExtr,                         variable,    ??
 vm_perm,                           variable,    ???
 vm_prodPe,                         variable,    ??
+sm_CES_calibration_iteration,      scalar,      only needed during calibration which is not support in negishi mode

--- a/modules/80_optimization/testOneRegi/solve.gms
+++ b/modules/80_optimization/testOneRegi/solve.gms
@@ -36,7 +36,7 @@ if (cm_keep_presolve_gdxes eq 1,
   loop (regi,
     execute_unload "presolve_tOR.gdx";
     put_utility logfile, "shell" /
-      "mv presolve_tOR.gdx presolve_tOR_" regi.tl "_CES-%c_CES_calibration_iteration%_Nash-" iteration.val "_Sol-" sol_itr.val ".gdx";
+      "mv presolve_tOR.gdx presolve_tOR_" regi.tl "_CES-" sm_CES_calibration_iteration "_Nash-" iteration.val "_Sol-" sol_itr.val ".gdx";
   );
   logfile.nr = sm_tmp;
   logfile.nd = sm_tmp2;

--- a/scripts/start/prepare_and_run.R
+++ b/scripts/start/prepare_and_run.R
@@ -1017,8 +1017,8 @@ run <- function(start_subsequent_runs = TRUE) {
       cat("CES calibration iteration: ", cal_itr, "\n")
 
       # Update calibration iteration in GAMS file
-      system(paste0("sed -i 's/^\\(\\$setglobal c_CES_calibration_iteration ",
-                    "\\).*/\\1", cal_itr, "/' full.gms"))
+      system(paste0("sed -i 's#^sm_CES_calibration_iteration.*/\\d/#",
+                             "sm_CES_calibration_iteration /", cal_itr, "/#' full.gms"))
 
       system(paste0(cfg$gamsv, " full.gms -errmsg=1 -a=", cfg$action,
                     " -ps=0 -pw=185 -pc=2 -gdxcompress=1 -holdFixedAsync=1 -logoption=", cfg$logoption))

--- a/scripts/start/prepare_and_run.R
+++ b/scripts/start/prepare_and_run.R
@@ -1017,8 +1017,8 @@ run <- function(start_subsequent_runs = TRUE) {
       cat("CES calibration iteration: ", cal_itr, "\n")
 
       # Update calibration iteration in GAMS file
-      system(paste0("sed -i 's#^sm_CES_calibration_iteration.*/\\d/#",
-                             "sm_CES_calibration_iteration /", cal_itr, "/#' full.gms"))
+      system(paste0("sed -i -r 's#^(sm_CES_calibration_iteration\\s+.*)/[0-9]+/#",
+                    "\\1/", cal_itr, "/#' full.gms"))
 
       system(paste0(cfg$gamsv, " full.gms -errmsg=1 -a=", cfg$action,
                     " -ps=0 -pw=185 -pc=2 -gdxcompress=1 -holdFixedAsync=1 -logoption=", cfg$logoption))

--- a/standalone/MOFEX/MOFEX.gms
+++ b/standalone/MOFEX/MOFEX.gms
@@ -464,7 +464,6 @@ $setglobal cm_CES_configuration  indu_fixed_shares-buil_simple-tran_complex-POP_
 
 $setglobal c_CES_calibration_new_structure  0    !! def =  0
 $setglobal c_CES_calibration_iterations  10    !! def = 10
-$setglobal c_CES_calibration_iteration          1    !! def =  1
 $setglobal c_CES_calibration_write_prices  0    !! def =  0
 $setglobal cm_CES_calibration_default_prices  0.01    !! def = 0.01
 $setglobal cm_calibration_string  off      !! def = off

--- a/standalone/template.gms
+++ b/standalone/template.gms
@@ -309,7 +309,6 @@ $setglobal cm_CES_configuration  indu_fixed_shares-buil_simple-tran_complex-POP_
 
 $setglobal c_CES_calibration_new_structure  0    !! def =  0
 $setglobal c_CES_calibration_iterations  10   !! def = 10
-$setglobal c_CES_calibration_iteration        1    !! def =  1
 $setglobal c_CES_calibration_write_prices  0    !! def =  0
 $setglobal cm_CES_calibration_default_prices  0.01    !! def = 0.01
 

--- a/standalone/trade/trade.gms
+++ b/standalone/trade/trade.gms
@@ -469,7 +469,6 @@ $setglobal cm_CES_configuration  stat_off-indu_fixed_shares-buil_simple-tran_com
 
 $setglobal c_CES_calibration_new_structure  0    !! def =  0
 $setglobal c_CES_calibration_iterations  10    !! def = 10
-$setglobal c_CES_calibration_iteration          1    !! def =  1
 $setglobal c_CES_calibration_write_prices  0    !! def =  0
 $setglobal cm_CES_calibration_default_prices  0    !! def = 0
 $setglobal cm_calibration_string  off      !! def = off


### PR DESCRIPTION
# Purpose of this PR

After #1112 , calibration runs were broken because `c_CES_calibration_iteration` was a compile-time variable (`$setglobal`), but prepare_and_run tried to change it in `full.gms`. That used to work because `singleGAMSfile` didn't actually compile main.gms to write full.gms, but only evaluated compile-time variables internally to resolve `include`s and `batincludes`. After #1112, main.gms is fully compiled, which evaluates compile-time variables and replaces them by their value in full.gms. Therefore, it is not possible to replace `c_CES_calibration_iteration` in full.gms any more.

The solution for the problem in this PR is to convert `c_CES_calibration_iteration` to a scalar `sm_CES_calibration_iteration`, which is a run-time variable and thus will survive into full.gms. That unfortunately means I had to touch all places where this was used and convert them from compile-time code to run-time code, which is a bit tedious and bug-prone.

I also looked at an alternative way to solve this: converting the calibration loop in `run()` such that it would re-compile from main.gms for subsequent runs. However, this also introduces a lot of changes because then `submit()` has to be split into multiple parts such that only the relevant parts can be re-run, and potentially also reporting needs to be changed to find the results. I personally would find it more coherent if each calibration iteration would be `submit()`ted individually, one after each other, but that would mean individual output folders for each iteration (which would be the point, such that each iteration would be re-startable on its own) and therefore introduce even more changes all over the place. Therefore, I think converting `c_CES_calibration_iteration` is less invasive now.

I started a test calibration run in `/p/tmp/pflueger/remind/output/SSP2EU-AMT-calibrate_2022-12-20_15.17.19`

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [x] Changes are commented, particularly in hard-to-understand areas
- [x] I have updated the in-code documentation
- [ ] I have adjusted reporting where it was needed
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] Calibration runs deliver the expected output


