### PR TITLE
fail transparently on long input filename

### DIFF
--- a/scripts/start/calculate_CES_configuration.R
+++ b/scripts/start/calculate_CES_configuration.R
@@ -1,16 +1,23 @@
-calculate_CES_configuration <- function(cfg) {
-    paste0("indu_", cfg$gms$industry,"-",
-           "buil_", cfg$gms$buildings,"-",
-           "tran_", cfg$gms$transport,"-",
-           "POP_",  cfg$gms$cm_POPscen, "-",
-           "GDP_",  cfg$gms$cm_GDPscen, "-",
-           "En_",   cfg$gms$cm_demScen, "-",
-           "Kap_",  cfg$gms$capitalMarket, "-",
-           if (cfg$gms$cm_calibration_string == "off") {
-               ""
-           } else {
-               paste0(cfg$gms$cm_calibration_string, "-")
-           },
-           "Reg_", madrat::regionscode(cfg$regionmapping)
+calculate_CES_configuration <- function(cfg, check = FALSE) {
+    CESstring <- paste0("indu_", cfg$gms$industry,"-",
+                        "buil_", cfg$gms$buildings,"-",
+                        "tran_", cfg$gms$transport,"-",
+                        "POP_",  cfg$gms$cm_POPscen, "-",
+                        "GDP_",  cfg$gms$cm_GDPscen, "-",
+                        "En_",   cfg$gms$cm_demScen, "-",
+                        "Kap_",  cfg$gms$capitalMarket, "-",
+                        if (! cfg$gms$cm_calibration_string == "off") paste0(cfg$gms$cm_calibration_string, "-"),
+                        "Reg_", madrat::regionscode(cfg$regionmapping)
     )
+    CESfile <- file.path(getwd(), "./modules/29_CES_parameters/load/input",
+                         paste0(CESstring, ".inc"))
+    if (check && nchar(CESfile) > 255) {
+        stop("Filename of CES file has more than 255 characters, which will ",
+             "cause GAMS to fail on loading it.\n",
+             "Rename and shorten the path to your REMIND directory by ",
+             (nchar(CESfile) - 255), " characters.\n",
+             "Like so: '",
+             substr(getwd(), 1, nchar(getwd()) - (nchar(CESfile) - 255)), "'")
+    }
+    return(CESstring)
 }

--- a/scripts/start/calculate_CES_configuration.R
+++ b/scripts/start/calculate_CES_configuration.R
@@ -1,0 +1,16 @@
+calculate_CES_configuration <- function(cfg) {
+    paste0("indu_", cfg$gms$industry,"-",
+           "buil_", cfg$gms$buildings,"-",
+           "tran_", cfg$gms$transport,"-",
+           "POP_",  cfg$gms$cm_POPscen, "-",
+           "GDP_",  cfg$gms$cm_GDPscen, "-",
+           "En_",   cfg$gms$cm_demScen, "-",
+           "Kap_",  cfg$gms$capitalMarket, "-",
+           if (cfg$gms$cm_calibration_string == "off") {
+               ""
+           } else {
+               paste0(cfg$gms$cm_calibration_string, "-")
+           },
+           "Reg_", madrat::regionscode(cfg$regionmapping)
+    )
+}

--- a/scripts/start/prepare.R
+++ b/scripts/start/prepare.R
@@ -141,10 +141,15 @@ prepare <- function() {
                                          "Kap_", cfg$gms$capitalMarket, "-",
                                          if(cfg$gms$cm_calibration_string == "off") "" else paste0(cfg$gms$cm_calibration_string, "-"),
                                          "Reg_", madrat::regionscode(cfg$regionmapping))
-
+  CESfile <- paste0("./modules/29_CES_parameters/load/input/", cfg$gms$cm_CES_configuration, ".inc")
+  CESfilefull <- file.path(cfg$remind_folder, CESfile)
+  if (nchar(CESfilefull) > 255) {
+    stop("Filename of CES file has more than 255 characters, which will cause GAMS to fail on loading it. ",
+         "Rename and shorten the path to your REMIND directory by ", (nchar(CESfilefull) - 255), " characters.")
+  }
   # write name of corresponding CES file to datainput.gms
   replace_in_file(file    = "./modules/29_CES_parameters/load/datainput.gms",
-                  content = paste0('$include "./modules/29_CES_parameters/load/input/',cfg$gms$cm_CES_configuration,'.inc"'),
+                  content = paste0('$include "', CESfile, '"'),
                   subject = "CES INPUT")
 
   # If a path to a MAgPIE report is supplied use it as REMIND input (used for REMIND-MAgPIE coupling)

--- a/scripts/start/prepare.R
+++ b/scripts/start/prepare.R
@@ -131,25 +131,13 @@ prepare <- function() {
     create_input_for_45_carbonprice_exogenous(as.character(cfg$files2export$start["input_carbonprice.gdx"]))
   }
 
-  # Calculate CES configuration string
-  cfg$gms$cm_CES_configuration <- paste0("indu_",cfg$gms$industry,"-",
-                                         "buil_",cfg$gms$buildings,"-",
-                                         "tran_",cfg$gms$transport,"-",
-                                         "POP_", cfg$gms$cm_POPscen, "-",
-                                         "GDP_", cfg$gms$cm_GDPscen, "-",
-                                         "En_",  cfg$gms$cm_demScen, "-",
-                                         "Kap_", cfg$gms$capitalMarket, "-",
-                                         if(cfg$gms$cm_calibration_string == "off") "" else paste0(cfg$gms$cm_calibration_string, "-"),
-                                         "Reg_", madrat::regionscode(cfg$regionmapping))
-  CESfile <- paste0("./modules/29_CES_parameters/load/input/", cfg$gms$cm_CES_configuration, ".inc")
-  CESfilefull <- file.path(cfg$remind_folder, CESfile)
-  if (nchar(CESfilefull) > 255) {
-    stop("Filename of CES file has more than 255 characters, which will cause GAMS to fail on loading it. ",
-         "Rename and shorten the path to your REMIND directory by ", (nchar(CESfilefull) - 255), " characters.")
-  }
+  cfg$gms$cm_CES_configuration <- calculate_CES_configuration(cfg)
+
   # write name of corresponding CES file to datainput.gms
   replace_in_file(file    = "./modules/29_CES_parameters/load/datainput.gms",
-                  content = paste0('$include "', CESfile, '"'),
+                  content = paste0('$include "',
+                                   "./modules/29_CES_parameters/load/input/",
+                                   cfg$gms$cm_CES_configuration, ".inc\""),
                   subject = "CES INPUT")
 
   # If a path to a MAgPIE report is supplied use it as REMIND input (used for REMIND-MAgPIE coupling)

--- a/start.R
+++ b/start.R
@@ -322,17 +322,7 @@ if (any(c("--reprepare", "--restart") %in% flags)) {
     }
 
     # abort on too long paths ----
-    cfg$gms$cm_CES_configuration <- calculate_CES_configuration(cfg)
-    CESfile <- file.path(getwd(), 'modules/29_CES_parameters/load/input',
-                         paste0(cfg$gms$cm_CES_configuration, '.inc'))
-    if (nchar(CESfile) > 255) {
-      stop("Filename of CES file has more than 255 characters, which will ",
-           "cause GAMS to fail on loading it.\n",
-           "Rename and shorten the path to your REMIND directory by ",
-           (nchar(CESfile) - 255), " characters.\n",
-           "Like so: '",
-           substr(getwd(), 1, nchar(getwd()) - (nchar(CESfile) - 255)), "'")
-    }
+    cfg$gms$cm_CES_configuration <- calculate_CES_configuration(cfg, check = TRUE)
 
     # save the cfg object for the later automatic start of subsequent runs (after preceding run finished)
     if (! "--gamscompile" %in% flags) {

--- a/start.R
+++ b/start.R
@@ -321,6 +321,19 @@ if (any(c("--reprepare", "--restart") %in% flags)) {
       cfg$slurmConfig <- slurmConfig
     }
 
+    # abort on too long paths ----
+    cfg$gms$cm_CES_configuration <- calculate_CES_configuration(cfg)
+    CESfile <- file.path(getwd(), 'modules/29_CES_parameters/load/input',
+                         paste0(cfg$gms$cm_CES_configuration, '.inc'))
+    if (nchar(CESfile) > 255) {
+      stop("Filename of CES file has more than 255 characters, which will ",
+           "cause GAMS to fail on loading it.\n",
+           "Rename and shorten the path to your REMIND directory by ",
+           (nchar(CESfile) - 255), " characters.\n",
+           "Like so: '",
+           substr(getwd(), 1, nchar(getwd()) - (nchar(CESfile) - 255)), "'")
+    }
+
     # save the cfg object for the later automatic start of subsequent runs (after preceding run finished)
     if (! "--gamscompile" %in% flags) {
       filename <- paste0(cfg$title,".RData")

--- a/start_bundle_coupled.R
+++ b/start_bundle_coupled.R
@@ -382,6 +382,9 @@ for(scen in common){
     cfg_rem$cm_nash_autoconverge_lastrun <- scenarios_coupled[scen, "cm_nash_autoconverge_lastrun"]
   }
 
+  # abort on too long paths ----
+  cfg_rem$gms$cm_CES_configuration <- calculate_CES_configuration(cfg_rem, check = TRUE)
+
   for (i in max_iterations:start_iter_first) {
     fullrunname <- paste0(runname, "-rem-", i)
     start_iter <- i


### PR DESCRIPTION
## Purpose of this PR

- avoid [intransparent GAMS fails](https://mattermost.pik-potsdam.de/rd3/channels/remind/thjz17corbytbd45jffhw7pyue) if the filename of the CES configuration file exceeds 255 characters.

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)

## Further information:

* Test runs are here:
- `/p/tmp/oliverr/remind-smallfix-for-whatever-reason-robert-likes-very-long-directory-names-but-let-us-see-whether-this-fails/output/testOneRegi`
- the `testOneRegi-shortpath` run was with the short directory name and worked

