### PR TITLE
Improve convergence of implicit quantity target tax in module 47

### DIFF
--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -371,6 +371,7 @@ loop(emi2te(enty,enty2,te,enty3)$teCCS(te),
 );
 
 *** Allocate emission factors to pm_emifac
+option pm_emifac:3:3:1; 
 pm_emifac(ttot,regi,enty,enty2,te,"co2")$emi2te(enty,enty2,te,"co2")   = fm_dataemiglob(enty,enty2,te,"co2");
 pm_emifac(ttot,regi,enty,enty2,te,"cco2")$emi2te(enty,enty2,te,"cco2") = fm_dataemiglob(enty,enty2,te,"cco2");
 *JeS scale N2O energy emissions to EDGAR

--- a/modules/47_regipol/regiCarbonPrice/datainput.gms
+++ b/modules/47_regipol/regiCarbonPrice/datainput.gms
@@ -18,7 +18,6 @@ option p47_implicitQttyTargetTax_prevIter:3:2:2;
 option pm_implicitQttyTarget_dev:3:2:2;
 option p47_implicitQttyTargetTax:3:2:2;
 option p47_implicitQttyTargetTaxRescale:3:2:2;
-option p47_implicitQttyTargetTax0:3:2:2;
 
 *** initialize regipol target deviation parameter
 pm_emiMktTarget_dev(ttot,ttot2,ext_regi,emiMktExt) = 0;

--- a/modules/47_regipol/regiCarbonPrice/datainput.gms
+++ b/modules/47_regipol/regiCarbonPrice/datainput.gms
@@ -30,6 +30,7 @@ option pm_taxemiMkt_iteration:3:3:1;
 
 *** initialize regipol target deviation parameter
 pm_emiMktTarget_dev(ttot,ttot2,ext_regi,emiMktExt) = 0;
+p47_implicitQttyTargetTaxRescale_iter("1", "2030", regi,qttyTarget,qttyTargetGroup) = 0;
 
 *** RR this should be replaced as soon as non-energy is treated endogenously in the model
 *** EUR in 2030 ~ 90Mtoe (90 * 10^6 toe -> 90 * 10^6 toe * 41.868 GJ/toe -> 3768.12 * 10^6 GJ * 10^-9 EJ/GJ -> 3.76812 EJ * 1 TWa/31.536 EJ -> 0.1194863 TWa) EU27 = 92% EU28"

--- a/modules/47_regipol/regiCarbonPrice/datainput.gms
+++ b/modules/47_regipol/regiCarbonPrice/datainput.gms
@@ -32,7 +32,7 @@ option pm_taxemiMkt_iteration:3:3:1;
 pm_emiMktTarget_dev(ttot,ttot2,ext_regi,emiMktExt) = 0;
 
 *** RR this should be replaced as soon as non-energy is treated endogenously in the model
-*** EUR in 2030 =~ 90Mtoe (90 * 10^6 toe -> 90 * 10^6 toe * 41.868 GJ/toe -> 3768.12 * 10^6 GJ * 10^-9 EJ/GJ -> 3.76812 EJ * 1 TWa/31.536 EJ -> 0.1194863 TWa) EU27 =~ 92% EU28"
+*** EUR in 2030 ~ 90Mtoe (90 * 10^6 toe -> 90 * 10^6 toe * 41.868 GJ/toe -> 3768.12 * 10^6 GJ * 10^-9 EJ/GJ -> 3.76812 EJ * 1 TWa/31.536 EJ -> 0.1194863 TWa) EU27 = 92% EU28"
 p47_nonEnergyUse("2030",ext_regi)$(sameas(ext_regi, "EUR_regi")) = 0.1194863;
 p47_nonEnergyUse("2030",ext_regi)$(sameas(ext_regi, "EU27_regi")) = 0.11;
 
@@ -95,7 +95,7 @@ p47_taxemiMkt_init(ttot,regi,emiMkt)$(p47_taxCO2eq_ref(ttot,regi) and (NOT(p47_t
       );
       if((cm_startyear le 2020),
         p47_taxemiMkt_init("2020",regi,emiMkt) = 0;
-***     p47_taxemiMkt_init("2020",regi,"ETS")   = 41.28*sm_DptCO2_2_TDpGtC; !! 2018 =~ 16.5€/tCO2, 2019 =~ 25€/tCO2, 2020 =~ 25€/tCO2, 2021 =~ 53.65€/tCO2, 2022 =~ 80€/tCO2 -> average 2020 = 40€/tCO2 -> 40*1.032 $/tCO2 = 41.28 $/t CO2
+***     p47_taxemiMkt_init("2020",regi,"ETS")   = 41.28*sm_DptCO2_2_TDpGtC; !! 2018 = 16.5€/tCO2, 2019 = 25€/tCO2, 2020 = 25€/tCO2, 2021 = 53.65€/tCO2, 2022 = 80€/tCO2 -> average 2020 = 40€/tCO2 -> 40*1.032 $/tCO2 = 41.28 $/t CO2
         p47_taxemiMkt_init("2020",regi,"ETS")  = 30*sm_DptCO2_2_TDpGtC;
 ***     p47_taxemiMkt_init("2020",regi,"ES")   = 30*sm_DptCO2_2_TDpGtC;
 ***     p47_taxemiMkt_init("2020",regi,"other")= 30*sm_DptCO2_2_TDpGtC;

--- a/modules/47_regipol/regiCarbonPrice/datainput.gms
+++ b/modules/47_regipol/regiCarbonPrice/datainput.gms
@@ -24,7 +24,7 @@ option pm_emiMktCurrent:3:3:1;
 option pm_emiMktTarget:3:3:3;
 option pm_emiMktRefYear:3:3:1;
 option pm_taxemiMkt_iteration:3:3:1;
-
+option pm_emiMktTarget_dev_iter:3:1:4
 
 
 

--- a/modules/47_regipol/regiCarbonPrice/datainput.gms
+++ b/modules/47_regipol/regiCarbonPrice/datainput.gms
@@ -30,7 +30,7 @@ option pm_taxemiMkt_iteration:3:3:1;
 
 *** initialize regipol target deviation parameter
 pm_emiMktTarget_dev(ttot,ttot2,ext_regi,emiMktExt) = 0;
-p47_implicitQttyTargetTaxRescale_iter("1", "2030", regi,qttyTarget,qttyTargetGroup) = 0;
+p47_implicitQttyTargetTaxRescale_iter("1", "2030",ext_regi,qttyTarget,qttyTargetGroup) = 0;
 
 *** RR this should be replaced as soon as non-energy is treated endogenously in the model
 *** EUR in 2030 ~ 90Mtoe (90 * 10^6 toe -> 90 * 10^6 toe * 41.868 GJ/toe -> 3768.12 * 10^6 GJ * 10^-9 EJ/GJ -> 3.76812 EJ * 1 TWa/31.536 EJ -> 0.1194863 TWa) EU27 = 92% EU28"

--- a/modules/47_regipol/regiCarbonPrice/datainput.gms
+++ b/modules/47_regipol/regiCarbonPrice/datainput.gms
@@ -18,6 +18,15 @@ option p47_implicitQttyTargetTax_prevIter:3:2:2;
 option pm_implicitQttyTarget_dev:3:2:2;
 option p47_implicitQttyTargetTax:3:2:2;
 option p47_implicitQttyTargetTaxRescale:3:2:2;
+option pm_emiMktTarget_dev:3:3:1;
+option pm_factorRescaleemiMktCO2Tax:3:3:1;
+option pm_emiMktCurrent:3:3:1;
+option pm_emiMktTarget:3:3:3;
+option pm_emiMktRefYear:3:3:1;
+option pm_taxemiMkt_iteration:3:3:1;
+
+
+
 
 *** initialize regipol target deviation parameter
 pm_emiMktTarget_dev(ttot,ttot2,ext_regi,emiMktExt) = 0;

--- a/modules/47_regipol/regiCarbonPrice/datainput.gms
+++ b/modules/47_regipol/regiCarbonPrice/datainput.gms
@@ -6,6 +6,20 @@
 *** |  Contact: remind@pik-potsdam.de
 *** SOF ./modules/47_regipol/regiCarbonPrice/datainput.gms
 
+*' RP: improve formatting of output: always have the iteration separate to allow easy comparison over iterations.
+*' For non-iteration values show time and regi down, and the other two sets to the right
+option p47_implicitQttyTarget_dev_iter:3:1:4;  
+option p47_implicitQttyTargetTaxRescale_iter:3:1:4;
+option p47_implicitQttyTargetTax_iter:3:1:4;
+option p47_implicitQttyTargetCurrent_iter:3:1:4;
+option p47_implicitQttyTargetCurrent:3:2:2;
+option pm_implicitQttyTarget:3:2:2;
+option p47_implicitQttyTargetTax_prevIter:3:2:2;
+option pm_implicitQttyTarget_dev:3:2:2;
+option p47_implicitQttyTargetTax:3:2:2;
+option p47_implicitQttyTargetTaxRescale:3:2:2;
+option p47_implicitQttyTargetTax0:3:2:2;
+
 *** initialize regipol target deviation parameter
 pm_emiMktTarget_dev(ttot,ttot2,ext_regi,emiMktExt) = 0;
 

--- a/modules/47_regipol/regiCarbonPrice/datainput.gms
+++ b/modules/47_regipol/regiCarbonPrice/datainput.gms
@@ -13,7 +13,7 @@ option p47_implicitQttyTargetTaxRescale_iter:3:1:4;
 option p47_implicitQttyTargetTax_iter:3:1:4;
 option p47_implicitQttyTargetCurrent_iter:3:1:4;
 option p47_implicitQttyTargetCurrent:3:2:2;
-option pm_implicitQttyTarget:3:2:2;
+option pm_implicitQttyTarget:3:2:4;
 option p47_implicitQttyTargetTax_prevIter:3:2:2;
 option pm_implicitQttyTarget_dev:3:2:2;
 option p47_implicitQttyTargetTax:3:2:2;

--- a/modules/47_regipol/regiCarbonPrice/declarations.gms
+++ b/modules/47_regipol/regiCarbonPrice/declarations.gms
@@ -83,7 +83,7 @@ Parameter
   p47_implicitQttyTargetTax0(ttot,all_regi)                                    "previous iteration quantity target tax revenue"
 
   p47_implicitQttyTargetTax_iter(iteration,ttot,all_regi,qttyTarget,qttyTargetGroup)        "tax/subsidy level necessary to achieve a quantity target per iteration"
-  pm_implicitQttyTarget_dev(ttot,ext_regi,qttyTarget,qttyTargetGroup)                 "deviation of current iteration quantity target from target"
+  pm_implicitQttyTarget_dev(ttot,ext_regi,qttyTarget,qttyTargetGroup)                 "relative deviation of current iteration quantity target from target"
   p47_implicitQttyTarget_dev_iter(iteration,ttot,ext_regi,qttyTarget,qttyTargetGroup) "parameter to save pm_implicitQttyTarget_dev across iterations"
   p47_implicitQttyTargetTaxRescale_iter(iteration,ttot,ext_regi,qttyTarget,qttyTargetGroup) "rescale factor for current implicit quantity target tax per iteration"    
   p47_implicitQttyTargetCurrent_iter(iteration,ttot,ext_regi,qttyTarget,qttyTargetGroup)    "current iteration total value for an specific quantity target per iteration"   

--- a/modules/47_regipol/regiCarbonPrice/declarations.gms
+++ b/modules/47_regipol/regiCarbonPrice/declarations.gms
@@ -82,10 +82,10 @@ Parameter
   p47_implicitQttyTargetTax_prevIter(ttot,all_regi,qttyTarget,qttyTargetGroup) "previous iteration quantity target tax"
   p47_implicitQttyTargetTax0(ttot,all_regi)                                    "previous iteration quantity target tax revenue"
 
-  p47_implicitQttyTargetTax_iter(iteration,ttot,all_regi,qttyTarget,qttyTargetGroup)        "tax/subsidy level necessary to achieve a quantity target per iteration"
-  pm_implicitQttyTarget_dev(ttot,ext_regi,qttyTarget,qttyTargetGroup)                 "deviation of current iteration quantity target from target - can be relative OR absolute!"
-  p47_implicitQttyTarget_dev_iter(iteration,ttot,ext_regi,qttyTarget,qttyTargetGroup) "parameter to save pm_implicitQttyTarget_dev across iterations"
-  p47_implicitQttyTargetTaxRescale_iter(iteration,ttot,ext_regi,qttyTarget,qttyTargetGroup) "rescale factor for current implicit quantity target tax per iteration"    
+  p47_implicitQttyTargetTax_iter(iteration,ttot,all_regi,qttyTarget,qttyTargetGroup)  "tax/subsidy level to achieve a quantity target that the model saw in a given iteration"
+  pm_implicitQttyTarget_dev(ttot,ext_regi,qttyTarget,qttyTargetGroup)                 "deviation of current iteration quantity target from target - relative for total targets, absolute (= share points) for share targets"
+  p47_implicitQttyTarget_dev_iter(iteration,ttot,ext_regi,qttyTarget,qttyTargetGroup) "deviation of current iteration quantity from target after the given iteration"
+  p47_implicitQttyTargetTaxRescale_iter(iteration,ttot,ext_regi,qttyTarget,qttyTargetGroup) "rescale factor for current implicit quantity target tax after the given iteration"    
   p47_implicitQttyTargetCurrent_iter(iteration,ttot,ext_regi,qttyTarget,qttyTargetGroup)    "current iteration total value for an specific quantity target per iteration"   
 
   pm_implicitQttyTarget(ttot,ext_regi,taxType,targetType,qttyTarget,qttyTargetGroup)  "quantity target [absolute: TWa or GtC; or percentage: 0.1]"  / %cm_implicitQttyTarget% /

--- a/modules/47_regipol/regiCarbonPrice/declarations.gms
+++ b/modules/47_regipol/regiCarbonPrice/declarations.gms
@@ -83,7 +83,7 @@ Parameter
   p47_implicitQttyTargetTax0(ttot,all_regi)                                    "previous iteration quantity target tax revenue"
 
   p47_implicitQttyTargetTax_iter(iteration,ttot,all_regi,qttyTarget,qttyTargetGroup)        "tax/subsidy level necessary to achieve a quantity target per iteration"
-  pm_implicitQttyTarget_dev(ttot,ext_regi,qttyTarget,qttyTargetGroup)                 "relative deviation of current iteration quantity target from target"
+  pm_implicitQttyTarget_dev(ttot,ext_regi,qttyTarget,qttyTargetGroup)                 "deviation of current iteration quantity target from target - can be relative OR absolute!"
   p47_implicitQttyTarget_dev_iter(iteration,ttot,ext_regi,qttyTarget,qttyTargetGroup) "parameter to save pm_implicitQttyTarget_dev across iterations"
   p47_implicitQttyTargetTaxRescale_iter(iteration,ttot,ext_regi,qttyTarget,qttyTargetGroup) "rescale factor for current implicit quantity target tax per iteration"    
   p47_implicitQttyTargetCurrent_iter(iteration,ttot,ext_regi,qttyTarget,qttyTargetGroup)    "current iteration total value for an specific quantity target per iteration"   

--- a/modules/47_regipol/regiCarbonPrice/postsolve.gms
+++ b/modules/47_regipol/regiCarbonPrice/postsolve.gms
@@ -442,9 +442,15 @@ loop((ttot,ext_regi,taxType,targetType,qttyTarget,qttyTargetGroup)$pm_implicitQt
       p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) = 2.5;
     );
     p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) =
-     ( p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) - 1 )
-     * exp( (p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) - 1.5 ) * 2 )
-     + 1
+      (  ( p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) - 1 )
+         * exp( (p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) - 1.5 ) * 2 )
+         + 1
+      )
+      *
+      ( 2 * ( exp( -0.025 * iteration.val) + 0.1 ) )  !! in order to also create some dampening over iterstions, 
+      !! this line decreases from 2.1 at iteration 1 to 0.36 in iteration 100. 
+    ;
+
   else !! if rescale is <1, do the same procedure on (1/rescale)
     if( p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) < 0.4,  !! prevent numeric explosion
       p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) = 0.4;
@@ -452,10 +458,13 @@ loop((ttot,ext_regi,taxType,targetType,qttyTarget,qttyTargetGroup)$pm_implicitQt
     p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) =
       1
       / (
-         ( (1 / p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) ) - 1 )
-         * exp( ( ( 1 / p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) ) - 1.5 ) * 2 )
-         + 1
-      )
+          (  ( (1 / p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) ) - 1 )
+             * exp( ( ( 1 / p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) ) - 1.5 ) * 2 )
+             + 1
+          )
+          *
+          ( 2 * ( exp( -0.025 * iteration.val) + 0.1 ) )  !! this line decreases from 2.1 at iteration 1 to 0.36 in iteration 100
+        )
   );
   option p47_implicitQttyTargetTaxRescale:3:0:4; display "p47_implicitQttyTargetTaxRescale after dampening: ", p47_implicitQttyTargetTaxRescale;
 

--- a/modules/47_regipol/regiCarbonPrice/postsolve.gms
+++ b/modules/47_regipol/regiCarbonPrice/postsolve.gms
@@ -477,6 +477,21 @@ loop((ttot,ext_regi,taxType,targetType,qttyTarget,qttyTargetGroup)$pm_implicitQt
          1 / ( 2 * EXP( -0.05 * iteration.val ) + 1.01)
     );
   display "p47_implicitQttyTargetTaxRescale after boundaries: ", p47_implicitQttyTargetTaxRescale;
+
+*** dampen if rescale oscillates
+  if( ( (iteration.val > 3) AND 
+        ( ( p47_implicitQttyTargetTaxRescale_iter(iteration-1,ttot,ext_regi,qttyTarget,qttyTargetGroup)  
+            * p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) ) < 0 
+        ) AND  !! sign changed between iteration -1 and current iteration
+        ( ( p47_implicitQttyTargetTaxRescale_iter(iteration-1,ttot,ext_regi,qttyTarget,qttyTargetGroup) 
+            p47_implicitQttyTargetTaxRescale_iter(iteration-2,ttot,ext_regi,qttyTarget,qttyTargetGroup) ) < 0
+        ) !! sign changed between iteration -2 and iteration -1
+      ),
+    p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) =
+      1 + ( ( p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) - 1 ) / 2 ) 
+    ; !! this brings the value closer to one. The formulation works reasonably well within the range of 0.5..2
+  );
+  display "p47_implicitQttyTargetTaxRescale reduction for oscillation in the previous 3 iterations: ", p47_implicitQttyTargetTaxRescale;  
 );
 
 p47_implicitQttyTargetTaxRescale_iter(iteration,ttot,ext_regi,qttyTarget,qttyTargetGroup) = p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup);

--- a/modules/47_regipol/regiCarbonPrice/postsolve.gms
+++ b/modules/47_regipol/regiCarbonPrice/postsolve.gms
@@ -446,7 +446,7 @@ loop((ttot,ext_regi,taxType,targetType,qttyTarget,qttyTargetGroup)$pm_implicitQt
       (  
         ( p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) - 1 )
           * exp( (p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) - 1.5 ) * 2 ) !! this is 0.4 at p47_rescale = 1.01; 1 at 1.5, 2.7 at 2 
-          * ( 2 * ( exp( -0.025 * iteration.val) + 0.1 ) )  !! in order to also have some dampening over iterstions, 
+          * ( 2 * ( exp( -0.025 * iteration.val) + 0.1 ) )  !! in order to also have some dampening over iterations, 
       !! this line decreases from 2.1 at iteration 1 to 0.36 in iteration 100. 
       )
       + 1
@@ -461,7 +461,7 @@ loop((ttot,ext_regi,taxType,targetType,qttyTarget,qttyTargetGroup)$pm_implicitQt
           (  
             ( 1 / p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) - 1 )
             * exp( ( 1 / p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) - 1.5 ) * 2 ) !! this is 0.4 at p47_rescale = 1.01; 1 at 1.5, 2.7 at 2 
-            * ( 2 * ( exp( -0.025 * iteration.val) + 0.1 ) )  !! in order to also have some dampening over iterstions, 
+            * ( 2 * ( exp( -0.025 * iteration.val) + 0.1 ) )  !! in order to also have some dampening over iterations, 
               !! this line decreases from 2.1 at iteration 1 to 0.36 in iteration 100. 
           )
           + 1

--- a/modules/47_regipol/regiCarbonPrice/postsolve.gms
+++ b/modules/47_regipol/regiCarbonPrice/postsolve.gms
@@ -438,7 +438,7 @@ loop((ttot,ext_regi,taxType,targetType,qttyTarget,qttyTargetGroup)$pm_implicitQt
   display "p47_implicitQttyTargetTaxRescale before dampening: ", p47_implicitQttyTargetTaxRescale;
 *** dampen rescale factor when closer than 1.5 / 0.75 to reduce oscillations
   if( p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) > 1,
-    if( p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) > 2.5, !! prevent numeric explosion
+    if( p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) > 2.5, !! prevent numeric explosion by limiting the maximum value
       p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) = 2.5;
     );
     p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) =
@@ -451,15 +451,16 @@ loop((ttot,ext_regi,taxType,targetType,qttyTarget,qttyTargetGroup)$pm_implicitQt
       + 1
     ;
   else !! if rescale is <1, do the same procedure on (1/rescale)
-    if( p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) < 0.4,  !! prevent numeric explosion
+    if( p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) < 0.4,  !! prevent numeric explosion by limiting the minimum value
       p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) = 0.4;
+      display "rescale limited to 0.4"
     );
     p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) =
       1
       / (
           (  
-            ( p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) - 1 )
-            * exp( (p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) - 1.5 ) * 2 ) !! this is 0.4 at p47_rescale = 1.01; 1 at 1.5, 2.7 at 2 
+            ( 1 / p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) - 1 )
+            * exp( ( 1 / p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) - 1.5 ) * 2 ) !! this is 0.4 at p47_rescale = 1.01; 1 at 1.5, 2.7 at 2 
             * ( 2 * ( exp( -0.025 * iteration.val) + 0.1 ) )  !! in order to also have some dampening over iterstions, 
               !! this line decreases from 2.1 at iteration 1 to 0.36 in iteration 100. 
           )

--- a/modules/47_regipol/regiCarbonPrice/postsolve.gms
+++ b/modules/47_regipol/regiCarbonPrice/postsolve.gms
@@ -435,6 +435,7 @@ loop((ttot,ext_regi,taxType,targetType,qttyTarget,qttyTargetGroup)$pm_implicitQt
       p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) = (1 - pm_implicitQttyTarget_dev(ttot,ext_regi,qttyTarget,qttyTargetGroup) ) ** 2;
     );  
   );
+  put_utility "msg" / "p47_implicitQttyTargetTaxRescale before dampening:" ttot.tl ext_regi.tl  qttyTarget.tl qttyTargetGroup.tl p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) ; 
   display "p47_implicitQttyTargetTaxRescale before dampening: ", p47_implicitQttyTargetTaxRescale;
 *** dampen rescale factor when closer than 1.5 / 0.75 to reduce oscillations
   if( p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) > 1,
@@ -467,6 +468,7 @@ loop((ttot,ext_regi,taxType,targetType,qttyTarget,qttyTargetGroup)$pm_implicitQt
         )
     ;
   );
+  put_utility "msg" / "p47_implicitQttyTargetTaxRescale after dampening:" ttot.tl ext_regi.tl  qttyTarget.tl qttyTargetGroup.tl p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) ; 
   display "p47_implicitQttyTargetTaxRescale after dampening: ", p47_implicitQttyTargetTaxRescale;
 
 *** put a bound around the rescale factor with increasing iterations to help convergence
@@ -476,6 +478,7 @@ loop((ttot,ext_regi,taxType,targetType,qttyTarget,qttyTargetGroup)$pm_implicitQt
          ),
          1 / ( 2 * EXP( -0.05 * iteration.val ) + 1.01)
     );
+  put_utility "msg" / "p47_implicitQttyTargetTaxRescale after boundaries:" ttot.tl ext_regi.tl  qttyTarget.tl qttyTargetGroup.tl p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) ; 
   display "p47_implicitQttyTargetTaxRescale after boundaries: ", p47_implicitQttyTargetTaxRescale;
 
 *** dampen if rescale oscillates
@@ -491,6 +494,8 @@ loop((ttot,ext_regi,taxType,targetType,qttyTarget,qttyTargetGroup)$pm_implicitQt
       p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) =
         1 + ( ( p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) - 1 ) / 2 ) 
       ; !! this brings the value closer to one. The formulation works reasonably well within the range of 0.5..2
+      put_utility "msg" / "reducing p47_implicitQttyTargetTaxRescale due to oscillation in the previous 3 iterations:"; 
+      put_utility "msg" / ttot.tl ext_regi.tl  qttyTarget.tl qttyTargetGroup.tl p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) ; 
       display "reducing p47_implicitQttyTargetTaxRescale due to oscillation in the previous 3 iterations: ", p47_implicitQttyTargetTaxRescale;
     );
   );

--- a/modules/47_regipol/regiCarbonPrice/postsolve.gms
+++ b/modules/47_regipol/regiCarbonPrice/postsolve.gms
@@ -479,17 +479,19 @@ loop((ttot,ext_regi,taxType,targetType,qttyTarget,qttyTargetGroup)$pm_implicitQt
   display "p47_implicitQttyTargetTaxRescale after boundaries: ", p47_implicitQttyTargetTaxRescale;
 
 *** dampen if rescale oscillates
-  if( ( (iteration.val > 3) AND 
-        ( ( p47_implicitQttyTargetTaxRescale_iter(iteration-1,ttot,ext_regi,qttyTarget,qttyTargetGroup)  
-            * p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) ) < 0 
-        ) AND  !! sign changed between iteration -1 and current iteration
-        ( ( p47_implicitQttyTargetTaxRescale_iter(iteration-1,ttot,ext_regi,qttyTarget,qttyTargetGroup) 
-            p47_implicitQttyTargetTaxRescale_iter(iteration-2,ttot,ext_regi,qttyTarget,qttyTargetGroup) ) < 0
-        ) !! sign changed between iteration -2 and iteration -1
-      ),
-    p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) =
-      1 + ( ( p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) - 1 ) / 2 ) 
-    ; !! this brings the value closer to one. The formulation works reasonably well within the range of 0.5..2
+  if( (iteration.val > 3) , 
+    if ( ( 
+            ( ( p47_implicitQttyTargetTaxRescale_iter(iteration-1,ttot,ext_regi,qttyTarget,qttyTargetGroup)  
+                * p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) ) < 0 
+            ) AND  !! sign changed between iteration -1 and current iteration
+            ( ( p47_implicitQttyTargetTaxRescale_iter(iteration-1,ttot,ext_regi,qttyTarget,qttyTargetGroup) 
+                p47_implicitQttyTargetTaxRescale_iter(iteration-2,ttot,ext_regi,qttyTarget,qttyTargetGroup) ) < 0
+           ) !! sign changed between iteration -2 and iteration -1
+        ) ,
+      p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) =
+        1 + ( ( p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) - 1 ) / 2 ) 
+      ; !! this brings the value closer to one. The formulation works reasonably well within the range of 0.5..2
+    );
   );
   display "p47_implicitQttyTargetTaxRescale reduction for oscillation in the previous 3 iterations: ", p47_implicitQttyTargetTaxRescale;  
 );

--- a/modules/47_regipol/regiCarbonPrice/postsolve.gms
+++ b/modules/47_regipol/regiCarbonPrice/postsolve.gms
@@ -438,8 +438,8 @@ loop((ttot,ext_regi,taxType,targetType,qttyTarget,qttyTargetGroup)$pm_implicitQt
   display "p47_implicitQttyTargetTaxRescale before dampening: ", p47_implicitQttyTargetTaxRescale;
 *** dampen rescale factor when closer than 1.5 / 0.75 to reduce oscillations
   if( p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) > 1,
-    if( p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) > 2.5, !! prevent numeric explosion by limiting the maximum value
-      p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) = 2.5;
+    if( p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) > 1.7, !! prevent numeric explosion by limiting the maximum value
+      p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) = 1.7;
     );
     p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) =
       (  
@@ -451,9 +451,8 @@ loop((ttot,ext_regi,taxType,targetType,qttyTarget,qttyTargetGroup)$pm_implicitQt
       + 1
     ;
   else !! if rescale is <1, do the same procedure on (1/rescale)
-    if( p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) < 0.4,  !! prevent numeric explosion by limiting the minimum value
-      p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) = 0.4;
-      display "rescale limited to 0.4"
+    if( p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) < 0.6,  !! prevent numeric explosion by limiting the minimum value
+      p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) = 0.6;
     );
     p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) =
       1
@@ -472,10 +471,10 @@ loop((ttot,ext_regi,taxType,targetType,qttyTarget,qttyTargetGroup)$pm_implicitQt
 
 *** put a bound around the rescale factor with increasing iterations to help convergence
   p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) =
-    max( min( 2 * EXP( -0.08 * iteration.val ) + 1.01 ,
+    max( min( 2 * EXP( -0.05 * iteration.val ) + 1.01 ,
               p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup)
          ),
-         1 / ( 2 * EXP( -0.08 * iteration.val ) + 1.01)
+         1 / ( 2 * EXP( -0.05 * iteration.val ) + 1.01)
     );
   display "p47_implicitQttyTargetTaxRescale after boundaries: ", p47_implicitQttyTargetTaxRescale;
 );
@@ -532,7 +531,8 @@ loop((ttot,ext_regi,taxType,targetType,qttyTarget,qttyTargetGroup)$pm_implicitQt
   p47_implicitQttyTarget_initialYear(ext_regi,taxType,targetType,qttyTarget,qttyTargetGroup) = ttot.val;
 );
 
-p47_implicitQttyTargetTax_iter(iteration,ttot,all_regi,qttyTarget,qttyTargetGroup) = p47_implicitQttyTargetTax(ttot,all_regi,qttyTarget,qttyTargetGroup);
+*** tax associated with a specific iteration is the tax that was used in this iteration
+p47_implicitQttyTargetTax_iter(iteration,ttot,all_regi,qttyTarget,qttyTargetGroup) = p47_implicitQttyTargetTax_prevIter(ttot,all_regi,qttyTarget,qttyTargetGroup); 
 
 display p47_implicitQttyTargetCurrent, pm_implicitQttyTarget, p47_implicitQttyTargetTax_prevIter, pm_implicitQttyTarget_dev, p47_implicitQttyTarget_dev_iter, p47_implicitQttyTargetTax, 
         p47_implicitQttyTargetTaxRescale, p47_implicitQttyTargetTaxRescale_iter, p47_implicitQttyTargetTax_iter, p47_implicitQttyTargetCurrent_iter, p47_implicitQttyTargetTax0;

--- a/modules/47_regipol/regiCarbonPrice/postsolve.gms
+++ b/modules/47_regipol/regiCarbonPrice/postsolve.gms
@@ -485,7 +485,7 @@ loop((ttot,ext_regi,taxType,targetType,qttyTarget,qttyTargetGroup)$pm_implicitQt
                 * p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) ) < 0 
             ) AND  !! sign changed between iteration -1 and current iteration
             ( ( p47_implicitQttyTargetTaxRescale_iter(iteration-1,ttot,ext_regi,qttyTarget,qttyTargetGroup) 
-                p47_implicitQttyTargetTaxRescale_iter(iteration-2,ttot,ext_regi,qttyTarget,qttyTargetGroup) ) < 0
+                * p47_implicitQttyTargetTaxRescale_iter(iteration-2,ttot,ext_regi,qttyTarget,qttyTargetGroup) ) < 0
            ) !! sign changed between iteration -2 and iteration -1
         ) ,
       p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) =

--- a/modules/47_regipol/regiCarbonPrice/postsolve.gms
+++ b/modules/47_regipol/regiCarbonPrice/postsolve.gms
@@ -481,19 +481,20 @@ loop((ttot,ext_regi,taxType,targetType,qttyTarget,qttyTargetGroup)$pm_implicitQt
 *** dampen if rescale oscillates
   if( (iteration.val > 3) , 
     if ( ( 
-            ( ( p47_implicitQttyTargetTaxRescale_iter(iteration-1,ttot,ext_regi,qttyTarget,qttyTargetGroup)  
-                * p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) ) < 0 
-            ) AND  !! sign changed between iteration -1 and current iteration
-            ( ( p47_implicitQttyTargetTaxRescale_iter(iteration-1,ttot,ext_regi,qttyTarget,qttyTargetGroup) 
-                * p47_implicitQttyTargetTaxRescale_iter(iteration-2,ttot,ext_regi,qttyTarget,qttyTargetGroup) ) < 0
-           ) !! sign changed between iteration -2 and iteration -1
+            ( ( ( p47_implicitQttyTargetTaxRescale_iter(iteration-1,ttot,ext_regi,qttyTarget,qttyTargetGroup) - 1 ) 
+                * ( p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) - 1 ) ) < 0 
+            ) AND  !! test if rescale changed from >1 to <1 or vice versa between iteration -1 and current iteration
+            ( ( ( p47_implicitQttyTargetTaxRescale_iter(iteration-1,ttot,ext_regi,qttyTarget,qttyTargetGroup) - 1 )
+                * ( p47_implicitQttyTargetTaxRescale_iter(iteration-2,ttot,ext_regi,qttyTarget,qttyTargetGroup) -1 ) ) < 0
+           ) !! test if rescale changed from >1 to <1 or vice versa between iteration -2 and iteration -1
         ) ,
       p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) =
         1 + ( ( p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup) - 1 ) / 2 ) 
       ; !! this brings the value closer to one. The formulation works reasonably well within the range of 0.5..2
+      display "reducing p47_implicitQttyTargetTaxRescale due to oscillation in the previous 3 iterations: ", p47_implicitQttyTargetTaxRescale;
     );
   );
-  display "p47_implicitQttyTargetTaxRescale reduction for oscillation in the previous 3 iterations: ", p47_implicitQttyTargetTaxRescale;  
+    
 );
 
 p47_implicitQttyTargetTaxRescale_iter(iteration,ttot,ext_regi,qttyTarget,qttyTargetGroup) = p47_implicitQttyTargetTaxRescale(ttot,ext_regi,qttyTarget,qttyTargetGroup);


### PR DESCRIPTION
## Purpose of this PR

Improve convergence of p47_implicitQttyTargetTax in module 47:
- relax the bounds on rescale a bit
- instead use a formulation that reduces rescalings that are closer to 1 than 1.5/ 0.75
- add an iteration-dependent rescaling
- halve rescaling if there was oscillation in the last 3 iterations
Also improves formatting of displays of the p47 parameters

## Type of change

- [x] Minor change (default scenarios show only small differences)

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)

## Further information (optional):

* Test runs are here: /p/projects/remind/users/robertp/save_for_pullRequests/2023-03-16_improveP47convergence_and_output