### PR TITLE
prepare REMIND for NDC 2023 update, not making it the default yet

### DIFF
--- a/core/sets.gms
+++ b/core/sets.gms
@@ -1024,7 +1024,7 @@ RCP_regions_world(RCP_regions_world_bunkers) "five RCP regions plus total (world
 ***-----------------------------------------------------------------------------
 Sets
   counter   "helper set to facilitate looping in defined order"   / 1 * 20 /
-  NDC_version "NDC data version for NDC realizations of 40_techpol and 45_carbonprice"  /2018_cond, 2018_uncond, 2021_cond, 2021_uncond, 2022_cond, 2022_uncond/
+  NDC_version "NDC data version for NDC realizations of 40_techpol and 45_carbonprice"  /2018_cond, 2018_uncond, 2021_cond, 2021_uncond, 2022_cond, 2022_uncond, 2023_cond, 2023_uncond/
 ;
 
 ***-----------------------------------------------------------------------------

--- a/main.gms
+++ b/main.gms
@@ -373,7 +373,7 @@ $setglobal banking  off          !! def = off
 *' * (NDC2constant): linearly phase in global constant price from NDC prices (default 2020-2040 phase-in)
 *' * (diffCurvPhaseIn2Lin): [REMIND 2.1 default for validation peakBudget runs, in combination with "iterative_target_adj" = 9] curved convergence of CO2 prices between regions until cm_CO2priceRegConvEndYr; developed countries have linear path from 0 in 2010 through cm_co2_tax_2020 in 2020;
 *' * (diffPhaseIn2Constant): !experimental! linearly phase in global constant price, with starting values differentiated by GDP/cap
-*' * (NDC): implements a carbon price trajectory consistent with the NDC targets (up to 2030) and a trajectory of comparable ambition post 2030 (1.25%/yr price increase and regional convergence of carbon price). Choose version using cm_NDC_version "2022_cond", "2022_uncond", or replace 2022 by 2021 or 2018 to get all NDC published until end of these years.
+*' * (NDC): implements a carbon price trajectory consistent with the NDC targets (up to 2030) and a trajectory of comparable ambition post 2030 (1.25%/yr price increase and regional convergence of carbon price). Choose version using cm_NDC_version "2023_cond", "2023_uncond", or replace 2023 by 2022, 2021 or 2018 to get all NDC published until end of these years.
 $setglobal carbonprice  none           !! def = none
 *'---------------------    46_carbonpriceRegi  ---------------------------------
 *'
@@ -1114,13 +1114,15 @@ $setglobal cm_MAgPIE_coupling  off     !! def = "off"
 *' *  (rcp85): RCP8.5
 $setglobal cm_rcp_scen  none         !! def = "none"
 *' cm_NDC_version            "choose version year of NDC targets as well as conditional vs. unconditional targets"
-*' *  (2022_cond):   all NDCs conditional to international financial support
-*' *  (2022_uncond): all NDCs independent of international financial support
+*' *  (2023_cond):   all NDCs conditional to international financial support published until February 24, 2023
+*' *  (2023_uncond): all NDCs independent of international financial support published until February 24, 2023
+*' *  (2022_cond):   all NDCs conditional to international financial support published until December 31, 2022
+*' *  (2022_uncond): all NDCs independent of international financial support published until December 31, 2022
 *' *  (2021_cond):   all NDCs conditional to international financial support published until December 31, 2021
 *' *  (2021_uncond): all NDCs independent of international financial support published until December 31, 2021
 *' *  (2018_cond):   all NDCs conditional to international financial support published until December 31, 2018
 *' *  (2018_uncond): all NDCs independent of international financial support published until December 31, 2018
-$setglobal cm_NDC_version  2022_cond    !! def = "2022_cond", "2022_uncond", "2021_cond", "2021_uncond", "2018_cond", "2018_uncond"
+$setglobal cm_NDC_version  2022_cond    !! def = "2023_cond", "2023_uncond", "2022_cond", "2022_uncond", "2021_cond", "2021_uncond", "2018_cond", "2018_uncond"
 *** cm_netZeroScen     "choose scenario of net zero targets of netZero realization of module 46_carbonpriceRegi"
 ***  (NGFS2022):       settings used for NGFS 2022
 ***  (ENGAGE4p5_GlP):  settings used for ENGAGE 4.5 Glasgow+ scenario

--- a/modules/45_carbonprice/NDC/realization.gms
+++ b/modules/45_carbonprice/NDC/realization.gms
@@ -12,11 +12,11 @@
 *' @limitations The NDC emission target refers to GHG emissions w/o land-use change and international bunkers. However, the submitted NDC targets of
 *' several countries include land-use emissions (e.g. Australia and US). See https://www4.unfccc.int/sites/NDCStaging/Pages/All.aspx. To be checked!
 
-*** Next update (2022):
-*** - Add NDC_2023.xlsx in /p/projects/rd3mod/inputdata/sources/UNFCCC_NDC/ on cluster, see README.txt in this folder
-*** - Set switch cm_NDC_version in /config/default.cfg and /main.gms to new year
-*** - add 2023_cond, 2023_uncond to set NDC_version in /core/sets.gms
-*** - Add new 2023 option in mrremind: calcEmiTarget, calcCapTarget, readUNFCCC_NDC
+*** Next update (2023):
+*** - Add NDC_2024.xlsx in /p/projects/rd3mod/inputdata/sources/UNFCCC_NDC/ on cluster, see README.txt in this folder
+*** - Set switch cm_NDC_version in ./main.gms to new year
+*** - add 2024_cond, 2024_uncond to set NDC_version in ./core/sets.gms
+*** - Add new 2024 option in mrremind: calcEmiTarget, calcCapTarget, readUNFCCC_NDC
 
 
 *####################### R SECTION START (PHASES) ##############################

--- a/modules/45_carbonprice/expoLinear/realization.gms
+++ b/modules/45_carbonprice/expoLinear/realization.gms
@@ -12,7 +12,7 @@
 *' the remaining admissible amount of cumulative gross CO2 emissions is no longer finite, and the Hotelling rule no longer represents an economically optimal solution. 
 *' A carbon price path following the Hotelling rule leads to rather low emission prices and therefore low emission reductions early in the century, 
 *' and to very high emission prices and massive CDR deployment towards the end of the century. 
-*' A Hotellling price path can only be considered optimal until the time of net-zero emissions. 
+*' A Hotelling price path can only be considered optimal until the time of net-zero emissions. 
 *' Afterwards, a moderate carbon price increase is sufficient to avoid a return of fossil fuels. 
 *' Therefore, we choose an exponentially increasing carbon price until the expected time of net-zero emissions and a linear increase at the rate of 2050 or 2060 afterwards.
 

--- a/modules/46_carbonpriceRegi/NDC/realization.gms
+++ b/modules/46_carbonpriceRegi/NDC/realization.gms
@@ -11,6 +11,8 @@
 *' @limitations The NDC emission target refers to GHG emissions w/o land-use change and international bunkers. However, the submitted NDC targets of
 *' several countries include land-use emissions (e.g. Australia and US). See https://www4.unfccc.int/sites/NDCStaging/Pages/All.aspx. To be checked!
 
+*' For more information, see 45_carbonprice/NDC
+
 *####################### R SECTION START (PHASES) ##############################
 $Ifi "%phase%" == "declarations" $include "./modules/46_carbonpriceRegi/NDC/declarations.gms"
 $Ifi "%phase%" == "datainput" $include "./modules/46_carbonpriceRegi/NDC/datainput.gms"


### PR DESCRIPTION
## Purpose of this PR

- prepare REMIND such that `2023_cond` and `2023_uncond` can be used as `NDC_version`
- not making it the default, yet, until it is not part of the input data

## Type of change

- [x] New feature (maybe a bit exaggerated)

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)

