### PR TITLE
Error corrections in formulas of the tutorial 12_Calbrating_CES_Parameters

### DIFF
--- a/tutorials/12_Calibrating_CES_Parameters.md
+++ b/tutorials/12_Calibrating_CES_Parameters.md
@@ -49,16 +49,16 @@ derivatives are the equilibrium prices $\pi_i$ of the input factors $V_i$ and
 the efficiency parameters can be expressed in terms of quantities, prices, and
 elasticity parameters:
 
-$\frac{\partial V_o}{\partial  V_i} = \pi_i \Leftrightarrow \alpha_i = \pi_i \left(\frac{V_o}{V_i}\right)^{1 - \rho_o}$
+$\frac{\partial V_o}{\partial  V_i} = \pi_i \Leftrightarrow \alpha_i = \pi_i \left(\frac{V_i}{V_o}\right)^{1 - \rho_o}$
 
 The basic process of the calibration is to use the price calculated using the
 partial derivatives of iteration $j$ and combine them with the exogenously
 prescribed target quantities $V^\ast$ to calculate the efficiency parameters of
 the next iteration $j+1$:
 
-$\pi_i^{(j)} = \alpha_i^{(j)} {V_i^{(j)}}^{1 - \rho_o} {V_o^{(j)}}^{1 - \rho_o}$
+$\pi_i^{(j)} = \alpha_i^{(j)} {V_i^{(j)}}^{\rho_o - 1} {V_o^{(j)}}^{1 - \rho_o}$
 
-$\alpha_i^{(j+1)} = \pi_i^{(j)} \left(\frac{V_o^\ast}{V_i^\ast}\right)^{1 - \rho_o}$
+$\alpha_i^{(j+1)} = \pi_i^{(j)} \left(\frac{V_i^\ast}{V_o^\ast}\right)^{1 - \rho_o}$
 
 
 ## Requirements


### PR DESCRIPTION
## Purpose of this PR
This pull request corrects errors in the formulas of the tutorial 12_Calibrating_CES_Parameters:

In the section "Iterative Calibration" the formulas are given that determine the prices $\pi_i$ and the efficiency parameter $\alpha_i$ (which is split in the implementation into xi, eff and effgr). In the formulas for $\alpha_i$ and for $\pi_i^{(j)}$ as well as $\alpha_i^{(j+1)}$ there were some errors in the exponent, which are corrected by this pull request.

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix 

## Checklist:

- [ ] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [ ] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)

## Further information (optional):

