### PR TITLE
add support for emissions targets with intra-EU bunkers

### DIFF
--- a/modules/47_regipol/regiCarbonPrice/postsolve.gms
+++ b/modules/47_regipol/regiCarbonPrice/postsolve.gms
@@ -113,6 +113,29 @@ p47_emiTargetMkt(ttot,regi, emiMktExt,"netGHG_LULUCFGrassi_noBunkers") =
   p47_emiTargetMkt(ttot,regi, emiMktExt,"netGHG_noBunkers")
   - ( p47_LULUCFEmi_GrassiShift(ttot,regi) )$(sameas(emiMktExt,"other") or sameas(emiMktExt,"all"));
 
+*** net CO2 per Mkt without bunkers and with Grassi LULUCF shift
+p47_emiTargetMkt(ttot,regi, emiMktExt,"netCO2_LULUCFGrassi_intraRegBunker") =
+  p47_emiTargetMkt(ttot,regi, emiMktExt,"netCO2_noBunkers")
+  - ( p47_LULUCFEmi_GrassiShift(ttot,regi) )$(sameas(emiMktExt,"other") or sameas(emiMktExt,"all"))
+  + (
+    sum(se2fe(enty,enty2,te),
+      pm_emifac(ttot,regi,enty,enty2,te,"co2")
+      * vm_demFeSector.l(ttot,regi,enty,enty2,"trans","other")
+      ) * 0.35  !!35% of total bunkers in average from 2000-2020 for EU27 + UKI countries according UNFCCC numbers
+  )$((regi_group("EUR_regi",regi)) and (sameas(emiMktExt,"other") or sameas(emiMktExt,"all")));
+
+*** net GHG per Mkt without bunkers and with Grassi LULUCF shift
+p47_emiTargetMkt(ttot,regi, emiMktExt,"netGHG_LULUCFGrassi_intraRegBunker") =
+  p47_emiTargetMkt(ttot,regi, emiMktExt,"netGHG_noBunkers")
+  - ( p47_LULUCFEmi_GrassiShift(ttot,regi) )$(sameas(emiMktExt,"other") or sameas(emiMktExt,"all"))
+  + (
+    sum(se2fe(enty,enty2,te),
+      pm_emifac(ttot,regi,enty,enty2,te,"co2")
+      * vm_demFeSector.l(ttot,regi,enty,enty2,"trans","other")
+      ) * 0.35  !!35% of total bunkers in average from 2000-2020 for EU27 + UKI countries according UNFCCC numbers
+  )$((regi_group("EUR_regi",regi)) and (sameas(emiMktExt,"other") or sameas(emiMktExt,"all")));
+
+
 ***--------------------------------------------------
 *** Emission markets (EU Emission trading system and Effort Sharing)
 ***--------------------------------------------------

--- a/modules/47_regipol/regiCarbonPrice/sets.gms
+++ b/modules/47_regipol/regiCarbonPrice/sets.gms
@@ -9,7 +9,12 @@
 SETS
 target_type_47 "CO2 policy target type" / budget , year /
 
-emi_type_47 "emission type used in regional target" / netCO2, netCO2_noBunkers, netCO2_noLULUCF_noBunkers, grossEnCO2_noBunkers, netGHG, netGHG_noLULUCF, netGHG_noBunkers, netGHG_noLULUCF_noBunkers, netCO2_LULUCFGrassi, netCO2_LULUCFGrassi_noBunkers, netGHG_LULUCFGrassi, netGHG_LULUCFGrassi_noBunkers /
+emi_type_47 "emission type used in regional target" 
+/ 
+  netCO2, netCO2_noBunkers, netCO2_noLULUCF_noBunkers, netCO2_LULUCFGrassi, netCO2_LULUCFGrassi_noBunkers, netCO2_LULUCFGrassi_intraRegBunker,
+  netGHG, netGHG_noBunkers, netGHG_noLULUCF_noBunkers, netGHG_LULUCFGrassi, netGHG_LULUCFGrassi_noBunkers, netGHG_LULUCFGrassi_intraRegBunker, netGHG_noLULUCF,
+  grossEnCO2_noBunkers 
+/
 
 *** Emission markets
 $ifThen.emiMkt not "%cm_emiMktTarget%" == "off" 


### PR DESCRIPTION
## Purpose of this PR

- add support for emissions targets (cm_emiMktTarget) with intra-EU bunkers in the regipol module

## Type of change

- [x] New feature 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)

## Further information (optional):

* Test runs are here: 
/p/projects/remind/users/renatoro/ECEMF/v11_2023_04_27/output/11_WP1_Nzero_2023-05-05_17.39.03
