### PR TITLE
make the q32_flexAdj equation more error-proof

### DIFF
--- a/modules/32_power/DTcoup/equations.gms
+++ b/modules/32_power/DTcoup/equations.gms
@@ -232,7 +232,10 @@ q32_flexPriceBalance(t,regi)$(cm_FlexTaxFeedback eq 1)..
 q32_flexAdj(t,regi,te)$(teFlexTax(te))..
 	vm_flexAdj(t,regi,te) 
 	=e=
-	(1-v32_flexPriceShare(t,regi,te)) * pm_SEPrice(t,regi,"seel")$((cm_flex_tax eq 1) AND (t.val ge 2025) and (pm_SEPrice(t,regi,"seel") gt 0))
+	(1-v32_flexPriceShare(t,regi,te)) 
+  * ( pm_SEPrice(t,regi,"seel")$((cm_flex_tax eq 1) AND (t.val ge 2025) and (pm_SEPrice(t,regi,"seel") gt 0) and (pm_SEPrice(t,regi,"seel") lt 2))
+      + 2$((cm_flex_tax eq 1) AND (t.val ge 2025) and (pm_SEPrice(t,regi,"seel") gt 0) and (pm_SEPrice(t,regi,"seel") ge 2)) !! limit maximum applied electricity price to 230$/MWh = 2T$/TWa 
+    )
 ;
 
 *** EOF ./modules/32_power/DTcoup/equations.gms


### PR DESCRIPTION
### ## Purpose of this PR
carry PR https://github.com/remindmodel/remind/pull/1205 to Dieter coupled realization (detailed reason see PR 1205)

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [ X] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

