### PR TITLE
remove deprecated piamInterfaces option

### DIFF
--- a/scripts/output/export/xlsx_IIASA.R
+++ b/scripts/output/export/xlsx_IIASA.R
@@ -132,8 +132,7 @@ withCallingHandlers({ # piping messages to logFile
   generateIIASASubmission(filename_remind2_mif, mapping = mapping, model = model, mappingFile = mappingFile,
                           removeFromScen = removeFromScen, addToScen = addToScen,
                           outputDirectory = outputFolder, outputPrefix = "",
-                          logFile = logFile, generateSingleOutput = TRUE,
-                          outputFilename = basename(OUTPUT_mif),
+                          logFile = logFile, outputFilename = basename(OUTPUT_mif),
                           iiasatemplate = if (file.exists(iiasatemplate)) iiasatemplate else NULL,
                           generatePlots = TRUE)
 


### PR DESCRIPTION
## Purpose of this PR

prepare for https://github.com/pik-piam/piamInterfaces/pull/96/

## Type of change

- [x] avoid future bugs once `generateSingleOutput = TRUE` is the default

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
