### PR TITLE
adding support for netCO2, with and without bunkers, LULUCFGrassi targets on the regipol module

### DIFF
--- a/modules/47_regipol/regiCarbonPrice/postsolve.gms
+++ b/modules/47_regipol/regiCarbonPrice/postsolve.gms
@@ -93,6 +93,16 @@ p47_emiTargetMkt(ttot,regi, emiMktExt,"netGHG_noLULUCF_noBunkers") =
   )$(sameas(emiMktExt,"other") or sameas(emiMktExt,"all"))
 ;
 
+*** net CO2 per Mkt with Grassi LULUCF shift
+p47_emiTargetMkt(ttot,regi, emiMktExt,"netCO2_LULUCFGrassi") =
+  p47_emiTargetMkt(ttot,regi, emiMktExt,"netCO2")
+  - ( p47_LULUCFEmi_GrassiShift(ttot,regi) )$(sameas(emiMktExt,"other") or sameas(emiMktExt,"all"));
+
+*** net CO2 per Mkt without bunkers and with Grassi LULUCF shift
+p47_emiTargetMkt(ttot,regi, emiMktExt,"netCO2_LULUCFGrassi_noBunkers") =
+  p47_emiTargetMkt(ttot,regi, emiMktExt,"netCO2_noBunkers")
+  - ( p47_LULUCFEmi_GrassiShift(ttot,regi) )$(sameas(emiMktExt,"other") or sameas(emiMktExt,"all"));
+
 *** net GHG per Mkt with Grassi LULUCF shift
 p47_emiTargetMkt(ttot,regi, emiMktExt,"netGHG_LULUCFGrassi") =
   p47_emiTargetMkt(ttot,regi, emiMktExt,"netGHG")
@@ -247,7 +257,7 @@ loop(ext_regi$regiEmiMktTarget(ext_regi),
 ***       linear price between first free year and current target terminal year
           loop(ttot3,
             s47_firstFreeYear = ttot3.val;
-            break$((ttot3.val ge ttot.val) and (ttot3.val ge cm_startyear) and (ttot.val ge 2020)); !!initial free price year
+            break$((ttot3.val ge ttot.val) and (ttot3.val ge cm_startyear) and (ttot3.val ge 2020)); !!initial free price year
             s47_prefreeYear = ttot3.val;
           );
           if(not(ttot2.val eq p47_firstTargetYear(ext_regi)), !! delay price change by cm_emiMktTargetDelay years for later targets

--- a/modules/47_regipol/regiCarbonPrice/sets.gms
+++ b/modules/47_regipol/regiCarbonPrice/sets.gms
@@ -9,7 +9,7 @@
 SETS
 target_type_47 "CO2 policy target type" / budget , year /
 
-emi_type_47 "emission type used in regional target" / netCO2, netCO2_noBunkers, netCO2_noLULUCF_noBunkers, grossEnCO2_noBunkers, netGHG, netGHG_noLULUCF, netGHG_noBunkers, netGHG_noLULUCF_noBunkers, netGHG_LULUCFGrassi, netGHG_LULUCFGrassi_noBunkers /
+emi_type_47 "emission type used in regional target" / netCO2, netCO2_noBunkers, netCO2_noLULUCF_noBunkers, grossEnCO2_noBunkers, netGHG, netGHG_noLULUCF, netGHG_noBunkers, netGHG_noLULUCF_noBunkers, netCO2_LULUCFGrassi, netCO2_LULUCFGrassi_noBunkers, netGHG_LULUCFGrassi, netGHG_LULUCFGrassi_noBunkers /
 
 *** Emission markets
 $ifThen.emiMkt not "%cm_emiMktTarget%" == "off" 


### PR DESCRIPTION
## Purpose of this PR

Additional targets support necessary for the European 2040 targets evaluation. 

## Type of change

- [x] New feature 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)

## Further information (optional):

* Test runs are here: 
`/p/projects/remind/users/renatoro/ECEMF/2040_target_analysis/v01_2023_02_24/output`


