### PR TITLE
fail start_bundle_coupled if magpie .Rprofile does not support renv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ config/gdx-files/*.gdx
 plotRuntime*.html
 plotRuntimeDependencies/
 .Rproj.user
+runtime.rds
 
 # main renv.lock should only be commited for releases
 /.Rbuildignore
@@ -74,3 +75,7 @@ plotRuntimeDependencies/
 
 # Main Python virtual environment
 .venv/
+
+# ignore slurm logs
+slurm-[0-9]*.log
+slurm-[0-9]*.out

--- a/start_bundle_coupled.R
+++ b/start_bundle_coupled.R
@@ -100,6 +100,9 @@ if (!is.null(renv::project())) {
   if (length(missingDeps) > 0) {
     renv::install(missingDeps)
   }
+  if (! any(grepl("renvVersion", readLines(file.path(path_magpie, ".Rprofile"), warn = FALSE)))) {
+    stop("REMIND uses renv, but no renvVersion defined in MAgPIE .Rprofile. Checkout a recent .Rprofile in ", path_magpie)
+  }
 }
 
 ########################################################################################################


### PR DESCRIPTION
## Purpose of this PR

- fail start_bundle_coupled if magpie .Rprofile does not support renv, complements #1322
- add runtime.rds and slurm-1239870.out to .gitignore

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
