### PR TITLE
Bugfix end-of-century target carbon price adjustment algorithm

### DIFF
--- a/core/postsolve.gms
+++ b/core/postsolve.gms
@@ -154,8 +154,8 @@ display s_actualbudgetco2;
 		);
 		display sm_budgetCO2eqGlob;
 	elseif cm_emiscen eq 9,
+		display pm_taxCO2eq;
 	    if(o_modelstat eq 2 AND ord(iteration)<cm_iteration_max AND s_actualbudgetco2 > 0 AND abs(c_budgetCO2from2020 - s_actualbudgetco2) ge 0.5,   !!only for optimal iterations, and not after the last one, and only if budget still possitive, and only if target not yet reached
-		display pm_taxCO2eq;		
 *** make sure that iteration converges: 
 *** use multiplicative for budgets higher than 1200 Gt; for lower budgets, use multiplicative adjustment only for first 3 iterations, 
 			if(ord(iteration) lt 3 or c_budgetCO2from2020 > 1200,
@@ -172,19 +172,22 @@ display s_actualbudgetco2;
 			    pm_taxCO2eq_iterationdiff(t,regi) = pm_taxCO2eq_iterationdiff_tmp(t,regi);
 			);
       o_taxCO2eq_iterDiff_Itr(iteration,regi) = pm_taxCO2eq_iterationdiff("2030",regi);
-      display o_taxCO2eq_iterDiff_Itr;
 		else
 			if(s_actualbudgetco2 > 0 or abs(c_budgetCO2from2020 - s_actualbudgetco2) < 2, !! if model was not optimal, or if budget already reached, keep tax constant
-			pm_taxCO2eq(t,regi) = pm_taxCO2eq(t,regi);
+				pm_taxCO2eq(t,regi) = pm_taxCO2eq(t,regi);
+				o_taxCO2eq_iterDiff_Itr(iteration,regi) = 0;
 			else
 *** if budget has turned negative, reduce CO2 price by 20%
-			pm_taxCO2eq(t,regi) = 0.8*pm_taxCO2eq(t,regi);
+				pm_taxCO2eq_iterationdiff(t,regi) = -0.2*pm_taxCO2eq(t,regi);
+				pm_taxCO2eq(t,regi) = pm_taxCO2eq(t,regi) + pm_taxCO2eq_iterationdiff(t,regi);
+				o_taxCO2eq_iterDiff_Itr(iteration,regi) = pm_taxCO2eq_iterationdiff("2030",regi);
 			);	
 		);
+		display o_taxCO2eq_iterDiff_Itr;
 		
     pm_taxCO2eq(t,regi)$(t.val gt 2110) = pm_taxCO2eq("2110",regi); !! to prevent huge taxes after 2110 and the resulting convergence problems, set taxes after 2110 equal to 2110 value
     display pm_taxCO2eq;
-	 );
+	);
 );
 
 *** ---------------------------------------------------------------------------------------------------------------

--- a/core/postsolve.gms
+++ b/core/postsolve.gms
@@ -97,9 +97,9 @@ display s_actualbudgetco2;
 		);
 		display sm_budgetCO2eqGlob;
 	elseif cm_emiscen eq 9,
+		display pm_taxCO2eq;
 	    if(o_modelstat eq 2 AND ord(iteration)<cm_iteration_max AND s_actualbudgetco2 > 0 AND abs(c_budgetCO2from2020 - s_actualbudgetco2) ge 0.5,   !!only for optimal iterations, and not after the last one, and only if budget still possitive, and only if target not yet reached
 		  sm_globalBudget_dev = s_actualbudgetco2 / c_budgetCO2from2020; 
-    display pm_taxCO2eq;		
 *** make sure that iteration converges: 
 *** use multiplicative for budgets higher than 1200 Gt; for lower budgets, use multiplicative adjustment only for first 3 iterations, 
 			if(ord(iteration) lt 3 or c_budgetCO2from2020 > 1200,
@@ -116,19 +116,22 @@ display s_actualbudgetco2;
 			    pm_taxCO2eq_iterationdiff(t,regi) = pm_taxCO2eq_iterationdiff_tmp(t,regi);
 			);
       o_taxCO2eq_iterDiff_Itr(iteration,regi) = pm_taxCO2eq_iterationdiff("2030",regi);
-      display o_taxCO2eq_iterDiff_Itr;
 		else
 			if(s_actualbudgetco2 > 0 or abs(c_budgetCO2from2020 - s_actualbudgetco2) < 2, !! if model was not optimal, or if budget already reached, keep tax constant
-			pm_taxCO2eq(t,regi) = pm_taxCO2eq(t,regi);
+				pm_taxCO2eq(t,regi) = pm_taxCO2eq(t,regi);
+				o_taxCO2eq_iterDiff_Itr(iteration,regi) = 0;
 			else
 *** if budget has turned negative, reduce CO2 price by 20%
-			pm_taxCO2eq(t,regi) = 0.8*pm_taxCO2eq(t,regi);
+				pm_taxCO2eq_iterationdiff(t,regi) = -0.2*pm_taxCO2eq(t,regi);
+				pm_taxCO2eq(t,regi) = pm_taxCO2eq(t,regi) + pm_taxCO2eq_iterationdiff(t,regi);
+				o_taxCO2eq_iterDiff_Itr(iteration,regi) = pm_taxCO2eq_iterationdiff("2030",regi);
 			);	
 		);
+		display o_taxCO2eq_iterDiff_Itr;
 		
     pm_taxCO2eq(t,regi)$(t.val gt 2110) = pm_taxCO2eq("2110",regi); !! to prevent huge taxes after 2110 and the resulting convergence problems, set taxes after 2110 equal to 2110 value
     display pm_taxCO2eq;
-	 );
+	);
 );
 
 if(cm_iterative_target_adj eq 6,


### PR DESCRIPTION
## Purpose of this PR
In scenarios with `cm_iterative_target_adj eq 5`, i.e. optimizing for an end-of-century budget, the carbon price adjustment algorithm was not working for some corner case. This in particular happened in combination with the `exponential` carbon price realization.
The problem was that, when the `s_actualbudgetco2` was negative in the first two iterations (due to very high initial carbon prices),  `pm_taxCO2eq_iterationdiff` was never properly initialized. That breaks the algorithm, since in subsequent iterations `pm_taxCO2eq_iterationdiff` is always [referring to itself](https://github.com/remindmodel/remind/blob/develop/core/postsolve.gms#L112-L116), which is not doing anything without prior initialization.
This is now fixed: `pm_taxCO2eq_iterationdiff` is now also initialized when `s_actualbudgetco2` is negative in the first two iterations.
Furthermore, the diagnostic parameter `o_taxCO2eq_iterDiff_Itr` is now printed after every iteration, as it helps debugging.

Edit: this problem may also occur for `cm_iterative_target_adj eq 6`, so it was changed there as well, respectively.

## Type of change

- [x] Bug fix 
- [x] Minor change (default scenarios show only small differences)


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed (N/A)
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches (N/A)
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)

## Further information (optional):

* Test runs are here (N/A) 
* Comparison of results (what changes by this PR?)  (N/A)

