### PR TITLE
Ensure library requirements are installed before running tests; add make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,12 @@ update-renv-all: ## Upgrade all packages (including CRAN packages) in your renv
 	[ -e ".venv/bin/python" ] && .venv/bin/python -mpip install --upgrade pip wheel
 	[ -e ".venv/bin/python" ] && .venv/bin/python -mpip install --upgrade --upgrade-strategy eager -r requirements.txt
 
+ensure-reqs:     ## Ensure the REMIND library requirements are fulfilled
+                 ## by installing updates and new libraries as necessary. Does not
+                 ## install updates unless it is required.
+	@Rscript -e 'source("scripts/start/ensureRequirementsInstalled.R"); ensureRequirementsInstalled(rerunPrompt="make ensure-reqs")'
+	@[ -e ".venv/bin/python" ] && .venv/bin/python -mpip -qq install -r requirements.txt
+
 archive-renv:    ## Write renv.lock into archive.
 	Rscript -e 'piamenv::archiveRenv()'
 

--- a/scripts/start/ensureRequirementsInstalled.R
+++ b/scripts/start/ensureRequirementsInstalled.R
@@ -1,7 +1,7 @@
 #' ensureRequirementsInstalled
 #'
 #' Ensure that requirements are installed.
-#' 
+#'
 #' @param ask Whether to ask before fixing dependencies. Default: check the autoRenvFixDeps environment variable.
 #' @param rerunPrompt If the requirements can not be installed automatically, the user is prompted to restart.
 #' The thing to restart can be given in the rerunPrompt variable.
@@ -9,14 +9,15 @@
 
 ensureRequirementsInstalled <- function(
     ask = "TRUE" != Sys.getenv("autoRenvFixDeps"),
-    rerunPrompt = "start.R in a fresh R session") {
-    # Check if dependencies for a model run are fulfilled
-    if (requireNamespace("piamenv", quietly = TRUE) && packageVersion("piamenv") >= "0.3.4") {
-        installedPackages <- piamenv::fixDeps(ask = ask)
-        piamenv::stopIfLoaded(names(installedPackages))
-    } else {
-        stop(paste0("REMIND requires piamenv >= 0.3.4, please run the following to update it:\n",
-            "renv::install('piamenv')\n",
-            "and re-run ", rerunPrompt, "."))
-    }
+    rerunPrompt = "start.R in a fresh R session"
+) {
+  # Check if dependencies for a model run are fulfilled
+  if (requireNamespace("piamenv", quietly = TRUE) && packageVersion("piamenv") >= "0.3.4") {
+    installedPackages <- piamenv::fixDeps(ask = ask)
+    piamenv::stopIfLoaded(names(installedPackages))
+  } else {
+    stop(paste0("REMIND requires piamenv >= 0.3.4, please run the following to update it:\n",
+                "renv::install('piamenv')\n",
+                "and re-run ", rerunPrompt, "."))
+  }
 }

--- a/scripts/start/ensureRequirementsInstalled.R
+++ b/scripts/start/ensureRequirementsInstalled.R
@@ -1,0 +1,22 @@
+#' ensureRequirementsInstalled
+#'
+#' Ensure that requirements are installed.
+#' 
+#' @param ask Whether to ask before fixing dependencies. Default: check the autoRenvFixDeps environment variable.
+#' @param rerunPrompt If the requirements can not be installed automatically, the user is prompted to restart.
+#' The thing to restart can be given in the rerunPrompt variable.
+
+
+ensureRequirementsInstalled <- function(
+    ask = "TRUE" != Sys.getenv("autoRenvFixDeps"),
+    rerunPrompt = "start.R in a fresh R session") {
+    # Check if dependencies for a model run are fulfilled
+    if (requireNamespace("piamenv", quietly = TRUE) && packageVersion("piamenv") >= "0.3.4") {
+        installedPackages <- piamenv::fixDeps(ask = ask)
+        piamenv::stopIfLoaded(names(installedPackages))
+    } else {
+        stop(paste0("REMIND requires piamenv >= 0.3.4, please run the following to update it:\n",
+            "renv::install('piamenv')\n",
+            "and re-run ", rerunPrompt, "."))
+    }
+}

--- a/start.R
+++ b/start.R
@@ -83,15 +83,7 @@ if (any(c("--testOneRegi", "--debug", "--quick") %in% flags) & "--restart" %in% 
   if (gms::getLine() %in% c("Y", "y")) flags <- c(flags, "--reprepare")
 }
 
-# Check if dependencies for a model run are fulfilled
-if (requireNamespace("piamenv", quietly = TRUE) && packageVersion("piamenv") >= "0.3.4") {
-  installedPackages <- piamenv::fixDeps(ask = TRUE)
-  piamenv::stopIfLoaded(names(installedPackages))
-} else {
-  stop("REMIND requires piamenv >= 0.3.4, please run the following to update it:\n",
-       "renv::install('piamenv')\n",
-       "and re-run start.R in a fresh R session.")
-}
+ensureRequirementsInstalled()
 
 if (   'TRUE' != Sys.getenv('ignoreRenvUpdates')
     && !getOption("autoRenvUpdates", FALSE)

--- a/start_bundle_coupled.R
+++ b/start_bundle_coupled.R
@@ -136,6 +136,7 @@ message("run_compareScenarios:  ", run_compareScenarios)
 if (! file.exists("output")) dir.create("output")
 
 # Check if dependencies for a REMIND model run are fulfilled
+# Use ensureRequirementsInstalled(rerunPrompt="start_bundle_coupled.R") when coupled runs are using renv.
 if (requireNamespace("piamenv", quietly = TRUE) && packageVersion("piamenv") >= "0.2.0") {
   piamenv::checkDeps(action = "stop")
 } else {

--- a/tests/testthat/setup_updateRenv.R
+++ b/tests/testthat/setup_updateRenv.R
@@ -1,0 +1,10 @@
+env <- paste0("unset R_PROFILE_USER;unset TESTTHAT;autoRenvFixDeps=TRUE;")
+withr::with_dir("../..", {
+  returnCode <- system2(
+    "make", "ensure-reqs",
+    env=env
+  )
+})
+if (returnCode != 0) {
+  stop("Not all requirements installed. Follow instructions above and re-start tests.")
+}

--- a/tests/testthat/setup_updateRenv.R
+++ b/tests/testthat/setup_updateRenv.R
@@ -1,4 +1,4 @@
-env <- paste0("unset R_PROFILE_USER;unset TESTTHAT;autoRenvFixDeps=TRUE;")
+env <- paste0("unset R_PROFILE_USER;unset TESTTHAT;autoRenvFixDeps=TRUE ")
 withr::with_dir("../..", {
   returnCode <- system2(
     "make", "ensure-reqs",

--- a/tests/testthat/setup_updateRenv.R
+++ b/tests/testthat/setup_updateRenv.R
@@ -1,4 +1,4 @@
-env <- paste0("unset R_PROFILE_USER;unset TESTTHAT;autoRenvFixDeps=TRUE ")
+env <- paste0("unset R_PROFILE_USER;unset TESTTHAT;")
 withr::with_dir("../..", {
   returnCode <- system2(
     "make", "ensure-reqs",


### PR DESCRIPTION
## Purpose of this PR

If a new requirement (e.g. new library or newer version) is added to develop, and then someone else pulls develop and runs `make test`, it just hangs because remind asks about installing the new library and the tests hide the question. Most recently, this happened with `reticulate`.

With this PR, we now make sure that the REMIND requirements are met before running tests.

## Type of change

- [x] Bug fix 
- [x] Refactoring


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)


