### PR TITLE
new CES parameters and gdx files for  6.336 for SDP_MC and SDP_EI

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -30,7 +30,7 @@ cfg$extramappings_historic <- ""
 cfg$inputRevision <- "6.336"
 
 #### Current CES parameter and GDX revision (commit hash) ####
-cfg$CESandGDXversion <- "5427b80f0219a5c149060136dac92199240674a1"
+cfg$CESandGDXversion <- "0810dad784a0ac31687016e316d30b2ea2599170"
 
 #### Force the model to download new input data ####
 cfg$force_download <- FALSE


### PR DESCRIPTION

## Purpose of this PR
add CES aprameters and gdx files for SDP_MC and SDP_EI from calibration runs in /p/tmp/lavinia/REMIND/REMIND_calibration_2023_03_24/remind/output


## Type of change

- [x] Minor change (default scenarios show only small differences)


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

