### PR TITLE
bugfix on KWTCint damages

### DIFF
--- a/modules/50_damages/KWTCint/datainput.gms
+++ b/modules/50_damages/KWTCint/datainput.gms
@@ -24,7 +24,7 @@ p50_damageFuncCoefTC0(isoTC) = 0;
 p50_damageFuncCoefTC1(isoTC) = 0;
 
 *** load TC damage parameter data
-parameter f50_TCconst(isoTC,all_TCpers,all_TCspec)	"damage parameter constant"
+parameter f50_TCconst(iso,all_TCpers,all_TCspec)	"damage parameter constant"
 /
 $ondelim
 $include "./modules/50_damages/KWTCint/input/f50_TC_df_const.cs4r"
@@ -32,7 +32,7 @@ $offdelim
 /
 ;
 
-parameter f50_TCtasK(isoTC,all_TCpers,all_TCspec)	"damage parameter, linear with temperature"
+parameter f50_TCtasK(iso,all_TCpers,all_TCspec)	"damage parameter, linear with temperature"
 /
 $ondelim
 $include "./modules/50_damages/KWTCint/input/f50_TC_df_tasK.cs4r"
@@ -58,7 +58,7 @@ $ondelim
 $include "./modules/50_damages/KWTCint/input/f50_gdp.cs3r"
 $offdelim
 ;
-pm_GDPfrac(tall,iso) = f50_countryGDP(tall,iso,"gdp_SSP2EU")/1000000/sum(regi2iso(regi,iso),pm_gdp(tall,regi)/pm_shPPPMER(regi));
+pm_GDPfrac(ttot,iso)$(ttot.val ge 2005) = f50_countryGDP(ttot,iso,"gdp_SSP2EU")/1000000/sum(regi2iso(regi,iso),pm_gdp(ttot,regi)/pm_shPPPMER(regi));
 loop(ttot$(ttot.val ge 2005),
 	loop(tall$(pm_tall_2_ttot(tall,ttot)),
 		pm_GDPfrac(tall,iso) = 

--- a/modules/50_damages/KWTCint/postsolve.gms
+++ b/modules/50_damages/KWTCint/postsolve.gms
@@ -50,7 +50,7 @@ pm_damageTC(tall,isoTC)$(tall.val ge 2020 and tall.val le 2300) =
 display pm_damageTC;
 
 *combined regional damage
-pm_damage(tall,regi)$(tall.val ge 2000 and tall.val le 2300) = 
+pm_damage(tall,regi)$(tall.val ge 2005 and tall.val le 2300) = 
     pm_damageProd(tall,regi)*sum(regi2iso(regi,iso),pm_damageTC(tall,iso)*pm_GDPfrac(tall,iso))
 ;
 


### PR DESCRIPTION
# Purpose of this PR
Fixes a domain and a division by zero error in `50_damages/KWTCint` when it was activated

## Type of change

- [x] Bug fix 
## Checklist:

- [X] My code follows the coding etiquette
- [X] I have performed a self-review of my own code
- [X] Changes are commented, particularly in hard-to-understand areas
- [X] I have updated the in-code documentation
- [X] I have adjusted reporting where it was needed
- [] All automated model tests pass (`FAIL 0` in the output of `make test`)

## Further information (optional):

There was a change in the input data generation where the tropical cyclone damage parameters (`f50_TC_df_tasK` etc) used to be defined only for the countries where these damages happen (set `isoTC`), and now they are defined for all countries (`iso`), with zeroes in countries where they don't apply. This caused a domain violation when trying to read them just in `isoTC`.

This PR changes the set used on reading, and also limits the calculation of `pm_GDPfrac` from `tall` to `ttot` after 2005 to prevent divisions by zero. The years in between timesteps are filled by interpolation in a later step anyway.



* Test runs are here: 
`/p/projects/piam/abrahao/runs_gcsf/phase2_dec/remind/output/SSP2-NDC_2023-01-05_15.37.09`


