### PR TITLE
fail on whitespaces in path_gdx entries, restrict scenario titles to A-z0-9_-

### DIFF
--- a/scripts/start/configureCfg.R
+++ b/scripts/start/configureCfg.R
@@ -96,7 +96,7 @@ configureCfg <- function(icfg, iscen, iscenarios, isettings, verboseGamsCompile 
           # if the above has not created a path to a valid gdx, stop
           if (!file.exists(isettings[iscen, path_to_gdx])) {
             icfg$errorsfoundInConfigureCfg <- sum(icfg$errorsfoundInConfigureCfg, 1)
-            message(red, "Error", NC, ": Can't find a gdx specified as ", isettings[iscen, path_to_gdx], " in column ",
+            message(red, "Error", NC, ": Can't find a gdx specified as '", isettings[iscen, path_to_gdx], "' in column ",
                     path_to_gdx, ".\nPlease specify full path to gdx or name of output subfolder that contains a ",
                     "fulldata.gdx from a previous normally completed run.")
           }

--- a/scripts/start/readCheckScenarioConfig.R
+++ b/scripts/start/readCheckScenarioConfig.R
@@ -27,18 +27,27 @@ readCheckScenarioConfig <- function(filename, remindPath = ".", testmode = FALSE
             paste0(rownames(scenConf)[regionname], collapse = ", "),
             " – Titles with three capital letters or 'glob' may be confused with region names by magclass. Stopping now.")
   }
-  containsdot <- grep("\\.", rownames(scenConf))
+  containsdot <- grepl("\\.", rownames(scenConf))
   if (any(containsdot)) {
     warning("These titles contain a dot: ",
             paste0(rownames(scenConf)[containsdot], collapse = ", "),
             " – GAMS would not tolerate this, and quit working at a point where you least expect it. Stopping now.")
   }
+  whitespaceerrors <- 0
+  for (path_gdx in intersect(names(path_gdx_list), names(scenConf))) {
+    haswhitespace <- grepl(" ", scenConf[[path_gdx]])
+    if (any(haswhitespace)) {
+      warning("The ", path_gdx, " cells of these runs contain whitespaces: ", paste0(rownames(scenConf)[haswhitespace], collapse = ", "),
+              " – scripts will fail to find corresponding runs and gdx files. Stopping now.")
+      whitespaceerrors <- whitespaceerrors + sum(haswhitespace)
+    }
+  }
+  errorsfound <- sum(toolong) + sum(regionname) + sum(containsdot) + whitespaceerrors
   if ("path_gdx_ref" %in% names(scenConf) && ! "path_gdx_refpolicycost" %in% names(scenConf)) {
     scenConf$path_gdx_refpolicycost <- scenConf$path_gdx_ref
     message("In ", filename,
         ", no column path_gdx_refpolicycost for policy cost comparison found, using path_gdx_ref instead.")
   }
-  errorsfound <- sum(toolong) + sum(regionname) + sum(containsdot)
   scenConf[, names(path_gdx_list)[! names(path_gdx_list) %in% names(scenConf)]] <- NA
   knownColumnNames <- c(names(cfg$gms), names(path_gdx_list), "start", "output", "description", "model",
                         "regionmapping", "extramappings_historic", "inputRevision", "slurmConfig",
@@ -87,6 +96,6 @@ readCheckScenarioConfig <- function(filename, remindPath = ".", testmode = FALSE
       errorsfound <- errorsfound + length(intersect(names(forbiddenColumnNames), unknownColumnNames))
     }
   }
-  if (errorsfound > 0) if (testmode) warning(errorsfound, " errors found.") else stop(errorsfound, " errors found.")
+  if (errorsfound > 0) if (testmode) warning(errorsfound, " errors found.") else stop(errorsfound, " errors found, see explanation in warnings.")
   return(scenConf)
 }

--- a/scripts/start/readCheckScenarioConfig.R
+++ b/scripts/start/readCheckScenarioConfig.R
@@ -31,7 +31,8 @@ readCheckScenarioConfig <- function(filename, remindPath = ".", testmode = FALSE
   if (any(illegalchars)) {
     warning("These titles contain illegal characters: ",
             paste0(rownames(scenConf)[illegalchars], collapse = ", "),
-            " – Please use only letters, digits, '_' and '-' to avoid errors. Stopping now.")
+            " – Please use only letters, digits, '_' and '-' to avoid errors, not '",
+            gsub("[[:alnum:]_-]", "", paste(rownames(scenConf), collapse = "")), "'. Stopping now.")
   }
   whitespaceerrors <- 0
   for (path_gdx in intersect(names(path_gdx_list), names(scenConf))) {

--- a/scripts/start/readCheckScenarioConfig.R
+++ b/scripts/start/readCheckScenarioConfig.R
@@ -35,7 +35,7 @@ readCheckScenarioConfig <- function(filename, remindPath = ".", testmode = FALSE
   }
   whitespaceerrors <- 0
   for (path_gdx in intersect(names(path_gdx_list), names(scenConf))) {
-    haswhitespace <- grepl(" ", scenConf[[path_gdx]])
+    haswhitespace <- grepl("\\s", scenConf[[path_gdx]])
     if (any(haswhitespace)) {
       warning("The ", path_gdx, " cells of these runs contain whitespaces: ", paste0(rownames(scenConf)[haswhitespace], collapse = ", "),
               " – scripts will fail to find corresponding runs and gdx files. Stopping now.")

--- a/scripts/start/readCheckScenarioConfig.R
+++ b/scripts/start/readCheckScenarioConfig.R
@@ -27,11 +27,11 @@ readCheckScenarioConfig <- function(filename, remindPath = ".", testmode = FALSE
             paste0(rownames(scenConf)[regionname], collapse = ", "),
             " – Titles with three capital letters or 'glob' may be confused with region names by magclass. Stopping now.")
   }
-  containsdot <- grepl("\\.", rownames(scenConf))
-  if (any(containsdot)) {
-    warning("These titles contain a dot: ",
-            paste0(rownames(scenConf)[containsdot], collapse = ", "),
-            " – GAMS would not tolerate this, and quit working at a point where you least expect it. Stopping now.")
+  illegalchars <- grepl("[^[:alnum:]_-]", rownames(scenConf))
+  if (any(illegalchars)) {
+    warning("These titles contain illegal characters: ",
+            paste0(rownames(scenConf)[illegalchars], collapse = ", "),
+            " – Please use only [:alnum:]_- to avoid errors. Stopping now.")
   }
   whitespaceerrors <- 0
   for (path_gdx in intersect(names(path_gdx_list), names(scenConf))) {
@@ -42,7 +42,7 @@ readCheckScenarioConfig <- function(filename, remindPath = ".", testmode = FALSE
       whitespaceerrors <- whitespaceerrors + sum(haswhitespace)
     }
   }
-  errorsfound <- sum(toolong) + sum(regionname) + sum(containsdot) + whitespaceerrors
+  errorsfound <- sum(toolong) + sum(regionname) + sum(illegalchars) + whitespaceerrors
   if ("path_gdx_ref" %in% names(scenConf) && ! "path_gdx_refpolicycost" %in% names(scenConf)) {
     scenConf$path_gdx_refpolicycost <- scenConf$path_gdx_ref
     message("In ", filename,

--- a/scripts/start/readCheckScenarioConfig.R
+++ b/scripts/start/readCheckScenarioConfig.R
@@ -31,7 +31,7 @@ readCheckScenarioConfig <- function(filename, remindPath = ".", testmode = FALSE
   if (any(illegalchars)) {
     warning("These titles contain illegal characters: ",
             paste0(rownames(scenConf)[illegalchars], collapse = ", "),
-            " – Please use only [:alnum:]_- to avoid errors. Stopping now.")
+            " – Please use only letters, digits, '_' and '-' to avoid errors. Stopping now.")
   }
   whitespaceerrors <- 0
   for (path_gdx in intersect(names(path_gdx_list), names(scenConf))) {

--- a/start.R
+++ b/start.R
@@ -140,6 +140,7 @@ if (any(c("--reprepare", "--restart") %in% flags)) {
     filestomove <- c("abort.gdx" = "abort_beforeRestart.gdx",
                      "non_optimal.gdx" = "non_optimal_beforeRestart.gdx",
                      "log.txt" = "log_beforeRestart.txt",
+                     "full.lst" = "full_beforeRestart.lst",
                      if ("--reprepare" %in% flags) c("full.gms" = "full_beforeRestart.gms",
                                                      "fulldata.gdx" = "fulldata_beforeRestart.gdx")
                     )

--- a/tests/testthat/test_01-readCheckScenarioConfig.R
+++ b/tests/testthat/test_01-readCheckScenarioConfig.R
@@ -24,7 +24,7 @@ for (csvfile in csvfiles) {
 test_that("readCheckScenarioConfig fails on error-loaden config", {
   csvfile <- tempfile(pattern = "scenario_config_a", fileext = ".csv")
   writeLines(c(";start;c_budgetCO2;path_gdx;path_gdx_carbonprice",
-               "abc.loremipsumloremipsumloremipsumloremipsumloremipsumloremipsumloremipsumloremipsum_;0;33;;",
+               "abc.loremipsumloremipsum@lorem&ipsumloremipsumloremipsumloremipsumloremipsumloremipsum_;0;33;;",
                "PBS;1;29; whitespacebefore;whitespaceafter ",
                "glob;0;33; ;nobreakspace	tab"),
              con = csvfile, sep = "\n")
@@ -33,6 +33,7 @@ test_that("readCheckScenarioConfig fails on error-loaden config", {
   expect_match(w, "These titles are too long", all = FALSE)
   expect_match(w, "These titles may be confused with regions", all = FALSE)
   expect_match(w, "These titles contain illegal characters", all = FALSE)
+  expect_match(w, "\\.@&", all = FALSE)
   expect_match(w, "Outdated column names found that must not be used", all = FALSE)
   expect_match(w, "contain whitespaces", all = FALSE)
 })

--- a/tests/testthat/test_01-readCheckScenarioConfig.R
+++ b/tests/testthat/test_01-readCheckScenarioConfig.R
@@ -26,10 +26,10 @@ test_that("readCheckScenarioConfig fails on error-loaden config", {
   writeLines(c(";start;c_budgetCO2;path_gdx;path_gdx_carbonprice",
                "abc.loremipsumloremipsumloremipsumloremipsumloremipsumloremipsumloremipsumloremipsum_;0;33;;",
                "PBS;1;29; whitespacebefore;whitespaceafter ",
-               "glob;0;33; ;onlywhitespace"),
+               "glob;0;33; ;nobreakspace	tab"),
              con = csvfile, sep = "\n")
   w <- capture_warnings(readCheckScenarioConfig(csvfile, remindPath = "../../", testmode = TRUE))
-  expect_match(w, "8 errors found", all = FALSE)
+  expect_match(w, "9 errors found", all = FALSE)
   expect_match(w, "These titles are too long", all = FALSE)
   expect_match(w, "These titles may be confused with regions", all = FALSE)
   expect_match(w, "These titles contain a dot", all = FALSE)

--- a/tests/testthat/test_01-readCheckScenarioConfig.R
+++ b/tests/testthat/test_01-readCheckScenarioConfig.R
@@ -32,7 +32,7 @@ test_that("readCheckScenarioConfig fails on error-loaden config", {
   expect_match(w, "9 errors found", all = FALSE)
   expect_match(w, "These titles are too long", all = FALSE)
   expect_match(w, "These titles may be confused with regions", all = FALSE)
-  expect_match(w, "These titles contain a dot", all = FALSE)
+  expect_match(w, "These titles contain illegal characters", all = FALSE)
   expect_match(w, "Outdated column names found that must not be used", all = FALSE)
   expect_match(w, "contain whitespaces", all = FALSE)
 })

--- a/tests/testthat/test_01-readCheckScenarioConfig.R
+++ b/tests/testthat/test_01-readCheckScenarioConfig.R
@@ -23,15 +23,16 @@ for (csvfile in csvfiles) {
 }
 test_that("readCheckScenarioConfig fails on error-loaden config", {
   csvfile <- tempfile(pattern = "scenario_config_a", fileext = ".csv")
-  writeLines(c(";start;c_budgetCO2",
-               "abc.loremipsumloremipsumloremipsumloremipsumloremipsumloremipsumloremipsumloremipsum_;0;33",
-               "PBS;1;29",
-               "glob;0;33"),
+  writeLines(c(";start;c_budgetCO2;path_gdx;path_gdx_carbonprice",
+               "abc.loremipsumloremipsumloremipsumloremipsumloremipsumloremipsumloremipsumloremipsum_;0;33;;",
+               "PBS;1;29; whitespacebefore;whitespaceafter ",
+               "glob;0;33; ;onlywhitespace"),
              con = csvfile, sep = "\n")
   w <- capture_warnings(readCheckScenarioConfig(csvfile, remindPath = "../../", testmode = TRUE))
-  expect_match(w, "5 errors found", all = FALSE)
+  expect_match(w, "8 errors found", all = FALSE)
   expect_match(w, "These titles are too long", all = FALSE)
   expect_match(w, "These titles may be confused with regions", all = FALSE)
   expect_match(w, "These titles contain a dot", all = FALSE)
   expect_match(w, "Outdated column names found that must not be used", all = FALSE)
+  expect_match(w, "contain whitespaces", all = FALSE)
 })

--- a/tutorials/03_RunningBundleOfRuns.md
+++ b/tutorials/03_RunningBundleOfRuns.md
@@ -21,7 +21,7 @@ Example for a scenario_config of REMIND
 
 Those two columns are mandatory and usually placed at the beginning:
 
-* `title` labels that run. It contains a unique identifier for each run, which must not contain a `.` to avoid a GAMS failure. The more runs you will have, the more it will be important that you label them in a way such that you easily remember the specific settings you chose for this run.
+* `title` labels that run. It contains a unique identifier for each run that must only consist of letters, digits, `_` and `-`. The more runs you will have, the more it will be important that you label them in a way such that you easily remember the specific settings you chose for this run.
 * `start` can be used as a boolean switch that lets you choose whether or not you would like to start this run once you submit this config file to the modeling routine. It often makes sense to keep some runs in the csv file to remember their configurations for the next time although you do not want to run them now and therefore switch them off. You do this by setting `start` to 0. You can also write a group name in this cell, and by running `./start.R --interactive`, you can select this group to be started.
 
 Further columns are the configurations that you can choose for the specific runs.


### PR DESCRIPTION
## Purpose of this PR
- avoid that files are not found because you have some spurious ` ` behind the file name/run name.
- restrict scenario titles to letters, digits, `_` and `-`
- also make a backup of the the full.lst file while restarting as desired by Robert here: https://mattermost.pik-potsdam.de/rd3/pl/pepp7th6obfjugjhj69ybe6sby

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)