### PR TITLE
use NDC2023 version

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -67,6 +67,11 @@
       "orcid": "0000-0002-3240-2608"
     },
     {
+      "name": "Fuchs, Sophie",
+      "affiliation": "Potsdam Institute for Climate Impact Research",
+      "orcid": "0009-0000-7258-1287"
+    },
+    {
       "name": "Führlich, Pascal",
       "affiliation": "Potsdam Institute for Climate Impact Research",
       "orcid": "0000-0002-6856-8239"
@@ -132,7 +137,13 @@
     },
     {
       "name": "Malik, Aman",
-      "affiliation": "Potsdam Institute for Climate Impact Research"
+      "affiliation": "Potsdam Institute for Climate Impact Research",
+      "orcid": "0000-0002-7310-8448"
+    },
+    {
+      "name": "Mandaroux, Rahel",
+      "affiliation": "Potsdam Institute for Climate Impact Research",
+      "orcid": "0000-0001-5596-2571"
     },
     {
       "name": "Manger, Susanne"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -66,6 +66,11 @@ authors:
   orcid: https://orcid.org/0000-0002-3240-2608
   affiliation: "Potsdam Institute for Climate Impact Research"
 
+- family-names: "Fuchs"
+  given-names:  "Sophie"
+  orcid: https://orcid.org/0009-0000-7258-1287
+  affiliation: "Potsdam Institute for Climate Impact Research"
+
 - family-names: "Führlich"
   given-names:  "Pascal"
   orcid: https://orcid.org/0000-0002-6856-8239
@@ -132,6 +137,12 @@ authors:
 
 - family-names: "Malik"
   given-names:  "Aman"
+  orcid: https://orcid.org/0000-0002-7310-8448
+  affiliation: "Potsdam Institute for Climate Impact Research"
+
+- family-names: "Mandaroux"
+  given-names:  "Rahel"
+  orcid: https://orcid.org/0000-0001-5596-2571
   affiliation: "Potsdam Institute for Climate Impact Research"
 
 - family-names: "Manger"

--- a/main.gms
+++ b/main.gms
@@ -1132,7 +1132,7 @@ $setglobal cm_rcp_scen  none         !! def = "none"
 *' *  (2021_uncond): all NDCs independent of international financial support published until December 31, 2021
 *' *  (2018_cond):   all NDCs conditional to international financial support published until December 31, 2018
 *' *  (2018_uncond): all NDCs independent of international financial support published until December 31, 2018
-$setglobal cm_NDC_version  2022_cond    !! def = "2023_cond", "2023_uncond", "2022_cond", "2022_uncond", "2021_cond", "2021_uncond", "2018_cond", "2018_uncond"
+$setglobal cm_NDC_version  2023_cond    !! def = "2023_cond", "2023_uncond", "2022_cond", "2022_uncond", "2021_cond", "2021_uncond", "2018_cond", "2018_uncond"
 *** cm_netZeroScen     "choose scenario of net zero targets of netZero realization of module 46_carbonpriceRegi"
 ***  (NGFS2022):       settings used for NGFS 2022
 ***  (ENGAGE4p5_GlP):  settings used for ENGAGE 4.5 Glasgow+ scenario


### PR DESCRIPTION
## Purpose of this PR

- set 2023 version of NDC as default
- add authors
- currently only the new NDC by Turkmenistan is included, and as this is filtered out [by this line anyway](https://github.com/pik-piam/mrremind/blob/master/R/convertUNFCCC_NDC.R#L376), it does not affect scenarios at all :)

## Type of change

- [x] Minor change (default scenarios show only small differences)

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
