### PR TITLE
remove all the latestSnapshot and automatic searches from .snapshot.Rprofile

### DIFF
--- a/.snapshot.Rprofile
+++ b/.snapshot.Rprofile
@@ -4,13 +4,11 @@
 
 local({ # prevent variables defined here from ending up in the global env
 
-# snapshots created with R 4.1 have a _R4 postfix
-maybeR4 <- if (R.version$major == 4) "_R4" else ""
-# Gather all library snapshots
-snapshots <- sort(list.files(path = '/p/projects/rd3mod/R/libraries/snapshots',
-                             pattern = paste0('^20[0-9]{2}_[0-9]{2}(_[0-9]{2})?', maybeR4, '$'),
-                             full.names = TRUE), decreasing = TRUE)
-latestSnapshot <- if (length(snapshots) > 0) snapshots[[1]] else NA
+# Set the snapshot path to a path of your choice.
+# Snapshots must be compatible to the R version used. If you are using R 4.1
+# make sure the selected snapshot's name ends with '_R4'.
+
+snapshot <- "/p/projects/rd3mod/R/libraries/snapshots/2022_12_15_R4"
 
 activateSnapshot <- function(snapshot) {
   stopifnot(file.exists(snapshot))
@@ -25,35 +23,6 @@ activateSnapshot <- function(snapshot) {
   message("libPaths was set to: ", snapshot)
 }
 
-# Just uncomment the following line and set the snapshot path
-# to a path of your choice or use the second line to use the latest snapshot.
-# Please make also sure that in your config file this .Rprofile file is copied
-# to the model output folder. Otherwise, the run itself will again use the
-# default library set!
-# Snapshots must be compatible to the R version used. If you are using R 4.1
-# make sure the selected snapshot's name ends with '_R4'.
-
-# snapshot <- "/p/projects/rd3mod/R/libraries/snapshots/2022_05_31_R4"
-# snapshot <- latestSnapshot
-
-if (exists("snapshot")) {
-  activateSnapshot(snapshot)
-}
-
-# Check if the library folder is currently being updated and if so use latest daily or monthly snapshot.
-if (any(grepl("^00LOCK.*", list.files(.libPaths())))) {
-  lockFolders <- grep("^00LOCK.*", list.files(.libPaths()), value = TRUE)
-  badPackages <- gsub("^00LOCK-", "", lockFolders)
-
-  # Give user diagnosis
-  message("\nThe following lock folders were found in your libPaths:\n  ", lockFolders)
-  message("That means that the ", badPackages, " package(s) is(are) currently being updated.")
-  message("All packages will be loaded from the library's latest snapshot instead:\n  ", latestSnapshot)
-  message("(If the lock folder isn't deleted automatically in the next couple of minutes, ",
-          "that means the package failed to update/install and that the folder has to be removed manually!)")
-  message("To avoid this automatic choice, specify a snapshot in your .Rprofile instead.")
-
-  activateSnapshot(latestSnapshot)
-}
+activateSnapshot(snapshot)
 
 })


### PR DESCRIPTION
## Purpose of this PR

- avoid that people let the script find a suitable snapshot for them. Instead, you have to specify one yourself.
- the snapshots should only be used with coupled runs, and then you want stability, so no automatic searching for snapshots
- has created confusion already
- first wanted to use `2022_12_R4`, but this contains a broken variant of `piamenv` which creates fails. So using a newer snapshot.

## Type of change

- [x] minor change to reduce confusion and failing runs because of bad snapshots picked.

## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`).