### PR TITLE
Added phase-out scenario option.

### DIFF
--- a/modules/35_transport/edge_esm/sets.gms
+++ b/modules/35_transport/edge_esm/sets.gms
@@ -146,6 +146,7 @@ NAV_tec
 NAV_ele
 NAV_lce
 NAV_all
+PhOP
 /
 
 EDGE_scenario(EDGE_scenario_all) "Selected EDGE-T scenario"


### PR DESCRIPTION
## Purpose of this PR
This PR adds a new scenario option for EDGE-T coupled runs, featuring phase-out of ICEs in Europe (LDVs and HDVs).

## Type of change
Minor change (default scenarios show only small differences)
