### PR TITLE
MAgPIE coupling: use new MAgPIE variable names; allow negative values for n2ofertsom (tiny fraction of total n2o)

### DIFF
--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -234,6 +234,7 @@ v_adjFactor.fx("2005",regi,te)=0;
 
 vm_emiMacSector.lo(t,regi,enty)    =  0;
 vm_emiMacSector.lo(t,regi,"co2luc")= -5.0;  !! afforestation can lead to negative emissions
+vm_emiMacSector.lo(t,regi,"n2ofertsom") =  -1; !! small negative emissions can result from human activity
 vm_emiMac.fx(t,regi,"so2") = 0;
 vm_emiMac.fx(t,regi,"bc") = 0;
 vm_emiMac.fx(t,regi,"oc") = 0;

--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -1360,6 +1360,8 @@ $if %carbonprice% == "NPi2018"  pm_macSwitch(emiMacMagpie) = 0;
 $if %cm_MAgPIE_coupling% == "on"  pm_macSwitch(enty)$emiMacMagpie(enty) = 0;
 *** As long as there is hardly any CO2 LUC reduction in MAgPIE we dont need MACs in REMIND
 $if %cm_MAgPIE_coupling% == "off"  pm_macSwitch("co2luc") = 0;
+*** The tiny fraction n2ofertsom of total land use n2o can get slitghliy negative in some cases. Ignore MAC for n2ofertsom by default.
+$if %cm_MAgPIE_coupling% == "off"  pm_macSwitch("n2ofertsom") = 0;
 
 pm_macCostSwitch(enty)=pm_macSwitch(enty);
 pm_macSwitch("co2cement_process") =0 ;

--- a/scripts/start/getReportData.R
+++ b/scripts/start/getReportData.R
@@ -111,30 +111,6 @@ getReportData <- function(path_to_report,inputpath_mag="magpie",inputpath_acc="c
     for (i in 1:nrow(map)) {
         tmp<-setNames(mag[,,map[i,]$emimag],map[i,]$emirem)
         tmp<-tmp*map[i,]$factor_mag2rem
-        #tmp["JPN",is.na(tmp["JPN",,]),] <- 0
-        # preliminary fix 20160111
-        #cat("Preliminary quick fix: filtering out NAs for all and negative values for almost all landuse emissions except for co2luc and n2ofertrb\n")
-        #tmp[is.na(tmp)] <- 0
-        # preliminary 20160114: filter out negative values except for co2luc and n2ofertrb
-        #if (map[i,]$emirem!="co2luc" &&  map[i,]$emirem!="n2ofertrb") {
-        # tmp[tmp<0] <- 0
-        #}
-
-        # Check for negative values, since only "co2luc" is allowed to be
-        # negative. All other emission variables are positive by definition.
-        if(map[i,]$emirem != "co2luc"){
-          if( !(all(tmp>=0)) ){
-            # Hotfix 2021-09-28: Raise warning and set negative values to zero.
-            # XXX Todo XXX: Make sure that MAgPIE is not reporting negative N2O
-            # or CH4 emissions and convert this warning into an error that
-            # breaks the model instead of setting the values to zero.
-            print(paste0("Warning: Negative values detected for '",
-                         map[i,]$emirem, "' / '", map[i,]$emimag, "'. ",
-                         "Hot fix: Set respective values to zero."))
-            tmp[tmp < 0] <- 0
-          }
-        }
-
         # Add emission variable to full dataframe
         out<-mbind(out,tmp)
     }
@@ -147,7 +123,7 @@ getReportData <- function(path_to_report,inputpath_mag="magpie",inputpath_acc="c
   }
   .agriculture_costs <- function(mag){
     notGLO <- getRegions(mag)[!(getRegions(mag)=="GLO")]
-    out <- mag[,,"Costs|MainSolve w/o GHG Emissions (million US$05/yr)"]/1000/1000 # with transformation factor from 10E6 US$2005 to 10E12 US$2005
+    out <- mag[,,"Costs Without Incentives (million US$05/yr)"]/1000/1000 # with transformation factor from 10E6 US$2005 to 10E12 US$2005
     out["JPN",is.na(out["JPN",,]),] <- 0
     dimnames(out)[[3]] <- NULL #Delete variable name to prevent it from being written into output file
     write.magpie(out[notGLO,,],paste0("./modules/26_agCosts/",inputpath_acc,"/input/p26_totLUcost_coupling.csv"),file_type="csvr")


### PR DESCRIPTION
- Replace old MAgPIE cost variable with new one.
- in coupling script: remove filtering of negative LU emissions (other than co2luc). Only n2ofertsom is expected to get negative, which is tolerated by REMIND from now on
- tolerate negative values for n2ofertsom and deactivate MAC for this tiny fraction of total land use n2o (as agreed in coupling meeting https://gitlab.pik-potsdam.de/piam/remind-magpie-coupling/-/wikis/Home/Meetings)

## Purpose of this PR

Prepare REMIND for new MAgPIE intput data.

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix 
- [ ] Refactoring
- [ ] New feature 
- [x] Minor change (default scenarios show only small differences)
- [ ] Fundamental change
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 
