### PR TITLE
prevent coupled runs with renv

### DIFF
--- a/start_bundle_coupled.R
+++ b/start_bundle_coupled.R
@@ -6,8 +6,11 @@
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
 if (!is.null(renv::project())) {
-  stop("Coupled runs are currently not supported with renv. Please use a snapshot instead, ",
-       "see https://github.com/remindmodel/remind/blob/develop/tutorials/11_ManagingRenv.md#legacy-snapshots")
+  stop("Coupled runs are currently not supported with renv. Please use a snapshot instead. ",
+       "How to switch from renv to snapshots: ",
+       "https://github.com/remindmodel/remind/blob/develop/tutorials/11_ManagingRenv.md#legacy-snapshots ",
+       "How to create a snapshot: https://github.com/remindmodel/remind/blob/develop/tutorials/",
+       "04_RunningREMINDandMAgPIE.md#create-snapshot-of-r-libraries")
 }
 require(lucode2)
 require(magclass)

--- a/start_bundle_coupled.R
+++ b/start_bundle_coupled.R
@@ -5,6 +5,10 @@
 # |  AGPL-3.0, you are granted additional permissions described in the
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
+if (!is.null(renv::project())) {
+  stop("Coupled runs are currently not supported with renv. Please use a snapshot instead, ",
+       "see https://github.com/remindmodel/remind/blob/develop/tutorials/11_ManagingRenv.md#legacy-snapshots")
+}
 require(lucode2)
 require(magclass)
 require(gms)


### PR DESCRIPTION
## Purpose of this PR
- added a check to `start_bundle_coupled.R` that throws an error if renv is active for a coupled run

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [ ] Bug fix 
- [ ] Refactoring
- [ ] New feature 
- [ ] Minor change (default scenarios show only small differences)
- [ ] Fundamental change
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [ ] I explained my changes within the PR, particularly in hard-to-understand areas
- [ ] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

