### PR TITLE
search for mifs and gdx if output script needs mif

### DIFF
--- a/output.R
+++ b/output.R
@@ -89,12 +89,17 @@ if (! exists("output")) {
 
 # Select output directories if not defined by readArgs
 if (! exists("outputdir")) {
+  modulesNeedingMif <- c("compareScenarios2", "xlsx_IIASA", "policyCosts", "Ariadne_output",
+                         "plot_compare_iterations", "varListHtml")
+  needingMif <- any(modulesNeedingMif %in% output)
   dir_folder <- if (exists("remind_dir")) remind_dir else "./output"
   dirs <- basename(dirname(Sys.glob(file.path(dir_folder, "*", "fulldata.gdx"))))
+  if (needingMif) dirs <- intersect(dirs, unique(basename(dirname(Sys.glob(file.path(dir_folder, "*", "REMIND_generic_*.mif"))))))
   names(dirs) <- stringr::str_extract(dirs, "rem-[0-9]+$")
   names(dirs)[is.na(names(dirs))] <- ""
   selectedDirs <- chooseFromList(dirs, type = "runs to be used for output generation",
-                    userinfo = if ("policyCosts" %in% output) "The reference run will be selected separately!" else NULL,
+                    userinfo = paste0(if ("policyCosts" %in% output) "The reference run will be selected separately! " else NULL,
+                                      if (needingMif) "Do you miss a run? Check if .mif exists and rerun reporting. " else NULL),
                     returnBoolean = FALSE, multiple = TRUE)
   outputdirs <- file.path("output", selectedDirs)
   if ("policyCosts" %in% output) {

--- a/scripts/output/comparison/policyCosts.R
+++ b/scripts/output/comparison/policyCosts.R
@@ -65,12 +65,11 @@ policy_costs_pdf <- function(policy_costs,
                  "<<echo=false>>=",
                  "options(width=110)",
                  "@")
-
+  tmpfolder <- paste0("tmp_", gsub("[\\. ]*", "", basename(fileName)))
   # Create temporary folder in which to create the policyCost pdf
-  system("mkdir tmp_policyCost")
-
+  dir.create(tmpfolder)
   # Open stream in tmp_folder
-  sw <- lusweave::swopen(fileName, folder = "tmp_policyCost", template = template)
+  sw <- lusweave::swopen(fileName, folder = tmpfolder, template = template)
 
   # Write title
   lusweave::swlatex(sw,"\\section{Policy Costs}")
@@ -110,8 +109,8 @@ policy_costs_pdf <- function(policy_costs,
   lusweave::swclose(sw)
 
   # Copy pdf from tmp folder to remind folder and delete tmp folder
-  system(paste0("mv tmp_policyCost/",fileName," ."))
-  system("rm -r tmp_policyCost")
+  system(paste0("mv ", file.path(tmpfolder, fileName), " ."))
+  system(paste0("rm -r ", tmpfolder))
 
 }
 


### PR DESCRIPTION
## Purpose of this PR
- old: if starting `output.R` and selecting `compareScenarios2` or `policyCosts`, it offers you runs with a `fulldata.gdx` where the reporting `*.mif` is missing (for whatever reason) but then the scripts fail
- now: if a scripts needs the mif, only show runs where both fulldata.gdx and mif file exists
- in `policyCosts`, avoid that two running scripts simultaneously operate on the same tmp folder

## Type of change

- [x] Bug fix 
- [x] Refactoring

## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
