### PR TITLE
Add documentation how to clone REMIND efficiently in the tutorials

### DIFF
--- a/tutorials/00_Git_and_GitHub_workflow.md
+++ b/tutorials/00_Git_and_GitHub_workflow.md
@@ -49,14 +49,54 @@ upstream repository (the original remindmodel fork).
 
 ## 2.2 Clone (download your personal repository)
 
-It is basically possible to change the code just using the GitHub
-interface, but since you want to test and run your code locally you have
-to clone the repository from your fork anyway. This can be done using
-the 'https' or 'ssh' address of your fork together with the `git clone`
-command (cmd/bash/GUI) at your machine. We recommend to upload an
-ssh-key and use ssh to connect to GitHub. Under Windows open a git bash as follows: 
-open the file explorer, right-click on the folder you want to execute the git commands in
-and choose "Git Bash Here" from the context menu. You need to have git installed.
+To run REMIND on your local machine or a high-performance cluster, you have to clone (download) the code from your fork.
+This can be done with your preferred git client (e.g. the `git` command line program or [GitHub Desktop](https://desktop.github.com/)).
+We recommend to upload an ssh-key and use ssh to connect to GitHub.
+
+If you want to use the `git` command line program in windows, open a git bash as follows: 
+open the file explorer, right-click on the folder you want to execute the git commands in and choose "Git Bash Here" from the context menu.
+You need to have git installed.
+
+Because of a storied history, the full REMIND repository is about 1.2 GB in size; therefore, it is recommended to only clone (download) the parts you need, or use a local reference repository if available.
+
+### Option 1: With a local reference
+
+If you have a local reference available (e.g. on the PIK cluster, or because you cloned REMIND previously), we strongly recommend to use it to avoid re-downloading and duplicating all data.
+On the PIK cluster, use the `cloneremind` command like this:
+```shell
+cloneremind git@github.com:<yourname>/remind.git
+```
+where you replace `<yourname>` with your GitHub username.
+
+If you are not on the PIK cluster but have a reference clone available, use
+```shell
+git clone --reference /path/to/reference/clone git@github.com:<yourname>/remind.git
+```
+where you replace `/path/to/reference/clone` with the path to your existing REMIND clone and `<yourname>` with your GitHub username.
+Do not delete the reference.
+
+### Option 2: Download only needed parts
+
+If you don't have a local reference available, you can filter large files when cloning REMIND.
+This saves a lot of time downloading everything and also saves space for storage, in exchange for needing to automatically download things on-demand if you want to examine old versions of remind.
+
+Using the git command line program, use
+```shell
+git clone --filter=blob:limit=1m git@github.com:<yourname>/remind.git
+```
+where you replace `<yourname>` with your GitHub username.
+
+### Option 3: Download everything
+
+If you don't care for download time and storage requirements, or want access to all historical versions of REMIND without internet access, just clone normally.
+
+Using the git command line program, use
+```shell
+git clone git@github.com:<yourname>/remind.git
+```
+where you replace `<yourname>` with your GitHub username.
+
+### Exercise
 
 > **Exercise**: Visit your fork and clone the repository at your
 > machine.
@@ -75,7 +115,7 @@ After you have added your changes locally, push (upload) them to your personal r
 ## 2.4 Pull (updates from the upstream repository)
 
 To keep your fork up-to-date with the upstream repository you can use
-the GitHub interface. Via `Compare` you are able to check, if the
+the GitHub interface. Via `Compare` you can check if the
 upstream is some commits ahead. If so merge these new changes into
 your fork. 
 

--- a/tutorials/01_GettingREMIND.md
+++ b/tutorials/01_GettingREMIND.md
@@ -20,17 +20,18 @@ REQUIREMENTS
 HOW TO INSTALL
 --------------
 
-To get the REMIND code first install git (<https://git-scm.com/downloads>). Then, to get the latest REMIND release:
+To get the REMIND code first install git (<https://git-scm.com/downloads>).
+Then, to get the latest REMIND release:
 ```sh
-git clone -b master https://github.com/remindmodel/remind.git
+git clone -b master --filter=blob:limit=1m https://github.com/remindmodel/remind.git
 ```
 To get a specific REMIND release (e.g. 2.2.0):
 ```sh
-git clone -b v2.2.0 https://github.com/remindmodel/remind.git
+git clone -b v2.2.0 --filter=blob:limit=1m https://github.com/remindmodel/remind.git
 ```
 To get the latest development version (might be unstable):
 ```sh
-git clone https://github.com/remindmodel/remind.git
+git clone --filter=blob:limit=1m https://github.com/remindmodel/remind.git
 ```
 
 REMIND requires *GAMS* (<https://www.gams.com/>) including licenses for the solvers *CONOPT* and (optionally) *CPLEX* for its core calculations. Please make sure that the GAMS installation path is added to the PATH variable of the system:
@@ -42,7 +43,7 @@ This tutorial shows how to check and add variables to your PATH variable: <https
 
 Please add the GAMS training license you have been provided (gamslice.txt) by saving the file to your local GAMS folder. Under Windows something like `C:\Program Files (x86)\GAMS\<version number>`
 
-In addition *R* (<https://www.r-project.org/>) is required for pre- and postprocessing and run management (needs to be added to the user's PATH variable as well). It is recommended to also install RSudio (<https://www.rstudio.com>).
+In addition, *R* (<https://www.r-project.org/>) is required for pre- and postprocessing and run management (needs to be added to the user's PATH variable as well). It is recommended to also install RSudio (<https://www.rstudio.com>).
 
 On Windows you need to install [Rtools](https://cran.r-project.org/bin/windows/Rtools/) and add it to the system PATH variable.
 

--- a/tutorials/02_RunningREMIND.md
+++ b/tutorials/02_RunningREMIND.md
@@ -63,7 +63,7 @@ The first line loads the `piam` environment once you log onto the cluster via co
 
 Open a console session on the cluster and create a folder on the cluster where you want to store REMIND. It is recommended not to use the `home` directory. For your first experiments you can use a subfolder of the `/p/tmp/YourPIKName/` directory (only stored for 3 months).
 
-In case you are using console and are not familiar with shell commands, google a list of basic shell commands such as `mkdir` to create a folder or `cd /p/tmp/YourPIKName/` to switch to your folder. Download REMIND into a directory in this folder via `git clone` (see tutorial [00_Git_and_GitHub_workflow](00_Git_and_GitHub_workflow.md)).
+In case you are using console and are not familiar with shell commands, google a list of basic shell commands such as `mkdir` to create a folder or `cd /p/tmp/YourPIKName/` to switch to your folder. Download REMIND into a directory in this folder via `cloneremind` (see tutorial [00_Git_and_GitHub_workflow](00_Git_and_GitHub_workflow.md)).
 
 Go to your REMIND main folder (i.e. it contains subfolders such as `config`, `core`, and `modules`) and start a REMIND run by typing:
 

--- a/tutorials/03_RunningBundleOfRuns.md
+++ b/tutorials/03_RunningBundleOfRuns.md
@@ -96,3 +96,15 @@ Further notes:
 git diffmif scenario_config_1.csv scenario_config_2.csv
 git diff --word-diff=color --word-diff-regex=. --no-index scenario_config_1.csv scenario_config_2.csv
 ```
+
+* As noted above, while the bundle is running, you may not change the code or `git checkout` another branch, because that would disturb runs which are started later. If you want to work on other things in REMIND while the bundle is running, you should therefore make a copy of the REMIND clone before starting the bundle. On linux, use `rsync` for a fast copy:
+
+```shell
+rsync -a --exclude='/output/' /path/to/remind/ /path/to/remind-copy
+```
+replace `/path/to/remind/` with the path to remind, and `/path/to/remind-copy` with the desired path for the remind copy. Note that you have to use a `/` at the end of the existing path, and no `/` at the end of the new path.
+
+After the run is finished, you can use `mv` to move the output folder generated in the copy back into the main folder, to have all your run output in one place:
+```shell
+mv /path/to/remind-copy/output/* /path/to/remind/output/
+```

--- a/tutorials/04_RunningREMINDandMAgPIE.md
+++ b/tutorials/04_RunningREMINDandMAgPIE.md
@@ -34,8 +34,9 @@ David Klein (<dklein@pik-potsdam.de>)
 
 ```bash
 git clone https://github.com/magpiemodel/magpie.git
-git clone https://github.com/remindmodel/remind.git
+git clone --filter=blob:limit=1m https://github.com/remindmodel/remind.git
 ```
+Note: On the PIK cluster, use `cloneremind https://github.com/remindmodel/remind.git` instead of `git clone --filter…` to clone REMIND.
 
 ### Switch to relevant branchs
 


### PR DESCRIPTION
## Purpose of this PR

Cloning the full REMIND model can take quite a while and uses a lot of storage space because REMIND used to contain big data files directly in the repo. Since large historical files are not needed usually, cloning can be a lot more efficient when either using a reference (appropriate on the cluster) or by using a filter (appropriate everywhere else).

In this PR, all the tutorials are updated to use either method, as appropriate. I also already added a `cloneremind` command on the cluster, which is just a `git clone` with a reference appropriate for cloning remind.

closes: https://github.com/remindmodel/remind/issues/302

## Type of change

- [x] Documentation update


## Checklist:

- [ ] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [ ] I explained my changes within the PR, particularly in hard-to-understand areas
- [ ] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)

