### PR TITLE
clarify pull request template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,4 +1,4 @@
-# Purpose of this PR
+## Purpose of this PR
 
 
 ## Type of change
@@ -15,12 +15,12 @@
 
 ## Checklist:
 
-- [ ] My code follows the coding etiquette
-- [ ] I have performed a self-review of my own code
-- [ ] Changes are commented, particularly in hard-to-understand areas
-- [ ] I have updated the in-code documentation
-- [ ] I have adjusted reporting where it was needed
-- [ ] I have adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches  
+- [ ] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
+- [ ] I performed a self-review of my own code
+- [ ] I explained my changes within the PR, particularly in hard-to-understand areas
+- [ ] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
+- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
+- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
 - [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)
 
 ## Further information (optional):


### PR DESCRIPTION
## Purpose of this PR

- improve PR template
- I think it is good to clearly separate the explanation of changes (in the PR) and the check whether the documentation is up-to-date, because I think we don't want a documentation of changes within the code
- I also moved the "purpose" to a lower level. Maybe it was intended that you replace the heading with your purpose, but most people put the purpose below and so it is confusing to have different heading levels