### PR TITLE
add non-convergence to debugging tutorial, cleanup help text

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -4,7 +4,7 @@
 # |  AGPL-3.0, you are granted additional permissions described in the
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
-#################
+##################
 #### SETTINGS ####
 ##################
 

--- a/modules/80_optimization/nash/output.gms
+++ b/modules/80_optimization/nash/output.gms
@@ -24,7 +24,7 @@ putclose prices_NASH;
 *** The file is formated in columns as follows: | Experiment title | Region | Year | Iteration | Market | surplus | price |  ..
 file nash_info_convergence / "nash_info_convergence.csv" / ;
 put nash_info_convergence;
-put 'Scenario',',','Region',',','Year',',','Iteration',',',"Market",",","surplus",",","pvp_nash_itr",",","p80_surplusMax",",","p80_surplusMaxRel",",":0 ;
+put 'Scenario',',','Region',',','Year',',','Iteration',',',"Market",",","p80_surplus",",","p80_pvp_itr",",","p80_surplusMax",",","p80_surplusMaxRel",",":0 ;
 put /;
 loop(ttot$(ttot.val ge 2005),
     loop(iteration$(iteration.val le cm_iteration_max),

--- a/output.R
+++ b/output.R
@@ -24,28 +24,28 @@ options(error = quote({
 helpText <- "
 #' Rscript output.R [options]
 #'
-#'    [options] can be the following flags:
+#' [options] can be the following flags:
 #'
-#'    --help, -h:      show this help text and exit
-#'    --test, -t:      tests output.R without actually starting any run
-#'    --renv=<path>    load the renv located at <path>, incompatible with --update
-#'    --update         update packages in renv first, incompatible with --renv=<path>
+#'   --help, -h:      show this help text and exit
+#'   --test, -t:      tests output.R without actually starting any run
+#'   --renv=<path>    load the renv located at <path>, incompatible with --update
+#'   --update         update packages in renv first, incompatible with --renv=<path>
 #'
-#'    [options] can also specify the following variables. If they are not specified
-#'    but needed, the scripts will ask the user.
+#' [options] can also specify the following variables. If they are not specified
+#' but needed, the scripts will ask the user.
 #'
-#'    comp:            comp=single means output for single runs (reporting, …)
+#'   comp=             comp=single means output for single runs (reporting, …)
 #'                     comp=comparison means scripts to compare runs (compareScenarios2, …)
 #'                     comp=export means scripts to export runs (xlsx_IIASA, …)
-#'    filename_prefix: string to be added to filenames by some output scripts
+#'   filename_prefix=  string to be added to filenames by some output scripts
 #'                     (compareScenarios, xlsx_IIASA)
-#'    output:          output=compareScenarios2 directly selects the specific script
-#'    outputdir:       Can be used to specify the output directories to be used.
+#'   output=           output=compareScenarios2 directly selects the specific script
+#'   outputdir=        Can be used to specify the output directories to be used.
 #'                     Example: outputdir=./output/SSP2-Base-rem-1,./output/NDC-rem-1
-#'    remind_dir:      path to remind or output folder(s) where runs can be found.
+#'   remind_dir=       path to remind or output folder(s) where runs can be found.
 #'                     Defaults to ./output but can also be used to specify multiple
 #'                     folders, comma-separated, such as remind_dir=.,../otherremind
-#'    slurmConfig:     use slurmConfig=direct, priority, short or standby to specify
+#'   slurmConfig=      use slurmConfig=direct, priority, short or standby to specify
 #'                     slurm selection. You may also pass complicated arguments such as
 #'                     slurmConfig='--qos=priority --mem=8000'
 "

--- a/start.R
+++ b/start.R
@@ -13,34 +13,34 @@ require(stringr, quietly = TRUE)
 helpText <- "
 #' Rscript start.R [options] [file]
 #'
-#'    Without [file] argument starts a single REMIND run using the settings from
-#'    `config/default.cfg` and `main.gms`.
+#' Without [file] argument starts a single REMIND run using the settings from
+#' config/default.cfg` and `main.gms`.
 #'
-#'    [file] must be a scenario config .csv file (usually in the config/
-#'    directory).  Using this will start all REMIND runs specified by
-#'    \"start = 1\" in that file.
+#' [file] must be a scenario config .csv file (usually in the config/
+#' directory).  Using this will start all REMIND runs specified by
+#' \"start = 1\" in that file.
 #'
-#'    --help, -h:        show this help text and exit
-#'    --debug, -d:       start a debug run with cm_nash_mode = debug
-#'    --gamscompile, -g: compile gms of all selected runs. Combined with
+#'   --help, -h:         show this help text and exit
+#'   --debug, -d:        start a debug run with cm_nash_mode = debug
+#'   --gamscompile, -g:  compile gms of all selected runs. Combined with
 #'                       --interactive, it stops in case of compilation errors,
 #'                       allowing the user to fix them and rerun gamscompile;
 #'                       combined with --restart, existing runs can be checked.
-#'    --interactive, -i: interactively select config file and run(s) to be
+#'   --interactive, -i:  interactively select config file and run(s) to be
 #'                       started
-#'    --quick, -q:       starting one fast REMIND run with one region, one
+#'   --quick, -q:        starting one fast REMIND run with one region, one
 #'                       iteration and reduced convergence criteria for testing
 #'                       the full model.
-#'    --reprepare, -R:   rewrite full.gms and restart run
-#'    --restart, -r:     interactively restart run(s)
-#'    --test, -t:        test scenario configuration and writing the RData files
+#'   --reprepare, -R:    rewrite full.gms and restart run
+#'   --restart, -r:      interactively restart run(s)
+#'   --test, -t:         test scenario configuration and writing the RData files
 #'                       in the REMIND main folder without starting the runs
-#'    --testOneRegi, -1: starting the REMIND run(s) in testOneRegi mode
+#'   --testOneRegi, -1:  starting the REMIND run(s) in testOneRegi mode
 #'
-#'    You can combine --reprepare with --debug, --testOneRegi or --quick and the
-#'    selected folders will be restarted using these settings.  Afterwards,
-#'    using --reprepare alone will restart the runs using their original
-#'    settings.
+#' You can combine --reprepare with --debug, --testOneRegi or --quick and the
+#' selected folders will be restarted using these settings.  Afterwards,
+#' using --reprepare alone will restart the runs using their original
+#' settings.
 "
 
 # Source everything from scripts/start so that all functions are available everywhere

--- a/start_bundle_coupled.R
+++ b/start_bundle_coupled.R
@@ -24,14 +24,15 @@ helpText <- "
 #'
 #' Control the script's behavior by providing additional arguments:
 #'
-#'  --help, -h:        show this help text and exit
-#'  --gamscompile, -g: compile gms of all selected runs. Combined with
-#'                     --interactive, it stops in case of compilation errors,
-#'                     allowing the user to fix them and rerun gamscompile
-#'  --interactive, -i: interactively select run(s) to be started. Asks for config
-#'                     file also if none is specified as path_settings_coupled.
-#'  --test, -t:        Test scenario configuration and writing the RData files
-#'                     in the REMIND main folder without starting the runs.
+#'   --help, -h:        show this help text and exit
+#'   --gamscompile, -g: compile gms of all selected runs. Combined with
+#'                      --interactive, it stops in case of compilation
+#'                      errors, allowing to fix them and rerun gamscompile
+#'   --interactive, -i: interactively select run(s) to be started. Asks for
+#'                      config file also if the one specified as
+#'                      path_settings_coupled cannot be found.
+#'   --test, -t:        Test scenario configuration and write the RData files
+#'                      in the REMIND main folder without starting the runs.
 #'
 "
 


### PR DESCRIPTION
## Purpose of this PR

- expand debugging tutorial to explain what one might check if REMIND did not convergence
- harmonize formatting of help text in output.R, start.R, start_bundle_coupled.R
- use actual GAMS names in `nash_info_convergence.csv` such that one can search them more easily

## Type of change

- [x] documentation update

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
