### PR TITLE
Residential and commercial floor space

### DIFF
--- a/modules/36_buildings/simple/datainput.gms
+++ b/modules/36_buildings/simple/datainput.gms
@@ -35,15 +35,17 @@ pm_cesdata_sigma(ttot,"enhgab")$ (ttot.val eq 2040) = 3;
 
 
 *** floor space demand for reporting
+
 Parameter
-p36_floorspace_scen(tall, all_regi, all_demScen) "floorspace, in buildings simple realization only used for reporting at the moment, not in optimization itself"
+p36_floorspace_scen(tall, all_regi, all_demScen, secBuild36) "floorspace, in buildings simple realization only used for reporting at the moment, not in optimization itself"
 /
 $ondelim
-$include "./modules/36_buildings/simple/input/p36_floorspace_scen.cs4r"
+$include "./modules/36_buildings/simple/input/f36_floorspace_scen.cs4r"
 $offdelim
 /
 ;
-p36_floorspace(ttot,regi) = p36_floorspace_scen(ttot,regi,"%cm_demScen%") * 1e-3; !! from million to billion m2
+p36_floorspace(ttot,regi,secBuild36) =
+  p36_floorspace_scen(ttot,regi,"%cm_demScen%",secBuild36) * 1e-3; !! from million to billion m2
 
 
 *** UE demand for reporting

--- a/modules/36_buildings/simple/declarations.gms
+++ b/modules/36_buildings/simple/declarations.gms
@@ -8,7 +8,7 @@
 
 Parameters
   p36_CESMkup(ttot,all_regi,all_in)        "parameter for those CES markup cost accounted as investment cost in the budget [trUSD/CES input]"
-  p36_floorspace(tall,all_regi)            "buildings floorspace, billion m2, in simple realization only used for reporting"
+  p36_floorspace(tall,all_regi,secBuild36) "buildings floorspace, billion m2, in simple realization only used for reporting"
   p36_uedemand_build(tall,all_regi,all_in) "useful energy demand in buildings in TWh/a, in simple realization only used for reporting"
 ;
 

--- a/modules/36_buildings/simple/input/files
+++ b/modules/36_buildings/simple/input/files
@@ -1,3 +1,3 @@
-p36_floorspace_scen.cs4r
+f36_floorspace_scen.cs4r
 f36_uedemand_build.cs4r
 f_fedemand_build.cs4r

--- a/modules/36_buildings/simple/sets.gms
+++ b/modules/36_buildings/simple/sets.gms
@@ -22,7 +22,16 @@ Sets
   /
 
   ppfen_buildings_dyn36(all_in)   "primary production factors energy - buildings"
-  / fesob, fehob, fegab, feh2b, feheb, feelcb, feelhpb, feelrhb /
+  /
+    fesob
+    fehob
+    fegab
+    feh2b
+    feheb
+    feelcb
+    feelhpb
+    feelrhb
+  /
 
   cal_ppf_buildings_dyn36(all_in)   "primary production factors for calibration - buildings"
  
@@ -56,21 +65,28 @@ Sets
   
   fe_tax_sub36(all_in,all_in)  "correspondence between tax and subsidy input data resolution and model sectoral resolution"
   /
-  fesob . fesob
-  fehob . fehob
-  fegab . fegab
-  feh2b . feh2b
-  feheb . feheb
-  feelb . (feelcb,feelhpb,feelrhb)
+    fesob . fesob
+    fehob . fehob
+    fegab . fegab
+    feh2b . feh2b
+    feheb . feheb
+    feelb . (feelcb,feelhpb,feelrhb)
   /
   
   ue_dyn36(all_in)  "useful energy items"
   //
 
- ppfen_MkupCost36(all_in)  "primary production factors in buildings on which CES mark-up cost can be levied that are counted as expenses in the macroeconomic budget equation"
+  ppfen_MkupCost36(all_in)  "primary production factors in buildings on which CES mark-up cost can be levied that are counted as expenses in the macroeconomic budget equation"
   /
-  feelhpb
-  feheb
+    feelhpb
+    feheb
+  /
+
+  secBuild36 "Buildings subsectors, only for floor space reporting"
+  /
+    buildings
+    residential
+    commercial
   /
 ;
 


### PR DESCRIPTION
# Purpose of this PR
If the input data allows, the parameter `p36_floorspace` now distinguishes reidential, commercial and total buildings. This parameter is not used in the optimisation but passed to [remind2](https://github.com/pik-piam/remind2/pull/379) to report sub-sectoral floor space.

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Minor change (default scenarios show only small differences)


## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [ ] Changes are commented, particularly in hard-to-understand areas
- [x] I have updated the in-code documentation
- [x] I have adjusted reporting where it was needed
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)

