### PR TITLE
Filter out intermediate CES nodes from the calibration report

### DIFF
--- a/scripts/output/single/reportCEScalib.R
+++ b/scripts/output/single/reportCEScalib.R
@@ -148,7 +148,17 @@ CES.cal.report$value <- as.numeric(as.character(CES.cal.report$value))
 
 CES.cal.report = CES.cal.report %>% filter(iteration %in% c("target", "origin", itr_num))
 
-
+#removing intermediate nodes
+interm.node <- c()
+config.Rdata <- new.env()
+load(file.path(outputdir, "config.Rdata"), envir = config.Rdata) # load config.Rdata
+if(config.Rdata$cfg$gms$industry == "subsectors"){
+  interm.node <- c(interm.node, "ue_industry", "ue_cement", "en_cement", "en_cement_non_electric", "ue_chemicals", "en_chemicals", "en_chemicals_fhth", "ue_steel", "ue_otherInd", "en_otherInd", "en_otherInd_hth")
+  if(config.Rdata$cfg$gms$cm_process_based_steel != "on"){
+    interm.node <- c(interm.node, "ue_steel_secondary", "ue_steel_primary", "en_steel_primary", "en_steel_furnace")
+  }
+}
+CES.cal.report <- CES.cal.report %>% filter(!(pf %in% c(interm.node)))
 
 iter.max = max(itr_num)
 

--- a/scripts/output/single/reportCEScalib.R
+++ b/scripts/output/single/reportCEScalib.R
@@ -148,17 +148,11 @@ CES.cal.report$value <- as.numeric(as.character(CES.cal.report$value))
 
 CES.cal.report = CES.cal.report %>% filter(iteration %in% c("target", "origin", itr_num))
 
-#removing intermediate nodes
-interm.node <- c()
-config.Rdata <- new.env()
-load(file.path(outputdir, "config.Rdata"), envir = config.Rdata) # load config.Rdata
-if(config.Rdata$cfg$gms$industry == "subsectors"){
-  interm.node <- c(interm.node, "ue_industry", "ue_cement", "en_cement", "en_cement_non_electric", "ue_chemicals", "en_chemicals", "en_chemicals_fhth", "ue_steel", "ue_otherInd", "en_otherInd", "en_otherInd_hth")
-  if(config.Rdata$cfg$gms$cm_process_based_steel != "on"){
-    interm.node <- c(interm.node, "ue_steel_secondary", "ue_steel_primary", "en_steel_primary", "en_steel_furnace")
-  }
-}
-CES.cal.report <- CES.cal.report %>% filter(!(pf %in% c(interm.node)))
+#selecting only calibrated nodes to show on report
+ppf_29 <- readGDX(gdx, "ppf_29")
+pf_eff_target_dyn37 <- readGDX(gdx, "pf_eff_target_dyn37")
+calib.node = c(ppf_29, pf_eff_target_dyn37)
+CES.cal.report <- CES.cal.report %>% filter((pf %in% c(calib.node)))
 
 iter.max = max(itr_num)
 


### PR DESCRIPTION
## Purpose of this PR

- Remove useless parts of the CES calibration report to make it useful again.

## Type of change

- [x] Refactoring

## Checklist:

- [x] I performed a self-review of my own code
- [x] wait for calibration expert feedback to make sure all relevant CES nodes for the calibration are included 

## Further information:

* Changes related with this issue: https://github.com/remindmodel/remind/issues/1249
