### PR TITLE
differentiate gdx_ref and gdx_refprices

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -59,7 +59,7 @@ Imports:
     raster,
     readr,
     readxl,
-    remind2 (>= 1.104.1),
+    remind2 (>= 1.111.2),
     renv,
     reshape2,
     reticulate,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -59,7 +59,7 @@ Imports:
     raster,
     readr,
     readxl,
-    remind2 (>= 1.111.2),
+    remind2 (>= 1.112.0),
     renv,
     reshape2,
     reticulate,

--- a/scripts/output/single/reporting.R
+++ b/scripts/output/single/reporting.R
@@ -14,7 +14,8 @@ library(edgeTransport)
 library(quitte)
 ############################# BASIC CONFIGURATION #############################
 gdx_name     <- "fulldata.gdx"             # name of the gdx
-gdx_ref_name <- "input_refpolicycost.gdx"  # name of the reference gdx (for policy cost calculation)
+gdx_ref_name <- "input_ref.gdx"            # name of the ref for < cm_startyear
+gdx_refpolicycost_name <- "input_refpolicycost.gdx"  # name of the reference gdx (for policy cost calculation)
 
 
 if(!exists("source_include")) {
@@ -23,9 +24,11 @@ if(!exists("source_include")) {
    readArgs("outputdir", "gdx_name", "gdx_ref_name")
 }
 
-gdx      <- file.path(outputdir,gdx_name)
-gdx_ref  <- file.path(outputdir,gdx_ref_name)
-if (!file.exists(gdx_ref)) { gdx_ref <- NULL }
+gdx     <- file.path(outputdir, gdx_name)
+gdx_ref <- file.path(outputdir, gdx_ref_name)
+gdx_refpolicycost <- file.path(outputdir, gdx_refpolicycost_name)
+if (! file.exists(gdx_ref)) { gdx_ref <- NULL }
+if (! file.exists(gdx_refpolicycost)) { gdx_refpolicycost <- NULL }
 scenario <- getScenNames(outputdir)
 ###############################################################################
 # paths of the reporting files
@@ -47,7 +50,7 @@ load(configfile, envir = envir)
 
 # produce REMIND reporting *.mif based on gdx information
 message("\n### start generation of mif files at ", Sys.time())
-tmp <- try(convGDX2MIF(gdx,gdx_ref,file=remind_reporting_file,scenario=scenario)) # try to execute convGDX2MIF
+tmp <- try(convGDX2MIF(gdx,gdx_ref = gdx_refpolicycost,file=remind_reporting_file,scenario=scenario, gdx_refprices = gdx_ref)) # try to execute convGDX2MIF
 if (inherits(tmp, "try-error")) {
   convGDX2MIF_REMIND2MAgPIE(gdx, file = remind_reporting_file, scenario = scenario)
 }

--- a/scripts/output/single/reporting.R
+++ b/scripts/output/single/reporting.R
@@ -21,18 +21,18 @@ gdx_refpolicycost_name <- "input_refpolicycost.gdx"  # name of the reference gdx
 if(!exists("source_include")) {
    # Define arguments that can be read from command line
    outputdir <- "."
-   readArgs("outputdir", "gdx_name", "gdx_ref_name")
+   readArgs("outputdir", "gdx_name", "gdx_ref_name", "gdx_refpolicycost_name")
 }
 
 gdx     <- file.path(outputdir, gdx_name)
 gdx_ref <- file.path(outputdir, gdx_ref_name)
 gdx_refpolicycost <- file.path(outputdir, gdx_refpolicycost_name)
-if (! file.exists(gdx_ref)) { gdx_ref <- NULL }
-if (! file.exists(gdx_refpolicycost)) { gdx_refpolicycost <- NULL }
+if (! file.exists(gdx_ref))           gdx_ref <- NULL
+if (! file.exists(gdx_refpolicycost)) gdx_refpolicycost <- NULL
 scenario <- getScenNames(outputdir)
 ###############################################################################
 # paths of the reporting files
-remind_reporting_file <- file.path(outputdir,paste0("REMIND_generic_",scenario,".mif"))
+remind_reporting_file <- file.path(outputdir,paste0("REMIND_generic_", scenario,".mif"))
 magicc_reporting_file <- file.path(outputdir,paste0("REMIND_climate_", scenario, ".mif"))
 LCOE_reporting_file   <- file.path(outputdir,paste0("REMIND_LCOE_", scenario, ".csv"))
 
@@ -50,7 +50,8 @@ load(configfile, envir = envir)
 
 # produce REMIND reporting *.mif based on gdx information
 message("\n### start generation of mif files at ", Sys.time())
-tmp <- try(convGDX2MIF(gdx,gdx_ref = gdx_refpolicycost,file=remind_reporting_file,scenario=scenario, gdx_refprices = gdx_ref)) # try to execute convGDX2MIF
+tmp <- try(convGDX2MIF(gdx, gdx_refpolicycost = gdx_refpolicycost, file = remind_reporting_file,
+                       scenario = scenario, gdx_ref = gdx_ref)) # try to execute convGDX2MIF
 if (inherits(tmp, "try-error")) {
   convGDX2MIF_REMIND2MAgPIE(gdx, file = remind_reporting_file, scenario = scenario)
 }
@@ -121,11 +122,11 @@ if (! is.null(magpie_reporting_file) && file.exists(magpie_reporting_file)) {
 message("### end generation of mif files at ", Sys.time())
 
 ## produce REMIND LCOE reporting *.csv based on gdx information
-message("start generation of LCOE reporting")
-if (! isTRUE(cfg$gms$c_empty_model == "on") && grepl("^C_TESTTHAT", scenario)) {
+if (! isTRUE(envir$cfg$gms$c_empty_model == "on") || ! grepl("^C_TESTTHAT", scenario)) {
+  message("start generation of LCOE reporting")
   tmp <- try(convGDX2CSV_LCOE(gdx,file=LCOE_reporting_file,scen=scenario)) # execute convGDX2MIF_LCOE
+  message("end generation of LCOE reporting")
 }
-message("end generation of LCOE reporting")
 
 ## generate DIETER reporting if it is needed
 ## the reporting is appended to REMIND_generic_<scenario>.MIF in "DIETER" Sub Directory


### PR DESCRIPTION
## Purpose of this PR

- see https://github.com/pik-piam/remind2/pull/410
- the reference runs for the prices (< cm_startyear) and policy costs are different

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
