### PR TITLE
avoid fails of NDC modules if cm_startyear > 2020

### DIFF
--- a/modules/45_carbonprice/NDC/datainput.gms
+++ b/modules/45_carbonprice/NDC/datainput.gms
@@ -82,6 +82,7 @@ $offdelim
 
 *** parameters for selecting NDC years
 Scalar p45_ignoreNDCbefore          "NDC targets before this years are ignored, for example to exclude 2030 targets" /2020/;
+p45_ignoreNDCbefore = max(p45_ignoreNDCbefore, cm_startyear)
 Scalar p45_ignoreNDCafter           "NDC targets after  this years are ignored, for example to exclude 2050 net zero targets" /2030/;
 Scalar p45_minRatioOfCoverageToMax  "only targets whose coverage is this times p45_bestNDCcoverage are considered. Use 1 for only best." /1.0/;
 Scalar p45_useSingleYearCloseTo     "if 0: use all. If > 0: use only one single NDC target per country closest to this year (use 2030.4 to prefer 2030 over 2035 over 2025)" /2030.4/;

--- a/modules/46_carbonpriceRegi/NDC/datainput.gms
+++ b/modules/46_carbonpriceRegi/NDC/datainput.gms
@@ -81,6 +81,7 @@ p46_2005shareTarget(ttot,regi)$(sameas(regi,"CHA") AND sameas(ttot,"2060")) = 1;
 
 *** parameters for selecting NDC years
 Scalar p46_ignoreNDCbefore          "NDC targets before this years are ignored, for example to exclude 2030 targets" /2028/;
+p46_ignoreNDCbefore = max(p46_ignoreNDCbefore, cm_startyear)
 Scalar p46_ignoreNDCafter           "NDC targets after  this years are ignored, for example to exclude 2050 net zero targets" /2070/;
 Scalar p46_minRatioOfCoverageToMax  "only targets whose coverage is this times p46_bestNDCcoverage are considered. Use 1 for only best." /0.2/;
 Scalar p46_useSingleYearCloseTo     "if 0: use all. If > 0: use only one single NDC target per country closest to this year (use 2030.4 to prefer 2030 over 2035 over 2025)" /0/;

--- a/modules/46_carbonpriceRegi/netZero/not_used.txt
+++ b/modules/46_carbonpriceRegi/netZero/not_used.txt
@@ -5,4 +5,4 @@
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
 name,type,reason
-
+cm_startyear,switch,not needed

--- a/modules/46_carbonpriceRegi/none/not_used.txt
+++ b/modules/46_carbonpriceRegi/none/not_used.txt
@@ -5,6 +5,7 @@
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
 name,type,reason
+cm_startyear,switch,not needed
 sm_c_2_co2,input,questionnaire
 sm_DptCO2_2_TDpGtC,input,questionnaire
 vm_co2eq,input,questionnaire

--- a/scripts/start/configureCfg.R
+++ b/scripts/start/configureCfg.R
@@ -67,7 +67,7 @@ configureCfg <- function(icfg, iscen, iscenarios, isettings, verboseGamsCompile 
           if (! str_sub(isettings[iscen, path_to_gdx], -4, -1) == ".gdx") {
             # search for fulldata.gdx in output directories starting with the path_to_gdx cell content.
             # may include folders that only _start_ with this string. They are sorted out later.
-            dirfolders <- c("./output/", icfg$modeltests_folder)
+            dirfolders <- c("./output", icfg$modeltests_folder)
             for (dirfolder in dirfolders) {
               dirs <- Sys.glob(file.path(dirfolder, paste0(isettings[iscen, path_to_gdx], "*/fulldata.gdx")))
               # if path_to_gdx cell content exactly matches folder name, use this one


### PR DESCRIPTION
## Purpose of this PR
- 45/NDC and 46/NDC runs failed if you wanted to use NDC goals earlier as `cm_startyear`. This fixes that.
- Fix superfluous `/` which creates messages such as
```
   Run can be started using 1 specified gdx file(s).
     input.gdx: ./output//SSP2-Base_covidCalib_2023-02-23_18.40.55/fulldata.gdx
```

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
