### PR TITLE
cs2: allow to specify profileName in command line, policyCosts: show setup always

### DIFF
--- a/config/scenario_config_coupled_NGFS_v4.csv
+++ b/config/scenario_config_coupled_NGFS_v4.csv
@@ -8,7 +8,7 @@ o_2c;NGFS;;o_2c;;short;SSP2|NDC|cc|rcp2p6;y2030;2;;;
 o_lowdem;NGFS;;o_lowdem;;short;SSP2|NDC|cc|rcp1p9;y2030;2;;;
 d_delfrag;NGFS;;d_delfrag;;priority;SSP2|NDC|cc|rcp2p6;y2030;2;;;
 d_rap;0;;d_rap;;priority;SSP2|NDC|cc|rcp1p9;y2030;2;;;
-d_strain;NGFS;;d_strain;;priority;SSP2|NDC|cc|rcp4p5;y2030;2;;;
+d_strain;NGFS;;d_strain;;short;SSP2|NDC|cc|rcp4p5;y2030;2;;;
 SSP2-Base_d50;d50;SSP2-Base;SSP2-Base;;priority;;;;;;
 SSP2-Base_d95;d95;SSP2-Base;SSP2-Base;;priority;;;;;;
 SSP2-Base_d50high;d50high;SSP2-Base;SSP2-Base;;priority;;;;;;

--- a/scripts/output/comparison/compareScenarios2.R
+++ b/scripts/output/comparison/compareScenarios2.R
@@ -84,14 +84,19 @@ startComp <- function(
 # Load cs2 profiles.
 profiles <- remind2::getCs2Profiles()
 
+lucode2::readArgs("profileNames")
+
 # Let user choose cs2 profile(s).
 profileNamesDefault <- determineDefaultProfiles(outputdirs[1])
-profileNames <- names(profiles)[gms::chooseFromList(
-  ifelse(names(profiles) %in% profileNamesDefault, crayon::cyan(names(profiles)), names(profiles)),
-  type = "profiles for cs2",
-  userinfo = paste0("Leave empty for ", crayon::cyan("cyan"), " default profiles."),
-  returnBoolean = TRUE
-)]
+
+if (! exists("profileNames") || ! all(profileNames %in% names(profiles))) {
+  profileNames <- names(profiles)[gms::chooseFromList(
+    ifelse(names(profiles) %in% profileNamesDefault, crayon::cyan(names(profiles)), names(profiles)),
+    type = "profiles for cs2",
+    userinfo = paste0("Leave empty for ", crayon::cyan("cyan"), " default profiles."),
+    returnBoolean = TRUE
+  )]
+}
 if (length(profileNames) == 0) {
   profileNames <- profileNamesDefault
   message("Default: ", paste(profileNamesDefault, collapse = ", "), ".\n")

--- a/scripts/output/comparison/policyCosts.R
+++ b/scripts/output/comparison/policyCosts.R
@@ -221,12 +221,13 @@ pc_pairs <- paste0(ifelse(file.exists(pol_mifs) & file.exists(pol_gdxs), crayon:
                    " w.r.t. ", ifelse(file.exists(ref_gdxs), crayon::green(ref_names), crayon::red(ref_names)))
 
 # If this script was called from output.R, check with user if the pol-ref pairs are correct.
+message(crayon::blue("\nSet-up:"))
+if (! all(file.exists(c(pol_mifs, pol_gdxs, ref_gdxs)))) message(crayon::red("Red"), " folder names have no fitting mif or gdx file, first run the reporting.")
+message("From the order with which you selected the directories, the following policy costs will be computed:")
+message(paste0("\t", pc_pairs, "\n"))
+
 if (exists("source_include")) {
-  message(crayon::blue("\nPlease confirm the set-up."))
-  if (! all(file.exists(c(pol_mifs, pol_gdxs, ref_gdxs)))) message(crayon::red("Red"), " folder names have no fitting mif or gdx file, first run the reporting.")
-  message("From the order with which you selected the directories, the following policy costs will be computed:")
-  message(paste0("\t", pc_pairs, "\n"))
-  message("Is that what you intended?")
+  message(crayon::blue("Is that what you intended? Please confirm the set-up"))
   message("Type '", crayon::green("y"), "' to continue, '", crayon::blue("s"), "' to skip red ones, ", crayon::red("n"), "' to abort: ")
 
   user_input <- gms::getLine()

--- a/tutorials/14_Calculate_policy_costs.md
+++ b/tutorials/14_Calculate_policy_costs.md
@@ -49,15 +49,21 @@ scenarioAndReference=( $( IFS="," ; echo "${scenarioAndReference[*]}") )
 Rscript output.R comp=T output=policyCosts outputdir=$scenarioAndReference
 ```
 
-Short version if you have a single base run for all your scenarios:
+Short version if you have a single base run for all your scenarios and want to automatically start a compareScenario2 and an IIASA export:
 ```
 # NGFS
 remnr=5
-runs=(h_cpol h_ndc o_1p5c o_2p d_delfrag d_rap)
+runs=(h_cpol h_ndc o_2c o_1p5c o_lowdem d_delfrag d_strain)
 baserun=h_cpol
 
-outputarray=( "${runs[@]/%/-rem-${remnr},${baserun}-rem-${remnr}}" )
-outputarray=( "${outputarray[@]/#/output/C_}" )
-outputstring="$(IFS=,; echo "${outputarray[*]}")"
-Rscript output.R comp=T output=policyCosts outputdir=$outputstring
+outputarraypc=( "${runs[@]/%/-rem-${remnr},output/C_${baserun}-rem-${remnr}}" )
+outputarraypc=( "${outputarraypc[@]/#/output/C_}" )
+outputstringpc="$(IFS=,; echo "${outputarraypc[*]}")"
+Rscript scripts/output/comparison/policyCosts.R outputdirs=$outputstringpc special_requests=
+
+outputarraycs=( "${runs[@]/%/-rem-${remnr}}" )
+outputarraycs=( "${outputarraycs[@]/#/output/C_}" )
+outputstringcs="$(IFS=,; echo "${outputarraycs[*]}")"
+Rscript output.R comp=export output=xlsx_IIASA outputdir=$outputstringcs project=NGFS_v4 filename_prefix=NGFS_v4
+Rscript output.R comp=comparison output=compareScenarios2 outputdir=$outputstringcs filename_prefix=NGFS_v4 slurmConfig=priority profileNames=REMIND-MAgPIE
 ```


### PR DESCRIPTION
## Purpose of this PR

- cs2: using readArgs, allow to specify profileName
- policyCosts: print set-up always even if not asking the user anything to make debugging easier
- bugfix and slight extension of policy costs tutorial

## Type of change

- [x] New very minor features

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
