### PR TITLE
re-enable summation checks for xlsx_IIASA

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,7 +51,7 @@ Imports:
     nleqslv,
     optparse,
     piamenv (>= 0.4.0),
-    piamInterfaces (>= 0.0.37),
+    piamInterfaces (>= 0.0.88),
     plotly,
     purrr,
     quitte (>= 0.3106.0),

--- a/scripts/output/export/xlsx_IIASA.R
+++ b/scripts/output/export/xlsx_IIASA.R
@@ -57,6 +57,17 @@ lucode2::readArgs("outputdirs", "filename_prefix", "outputFilename", "model",
 # variables to be deleted although part of the template
 temporarydelete <- NULL # example: c("GDP|MER", "GDP|PPP")
 
+### select mapping
+
+mappingFile <- NULL
+if (length(mapping) == 1 && file.exists(mapping)) {
+  mappingFile <- mapping
+  mapping <- NULL
+} else if (! all(mapping %in% names(templateNames())) || length(mapping) == 0) {
+  message("# Mapping = '", paste(mapping, collapse = ","), "' exists neither as file nor mapping name.")
+  mapping <- gms::chooseFromList(names(piamInterfaces::templateNames()), type = "mapping template")
+}
+
 ### define filenames
 
 outputFolder <- file.path("output", "export")
@@ -74,22 +85,6 @@ if (! exists("logFile")) logFile <- paste0(outputFilename, ".log")
 
 message("### Find various logs in ", logFile)
 withCallingHandlers({ # piping messages to logFile
-
-  if (length(mapping) == 1 && file.exists(mapping)) {
-    mappingFile <- mapping
-    mapping <- NULL
-  } else {
-    if (all(mapping %in% names(templateNames())) && length(mapping) > 0) {
-      mappingFile <- file.path(outputFolder, paste0(paste0(c("mapping", if (is.null(project)) mapping else project), collapse = "_"), ".csv"))
-    } else {
-      message("# Mapping = '", paste(mapping, collapse = ","), "' exists neither as file nor mapping name.")
-      mapping <- gms::chooseFromList(names(piamInterfaces::templateNames()))
-      mappingFile <- file.path(outputFolder, paste0(paste0(c("mapping", mapping), collapse = "_"), ".csv"))
-    }
-    generateMappingfile(templates = mapping, outputDirectory = NULL,
-                        fileName = mappingFile, model = model, logFile = logFile,
-                        iiasatemplate = if (file.exists(iiasatemplate)) iiasatemplate else NULL)
-  }
 
   message("\n### Generating ", OUTPUT_xlsx, ".")
   ### define filenames
@@ -131,7 +126,7 @@ withCallingHandlers({ # piping messages to logFile
   # message("\n### Generate joint mif, remind2 format: ", filename_remind2_mif)
   # write.mif(mifdata, filename_remind2_mif)
 
-  generateIIASASubmission(mifdata, mapping = NULL, model = model, mappingFile = mappingFile,
+  generateIIASASubmission(mifdata, mapping = mapping, model = model, mappingFile = mappingFile,
                           removeFromScen = removeFromScen, addToScen = addToScen,
                           outputDirectory = outputFolder,
                           logFile = logFile, outputFilename = basename(OUTPUT_xlsx),

--- a/tests/testthat/test_06-output.R
+++ b/tests/testthat/test_06-output.R
@@ -15,13 +15,24 @@ test_that("output.R -> single -> reporting works", {
 })
 
 test_that("output.R -> export -> xlsx_IIASA works", {
-  skipIfFast()
+# skipIfFast()
   skipIfPreviousFailed()
+  exportfiles <- Sys.glob(file.path("..", "..", "output", "export", "*TESTTHAT*"))
+  unlink(exportfiles)
   output <- localSystem2("Rscript", c("output.R", "project=TESTTHAT", "filename_prefix=TESTTHAT",
                                       "comp=export", "output=xlsx_IIASA", "outputdir=output/testOneRegi"))
   printIfFailed(output)
   exportfiles <- Sys.glob(file.path("..", "..", "output", "export", "*TESTTHAT*"))
-  expect_true(length(exportfiles) >= 3)
-  unlink(exportfiles)
+  expect_true(sum(grepl("REMIND_TESTTHAT.*xlsx$", exportfiles)) == 1)
+  expect_true(sum(grepl("REMIND_TESTTHAT.*log$", exportfiles)) == 1)
+  expect_true(sum(grepl("REMIND_TESTTHAT.*checkSummations\\.csv$", exportfiles)) == 1)
+  expect_true(sum(grepl("REMIND_TESTTHAT.*checkSummations.*pdf$", exportfiles)) == 1)
   expectSuccessStatus(output)
+})
+
+test_that("cleanup output.R", {
+  skipIfFast()
+  skipIfPreviousFailed()
+  exportfiles <- Sys.glob(file.path("..", "..", "output", "export", "*TESTTHAT*"))
+  unlink(exportfiles)
 })


### PR DESCRIPTION
## Purpose of this PR

- after redesigning `generateIIASASubmission`, the summation check was not executed anymore: https://github.com/pik-piam/piamInterfaces/issues/117
- Reason was that generateIIASASubmission was not automatically writing a mapping file anymore, but instead passed the mapping data directly.
- Now, we skip writing mapping files here as well and rather pass the mapping directly
- output tests had the problems of deleting possible summation checks, that was fixed, together with https://github.com/pik-piam/piamInterfaces/pull/121

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`) (including test_output)
