### PR TITLE
remove whitespace from REMIND_climate*.mif

### DIFF
--- a/scripts/output/single/reporting.R
+++ b/scripts/output/single/reporting.R
@@ -59,7 +59,7 @@ if (0 == nchar(Sys.getenv('MAGICC_BINARY'))) {
              "awk -f MAGICC_reporting.awk -v c_expname=\"", scenario, "\"",
              " < climate_reporting_template.txt ",
              " > ","../../../", magicc_reporting_file,"; ",
-             "sed -i 's/;glob;/;World;/g' ","../../../", magicc_reporting_file, "; ",
+             "sed -i 's/;glob;/;World;/g; s/ *; */;/g' ","../../../", magicc_reporting_file, "; ",
              "cat ", "../../../",magicc_reporting_file, " >> ", "../../../",remind_reporting_file, "; ",
              sep = ""))
 }


### PR DESCRIPTION
## Purpose of this PR

`REMIND_climate_*.mif` has the ugly whitespaces:
```
REMIND;d_rap;glob;Forcing|AN3A; W/m2;  2.463299;  2.604342;  2.829047;  3.054748;  3.276251;  3.346923;  3.347175;  3.288266;  3.218561;  3.156801;  3.098061;  3.054395;  2.989879;  2.939469;  2.893963;  2.852875;  2.810091;  2.722833;  2.669451;
```
Reading the `mif` file into `quitte` gives problems with the unit, as noticed by @fbenke-pik:
```
# A tibble: 418 × 7
   model  scenario region variable     unit    period value
   <fct>  <fct>    <fct>  <fct>        <fct>    <int> <dbl>
 1 REMIND d_rap    glob   Forcing|AN3A " W/m2"   2005  2.46
```
Deleting the whitespaces around `;` fixes the problem, see the mif files in `/p/tmp/oliverr/remind-smallfix/output/`.

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
