### PR TITLE
Normalize iteration numbers in calibration reporting.

### DIFF
--- a/scripts/output/single/reportCEScalib.R
+++ b/scripts/output/single/reportCEScalib.R
@@ -100,6 +100,11 @@ if (file.exists(filename)) {
 
 in_set = readGDX(gdx, "in", "sets")
 
+# normalize iteration numbers, which are characters because they contain "origin" and "target" as well
+CES.cal.report$iteration <- coalesce(
+  CES.cal.report$iteration %>% as.double() %>% as.character(),
+  CES.cal.report$iteration)
+
 itr <- getColValues(CES.cal.report,"iteration")
 itr_num <- sort(as.double(setdiff(itr, c("origin","target"))))
 itr <- c("origin", "target", itr_num)


### PR DESCRIPTION
# Purpose of this PR

Fixes reportCEScalib by normalizing iteration numbers to a nice formatting, which is evidently necessary for later processing.

At the moment this still outputs a warning:
```
1: In CES.cal.report$iteration %>% as.double() %>% as.character() :
  NAs introduced by coercion
```
Can I formulate that differently to not get the warning?

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix 
- [ ] Refactoring
- [ ] New feature 
- [ ] Minor change (default scenarios show only small differences)
- [ ] Fundamental change
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [x] Changes are commented, particularly in hard-to-understand areas
- [ ] I have updated the in-code documentation
- [x] I have adjusted reporting where it was needed
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)
