### PR TITLE
handle deps check w/o renv

### DIFF
--- a/scripts/start/ensureRequirementsInstalled.R
+++ b/scripts/start/ensureRequirementsInstalled.R
@@ -1,6 +1,7 @@
 #' ensureRequirementsInstalled
 #'
-#' Ensure that requirements are installed.
+#' Ensure that requirements are installed. If running in an renv, attempt to fix unfulfilled
+#' dependencies automatically. Outside of an renv just stop in case of unfulfilled dependencies.
 #'
 #' @param ask Whether to ask before fixing dependencies. Default: check the autoRenvFixDeps environment variable.
 #' @param rerunPrompt If the requirements can not be installed automatically, the user is prompted to restart.
@@ -13,8 +14,12 @@ ensureRequirementsInstalled <- function(
 ) {
   # Check if dependencies for a model run are fulfilled
   if (requireNamespace("piamenv", quietly = TRUE) && packageVersion("piamenv") >= "0.3.4") {
-    installedPackages <- piamenv::fixDeps(ask = ask)
-    piamenv::stopIfLoaded(names(installedPackages))
+    if (is.null(renv::project())) {
+      piamenv::checkDeps()
+    } else {
+      installedPackages <- piamenv::fixDeps(ask = ask)
+      piamenv::stopIfLoaded(names(installedPackages))
+    }
   } else {
     stop(paste0("REMIND requires piamenv >= 0.3.4, please run the following to update it:\n",
                 "renv::install('piamenv')\n",


### PR DESCRIPTION
## Purpose of this PR
The dependency check/fixing was always assuming to be in an renv. This PR handles the non-renv case. If a dependency requirement is not fulfilled this is reported and an error is thrown.

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [ ] Bug fix 
- [ ] Refactoring
- [ ] New feature 
- [ ] Minor change (default scenarios show only small differences)
- [ ] Fundamental change
- [ ] This change requires a documentation update


## Checklist:

- [ ] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [ ] I explained my changes within the PR, particularly in hard-to-understand areas
- [ ] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

