### PR TITLE
new input data 6.336 and correltated CES parameters and gdx files

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -27,10 +27,10 @@ cfg$regionmapping <- "config/regionmappingH12.csv"
 ### Additional (optional) region mapping, so that those validation data can be loaded that contain the corresponding additional regions.
 cfg$extramappings_historic <- ""
 #### Current input data revision (<mainrevision>.<subrevision>) ####
-cfg$inputRevision <- "6.333"
+cfg$inputRevision <- "6.336"
 
 #### Current CES parameter and GDX revision (commit hash) ####
-cfg$CESandGDXversion <- "5c085fc9084eb0a3a07c68929930046d09e84732"
+cfg$CESandGDXversion <- "5427b80f0219a5c149060136dac92199240674a1"
 
 #### Force the model to download new input data ####
 cfg$force_download <- FALSE

--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -814,7 +814,7 @@ pm_dataren(all_regi,"maxprod","1","geohdr") = 1e-5; !!minimal production potenti
 
 pm_dataren(all_regi,"maxprod","1","geohdr")$f_maxProdGeothermal(all_regi,"maxprod") = sm_EJ_2_TWa * f_maxProdGeothermal(all_regi,"maxprod");
 *** FS: temporary fix: set minimum geothermal potential across all regions to 10 PJ (still negligible even in small regions) to get rid of infeasibilities
-***pm_dataren(all_regi,"maxprod","1","geohdr")$(f_maxProdGeothermal(all_regi,"maxprod") <= 0.01) = sm_EJ_2_TWa * 0.01;
+pm_dataren(all_regi,"maxprod","1","geohdr")$(f_maxProdGeothermal(all_regi,"maxprod") <= 0.01) = sm_EJ_2_TWa * 0.01;
 
 
 *mh* set 'nur' for all non renewable technologies to '1':

--- a/modules/37_industry/subsectors/input/files
+++ b/modules/37_industry/subsectors/input/files
@@ -1,4 +1,3 @@
-p37_cesIO_up_steel_secondary.cs4r
 p37_clinker-to-cement-ratio.cs3r
 p37_steel_secondary_max_share.cs4r
 pm_energy_limit.csv


### PR DESCRIPTION


## Purpose of this PR
new input data revision 6.336 and correltated new CES parameters and gdx files for input data 6.336 for SSP2EU, SSP1, SSP5, SSP2EU_lowEn and SDP_RC (/p/tmp/lavinia/REMIND/REMIND_calibration_2023_03_24/remind/output) and SSP2EU_EU21 (/p/tmp/robertp/zuloesch_2023-03_calibration_NES/remind_maxprod_1p5/output/SSP2EU-EU21-calibrate_2023-03-24_21.46.31); in addition, activate line on production potential for geohdr

## Type of change

- [x] Minor change (default scenarios show only small differences)

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code

## Further information (optional):

* Test runs are here: /p/tmp/lavinia/REMIND/REMIND_2023_03_26/remind/config
* Comparison of results (what changes by this PR?): 

