### PR TITLE
Fix H2 in buildings to zero by default

### DIFF
--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -504,8 +504,8 @@ v_shfe.lo(t,regi,entyFe,sector)$pm_shfe_lo(t,regi,entyFe,sector) = pm_shfe_lo(t,
 v_shGasLiq_fe.up(t,regi,sector)$pm_shGasLiq_fe_up(t,regi,sector) = pm_shGasLiq_fe_up(t,regi,sector);
 v_shGasLiq_fe.lo(t,regi,sector)$pm_shGasLiq_fe_lo(t,regi,sector) = pm_shGasLiq_fe_lo(t,regi,sector);
 
-*** FS: allow for H2 use in buildings only from 2030 onwards
-vm_demFeSector.up(t,regi,"seh2","feh2s","build",emiMkt)$(t.val le 2025)=0;
+*** RH: Fix H2 in buildings to zero until given year (always zero by default)
+vm_demFeSector.up(t,regi,"seh2","feh2s","build",emiMkt)$(t.val le c_H2InBuildOnlyAfter) = 0;
 
 ***----------------------------------------------------------------------------
 ***  Controlling if active, dampening factor to align edge-t non-energy transportation costs with historical GDP data

--- a/main.gms
+++ b/main.gms
@@ -930,6 +930,11 @@ parameter
   cm_noReboundEffect     = 0;
 *'  price sensitivity of logit function for heating and cooking technological choice
 parameter
+  c_H2InBuildOnlyAfter "Switch to fix H2 in buildings to zero until given year"
+;
+  c_H2InBuildOnlyAfter = 2150;   !! def = 2150 (rule out H2 in buildings)
+*' For all years until the given year, FE demand for H2 in buildings is set to zero
+parameter
   cm_priceSensiBuild    "Price sensitivity of energy carrier choice in buildings"
 ;
   cm_priceSensiBuild     = -3;


### PR DESCRIPTION
## Purpose of this PR
Rule out H2 in Buildings overall to avoid spikes in particular regions. I introduced the switch `c_H2InBuildOnlyAfter` that is by default defined such that no H2 is allowed at any time in buildings. To get the old behaviour, set it to `2025`.

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix 
- [x] New feature 



## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)

## Further information (optional):

* Test runs are here: 
`/p/tmp/krekeler/dev/REMIND/remind/output/SSP2EU-PkBudg500_2023-04-20_16.13.19`

