### PR TITLE
"change input data revision to 6.333, new CES parameters and gdx file…

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -27,10 +27,10 @@ cfg$regionmapping <- "config/regionmappingH12.csv"
 ### Additional (optional) region mapping, so that those validation data can be loaded that contain the corresponding additional regions.
 cfg$extramappings_historic <- ""
 #### Current input data revision (<mainrevision>.<subrevision>) ####
-cfg$inputRevision <- "6.327"
+cfg$inputRevision <- "6.333"
 
 #### Current CES parameter and GDX revision (commit hash) ####
-cfg$CESandGDXversion <- "f2804de14dce2a0158f5d3bf2083ada517de6c94"
+cfg$CESandGDXversion <- "845b0a686b0a4a8dbd8d1bf904b7d5c70be102ab"
 
 #### Force the model to download new input data ####
 cfg$force_download <- FALSE


### PR DESCRIPTION
…s for SSP1, SSP2EU, SSP5, SSP2EU_lowEn and SSP2EU-EU21"

## Purpose of this PR
update to new input data revision including update for GDP and population data and corresponding CES parameters and gdx files; calibration runs are here: /p/tmp/lavinia/REMIND/REMIND_calibration_2023_03_11/remind/output

## Type of change

- [x] Minor change (default scenarios show only small differences)

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

