### PR TITLE
Removing q39_EqualSecShare_BioSyn equation from the model

### DIFF
--- a/modules/39_CCU/off/not_used.txt
+++ b/modules/39_CCU/off/not_used.txt
@@ -11,4 +11,3 @@ cm_emiscen,input,questionnaire
 cm_shSynGas,input,questionnaire
 vm_prodSe,input,questionnaire
 vm_co2capture,input,questionnaire
-vm_demFeSector_afterTax,input,questionnaire

--- a/modules/39_CCU/on/declarations.gms
+++ b/modules/39_CCU/on/declarations.gms
@@ -20,7 +20,6 @@ equations
 q39_emiCCU(ttot,all_regi,all_te)                                        "calculate CCU emissions"
 q39_shSynLiq(ttot,all_regi)                                             "calculate share of of synthetic liquids in all SE liquids."
 q39_shSynGas(ttot,all_regi)                                             "calculate share of of synthetic gas in all SE gases."
-q39_EqualSecShare_BioSyn(ttot,all_regi,all_enty,emi_sectors,emiMkt)     "constraint on equal share of synfuels in biofuels+synfuels for sectors"
 ;
 
 *** EOF ./modules/39_CCU/on/declarations.gms

--- a/modules/39_CCU/on/equations.gms
+++ b/modules/39_CCU/on/equations.gms
@@ -48,17 +48,4 @@ q39_shSynGas(t,regi)$(cm_shSynGas gt 0)..
     vm_prodSe(t,regi,entySe,entySe2,te))
 ;
 
-*** impose same shares of synfuels in total biofuel+synfuel across all transport subsectors
-q39_EqualSecShare_BioSyn(t,regi,entyFe,sector,emiMkt)$(enty_BioSyn_39(entyFe,sector,emiMkt))..
-  vm_demFeSector_afterTax(t,regi,"seliqsyn",entyFe,sector,emiMkt)
-  * sum(enty_BioSyn_39(entyFe2,sector2,emiMkt2),
-      ( vm_demFeSector_afterTax(t,regi,"seliqsyn",entyFe2,sector2,emiMkt2)
-      + vm_demFeSector_afterTax(t,regi,"seliqbio",entyFe2,sector2,emiMkt2)))
-  =e=
-  ( vm_demFeSector_afterTax(t,regi,"seliqsyn",entyFe,sector,emiMkt)
-    + vm_demFeSector_afterTax(t,regi,"seliqbio",entyFe,sector,emiMkt))
-  * sum(enty_BioSyn_39(entyFe2,sector2,emiMkt2), 
-      vm_demFeSector_afterTax(t,regi,"seliqsyn",entyFe2,sector2,emiMkt2))
-;
-
 *** EOF ./modules/39_CCU/on/equations.gms

--- a/scripts/start/prepare.R
+++ b/scripts/start/prepare.R
@@ -512,8 +512,7 @@ prepare <- function() {
                                 list(c("v39_shSynGas.M", "!!v39_shSynGas.M")),
                                 list(c("q39_emiCCU.M", "!!q39_emiCCU.M")),
                                 list(c("q39_shSynTrans.M", "!!q39_shSynTrans.M")),
-                                list(c("q39_shSynGas.M", "!!q39_shSynGas.M")),
-                                list(c("q39_EqualSecShare_BioSyn.M", "!!q39_EqualSecShare_BioSyn.M")))
+                                list(c("q39_shSynGas.M", "!!q39_shSynGas.M")))
     }
 
     #RP filter out module 40 techpol fixings
@@ -635,8 +634,8 @@ prepare <- function() {
     fixings_manipulateThis <- c(fixings_manipulateThis,
                                 list(c("vm_shBioFe.FX","!!vm_shBioFe.FX")))
     margs_manipulateThis <- c(margs_manipulateThis,
-                                list(c("vm_shBioFe.M", "!!vm_shBioFe.M")))
-
+                                list(c("vm_shBioFe.M", "!!vm_shBioFe.M")),
+                                list(c("q39_EqualSecShare_BioSyn.M", "!!q39_EqualSecShare_BioSyn.M")))
 
     # OR: renamed for sectoral taxation
     levs_manipulateThis <- c(levs_manipulateThis,

--- a/scripts/start/prepare.R
+++ b/scripts/start/prepare.R
@@ -512,7 +512,7 @@ prepare <- function() {
                                 list(c("v39_shSynGas.M", "!!v39_shSynGas.M")),
                                 list(c("q39_emiCCU.M", "!!q39_emiCCU.M")),
                                 list(c("q39_shSynTrans.M", "!!q39_shSynTrans.M")),
-                                list(c("q39_shSynGas.M", "!!q39_shSynGas.M"))))
+                                list(c("q39_shSynGas.M", "!!q39_shSynGas.M")))
     }
 
     #RP filter out module 40 techpol fixings

--- a/scripts/start/prepare.R
+++ b/scripts/start/prepare.R
@@ -512,8 +512,7 @@ prepare <- function() {
                                 list(c("v39_shSynGas.M", "!!v39_shSynGas.M")),
                                 list(c("q39_emiCCU.M", "!!q39_emiCCU.M")),
                                 list(c("q39_shSynTrans.M", "!!q39_shSynTrans.M")),
-                                list(c("q39_shSynGas.M", "!!q39_shSynGas.M")),
-                                list(c("q39_EqualSecShare_BioSyn.M", "!!q39_EqualSecShare_BioSyn.M")))
+                                list(c("q39_shSynGas.M", "!!q39_shSynGas.M"))))
     }
 
     #RP filter out module 40 techpol fixings

--- a/scripts/start/prepare.R
+++ b/scripts/start/prepare.R
@@ -512,7 +512,8 @@ prepare <- function() {
                                 list(c("v39_shSynGas.M", "!!v39_shSynGas.M")),
                                 list(c("q39_emiCCU.M", "!!q39_emiCCU.M")),
                                 list(c("q39_shSynTrans.M", "!!q39_shSynTrans.M")),
-                                list(c("q39_shSynGas.M", "!!q39_shSynGas.M")))
+                                list(c("q39_shSynGas.M", "!!q39_shSynGas.M")),
+                                list(c("q39_EqualSecShare_BioSyn.M", "!!q39_EqualSecShare_BioSyn.M")))
     }
 
     #RP filter out module 40 techpol fixings


### PR DESCRIPTION
## Purpose of this PR

As explained in this issue https://github.com/remindmodel/remind/issues/1137 , the current formulation of `q39_EqualSecShare_BioSyn` can cause infeasibilities due to corner conditions caused by some carriers being zero while others are not, and/or hard to solve situations for the solver due to badly scaled values.

This PR removes this equation from the model as, acording to @fschreyer, this is already handled in the reporting. 

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)

## Further information (optional):

* Test runs are here: /p/projects/remind/users/renatoro/ECEMF/v09_2023_02_21/output/