### PR TITLE
add changelog info section to PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -12,7 +12,6 @@
 - [ ] Fundamental change
 - [ ] This change requires a documentation update
 
-
 ## Checklist:
 
 - [ ] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
@@ -22,9 +21,15 @@
 - [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
 - [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
 - [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)
+- [ ] Include in next release changelog (I filled out the changelog section below)
+
+## Information for release changelog (optional):
+
+(Leave empty if this PR does not concern changes to be mentioned in the changelog)
 
 ## Further information (optional):
 
 * Test runs are here: 
 * Comparison of results (what changes by this PR?): 
+
 


### PR DESCRIPTION
## Purpose of this PR
In order to generate a changelog for releases, we want to collect relevant info as part of the PRs. The PR template now has a section where devs can add a concise description of the changes in their PR to be included in the changelog of the next release. It is optional, as not all PRs contain relevant info for the changelog. 

We will later use the info to create the changelog in a semi-automatic process using a script gathering the info from all PRs (text and link to PR).

## Type of change
- [x] New feature 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
