### PR TITLE
make the q32_flexAdj equation more error-proof

### DIFF
--- a/modules/32_power/IntC/equations.gms
+++ b/modules/32_power/IntC/equations.gms
@@ -278,9 +278,12 @@ q32_flexPriceBalance(t,regi)$(cm_FlexTaxFeedback eq 1)..
 *** while inflexible technologies are penalized (v32_flexPriceShare > 1).  
 *** Flexibility tax is switched only if cm_flex_tax = 1 and is active from 2025 onwards. 
 q32_flexAdj(t,regi,te)$(teFlexTax(te))..
-	vm_flexAdj(t,regi,te) 
-	=e=
-	(1-v32_flexPriceShare(t,regi,te)) * pm_SEPrice(t,regi,"seel")$((cm_flex_tax eq 1) AND (t.val ge 2025) and (pm_SEPrice(t,regi,"seel") gt 0))
+  vm_flexAdj(t,regi,te) 
+  =e=
+  (1-v32_flexPriceShare(t,regi,te)) 
+  * ( pm_SEPrice(t,regi,"seel")$((cm_flex_tax eq 1) AND (t.val ge 2025) and (pm_SEPrice(t,regi,"seel") gt 0) and (pm_SEPrice(t,regi,"seel") lt 2))
+      + 2$((cm_flex_tax eq 1) AND (t.val ge 2025) and (pm_SEPrice(t,regi,"seel") gt 0) and (pm_SEPrice(t,regi,"seel") ge 2)) !! limit maximum applied electricity price to 230$/MWh = 2T$/TWa 
+    )
 ;
 
 *** EOF ./modules/32_power/IntC/equations.gms


### PR DESCRIPTION
## Purpose of this PR

Prevent the use of faulty marginals from a previous run to calculate vm_flexAdj. 

pm_SEPrice is only used for the calculation of vm_flexAdj as long as the pm_SEPrice is below 230$/MWh (equal to 2T$/TWa), otherwise 230$/MWh is used as maximum value.  In the real world, having electricity prices > such a value for a 5 year period seems hardly imaginable.  (the energy crisis in the EU forced power prices up to 200-400 €/MWh for a year, but then they dropped down to below 200€/MWh)

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)

## Further information (optional):


