### PR TITLE
lock model for gamscompile in start_bundle_coupled

### DIFF
--- a/start_bundle_coupled.R
+++ b/start_bundle_coupled.R
@@ -513,8 +513,10 @@ for(scen in common){
 
   if ("--gamscompile" %in% flags) {
     message("Compiling ", fullrunname)
+    lockID <- gms::model_lock()
     gcresult <- runGamsCompile(if (is.null(cfg_rem$model)) "main.gms" else cfg_rem$model, cfg_rem,
                                interactive = "--interactive" %in% flags)
+    gms::model_unlock(lockID)
     errorsfound <- errorsfound + ! gcresult
   }
   if (!start_now) {


### PR DESCRIPTION
## Purpose of this PR
- similar to `start.R` ([lock](https://github.com/remindmodel/remind/blob/develop/start.R#L245) -> [unlock](https://github.com/remindmodel/remind/blob/develop/start.R#L353)), lock the model when running `--gamscompile` with `start_bundle_coupled.R`

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
