### PR TITLE
avoid gamscompile fails if no inputdata present

### DIFF
--- a/start.R
+++ b/start.R
@@ -223,6 +223,10 @@ if (any(c("--reprepare", "--restart") %in% flags)) {
   # ask for slurmConfig if not specified for every run
   if ("--gamscompile" %in% flags) {
     slurmConfig <- "direct"
+    if (! file.exists("input/source_files.log")) {
+      message("\n### Input data missing, need to compile REMIND first (2 min.)\n")
+      system("Rscript start.R config/tests/scenario_config_compile.csv")
+    }
     message("\nTrying to compile the selected runs...")
     lockID <- gms::model_lock()
   }


### PR DESCRIPTION
## Purpose of this PR
- if you run `--gamscompile` before input data was distributed, REMIND failed.
- now, compile once if that is the case to avoid that failure.

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
