### PR TITLE
bugfix that baseline emission peaks in 2020 already in China

### DIFF
--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -533,8 +533,12 @@ $ENDIF.tech_earlyreti
 *SB* Time-dependent early retirement rates in Baseline scenarios
 $ifthen.Base_Cprice %carbonprice% == "none"
 $ifthen.Base_techpol %techpol% == "none"
-*** Allow no early retirement in future periods under baseline for China; disallowing early retirement of coal all regions runs into EUR infesibility under H12
-pm_regiEarlyRetiRate(t,"CHA","pc")$(t.val ge 2020) = 0;
+*** CG: Allow no early retirement in future periods under baseline for developing countries; disallowing early retirement of coal all regions runs into EUR infesibility under H12
+loop(regi,
+if ( p_developmentState("2015",regi) < 1,
+pm_regiEarlyRetiRate(t,regi,"pc")= 0;
+);
+);
 $endif.Base_techpol
 $endif.Base_Cprice
 

--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -533,8 +533,8 @@ $ENDIF.tech_earlyreti
 *SB* Time-dependent early retirement rates in Baseline scenarios
 $ifthen.Base_Cprice %carbonprice% == "none"
 $ifthen.Base_techpol %techpol% == "none"
-*** Allow very little early retirement future periods
-pm_regiEarlyRetiRate(t,regi,"pc")$(t.val gt 2025) = 0.01;
+*** Allow no early retirement in future periods under baseline
+pm_regiEarlyRetiRate(t,"CHA","pc")$(t.val ge 2020) = 0;
 $endif.Base_techpol
 $endif.Base_Cprice
 

--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -533,7 +533,7 @@ $ENDIF.tech_earlyreti
 *SB* Time-dependent early retirement rates in Baseline scenarios
 $ifthen.Base_Cprice %carbonprice% == "none"
 $ifthen.Base_techpol %techpol% == "none"
-*** CG: Allow no early retirement in future periods under baseline for developing countries; disallowing early retirement of coal all regions runs into EUR infesibility under H12
+*** CG: Allow no early retirement in future periods under baseline for developing countries
 loop(regi,
 if ( p_developmentState("2015",regi) < 1,
 pm_regiEarlyRetiRate(t,regi,"pc")= 0;

--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -533,7 +533,7 @@ $ENDIF.tech_earlyreti
 *SB* Time-dependent early retirement rates in Baseline scenarios
 $ifthen.Base_Cprice %carbonprice% == "none"
 $ifthen.Base_techpol %techpol% == "none"
-*** Allow no early retirement in future periods under baseline
+*** Allow no early retirement in future periods under baseline for China; disallowing early retirement of coal all regions runs into EUR infesibility under H12
 pm_regiEarlyRetiRate(t,"CHA","pc")$(t.val ge 2020) = 0;
 $endif.Base_techpol
 $endif.Base_Cprice


### PR DESCRIPTION
this potentially fixes issue https://github.com/remindmodel/development_issues/issues/180

## Purpose of this PR


## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [X ] Bug fix 
- [ ] Fundamental change
- [ ] This change requires a documentation update


## Checklist:

- [ X] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ X] I performed a self-review of my own code
- [ X] I explained my changes within the PR, particularly in hard-to-understand areas
- [ X] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ X] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ X] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)

## Further information (optional):

* Test runs are here: 
after change:
 /p/tmp/chengong/cha_coalphaseout/remind/output/SSP2EU-AMT-Base_after_2023-02-19_15.33.34
 /p/tmp/chengong/cha_coalphaseout/remind/output/SSP1-AMT-Base_after_2023-02-19_15.33.16
before change:
 /p/tmp/chengong/cha_coalphaseout/remind/output/SSP2EU-AMT-Base_before_2023-02-19_13.36.20
 /p/tmp/chengong/cha_coalphaseout/remind/output/SSP1-AMT-Base_before_2023-02-19_13.36.00

* Comparison of results (what changes by this PR?): 
/p/tmp/chengong/cha_coalphaseout/remind/compScen-cha_baseline_fix-2023-02-20_09.58.42-H12
