### PR TITLE
Avoiding one of the possible unstable infeasibility sources in the model: relaxing vm_cap lower bound to be active only until 2070

### DIFF
--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -21,7 +21,7 @@ vm_costTeCapital.fx(t,regi,teNoLearn)     = pm_inco0_t(t,regi,teNoLearn);
 *** CB 20120402 Lower limit on all P2SE technologies capacities to 100 kW of all technologies and all time steps
 loop(pe2se(enty,enty2,te)$((not sameas(te,"biotr"))  AND (not sameas(te,"biodiesel")) AND (not sameas(te,"bioeths")) AND (not sameas(te,"gasftcrec")) AND (not sameas(te,"gasftrec"))
 AND (not sameas(te,"tnrs"))),
-  vm_cap.lo(t,regi,te,"1")$(t.val gt 2021 AND t.val lt 2100) = 1e-7;
+  vm_cap.lo(t,regi,te,"1")$(t.val gt 2021 AND t.val le 2070) = 1e-7;
 );
 
 


### PR DESCRIPTION
## Purpose of this PR

### The issue (as far as I can understand):

- Scenarios that go into the direction of phasing-out certain technologies are limited to a minimal capacity for certain technologies defined by the lower bound that is set to `vm_cap.lo` to `1e-7`.
- at a given iteration, the solver could search for a solution that considers very low values for `vm_cap` in this phase-out situation, which would imply even lower energy production and demand variable values after capacity is multiplied by the respective capacity factor for the technology. 
- Under this case, the variable values for the technology in question could dangerously approach the considered "model zero limit", either at variable level (e.g. `vm_prodSe`) and/or equation marginal level (e.g. `q_cap`).
- The solver could then be induced to disconsider adjusting the demand side variables to respect this lower bound, e.g. `vm_demSe` could be so small that the solver can consider it an approximated zero, creating an infeasibility when this approximated zero is compared to the vm_cap minimal value set by the bound.

### Infeasible runs related with the issue:

- normal run: `/p/projects/ecemf/REMIND/2040_scenarios/v01_2023_05_15/output/_testRuns/01_Nzero_55_pEUEff_bio12_2023-05-22_11.13.08`
- debug run: `/p/projects/ecemf/REMIND/2040_scenarios/v01_2023_05_15/output/_testRuns/debug_Nzero_55_pEUEff_bio12_2023-05-22_17.47.35`

### Partial solution:

- As the original goal of the lower bound at `vm_cap` is to make easier for the model to "see" available technologies, we could most probably assume that if a technology was not used until 2070, it will probably not start being used afterwards.
- Considering this, the lower bound was removed for years later than 2070 to avoid this infesibility to happen at latter years.
- This would not solve the issue if the "full phase-out" behavior happen before 2070. However, these cases are less probably to happen because the inertias we have in the model to change technology capacity from one period to the next.
- This partial solution will need to be revisited in the future if more stringent scenarios and/or other technologies introduced could present the behavior described above.    
    
### Feasible run after the change:

- `/p/projects/ecemf/REMIND/2040_scenarios/v01_2023_05_15/output/_testRuns/lo2070_Nzero_55_pEUEff_bio12_2023-05-24_07.01.59`

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)

