### PR TITLE
remove --vanilla

### DIFF
--- a/modules/11_aerosols/exoGAINS/postsolve.gms
+++ b/modules/11_aerosols/exoGAINS/postsolve.gms
@@ -19,7 +19,7 @@ if((o_modelstat le 2),
 );
 
 *** Calculate AP emissions
-Execute "Rscript --vanilla exoGAINSAirpollutants.R";
+Execute "Rscript exoGAINSAirpollutants.R";
 
 *** Read input ref results for tall with following dimensions: pm_emiAPexsolve(tall,all_regi,all_sectorEmi,emiRCP)
 if((cm_startyear gt 2005),

--- a/modules/15_climate/magicc/postsolve.gms
+++ b/modules/15_climate/magicc/postsolve.gms
@@ -18,11 +18,11 @@
 *** Generate MAGICC scenario file
 $include "./core/magicc.gms";
 *** execute MAGICC (this is cheap enough, ~2s)
-Execute "Rscript --vanilla run_magicc.R";
+Execute "Rscript run_magicc.R";
 *** read in results
-Execute "Rscript --vanilla read_DAT_TOTAL_ANTHRO_RF.R";
+Execute "Rscript read_DAT_TOTAL_ANTHRO_RF.R";
 Execute_Loadpoint 'p15_forc_magicc'  p15_forc_magicc;
-Execute "Rscript --vanilla read_DAT_SURFACE_TEMP.R";
+Execute "Rscript read_DAT_SURFACE_TEMP.R";
 Execute_Loadpoint 'p15_magicc_temp' pm_globalMeanTemperature = pm_globalMeanTemperature;
 *** MAGICC only reports unitl 2300:
 pm_globalMeanTemperature(tall)$(tall.val gt 2300) = 0;
@@ -62,7 +62,7 @@ $ifthen.cm_magicc_tirf "%cm_magicc_temperatureImpulseResponse%" == "on"
 * thus only compute TIRF after each of the first 10 iterations, then only every fifth iteration. 
 * runtime is ca 30s, so switching on TIRF adds ca 10min to runtime
 if( ((iteration.val le 10) or ( mod(iteration.val,5 ) eq 0)) ,
-    execute "Rscript --vanilla run_magicc_temperatureImpulseResponse.R";
+    execute "Rscript run_magicc_temperatureImpulseResponse.R";
     execute_loadpoint 'pm_magicc_temperatureImpulseResponse'  pm_temperatureImpulseResponseCO2 = pm_temperatureImpulseResponse;
 );
 *NOTE the MAGICC results (*.OUT files) are from  the last pulse experiment now, so take care if reading them in after this point.


### PR DESCRIPTION
## Purpose of this PR

- Partly undo #1340, see comment there, to make sure renv is always used.
- Great you paid attention!
 
## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
