### PR TITLE
in 45&46/NDC load table with tall instead of ttot

### DIFF
--- a/modules/45_carbonprice/NDC/datainput.gms
+++ b/modules/45_carbonprice/NDC/datainput.gms
@@ -32,7 +32,7 @@ elseif cm_NDC_divergentScenario = 2,
 );
 
 *** load NDC data
-Table f45_factorTargetyear(ttot,all_regi,NDC_version,all_GDPscen) "Table for all NDC versions with multiplier for target year emissions vs 2005 emissions, as weighted average for all countries with quantifyable emissions under NDC in particular region"
+Table f45_factorTargetyear(tall,all_regi,NDC_version,all_GDPscen) "Table for all NDC versions with multiplier for target year emissions vs 2005 emissions, as weighted average for all countries with quantifyable emissions under NDC in particular region"
 $offlisting
 $ondelim
 $include "./modules/45_carbonprice/NDC/input/fm_factorTargetyear.cs3r"
@@ -45,7 +45,7 @@ p45_factorTargetyear(ttot,all_regi) = f45_factorTargetyear(ttot,all_regi,"%cm_ND
 
 display p45_factorTargetyear;
 
-Table f45_2005shareTarget(ttot,all_regi,NDC_version,all_GDPscen) "Table for all NDC versions with 2005 GHG emission share of countries with quantifyable emissions under NDC in particular region, time dimension specifies alternative future target years"
+Table f45_2005shareTarget(tall,all_regi,NDC_version,all_GDPscen) "Table for all NDC versions with 2005 GHG emission share of countries with quantifyable emissions under NDC in particular region, time dimension specifies alternative future target years"
 $offlisting
 $ondelim
 $include "./modules/45_carbonprice/NDC/input/fm_2005shareTarget.cs3r"

--- a/modules/46_carbonpriceRegi/NDC/datainput.gms
+++ b/modules/46_carbonpriceRegi/NDC/datainput.gms
@@ -13,7 +13,7 @@ p46_taxCO2eqGlobal2030 = 0 * sm_DptCO2_2_TDpGtC;
 Scalar p46_taxCO2eqYearlyIncrease "yearly multiplicative increase of co2 tax, write 3% as 1.03" /1/;
 
 *** load NDC data
-Table f46_factorTargetyear(ttot,all_regi,NDC_version,all_GDPscen) "Table for all NDC versions with multiplier for target year emissions vs 2005 emissions, as weighted average for all countries with quantifyable emissions under NDC in particular region"
+Table f46_factorTargetyear(tall,all_regi,NDC_version,all_GDPscen) "Table for all NDC versions with multiplier for target year emissions vs 2005 emissions, as weighted average for all countries with quantifyable emissions under NDC in particular region"
 $offlisting
 $ondelim
 $include "./modules/46_carbonpriceRegi/NDC/input/fm_factorTargetyear.cs3r"
@@ -26,7 +26,7 @@ p46_factorTargetyear(ttot,all_regi) = f46_factorTargetyear(ttot,all_regi,"%cm_ND
 
 display p46_factorTargetyear;
 
-Table f46_2005shareTarget(ttot,all_regi,NDC_version,all_GDPscen) "Table for all NDC versions with 2005 GHG emission share of countries with quantifyable emissions under NDC in particular region, time dimension specifies alternative future target years"
+Table f46_2005shareTarget(tall,all_regi,NDC_version,all_GDPscen) "Table for all NDC versions with 2005 GHG emission share of countries with quantifyable emissions under NDC in particular region, time dimension specifies alternative future target years"
 $offlisting
 $ondelim
 $include "./modules/46_carbonpriceRegi/NDC/input/fm_2005shareTarget.cs3r"


### PR DESCRIPTION
## Purpose of this PR
- avoid non ttot years lead to error in modules 45 and 46 loading NDC input data

## Type of change

- [x] Bug fix 



## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date


- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)





