### PR TITLE
fix false positives on f04_IO_input/f04_IO_output in full.lst

### DIFF
--- a/modules/04_PE_FE_parameters/iea2014/datainput.gms
+++ b/modules/04_PE_FE_parameters/iea2014/datainput.gms
@@ -14,24 +14,17 @@ $offdelim
 /
 ;
 
-file diagnosis_f04_IO_input_negatives;
-if( smin( (t,regi,entyPe,entySe,te), f04_IO_input(t,regi,entyPe,entySe,te)) lt 0,
-  put_utility "msg" / "**""** input data problem: f04_IO_input has negative values that are overwritten to still allow model solving." ;
-  put_utility "msg" / "Check input data. More details in the file diagnosis_f04_input_negatives";
-  put diagnosis_f04_IO_input_negatives;
-  put "f04_IO_input has the following negative values that are overwritten by 0 in 04/iea2014/datainput.gms" //;
-  put "te", @15, "regi", @20, "value"//;
-  loop(t,
-    loop(regi,
-      loop(pe2se(entyPe,entySe,te),
-        if( f04_IO_input(t,regi,entyPe,entySe,te)  lt 0,
-          put te.tl, @ 15, regi.tl, @20, f04_IO_input(t,regi,entyPe,entySe,te):10:8 /;
-        );
-      );
+if (smin((t,regi,pe2se(entyPe,entySe,te)), f04_IO_input(t,regi,entyPe,entySe,te)) lt 0,
+  put_utility "msg" / "**""** input data problem: f04_IO_input has negative values that are overwritten";
+  put_utility "msg" / "**""** to still allow model solving. Check input data." /;
+  loop ((t,regi,pe2se(entyPe,entySe,te)),
+    if (f04_IO_input(t,regi,entyPe,entySe,te) lt 0,
+      put_utility "msg" /
+	f04_IO_input.tn(t,regi,entyPE,entySE,te), " = ",
+        f04_IO_input(t,regi,entyPe,entySe,te):10:8;
     );
   );
 );
-putclose diagnosis_f04_IO_input_negatives;
 *' overwrite negative values with 0 to allow the model to solve. In the mid-term, the input data/mapping needs to be improved to prevent negative values
 f04_IO_input(tall,regi,entyPe,entySe,te)$(f04_IO_input(tall,regi,entyPe,entySe,te) lt 0) = 0;
 
@@ -48,24 +41,17 @@ $offdelim
 /
 ;
 
-file diagnosis_f04_IO_output_negatives;
-if( smin( (t,regi,entyPe,entySe,te), f04_IO_output(t,regi,entyPe,entySe,te)) lt 0,
-  put_utility "msg" / "**""** input data problem: f04_IO_output has negative values that are overwritten to still allow model solving." ;
-  put_utility "msg" / "Check input data. More details in the file diagnosis_f04_IO_output_negatives";
-  put diagnosis_f04_IO_output_negatives;
-  put "f04_IO_output has the following negative values that are overwritten by 0 in 04/iea2014/datainput.gms" //;
-  put "te", @15, "regi", @20, "value"//;
-  loop(t,
-    loop(regi,
-      loop(pe2se(entyPe,entySe,te),
-        if( f04_IO_output(t,regi,entyPe,entySe,te)  lt 0,
-          put te.tl, @ 15, regi.tl, @20, f04_IO_output(t,regi,entyPe,entySe,te):10:8 /;
-        );
-      );
+if (smin((t,regi,pe2se(entyPe,entySe,te)), f04_IO_output(t,regi,entyPe,entySe,te)) lt 0,
+  put_utility "msg" / "**""** input data problem: f04_IO_output has negative values that are overwritten" /
+  put_utility "msg" / "**""** to still allow model solving. Check input data." /;
+  loop ((t,regi,pe2se(entyPe,entySe,te)),
+    if (f04_IO_output(t,regi,entyPe,entySe,te) lt 0,
+     put_utility "msg" /
+       f04_IO_output.tn(t,regi,entyPE,entySE, te), " = ",
+       f04_IO_output(t,regi,entyPe,entySe,te):10:8;
     );
   );
 );
-putclose diagnosis_f04_IO_output_negatives;
 
 *' overwrite negative values with 0 to allow the model to solve. In the mid-term, the input data/mapping needs to be improved to prevent negative values
 f04_IO_output(tall,regi,entyPe,entySe,te)$(f04_IO_output(tall,regi,entyPe,entySe,te) lt 0) = 0;


### PR DESCRIPTION
- [x] Bug fix 

## Checklist:

- [x] My code follows the coding etiquette
- [ ] I have performed a self-review of my own code
- [x] Changes are commented, particularly in hard-to-understand areas
- [x] I have updated the in-code documentation
- [x] I have adjusted reporting where it was needed
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)

Output changed to e.g.
```
f04_IO_output('2005','FRA','pecoal','segafos','coalgas') = -0.0021515
```