### PR TITLE
updating REMIND 21 SSP2 calibration

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -30,7 +30,7 @@ cfg$extramappings_historic <- ""
 cfg$inputRevision <- "6.327"
 
 #### Current CES parameter and GDX revision (commit hash) ####
-cfg$CESandGDXversion <- "ccdc8b787b17172204a34e74d37f992037b4e486"
+cfg$CESandGDXversion <- "f2804de14dce2a0158f5d3bf2083ada517de6c94"
 
 #### Force the model to download new input data ####
 cfg$force_download <- FALSE


### PR DESCRIPTION
## Purpose of this PR

Update REMIND 21 SSP2 calibration files

## Further information (optional):

* Test runs are here: `/p/projects/remind/users/renatoro/ECEMF/v09_2023_02_21/output/09_Calib_2023-02-21_12.01.47`

