### PR TITLE
fix entySEsyn to contain synfuels instead of biomass SE

### DIFF
--- a/core/sets.gms
+++ b/core/sets.gms
@@ -1735,11 +1735,10 @@ entySeBio(all_enty)       "biomass secondary energy types"
 	segabio      "secondary energy gas from biomass"
 /
 
-entySeSyn(all_enty)       "synfuel secondary energy types"
+entySeSyn(all_enty)   "synfuel secondary energy types"
 /
-	seliqbio     "secondary energy liquids from biomass"
-	sesobio      "secondary energy solids from biomass"
-	segabio      "secondary energy gas from biomass"
+  seliqsyn   "secondary energy liquids from H2"
+  segasyn    "secondary energy gas from H2"
 /
 
 entySeFos(all_enty) "secondary energy types from fossil primary energy"

--- a/modules/02_welfare/ineqLognormal/equations.gms
+++ b/modules/02_welfare/ineqLognormal/equations.gms
@@ -54,10 +54,10 @@ $ifthen %cm_INCONV_PENALTY% == "on"
 $endif
 $ifthen "%cm_INCONV_PENALTY_FESwitch%" == "on"
       - sum((entySe,entyFe,te,sector,emiMkt)$(
-	        se2fe(entySe,entyFe,te)
-            AND entyFe2Sector(entyFe,sector)
-            AND sector2emiMkt(sector,emiMkt) 
-	    AND (entySeBio(entySe) OR entySeSyn(entySe) OR entySeFos(entySe)) ),
+                                    se2fe(entySe,entyFe,te)
+                                AND entyFe2Sector(entyFe,sector)
+                                AND sector2emiMkt(sector,emiMkt) 
+                                AND (entySeBio(entySe) OR  entySeFos(entySe)) ),
           v02_NegInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt)
 	+ v02_PosInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt)
 	)
@@ -320,11 +320,11 @@ $ENDIF.INCONV
 *** between time steps as those sectors and markets do not have se2fe capcities
 $IFTHEN.INCONV_bioSwitch "%cm_INCONV_PENALTY_FESwitch%" == "on"
 q02_inconvPenFeBioSwitch(ttot,regi,entySe,entyFe,te,sector,emiMkt)$(
-              ttot.val ge cm_startyear
-          AND se2fe(entySe,entyFe,te) 
-          AND entyFe2Sector(entyFe,sector) 
-          AND sector2emiMkt(sector,emiMkt) 
-          AND (entySeBio(entySe) OR entySeSyn(entySe) OR entySeFos(entySe)) ) ..
+                                  ttot.val ge cm_startyear
+                              AND se2fe(entySe,entyFe,te) 
+                              AND entyFe2Sector(entyFe,sector) 
+                              AND sector2emiMkt(sector,emiMkt) 
+                              AND (entySeBio(entySe) OR  entySeFos(entySe)) ) ..
     vm_demFeSector(ttot,regi,entySe,entyFe,sector,emiMkt) 
   - vm_demFeSector(ttot-1,regi,entySe,entyFe,sector,emiMkt)
   + v02_NegInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt)

--- a/modules/02_welfare/ineqLognormal/equations.gms
+++ b/modules/02_welfare/ineqLognormal/equations.gms
@@ -17,29 +17,54 @@ q02_welfareGlob..
 ;
 
 ***---------------------------------------------------------------------------
-*' Total discounted intertemporal regional welfare calculated from per capita consumption
-*' summing over all time steps taking into account the pure time preference rate.
-*' Assuming an intertemporal elasticity of substitution of 1, it holds:
+*' Total discounted intertemporal regional welfare calculated from per capita
+*' consumption summing over all time steps taking into account the pure time
+*' preference rate. Assuming an intertemporal elasticity of substitution of 1,
+*' it holds:
 ***---------------------------------------------------------------------------
-q02_welfare(regi)..
-    v02_welfare(regi)
+q02_welfare(regi) ..
+  v02_welfare(regi)
   =e=
-    sum(ttot $(ttot.val ge 2005),
-        pm_welf(ttot) * pm_ts(ttot) * (1 / ( (1 + pm_prtp(regi))**(pm_ttot_val(ttot)-2005) ) )
-        *   (  (pm_pop(ttot,regi)
-                *   (
-                        ((((vm_cons(ttot,regi)*exp(-0.5*(1/pm_ies(regi))*v02_distrFinal_sigmaSq_welfare(ttot,regi)))/pm_pop(ttot,regi))**(1-1/pm_ies(regi))-1)/(1-1/pm_ies(regi)) )$(pm_ies(regi) ne 1)
-                        
-
-
-                        + ( log((vm_cons(ttot,regi)) / pm_pop(ttot,regi))
-                              - 0.5*v02_distrFinal_sigmaSq_welfare(ttot,regi) )$(pm_ies(regi) eq 1)
-                    )
-                )
-$if %cm_INCONV_PENALTY% == "on"  - v02_inconvPen(ttot,regi) - v02_inconvPenCoalSolids(ttot,regi)
-$if "%cm_INCONV_PENALTY_FESwitch%" == "on"  - sum((entySe,entyFe,te,sector,emiMkt)$(se2fe(entySe,entyFe,te) AND entyFe2Sector(entyFe,sector) AND sector2emiMkt(sector,emiMkt) AND (entySeBio(entySe) OR entySeSyn(entySe) OR entySeFos(entySe)) ), v02_NegInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt) + v02_PosInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt))/1e3	
-            )
+    sum(ttot$( ttot.val ge 2005 ),
+      pm_welf(ttot)
+    * pm_ts(ttot)
+    / ((1 + pm_prtp(regi)) ** (pm_ttot_val(ttot) - 2005))
+    * ( ( pm_pop(ttot,regi)
+        * ( ( ( ( (  vm_cons(ttot,regi)
+		  * exp(
+		      -0.5 
+		    * (1 / pm_ies(regi))
+		    * v02_distrFinal_sigmaSq_welfare(ttot,regi)
+		    )
+		  )
+		/ pm_pop(ttot,regi)
+		)
+	     ** (1 - 1 / pm_ies(regi))
+	      - 1
+	      )
+	    / (1 - 1/pm_ies(regi)) 
+	    )$( pm_ies(regi) ne 1 )
+	  + ( log((vm_cons(ttot,regi)) / pm_pop(ttot,regi))
+	    - 0.5 * v02_distrFinal_sigmaSq_welfare(ttot,regi)
+	    )$( pm_ies(regi) eq 1 )
+          )
         )
+$ifthen %cm_INCONV_PENALTY% == "on"
+      - v02_inconvPen(ttot,regi) - v02_inconvPenCoalSolids(ttot,regi)
+$endif
+$ifthen "%cm_INCONV_PENALTY_FESwitch%" == "on"
+      - sum((entySe,entyFe,te,sector,emiMkt)$(
+	        se2fe(entySe,entyFe,te)
+            AND entyFe2Sector(entyFe,sector)
+            AND sector2emiMkt(sector,emiMkt) 
+	    AND (entySeBio(entySe) OR entySeSyn(entySe) OR entySeFos(entySe)) ),
+          v02_NegInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt)
+	+ v02_PosInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt)
+	)
+      / 1e3	
+$endif
+      )
+    )
 ;
 
 ***---------------------------------------------------------------------------
@@ -289,20 +314,23 @@ q02_inconvPenCoalSolids(t,regi)$(t.val > 2005)..
 ;
 $ENDIF.INCONV
 
-*** small inconvenience penalty for increasing/decreasing biomass/synfuel use between two time steps in buildings and industry and emissison markets
-*** necessary to avoid switching behavior in sectors and emissions markets between time steps as those sectors and markets do not have se2fe capcities
+*** small inconvenience penalty for increasing/decreasing biomass/synfuel use
+*** between two time steps in buildings and industry and emissison markets
+*** necessary to avoid switching behavior in sectors and emissions markets
+*** between time steps as those sectors and markets do not have se2fe capcities
 $IFTHEN.INCONV_bioSwitch "%cm_INCONV_PENALTY_FESwitch%" == "on"
-q02_inconvPenFeBioSwitch(ttot,regi,entySe,entyFe,te,sector,emiMkt)$((ttot.val ge cm_startyear) 
-                                                            AND se2fe(entySe,entyFe,te) 
-                                                            AND entyFe2Sector(entyFe,sector) 
-                                                            AND sector2emiMkt(sector,emiMkt) 
-                                                            AND (entySeBio(entySe) OR entySeSyn(entySe) OR entySeFos(entySe)) )..
-                                                              vm_demFeSector(ttot,regi,entySe,entyFe,sector,emiMkt) 
-                                                              - vm_demFeSector(ttot-1,regi,entySe,entyFe,sector,emiMkt)
-                                                              + v02_NegInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt)
-                                                              - v02_PosInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt)
-                                                            =e=
-                                                            0
+q02_inconvPenFeBioSwitch(ttot,regi,entySe,entyFe,te,sector,emiMkt)$(
+              ttot.val ge cm_startyear
+          AND se2fe(entySe,entyFe,te) 
+          AND entyFe2Sector(entyFe,sector) 
+          AND sector2emiMkt(sector,emiMkt) 
+          AND (entySeBio(entySe) OR entySeSyn(entySe) OR entySeFos(entySe)) ) ..
+    vm_demFeSector(ttot,regi,entySe,entyFe,sector,emiMkt) 
+  - vm_demFeSector(ttot-1,regi,entySe,entyFe,sector,emiMkt)
+  + v02_NegInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt)
+  - v02_PosInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt)
+  =e=
+  0
 ;
 $ENDIF.INCONV_bioSwitch
 *** EOF ./modules/02_welfare/ineqLognormal/equations.gms

--- a/modules/02_welfare/ineqLognormal/postsolve.gms
+++ b/modules/02_welfare/ineqLognormal/postsolve.gms
@@ -7,14 +7,18 @@
 *** SOF ./modules/02_welfare/ineqLognormal/postsolve.gms
 
 $IFTHEN.INCONV_bioSwitch "%cm_INCONV_PENALTY_FESwitch%" == "on"
-*** track inconvenience penalty for bio/synfuel switching to check how large it is relative to consumption
-p02_inconvPen_Switch_Track(t,regi) = (sum((entySe,entyFe,te,sector,emiMkt)$(se2fe(entySe,entyFe,te) 
-                                                                    AND entyFe2Sector(entyFe,sector) 
-                                                                    AND sector2emiMkt(sector,emiMkt) 
-                                                                    AND (entySeBio(entySe) OR entySeSyn(entySe) OR entySeFos(entySe) )), 
-                                                                        v02_NegInconvPenFeBioSwitch.l(t,regi,entySe,entyFe,sector,emiMkt) 
-                                                                        + v02_PosInconvPenFeBioSwitch.l(t,regi,entySe,entyFe,sector,emiMkt))/1e3)
-																		/ vm_cons.l(t,regi);	
+*** track inconvenience penalty for bio/synfuel switching to check how large it
+*** is relative to consumption
+p02_inconvPen_Switch_Track(t,regi)
+  = sum((entySe,entyFe,te,sector,emiMkt)$(
+              se2fe(entySe,entyFe,te) 
+          AND entyFe2Sector(entyFe,sector) 
+          AND sector2emiMkt(sector,emiMkt) 
+          AND (entySeBio(entySe) OR entySeSyn(entySe) OR entySeFos(entySe) )), 
+      v02_NegInconvPenFeBioSwitch.l(t,regi,entySe,entyFe,sector,emiMkt) 
+    + v02_PosInconvPenFeBioSwitch.l(t,regi,entySe,entyFe,sector,emiMkt)
+    )
+  / 1e3;
 $ENDIF.INCONV_bioSwitch
 
 *for use in the SCC calculation
@@ -30,7 +34,5 @@ loop(ttot$(ttot.val ge 2005),
 
 * assume sigma is flat from 2150 on (only enters damage calculations in the far future)
 pm_sccIneq(tall,regi)$(tall.val ge 2150) = pm_sccIneq("2149",regi); 
-
-
 
 *** EOF ./modules/02_welfare/ineqLognormal/postsolve.gms

--- a/modules/02_welfare/ineqLognormal/postsolve.gms
+++ b/modules/02_welfare/ineqLognormal/postsolve.gms
@@ -11,10 +11,10 @@ $IFTHEN.INCONV_bioSwitch "%cm_INCONV_PENALTY_FESwitch%" == "on"
 *** is relative to consumption
 p02_inconvPen_Switch_Track(t,regi)
   = sum((entySe,entyFe,te,sector,emiMkt)$(
-              se2fe(entySe,entyFe,te) 
-          AND entyFe2Sector(entyFe,sector) 
-          AND sector2emiMkt(sector,emiMkt) 
-          AND (entySeBio(entySe) OR entySeSyn(entySe) OR entySeFos(entySe) )), 
+                                    se2fe(entySe,entyFe,te) 
+                                AND entyFe2Sector(entyFe,sector) 
+                                AND sector2emiMkt(sector,emiMkt) 
+                                AND (entySeBio(entySe) OR  entySeFos(entySe) )), 
       v02_NegInconvPenFeBioSwitch.l(t,regi,entySe,entyFe,sector,emiMkt) 
     + v02_PosInconvPenFeBioSwitch.l(t,regi,entySe,entyFe,sector,emiMkt)
     )

--- a/modules/02_welfare/utilitarian/equations.gms
+++ b/modules/02_welfare/utilitarian/equations.gms
@@ -47,10 +47,10 @@ $ifthen %cm_INCONV_PENALTY% == "on"
 $endif
 $ifthen "%cm_INCONV_PENALTY_FESwitch%" == "on"
       - sum((entySe,entyFe,te,sector,emiMkt)$(
-                se2fe(entySe,entyFe,te)
-            AND entyFe2Sector(entyFe,sector) 
-            AND sector2emiMkt(sector,emiMkt) 
-	    AND (entySeBio(entySe) OR entySeSyn(entySe) OR entySeFos(entySe)) ),
+                                    se2fe(entySe,entyFe,te)
+                                AND entyFe2Sector(entyFe,sector) 
+                                AND sector2emiMkt(sector,emiMkt) 
+                                AND (entySeBio(entySe) OR  entySeFos(entySe)) ),
           v02_NegInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt)
 	+ v02_PosInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt)
 	)
@@ -89,11 +89,11 @@ $ENDIF.INCONV
 *** between time steps as those sectors and markets do not have se2fe capcities
 $IFTHEN.INCONV_bioSwitch "%cm_INCONV_PENALTY_FESwitch%" == "on"
 q02_inconvPenFeBioSwitch(ttot,regi,entySe,entyFe,te,sector,emiMkt)$(
-              ttot.val ge cm_startyear
-          AND se2fe(entySe,entyFe,te) 
-          AND entyFe2Sector(entyFe,sector) 
-          AND sector2emiMkt(sector,emiMkt) 
-          AND (entySeBio(entySe) OR entySeSyn(entySe) OR entySeFos(entySe)) ) ..
+                                  ttot.val ge cm_startyear
+                              AND se2fe(entySe,entyFe,te) 
+                              AND entyFe2Sector(entyFe,sector) 
+                              AND sector2emiMkt(sector,emiMkt) 
+                              AND (entySeBio(entySe) OR  entySeFos(entySe)) ) ..
     vm_demFeSector(ttot,regi,entySe,entyFe,sector,emiMkt) 
   - vm_demFeSector(ttot-1,regi,entySe,entyFe,sector,emiMkt)
   + v02_NegInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt)

--- a/modules/02_welfare/utilitarian/equations.gms
+++ b/modules/02_welfare/utilitarian/equations.gms
@@ -17,25 +17,47 @@ q02_welfareGlob..
 ;
 
 ***---------------------------------------------------------------------------
-*' Total discounted intertemporal regional welfare calculated from per capita consumption 
-*' summing over all time steps taking into account the pure time preference rate.
-*' Assuming an intertemporal elasticity of substitution of 1, it holds:
+*' Total discounted intertemporal regional welfare calculated from per capita
+*' consumption summing over all time steps taking into account the pure time
+*' preference rate.  Assuming an intertemporal elasticity of substitution of 1,
+*' it holds:
 ***---------------------------------------------------------------------------
-q02_welfare(regi)..
-    v02_welfare(regi) 
+q02_welfare(regi) ..
+  v02_welfare(regi) 
   =e=
-    sum(ttot $(ttot.val ge 2005),
-        pm_welf(ttot) * pm_ts(ttot) * (1 / ( (1 + pm_prtp(regi))**(pm_ttot_val(ttot)-2005) ) )
-        *   (  (pm_pop(ttot,regi) 
-                *   (
-                        ((( (vm_cons(ttot,regi))/pm_pop(ttot,regi))**(1-1/pm_ies(regi))-1)/(1-1/pm_ies(regi)) )$(pm_ies(regi) ne 1)
-                       + (log((vm_cons(ttot,regi)) / pm_pop(ttot,regi)))$(pm_ies(regi) eq 1)
-                    )
-                )
-$if %cm_INCONV_PENALTY% == "on"  - v02_inconvPen(ttot,regi) - v02_inconvPenCoalSolids(ttot,regi)
-$if "%cm_INCONV_PENALTY_FESwitch%" == "on"  - sum((entySe,entyFe,te,sector,emiMkt)$(se2fe(entySe,entyFe,te) AND entyFe2Sector(entyFe,sector) AND sector2emiMkt(sector,emiMkt) AND (entySeBio(entySe) OR entySeSyn(entySe) OR entySeFos(entySe)) ), v02_NegInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt) + v02_PosInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt))/1e3	
-            )
+    sum(ttot$( ttot.val ge 2005 ),
+      pm_welf(ttot)
+    * pm_ts(ttot)
+    / ((1 + pm_prtp(regi)) ** (pm_ttot_val(ttot) - 2005))
+    * ( ( pm_pop(ttot,regi) 
+        * ( ( ( ( vm_cons(ttot,regi)
+	        / pm_pop(ttot,regi)
+		)
+	     ** (1 - 1 / pm_ies(regi))
+	      - 1
+	      )
+	    / (1 - 1 / pm_ies(regi))
+	    )$( pm_ies(regi) ne 1 )
+	  + log(vm_cons(ttot,regi) / pm_pop(ttot,regi))$( pm_ies(regi) eq 1 )
+          )
         )
+$ifthen %cm_INCONV_PENALTY% == "on"
+      - v02_inconvPen(ttot,regi)
+      - v02_inconvPenCoalSolids(ttot,regi)
+$endif
+$ifthen "%cm_INCONV_PENALTY_FESwitch%" == "on"
+      - sum((entySe,entyFe,te,sector,emiMkt)$(
+                se2fe(entySe,entyFe,te)
+            AND entyFe2Sector(entyFe,sector) 
+            AND sector2emiMkt(sector,emiMkt) 
+	    AND (entySeBio(entySe) OR entySeSyn(entySe) OR entySeFos(entySe)) ),
+          v02_NegInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt)
+	+ v02_PosInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt)
+	)
+      / 1e3	
+$endif
+      )
+    )
 ;
 
 ***---------------------------------------------------------------------------
@@ -61,20 +83,23 @@ q02_inconvPenCoalSolids(t,regi)$(t.val > 2005)..
 ;
 $ENDIF.INCONV
 
-*** small inconvenience penalty for increasing/decreasing biomass/synfuel use between two time steps in buildings and industry and emissison markets
-*** necessary to avoid switching behavior in sectors and emissions markets between time steps as those sectors and markets do not have se2fe capcities
+*** small inconvenience penalty for increasing/decreasing biomass/synfuel use
+*** between two time steps in buildings and industry and emissison markets
+*** necessary to avoid switching behavior in sectors and emissions markets
+*** between time steps as those sectors and markets do not have se2fe capcities
 $IFTHEN.INCONV_bioSwitch "%cm_INCONV_PENALTY_FESwitch%" == "on"
-q02_inconvPenFeBioSwitch(ttot,regi,entySe,entyFe,te,sector,emiMkt)$((ttot.val ge cm_startyear) 
-                                                            AND se2fe(entySe,entyFe,te) 
-                                                            AND entyFe2Sector(entyFe,sector) 
-                                                            AND sector2emiMkt(sector,emiMkt) 
-                                                            AND (entySeBio(entySe) OR entySeSyn(entySe) OR entySeFos(entySe)) )..
-                                                              vm_demFeSector(ttot,regi,entySe,entyFe,sector,emiMkt) 
-                                                              - vm_demFeSector(ttot-1,regi,entySe,entyFe,sector,emiMkt)
-                                                              + v02_NegInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt)
-                                                              - v02_PosInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt)
-                                                            =e=
-                                                            0
+q02_inconvPenFeBioSwitch(ttot,regi,entySe,entyFe,te,sector,emiMkt)$(
+              ttot.val ge cm_startyear
+          AND se2fe(entySe,entyFe,te) 
+          AND entyFe2Sector(entyFe,sector) 
+          AND sector2emiMkt(sector,emiMkt) 
+          AND (entySeBio(entySe) OR entySeSyn(entySe) OR entySeFos(entySe)) ) ..
+    vm_demFeSector(ttot,regi,entySe,entyFe,sector,emiMkt) 
+  - vm_demFeSector(ttot-1,regi,entySe,entyFe,sector,emiMkt)
+  + v02_NegInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt)
+  - v02_PosInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt)
+  =e=
+  0
 ;
 $ENDIF.INCONV_bioSwitch
 

--- a/modules/02_welfare/utilitarian/postsolve.gms
+++ b/modules/02_welfare/utilitarian/postsolve.gms
@@ -7,18 +7,21 @@
 *** SOF ./modules/02_welfare/utilitarian/postsolve.gms
 
 $IFTHEN.INCONV_bioSwitch "%cm_INCONV_PENALTY_FESwitch%" == "on"
-*** track inconvenience penalty for bio/synfuel switching to check how large it is relative to consumption
-p02_inconvPen_Switch_Track(t,regi) = (sum((entySe,entyFe,te,sector,emiMkt)$(se2fe(entySe,entyFe,te) 
-                                                                    AND entyFe2Sector(entyFe,sector) 
-                                                                    AND sector2emiMkt(sector,emiMkt) 
-                                                                    AND (entySeBio(entySe) OR entySeSyn(entySe) OR entySeFos(entySe) )), 
-                                                                        v02_NegInconvPenFeBioSwitch.l(t,regi,entySe,entyFe,sector,emiMkt) 
-                                                                        + v02_PosInconvPenFeBioSwitch.l(t,regi,entySe,entyFe,sector,emiMkt))/1e3)
-																		/ vm_cons.l(t,regi);	
+*** track inconvenience penalty for bio/synfuel switching to check how large it
+*** is relative to consumption
+p02_inconvPen_Switch_Track(t,regi)
+  = sum((entySe,entyFe,te,sector,emiMkt)$(
+              se2fe(entySe,entyFe,te) 
+          AND entyFe2Sector(entyFe,sector) 
+          AND sector2emiMkt(sector,emiMkt) 
+          AND (entySeBio(entySe) OR entySeSyn(entySe) OR entySeFos(entySe) )), 
+      v02_NegInconvPenFeBioSwitch.l(t,regi,entySe,entyFe,sector,emiMkt) 
+    + v02_PosInconvPenFeBioSwitch.l(t,regi,entySe,entyFe,sector,emiMkt)
+    )
+  / 1e3
 $ENDIF.INCONV_bioSwitch
 
 *the inequality term in the SCC calculation is set to 1 here
 pm_sccIneq(tall,regi) = 1;
-
 
 *** EOF ./modules/02_welfare/utilitarian/postsolve.gms

--- a/modules/02_welfare/utilitarian/postsolve.gms
+++ b/modules/02_welfare/utilitarian/postsolve.gms
@@ -11,14 +11,14 @@ $IFTHEN.INCONV_bioSwitch "%cm_INCONV_PENALTY_FESwitch%" == "on"
 *** is relative to consumption
 p02_inconvPen_Switch_Track(t,regi)
   = sum((entySe,entyFe,te,sector,emiMkt)$(
-              se2fe(entySe,entyFe,te) 
-          AND entyFe2Sector(entyFe,sector) 
-          AND sector2emiMkt(sector,emiMkt) 
-          AND (entySeBio(entySe) OR entySeSyn(entySe) OR entySeFos(entySe) )), 
+                                    se2fe(entySe,entyFe,te) 
+                                AND entyFe2Sector(entyFe,sector) 
+                                AND sector2emiMkt(sector,emiMkt) 
+                                AND (entySeBio(entySe) OR  entySeFos(entySe) )), 
       v02_NegInconvPenFeBioSwitch.l(t,regi,entySe,entyFe,sector,emiMkt) 
     + v02_PosInconvPenFeBioSwitch.l(t,regi,entySe,entyFe,sector,emiMkt)
     )
-  / 1e3
+  / 1e3;
 $ENDIF.INCONV_bioSwitch
 
 *the inequality term in the SCC calculation is set to 1 here


### PR DESCRIPTION
- entySEsyn was a copy of entySEbio (most likely a mistake in https://github.com/remindmodel/remind/pull/544
- contains seliqsyn and segasyn now
- entySEsyn was removed from the six places it was used (all in
  02_welfare), where it did not have any effect before

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)