### PR TITLE
improve help text in start_bundle_coupled.R

### DIFF
--- a/start_bundle_coupled.R
+++ b/start_bundle_coupled.R
@@ -24,14 +24,14 @@ helpText <- "
 #'
 #' Control the script's behavior by providing additional arguments:
 #'
-#' --help, -h:        show this help text and exit
-#' --gamscompile, -g: compile gms of all selected runs. Combined with
-#'                    --interactive, it stops in case of compilation errors,
-#'                    allowing the user to fix them and rerun gamscompile;
-#' --interactive, -i: interactively select config file and run(s) to be
-#'                    started
-#' --test, -t:        Test scenario configuration and writing the RData files
-#'                    in the REMIND main folder without starting the runs.
+#'  --help, -h:        show this help text and exit
+#'  --gamscompile, -g: compile gms of all selected runs. Combined with
+#'                     --interactive, it stops in case of compilation errors,
+#'                     allowing the user to fix them and rerun gamscompile
+#'  --interactive, -i: interactively select run(s) to be started. Asks for config
+#'                     file also if none is specified as path_settings_coupled.
+#'  --test, -t:        Test scenario configuration and writing the RData files
+#'                     in the REMIND main folder without starting the runs.
 #'
 "
 


### PR DESCRIPTION
## Purpose of this PR

- improve help text in start_bundle_coupled.R

## Type of change

- [x] minor documentation change

## Checklist:

- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
