### PR TITLE
fix error after generateIIASASubmission was refactored

### DIFF
--- a/scripts/output/export/xlsx_IIASA.R
+++ b/scripts/output/export/xlsx_IIASA.R
@@ -84,7 +84,7 @@ withCallingHandlers({ # piping messages to logFile
   } else if (all(mapping %in% names(templateNames())) && length(mapping) > 0) {
     mappingFile <- file.path(outputFolder, paste0(paste0(c("mapping", if (is.null(project)) mapping else project), collapse = "_"), ".csv"))
   } else {
-    message("# Mapping = '", paste(mapping, collapse = ","), " exists neither as file nor mapping name.")
+    message("# Mapping = '", paste(mapping, collapse = ","), "' exists neither as file nor mapping name.")
     mapping <- gms::chooseFromList(names(piamInterfaces::templateNames()))
     mappingFile <- file.path(outputFolder, paste0(paste0(c("mapping", mapping), collapse = "_"), ".csv"))
   }
@@ -131,7 +131,7 @@ withCallingHandlers({ # piping messages to logFile
 
   generateIIASASubmission(filename_remind2_mif, mapping = mapping, model = model, mappingFile = mappingFile,
                           removeFromScen = removeFromScen, addToScen = addToScen,
-                          outputDirectory = outputFolder, outputPrefix = "",
+                          outputDirectory = outputFolder,
                           logFile = logFile, outputFilename = basename(OUTPUT_mif),
                           iiasatemplate = if (file.exists(iiasatemplate)) iiasatemplate else NULL,
                           generatePlots = TRUE)


### PR DESCRIPTION
## Purpose of this PR

- `outputPrefix` is not supported anymore since https://github.com/pik-piam/piamInterfaces/pull/96

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)