### PR TITLE
improve warnings in readCheckScenarioConfig

### DIFF
--- a/scripts/start/readCheckScenarioConfig.R
+++ b/scripts/start/readCheckScenarioConfig.R
@@ -76,13 +76,17 @@ readCheckScenarioConfig <- function(filename, remindPath = ".", testmode = FALSE
        "cm_BioImportTax_EU" = "Use more flexible cm_import_tax switch instead, see https://github.com/remindmodel/remind/issues/1157"
      )
     for (i in intersect(names(forbiddenColumnNames), unknownColumnNames)) {
-      message("Column name ", i, " in remind settings is outdated. ", forbiddenColumnNames[i])
+      if (testmode) {
+        warning("Column name ", i, " in remind settings is outdated. ", forbiddenColumnNames[i])
+      } else {
+        message("Column name ", i, " in remind settings is outdated. ", forbiddenColumnNames[i])
+      }
     }
     if (any(names(forbiddenColumnNames) %in% unknownColumnNames)) {
       warning("Outdated column names found that must not be used.")
       errorsfound <- errorsfound + length(intersect(names(forbiddenColumnNames), unknownColumnNames))
     }
   }
-  if (errorsfound > 0) stop(errorsfound, " errors found.")
+  if (errorsfound > 0) if (testmode) warning(errorsfound, " errors found.") else stop(errorsfound, " errors found.")
   return(scenConf)
 }

--- a/tests/testthat/test_01-readCheckScenarioConfig.R
+++ b/tests/testthat/test_01-readCheckScenarioConfig.R
@@ -28,8 +28,8 @@ test_that("readCheckScenarioConfig fails on error-loaden config", {
                "PBS;1;29",
                "glob;0;33"),
              con = csvfile, sep = "\n")
-  w <- capture_warnings(expect_error(readCheckScenarioConfig(csvfile, remindPath = "../../", testmode = TRUE),
-                                     "5 errors found"))
+  w <- capture_warnings(readCheckScenarioConfig(csvfile, remindPath = "../../", testmode = TRUE))
+  expect_match(w, "5 errors found", all = FALSE)
   expect_match(w, "These titles are too long", all = FALSE)
   expect_match(w, "These titles may be confused with regions", all = FALSE)
   expect_match(w, "These titles contain a dot", all = FALSE)


### PR DESCRIPTION
## Purpose of this PR

- any error that appeared was hiding all the warnings that contained actual useful information on how to fix the error. That is not that useful :)

## Type of change

- [x] Refactoring
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)