### PR TITLE
remove renv scripts

### DIFF
--- a/scripts/utils/archiveRenv.R
+++ b/scripts/utils/archiveRenv.R
@@ -1,2 +1,0 @@
-message("This feature moved. To archive your renv now please run 'make archive-renv' or ",
-        "in R 'piamenv::archiveRenv()'. This script will be deleted on 2023-03-01.")

--- a/scripts/utils/restoreRenv.R
+++ b/scripts/utils/restoreRenv.R
@@ -1,2 +1,0 @@
-message("This feature moved. To restore an renv from an renv.lock now please run 'make restore-renv' or ",
-        "in R 'piamenv::restoreRenv()'. This script will be deleted on 2023-03-01.")

--- a/scripts/utils/updateRenv.R
+++ b/scripts/utils/updateRenv.R
@@ -1,2 +1,0 @@
-message("This feature moved. To update your renv now please run 'make update-renv' or ",
-        "in R 'piamenv::updateRenv()'. This script will be deleted on 2023-03-01.")


### PR DESCRIPTION
## Purpose of this PR
The renv scripts were only notifying the user where the feature moved. This PR deletes these placeholder scripts.

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [ ] Bug fix 
- [ ] Refactoring
- [ ] New feature 
- [ ] Minor change (default scenarios show only small differences)
- [ ] Fundamental change
- [ ] This change requires a documentation update


## Checklist:

- [ ] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [ ] I explained my changes within the PR, particularly in hard-to-understand areas
- [ ] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

