### PR TITLE
small fix in regipol

### DIFF
--- a/modules/47_regipol/regiCarbonPrice/datainput.gms
+++ b/modules/47_regipol/regiCarbonPrice/datainput.gms
@@ -8,6 +8,7 @@
 
 *' RP: improve formatting of output: always have the iteration separate to allow easy comparison over iterations.
 *' For non-iteration values show time and regi down, and the other two sets to the right
+$ifthen.cm_implicitQttyTarget not "%cm_implicitQttyTarget%" == "off"
 option p47_implicitQttyTarget_dev_iter:3:1:4;  
 option p47_implicitQttyTargetTaxRescale_iter:3:1:4;
 option p47_implicitQttyTargetTax_iter:3:1:4;
@@ -18,6 +19,9 @@ option p47_implicitQttyTargetTax_prevIter:3:2:2;
 option pm_implicitQttyTarget_dev:3:2:2;
 option p47_implicitQttyTargetTax:3:2:2;
 option p47_implicitQttyTargetTaxRescale:3:2:2;
+$endIf.cm_implicitQttyTarget
+
+$ifThen.emiMkt not "%cm_emiMktTarget%" == "off" 
 option pm_emiMktTarget_dev:3:3:1;
 option pm_factorRescaleemiMktCO2Tax:3:3:1;
 option pm_emiMktCurrent:3:3:1;
@@ -25,12 +29,15 @@ option pm_emiMktTarget:3:3:3;
 option pm_emiMktRefYear:3:3:1;
 option pm_taxemiMkt_iteration:3:3:1;
 option pm_emiMktTarget_dev_iter:3:1:4;
-
+$endIf.emiMkt
 
 
 *** initialize regipol target deviation parameter
 pm_emiMktTarget_dev(ttot,ttot2,ext_regi,emiMktExt) = 0;
+
+$ifthen.cm_implicitQttyTarget not "%cm_implicitQttyTarget%" == "off"
 p47_implicitQttyTargetTaxRescale_iter("1", "2030",ext_regi,qttyTarget,qttyTargetGroup) = 0;
+$endIf.cm_implicitQttyTarget
 
 *** RR this should be replaced as soon as non-energy is treated endogenously in the model
 *** EUR in 2030 ~ 90Mtoe (90 * 10^6 toe -> 90 * 10^6 toe * 41.868 GJ/toe -> 3768.12 * 10^6 GJ * 10^-9 EJ/GJ -> 3.76812 EJ * 1 TWa/31.536 EJ -> 0.1194863 TWa) EU27 = 92% EU28"


### PR DESCRIPTION
## Purpose of this PR
Runs did not compile if regipol was activitated but cm_implicitQttyTarget and cm_emiMktTarget turned off. This fix adds conditions to the output formatting in datainput.gms as done in the other parts of the file & module. 

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [ ] I explained my changes within the PR, particularly in hard-to-understand areas
- [ ] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

