### PR TITLE
Additional options to price trajectories after convergence in the regipol module

### DIFF
--- a/main.gms
+++ b/main.gms
@@ -870,11 +870,6 @@ parameter
   c_budgetCO2from2020      = 1150;   !! def = 1150
 *'  budgets from AR6 for 2020-2100 (including 2020), for 1.5 C: 500 Gt CO2 peak budget (400 Gt CO2 end of century), for 2 C: 1150 Gt CO2
 parameter
-  cm_postTargetIncrease     "carbon price increase per year after regipol emission target is reached (euro per tCO2)"
-;
-  cm_postTargetIncrease    = 0;      !! def = 0
-*'
-parameter
   cm_emiMktTargetDelay  "number of years for delayed price change in the emission tax convergence algorithm. Not applied to first target set."
 ;
   cm_emiMktTargetDelay    = 0;       !! def = 0
@@ -1228,6 +1223,13 @@ $setGlobal cm_emiMktTarget  off    !! def = off
 *** cm_quantity_regiCO2target "emissions quantity upper bound from specific year for region group."
 ***   Example on how to use:
 ***     '2050.EUR_regi.netGHG 0.000001, obliges European GHG emissions to be approximately zero from 2050 onward"
+$setGlobal cm_postTargetIncrease  off    !! def = off, alternatives: NPi, NDC, number
+*** cm_postTargetIncrease "carbon price behavior after the last regipol emission target"
+***   Example on how to use:
+***     'any number', e.g. '2', carbon prices increase 2 euros per tCO2 per year after regipol emission target is reached
+***     'NPi', carbon price follow NPi global convergence criteria after regipol emission target is reached
+***     'NDC', carbon price follow NDC global convergence criteria after regipol emission target is reached 
+***     '0' or 'off', carbon prices is kept without change year after regipol emission target is reached
 $setGlobal cm_quantity_regiCO2target  off !! def = off
 *** cm_dispatchSetyDown <- "off", if set to some value, this allows dispatching of pe2se technologies,
 *** i.e. the capacity factors can be varied by REMIND and are not fixed. The value of this switch gives the percentage points by how much the lower bound of capacity factors should be lowered.

--- a/modules/47_regipol/none/not_used.txt
+++ b/modules/47_regipol/none/not_used.txt
@@ -22,7 +22,6 @@ pm_data,input,questionnaire
 pm_inco0_t,input,questionnaire
 pm_taxCO2eqSCC,input,questionnaire
 pm_ts,input,questionnaire
-cm_postTargetIncrease,input,questionnaire
 cm_emiMktTargetDelay,input,questionnaire
 pm_histCap,input,questionnaire
 vm_emiCdr,input,questionnaire

--- a/modules/47_regipol/regiCarbonPrice/postsolve.gms
+++ b/modules/47_regipol/regiCarbonPrice/postsolve.gms
@@ -278,8 +278,16 @@ loop(ext_regi$regiEmiMktTarget(ext_regi),
               pm_taxemiMkt(t,regi,emiMkt)$(t.val gt ttot3.val) = pm_taxemiMkt(ttot3,regi,emiMkt) + (cm_postTargetIncrease*sm_DptCO2_2_TDpGtC)*(t.val-ttot3.val); !! price after next target year
             );
           else
-***         fixed year increase after terminal year price (cm_postTargetIncrease €/tCO2 increase per year)
-            pm_taxemiMkt(t,regi,emiMkt)$(t.val gt ttot2.val) = pm_taxemiMkt(ttot2,regi,emiMkt) + (cm_postTargetIncrease*sm_DptCO2_2_TDpGtC)*(t.val-ttot2.val);
+***         behavior after terminal year: fixed price (cm_postTargetIncrease=off or 0), global convergence (cm_postTargetIncrease=NPi or NDC), or fixed year increase (cm_postTargetIncrease €/tCO2 increase per year)
+$ifthen %cm_postTargetIncrease% == "off"
+            pm_taxemiMkt(t,regi,emiMkt)$(t.val gt ttot2.val) = pm_taxemiMkt(ttot2,regi,emiMkt);
+$elseif %cm_postTargetIncrease% == "NPi"
+
+$elseif %cm_postTargetIncrease% == "NDC"
+
+$else
+            pm_taxemiMkt(t,regi,emiMkt)$(t.val gt ttot2.val) = pm_taxemiMkt(ttot2,regi,emiMkt) + (%cm_postTargetIncrease%*sm_DptCO2_2_TDpGtC)*(t.val-ttot2.val);
+$endif
           );
         );
       );

--- a/standalone/MOFEX/MOFEX.gms
+++ b/standalone/MOFEX/MOFEX.gms
@@ -182,8 +182,6 @@ c_budgetCO2        "carbon budget for all CO2 emissions (in GtCO2)"
 cm_trdcst              "parameter to scale trade export cost for gas"
 cm_trdadj              "parameter scale the adjustment cost parameter for increasing gas trade export"
 
-cm_postTargetIncrease     "carbon price increase per year after target is reached (euro per tCO2)"
-
 cm_damages_BurkeLike_specification      "empirical specification for Burke-like damage functions"
 cm_damages_BurkeLike_persistenceTime    " persistence time in years for Burke-like damage functions"
 cm_damages_SccHorizon               "Horizon for SCC calculation. Damages cm_damagesSccHorizon years into the future are internalized."
@@ -326,7 +324,7 @@ c_abtrdy                 = 2010;   !! def = 2010
 c_abtcst                 = 1;      !! def = 1
 c_budgetCO2              = 0;   !! def = 1300
 $setGlobal cm_emiMktTarget  off   !! def = off
-cm_postTargetIncrease    = 0;      !! def = 0
+$setGlobal cm_postTargetIncrease off   !! def = 0
 $setGlobal cm_quantity_regiCO2target  off !! def = off
 cm_peakBudgYr            = 2050;   !! def = 2050
 cm_taxCO2inc_after_peakBudgYr = 2; !! def = 2

--- a/standalone/trade/trade.gms
+++ b/standalone/trade/trade.gms
@@ -186,8 +186,6 @@ c_budgetCO2        "carbon budget for all CO2 emissions (in GtCO2)"
 cm_trdcst              "parameter to scale trade export cost for gas"
 cm_trdadj              "parameter scale the adjustment cost parameter for increasing gas trade export"
 
-cm_postTargetIncrease     "carbon price increase per year after target is reached (euro per tCO2)"
-
 cm_damages_BurkeLike_specification      "empirical specification for Burke-like damage functions"
 cm_damages_BurkeLike_persistenceTime    " persistence time in years for Burke-like damage functions"
 cm_damages_SccHorizon               "Horizon for SCC calculation. Damages cm_damagesSccHorizon years into the future are internalized."
@@ -331,7 +329,7 @@ c_abtrdy                 = 2010;   !! def = 2010
 c_abtcst                 = 1;      !! def = 1
 c_budgetCO2              = 1350;   !! def = 1300
 $setGlobal cm_emiMktTarget  off   !! def = off
-cm_postTargetIncrease    = 0;      !! def = 0
+$setGlobal cm_postTargetIncrease off   !! def = 0
 $setGlobal cm_quantity_regiCO2target  off !! def = off
 cm_peakBudgYr            = 2050;   !! def = 2050
 cm_taxCO2inc_after_peakBudgYr = 2; !! def = 2


### PR DESCRIPTION
## Purpose of this PR

- Add support for global convergence assumptions in NPi and NDC scenarios while using the regipol module to define regional carbon pricing 

## Type of change

- [x] New feature 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [ ] Add NPi convergence formulation to regipol postsolve.gms @christophbertram @orichters 
- [ ] Add NDC convergence formulation to regipol postsolve.gms @christophbertram @orichters 
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] Do test runs @christophbertram @orichters 

