### PR TITLE
restrict readCheckScenarioConfig test to git files

### DIFF
--- a/tests/testthat/test_01-readCheckScenarioConfig.R
+++ b/tests/testthat/test_01-readCheckScenarioConfig.R
@@ -1,5 +1,8 @@
-csvfiles <- Sys.glob(c(file.path("../../config/scenario_config*.csv"),
-                       file.path("../../config", "*", "scenario_config*.csv")))
+csvfiles <- system("git ls-files ../../config/scenario_config*.csv ../../config/*/scenario_config*.csv", intern = TRUE)
+if (length(csvfiles) == 0) {
+  csvfiles <- Sys.glob(c(file.path("../../config/scenario_config*.csv"),
+                         file.path("../../config", "*", "scenario_config*.csv")))
+}
 for (csvfile in csvfiles) {
   # This is a new test and we currently still have errors. Let's fix them ASAP.
   if (csvfile %in% c(


### PR DESCRIPTION
## Purpose of this PR
- avoid that people get annoyed to fix some old files lingering around in their folder
- the check will still fail/warn of course if they dare to use them

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
