### PR TITLE
cleanup of deleted switches cm_trdadj, cm_trdcst, old redmine wiki links

### DIFF
--- a/modules/31_fossil/MOFEX/bounds.gms
+++ b/modules/31_fossil/MOFEX/bounds.gms
@@ -15,7 +15,6 @@
 *   change for example.
 *===========================================
 * Authors...: SB
-* Wiki......: http://redmine.pik-potsdam.de/projects/remind-r/wiki/31_fossil
 * History...:
 *   - 2019-09-10 : Creation
 *===========================================

--- a/modules/31_fossil/MOFEX/datainput.gms
+++ b/modules/31_fossil/MOFEX/datainput.gms
@@ -15,7 +15,6 @@
 *   change for example.
 *===========================================
 * Authors...: SB
-* Wiki......: http://redmine.pik-potsdam.de/projects/remind-r/wiki/31_fossil
 * History...:
 *   - 2012-09-10 : Creation
 *===========================================
@@ -113,7 +112,7 @@ p31_fosadjco_xi5xi6(regi, "xi6", "pegas")  = 1/1;
 *NB*110720 include data for constraints on maximum growth and decline of vm_fuExtr, and also the offsets
 *SB*04022020 Hardcoded this into the preloop instead of the FFECCM input routines
 
-p31_datafosdyn(regi,"pegas",rlf,"alph") = cm_trdadj * p31_datafosdyn(regi,"pegas",rlf,"alph");
+p31_datafosdyn(regi,"pegas",rlf,"alph") = 2 * p31_datafosdyn(regi,"pegas",rlf,"alph");
 
 p31_extraseed(ttot,regi,enty,rlf) = 0;
 *NB* extra seed value for the US gas sector to reduce initial price in EJ/yr

--- a/modules/31_fossil/MOFEX/declarations.gms
+++ b/modules/31_fossil/MOFEX/declarations.gms
@@ -15,7 +15,6 @@
 *   change for example. 
 *===========================================
 * Authors...: JH, NB, TAC
-* Wiki......: http://redmine.pik-potsdam.de/projects/remind-r/wiki/31_fossil   
 * History...:
 *   - 2012-09-10 : Creation
 *===========================================

--- a/modules/31_fossil/MOFEX/equations.gms
+++ b/modules/31_fossil/MOFEX/equations.gms
@@ -15,7 +15,6 @@
 *   change for example.
 *===========================================
 * Authors...: SB
-* Wiki......: http://redmine.pik-potsdam.de/projects/remind-r/wiki/31_fossil
 * History...:
 *   - 2012-09-10 : Creation
 *===========================================

--- a/modules/31_fossil/MOFEX/output.gms
+++ b/modules/31_fossil/MOFEX/output.gms
@@ -15,7 +15,6 @@
 *   change for example.
 *===========================================
 * Authors...: SB
-* Wiki......: http://redmine.pik-potsdam.de/projects/remind-r/wiki/31_fossil
 * History...:
 *   - 2012-09-10 : Creation
 *===========================================

--- a/modules/31_fossil/MOFEX/preloop.gms
+++ b/modules/31_fossil/MOFEX/preloop.gms
@@ -15,7 +15,6 @@
 *   change for example.
 *===========================================
 * Authors...: SB
-* Wiki......: http://redmine.pik-potsdam.de/projects/remind-r/wiki/31_fossil
 * History...:
 *   - 2012-09-10 : Creation
 *===========================================

--- a/modules/31_fossil/MOFEX/solve.gms
+++ b/modules/31_fossil/MOFEX/solve.gms
@@ -15,7 +15,6 @@
 *   change for example.
 *===========================================
 * Authors...: SB
-* Wiki......: http://redmine.pik-potsdam.de/projects/remind-r/wiki/31_fossil
 * History...:
 *   - 2019-09-10 : Creation
 *===========================================

--- a/modules/31_fossil/timeDepGrades/bounds.gms
+++ b/modules/31_fossil/timeDepGrades/bounds.gms
@@ -15,7 +15,6 @@
 *   change for example.
 *===========================================
 * Authors...: JH, NB, TAC, SB
-* Wiki......: http://redmine.pik-potsdam.de/projects/remind-r/wiki/31_fossil
 * History...:
 *   - 2020-04-15 : Created moinput functions for input data handling, including region-specific constraints
 *                  previously in the GAMS code. Data aggregated to H12 regions.

--- a/modules/31_fossil/timeDepGrades/datainput.gms
+++ b/modules/31_fossil/timeDepGrades/datainput.gms
@@ -15,7 +15,6 @@
 *   change for example.
 *===========================================
 * Authors...: JH, NB, TAC, SB
-* Wiki......: http://redmine.pik-potsdam.de/projects/remind-r/wiki/31_fossil
 * History...:
 *   - 2020-04-15 : Created moinput functions for input data handling, including region-specific constraints
 *                  previously in the GAMS code. Data aggregated to H12 regions.
@@ -171,7 +170,7 @@ if (cm_nucscen eq 6,
   s31_max_disp_peur = 23*10;
 );
 
-p31_datafosdyn(regi,"pegas",rlf,"alph") = cm_trdadj * p31_datafosdyn(regi,"pegas",rlf,"alph");
+p31_datafosdyn(regi,"pegas",rlf,"alph") = 2 * p31_datafosdyn(regi,"pegas",rlf,"alph");
 
 *NB* extra seed value for the US gas sector to reduce initial price in EJ/yr
 *SB 04/15/2020* Moved this parameter definition to moinput

--- a/modules/31_fossil/timeDepGrades/declarations.gms
+++ b/modules/31_fossil/timeDepGrades/declarations.gms
@@ -15,7 +15,6 @@
 *   change for example. 
 *===========================================
 * Authors...: JH, NB, TAC, SB
-* Wiki......: http://redmine.pik-potsdam.de/projects/remind-r/wiki/31_fossil   
 * History...:
 *   - 2015-12-03 : Cleaning up
 *   - 2015-02-06 : Add possibility for user-defined fuel extraction in 2005 

--- a/modules/31_fossil/timeDepGrades/equations.gms
+++ b/modules/31_fossil/timeDepGrades/equations.gms
@@ -15,7 +15,6 @@
 *   change for example.
 *===========================================
 * Authors...: JH, NB, TAC
-* Wiki......: http://redmine.pik-potsdam.de/projects/remind-r/wiki/31_fossil
 * History...:
 *   - 2015-12-03 : Cleaning up
 *   - 2013-10-01 : Cleaning up

--- a/modules/31_fossil/timeDepGrades/output.gms
+++ b/modules/31_fossil/timeDepGrades/output.gms
@@ -15,7 +15,6 @@
 *   change for example.
 *===========================================
 * Authors...: JH, NB, TAC
-* Wiki......: http://redmine.pik-potsdam.de/projects/remind-r/wiki/31_fossil
 * History...:
 *   - 2015-12-03 : Cleaning up
 *   - 2013-10-01 : Cleaning up

--- a/modules/31_fossil/timeDepGrades/preloop.gms
+++ b/modules/31_fossil/timeDepGrades/preloop.gms
@@ -15,7 +15,6 @@
 *   change for example.
 *===========================================
 * Authors...: JH, NB, TAC, CB, SB
-* Wiki......: http://redmine.pik-potsdam.de/projects/remind-r/wiki/31_fossil
 * History...:
 *   - 2020-04-15 : Created moinput functions for input data handling, including region-specific constraints
 *                  previously in the GAMS code. Data aggregated to H12 regions.

--- a/scripts/start/readCheckScenarioConfig.R
+++ b/scripts/start/readCheckScenarioConfig.R
@@ -112,7 +112,10 @@ readCheckScenarioConfig <- function(filename, remindPath = ".", testmode = FALSE
        "cm_build_costDecayStart" = "Rename to cm_build_H2costDecayStart, see https://github.com/remindmodel/remind/pull/1057",
        "c_BaselineAgriEmiRed" = "Use more flexible c_agricult_base_shift switch instead, see https://github.com/remindmodel/remind/issues/1157",
        "cm_bioprod_histlim" = "Use more flexible cm_bioprod_regi_lim switch instead, see https://github.com/remindmodel/remind/issues/1157",
-       "cm_BioImportTax_EU" = "Use more flexible cm_import_tax switch instead, see https://github.com/remindmodel/remind/issues/1157"
+       "cm_BioImportTax_EU" = "Use more flexible cm_import_tax switch instead, see https://github.com/remindmodel/remind/issues/1157",
+       "cm_trdcst" = "Now always fixed to 1.5, see https://github.com/remindmodel/remind/pull/1052",
+       "cm_trdadj" = "Now always fixed to 2, see https://github.com/remindmodel/remind/pull/1052",
+       "cm_OILRETIRE" = "Now always on by default, see https://github.com/remindmodel/remind/pull/1102"
      )
     for (i in intersect(names(forbiddenColumnNames), unknownColumnNames)) {
       if (testmode) {

--- a/standalone/MOFEX/MOFEX.gms
+++ b/standalone/MOFEX/MOFEX.gms
@@ -179,9 +179,6 @@ c_abtrdy              "first year in which advanced bio-energy technology are re
 c_abtcst              "scaling of the cost of advanced bio-energy technologies (no unit, 50% increase means 1.5)"
 c_budgetCO2        "carbon budget for all CO2 emissions (in GtCO2)"
 
-cm_trdcst              "parameter to scale trade export cost for gas"
-cm_trdadj              "parameter scale the adjustment cost parameter for increasing gas trade export"
-
 cm_postTargetIncrease     "carbon price increase per year after target is reached (euro per tCO2)"
 
 cm_damages_BurkeLike_specification      "empirical specification for Burke-like damage functions"

--- a/standalone/template.gms
+++ b/standalone/template.gms
@@ -175,9 +175,6 @@ c_abtrdy              "first year in which advanced bio-energy technology are re
 c_abtcst              "scaling of the cost of advanced bio-energy technologies (no unit, 50% increase means 1.5)"
 c_budgetCO2        "carbon budget for all CO2 emissions (in GtCO2)"
 
-cm_trdcst              "parameter to scale trade export cost for gas"
-cm_trdadj              "parameter scale the adjustment cost parameter for increasing gas trade export"
-
 cm_damages_BurkeLike_specification      "empirical specification for Burke-like damage functions"
 cm_damages_BurkeLike_persistenceTime    " persistence time in years for Burke-like damage functions"
 cm_damages_SccHorizon               "Horizon for SCC calculation. Damages cm_damagesSccHorizon years into the future are internalized."
@@ -272,8 +269,6 @@ c_abtcst                 = 1;      !! def = 1
 c_budgetCO2              = 1350;   !! def = 1300
 $setGlobal cm_emiMktTarget  off   !! def = off
 
-cm_trdadj            = 2;    !! def = 2.0
-cm_trdcst             = 1.5;  !! def = 1.5
 cm_frac_CCS          = 10;   !! def = 10
 cm_frac_NetNegEmi    = 0.5;  !! def = 0.5
 

--- a/standalone/trade/trade.gms
+++ b/standalone/trade/trade.gms
@@ -183,9 +183,6 @@ c_abtrdy              "first year in which advanced bio-energy technology are re
 c_abtcst              "scaling of the cost of advanced bio-energy technologies (no unit, 50% increase means 1.5)"
 c_budgetCO2        "carbon budget for all CO2 emissions (in GtCO2)"
 
-cm_trdcst              "parameter to scale trade export cost for gas"
-cm_trdadj              "parameter scale the adjustment cost parameter for increasing gas trade export"
-
 cm_postTargetIncrease     "carbon price increase per year after target is reached (euro per tCO2)"
 
 cm_damages_BurkeLike_specification      "empirical specification for Burke-like damage functions"

--- a/tests/testthat/test_20-coupled.R
+++ b/tests/testthat/test_20-coupled.R
@@ -5,6 +5,7 @@
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
 
+skipIfFast()
 coupledConfig <- "config/tests/scenario_config_coupled_shortCascade.csv"
 magpie_folder <- "../../../magpie"
 config <- readCheckScenarioConfig(file.path("..", "..", coupledConfig), remindPath <- file.path("..", ".."))
@@ -27,7 +28,6 @@ for (scen in rownames(config)) {
 expect_true(0 == unlink(deleteallfiles, recursive = TRUE))
 
 test_that("environment is suitable for coupled tests", {
-  skipIfFast()
   skipIfPreviousFailed()
   # magpie needs to be cloned by the user before running coupled tests
   expect_true(dir.exists(magpie_folder))
@@ -36,7 +36,6 @@ test_that("environment is suitable for coupled tests", {
 })
 
 test_that("using start_bundle_coupled.R --gamscompile works", {
-  skipIfFast()
   skipIfPreviousFailed()
   # try compiling
   output <- localSystem2("Rscript", c("start_bundle_coupled.R", "--gamscompile", coupledConfig),
@@ -56,7 +55,6 @@ test_that("using start_bundle_coupled.R --gamscompile works", {
 })
 
 test_that("using start_bundle_coupled.R --test works", {
-  skipIfFast()
   skipIfPreviousFailed()
   # just test the settings and RData files are written
   output <- localSystem2("Rscript", c("start_bundle_coupled.R", "--test", coupledConfig),
@@ -97,7 +95,6 @@ test_that("using start_bundle_coupled.R --test works", {
 })
 
 test_that("runs coupled to MAgPIE work", {
-  skipIfFast()
   skipIfPreviousFailed()
   # try running actual runs
   output <- localSystem2("Rscript", c("start_bundle_coupled.R", coupledConfig),
@@ -154,7 +151,6 @@ test_that("runs coupled to MAgPIE work", {
 })
 
 test_that("don't run again if completed", {
-  skipIfFast()
   skipIfPreviousFailed()
   # do not delete anything to simulate re-running already completed run
   output <- localSystem2("Rscript", c("start_bundle_coupled.R", coupledConfig),
@@ -168,7 +164,6 @@ test_that("don't run again if completed", {
 })
 
 test_that("delete last REMIND run to simulate re-starting aborted run", {
-  skipIfFast()
   skipIfPreviousFailed()
   scen <- rownames(config)[[2]]
   filestodelete <- c(
@@ -223,7 +218,6 @@ test_that("delete last REMIND run to simulate re-starting aborted run", {
 
 test_that("Check path_mif_ghgprice_land with file", {
   # note: needs Base-rem-1 and -2 still present
-  skipIfFast()
   skipIfPreviousFailed()
   output <- localSystem2("Rscript", c("start_bundle_coupled.R", coupledConfig, "startgroup=2"),
                          env = "R_PROFILE_USER=.snapshot.Rprofile")
@@ -244,7 +238,6 @@ test_that("Check path_mif_ghgprice_land with file", {
 
 test_that("delete files to leave clean state", {
   # leave clean state
-  skipIfFast()
   skipIfPreviousFailed()
   expect_true(0 == unlink(deleteallfiles, recursive = TRUE))
 })

--- a/tutorials/04_RunningREMINDandMAgPIE.md
+++ b/tutorials/04_RunningREMINDandMAgPIE.md
@@ -207,7 +207,7 @@ There are two components of the REMIND-MAgPIE coupling: the prominent dynamic pa
 * GHG emission baselines for SSPs/RCPs (delivered to REMIND via (updated in coupled runs)
 * total agricultural production costs (fixed for standalone and coupled)
 
-Please find here a [detailed list of the REMIND input files and were they come from](https://redmine.pik-potsdam.de/projects/remind-r/wiki/Updating_inputs_from_MAgPIE).
+Please find a detailed list of the REMIND input files and were they come from [in the gitlab wiki](https://gitlab.pik-potsdam.de/REMIND/wiki/-/wikis/Updating-Inputs-from-Magpie).
 
 ### Assumptions
 

--- a/tutorials/05_AnalysingModelOutputs.md
+++ b/tutorials/05_AnalysingModelOutputs.md
@@ -39,7 +39,7 @@ Looking at the *REMIND_generic_NameofYourRun.mif*, the column **scenario** gives
 
 ### 3.1 Access the Cluster
 
-To analyze your model results, you can load the output of the mif-file into a local session in RStudio. To get the file from the cluster, you can download the mif-file, for example, via WinSCP. You can read more details on how to access the cluster on [Redmine](https://redmine.pik-potsdam.de/projects/mo/wiki/Getting_ready_to_use_the_Cluster).
+To analyze your model results, you can load the output of the mif-file into a local session in RStudio. To get the file from the cluster, you can download the mif-file, for example, via WinSCP. You can read more details on how to access the cluster in [the gitlab wiki](https://gitlab.pik-potsdam.de/REMIND/wiki/-/wikis/Updating-Inputs-from-Magpie).
 
 ### 3.2 Load a mif file as a Magpie Object
 

--- a/tutorials/12_Calibrating_CES_Parameters.md
+++ b/tutorials/12_Calibrating_CES_Parameters.md
@@ -139,7 +139,7 @@ use the calibration results, copy the parameter (`.inc`) file (without the
 iteration counter) to the directory `./modules/29_CES_parameters/load/input/`
 and the .gdx file to the directory `./config/gdx-files/`.  At PIK, this is done
 automatically using the RSE support scripts.  See [this wiki
-page](https://redmine.pik-potsdam.de/projects/remind-r/wiki/GDX_and_CES_parameter_Handling)
+page](https://gitlab.pik-potsdam.de/REMIND/wiki/-/wikis/Handling-of-Gdx-and-Ces-Parameter-Files-in-Remind)
 for details.
 
 If the specific calibration settings (e.g. `cm_CES_configuration`) have not been


### PR DESCRIPTION
## Purpose of this PR

- cm_trdadj, cm_trdcst were incompletely deleted in https://github.com/remindmodel/remind/pull/1052, now deleting the last occurrences
- add an explanation about what happened to them to readCheckScenConf
- delete or change links to redmine wiki pages that don't exist anymore
- skip all coupled tests in one go, not each on individually

## Type of change

- [x] Documentation
- [x] Code cleanup

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
