### PR TITLE
let cs2 support slurmConfig=direct, delete tabs from main.gms

### DIFF
--- a/main.gms
+++ b/main.gms
@@ -689,7 +689,7 @@ parameter
 parameter
   cm_distrBeta              "elasticity of tax revenue redistribution"
 ;
-  cm_distrBeta        = 1;	   !! def = 1
+  cm_distrBeta        = 1;       !! def = 1
 *' (0): equal per capita redistribution
 *' (1): proportional redistribution
 *'
@@ -880,7 +880,7 @@ parameter
   cm_emiMktTargetDelay    = 0;       !! def = 0
 *'
 parameter
-  cm_distrAlphaDam	"income elasticity of damages for inequality"
+  cm_distrAlphaDam    "income elasticity of damages for inequality"
 ;
   cm_distrAlphaDam     = 1;    !! def = 1
 *'  1 means damage is distributed proportional to income, i.e. distributionally neutral, 0 means equal per capita distribution of damage

--- a/scripts/output/comparison/compareScenarios2.R
+++ b/scripts/output/comparison/compareScenarios2.R
@@ -53,7 +53,7 @@ startComp <- function(
   outFileName <- jobName
   script <- "scripts/cs2/run_compareScenarios2.R"
   cat("Starting ", jobName, "\n")
-  if (isSlurmAvailable()) {
+  if (isSlurmAvailable() && ! identical(slurmConfig, "direct")) {
     clcom <- paste0(
       "sbatch ", slurmConfig,
       " --job-name=", jobName,


### PR DESCRIPTION
## Purpose of this PR

- selecting `slurmConfig = direct` with `compareScenarios2` did not work, now it does
- tabs -> blanks in main.gms

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)