### PR TITLE
input data 6.48, CES parameter and gdx files for SSP2EU, SSP1, SSP5, SSP2EU_lowEn, SDP_MC, SDP_EI, SDP_RC

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -27,10 +27,10 @@ cfg$regionmapping <- "config/regionmappingH12.csv"
 ### Additional (optional) region mapping, so that those validation data can be loaded that contain the corresponding additional regions.
 cfg$extramappings_historic <- ""
 #### Current input data revision (<mainrevision>.<subrevision>) ####
-cfg$inputRevision <- "6.46"
+cfg$inputRevision <- "6.48"
 
 #### Current CES parameter and GDX revision (commit hash) ####
-cfg$CESandGDXversion <- "06257294174f45936b3961a056f69ca3511d77f6"
+cfg$CESandGDXversion <- "038c1b7f7507c6e784e4447d3fbd9ba9df08e6d1"
 
 #### Force the model to download new input data ####
 cfg$force_download <- FALSE


### PR DESCRIPTION
## Purpose of this PR
new input data revision 6.48 and new CES parameter and gdx files for input data 6.48 for SSP2EU, SSP1, SSP5, SSP2EU_lowEn, SDP_MC, SDP_EI and SDP_RC, calibration runs are here: /p/tmp/lavinia/REMIND/REMIND_calibration_2023_04_07/remind/output

## Type of change

- [x] Minor change (default scenarios show only small differences)


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

