### PR TITLE
relax "no nuclear renaissance" constraint in NDCplus techpol 

### DIFF
--- a/modules/40_techpol/NDCplus/bounds.gms
+++ b/modules/40_techpol/NDCplus/bounds.gms
@@ -63,8 +63,8 @@ $endif.complex_transport
 
  display vm_cap.lo;
 ***NDCplus variant: additional bounds on nuclear policies:  no nuclear renaissance - no further ramping up of the industry, and focus on countries currently investing (mostly CHA, IND, RUS)
-***nuclear yearly additions per year are max. 10% of total currently under construction and 2.5% of combined planned and proposed plants 
-vm_deltaCap.up(t,regi,"tnrs","1")$(t.val gt 2030) = 0.1 * pm_NuclearConstraint("2020",regi,"tnrs") + 0.025 * (pm_NuclearConstraint("2025",regi,"tnrs")+pm_NuclearConstraint("2030",regi,"tnrs"));
+***nuclear yearly additions per year are max. 30% of total currently under construction and 7.5% of combined planned and proposed plants
+vm_deltaCap.up(t,regi,"tnrs","1")$(t.val gt 2030) = 0.3 * pm_NuclearConstraint("2020",regi,"tnrs") + 0.075 * (pm_NuclearConstraint("2025",regi,"tnrs")+pm_NuclearConstraint("2030",regi,"tnrs"));
 
 ***SR/BS/CB 2020-09-09
 *** -----------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Purpose of this PR
Previous constraint led to infeasibility in IND for all SDP_XX scenarios. Constraint is now relaxed to allow for more capacity additions (for all regions, not just IND). Change in parameters guided and results checked by @christophbertram . Only affects SDP_XX scenarios.

## Type of change
- [x ] Minor change (default scenarios show only small differences)

![image](https://user-images.githubusercontent.com/16190669/230356906-bd076f23-add0-462a-a2f7-c3aed0678f7f.png)


