### PR TITLE
remove MAgPIE 1995,2000 values in joint mif

### DIFF
--- a/output.R
+++ b/output.R
@@ -278,7 +278,7 @@ if (comp %in% c("comparison", "export")) {
               # send the output script to slurm
               logfile <- paste0(outputdir, "/log_", rout, ".txt")
               slurmcmd <- paste0("sbatch ", slurmConfig, " --job-name=", logfile, " --output=", logfile,
-                                 " --mail-type=END --comment=REMIND --wrap=\"Rscript scripts/output/single/", rout,
+                                 " --mail-type=END --comment=", rout, " --wrap=\"Rscript scripts/output/single/", rout,
                                  ".R  outputdir=", outputdir, "\"")
               message("Sending to slurm: ", name, ". Find log in ", logfile)
               system(slurmcmd)

--- a/scripts/output/comparison/compareScenarios2.R
+++ b/scripts/output/comparison/compareScenarios2.R
@@ -57,6 +57,7 @@ startComp <- function(
     clcom <- paste0(
       "sbatch ", slurmConfig,
       " --job-name=", jobName,
+      " --comment=compareScenarios2",
       " --output=", jobName, ".out",
       " --error=", jobName, ".out",
       " --mail-type=END --time=200 --mem-per-cpu=8000",

--- a/scripts/output/single/reporting.R
+++ b/scripts/output/single/reporting.R
@@ -105,7 +105,7 @@ magpie_reporting_file <- envir$cfg$pathToMagpieReport
 if (! is.null(magpie_reporting_file) && file.exists(magpie_reporting_file)) {
   message("add MAgPIE reporting from ", magpie_reporting_file)
   tmp_rem <- quitte::as.quitte(remind_reporting_file)
-  tmp_mag <- quitte::as.quitte(magpie_reporting_file)
+  tmp_mag <- dplyr::filter(quitte::as.quitte(magpie_reporting_file), .data$period %in% levels(tmp_rem$period))
   # remove population from magpie reporting to avoid duplication (units "million" vs. "million people")
   sharedvariables <- intersect(tmp_mag$variable, tmp_rem$variable)
   if (length(sharedvariables) > 0) {


### PR DESCRIPTION
## Purpose of this PR

- I [accidentally removed](https://github.com/remindmodel/remind/commit/87508110352dc72b20e03411ed9bd0844568ad0d#diff-884efab47a011979cffb82b1c8bbed15316e0ffad1049e3a83b87182f7b59383L100) the code deleted the MAgPIE 1995 + 2000 values
- did not lead to fails, only if you used different versions of `reporting.R` in one folder
- improve slurm comments for reporting scripts

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
