### PR TITLE
avoid unnecessary fails if runs are restarted automatically

### DIFF
--- a/scripts/start/submit.R
+++ b/scripts/start/submit.R
@@ -32,7 +32,8 @@ submit <- function(cfg, restart = FALSE, stopOnFolderCreateError = TRUE) {
       if (stopOnFolderCreateError) {
         stop(couldnotdelete, ".")
       } else if (! all(grepl("^log*.txt", list.files(cfg$results_folder)))) {
-        stop(couldnotdelete, " and it contains not only log files.")
+        message(couldnotdelete, " and it contains not only log files. ",
+                "Probably the slurm job was aborted and restarted.")
       } else {
         message(couldnotdelete, " containing only log files as expected for coupled runs.")
       }


### PR DESCRIPTION
## Purpose of this PR

- if a coupled run is run on `standby`, is aborted and restarted automatically, it fails because the folder already contains files (no surprise). After this PR, it only prints a warning.
- I remember adding this `stop` when implementing #794 rather as a check that no coupled run was started that was already on his way, but `start_bundle_coupled.R` either avoids that or deletes the folder, so this serves no functionality anymore.

## Type of change

- [x] Bug fix

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)

## Further information (optional):

* The error was identified here: `/p/projects/magpie/users/florianh/projects/paper/LandEnergy/modelruns/remind/output/C_SSP2EU-PkBudg630-EatLancetPure-rem-3/`
