### PR TITLE
Fix switch c_ccsinjecrateRegi to set regionalized CCS injection rates

### DIFF
--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -240,7 +240,6 @@ Parameter p_extRegiccsinjecrateRegi(ext_regi) "Regional CCS injection rate facto
 loop((ext_regi)$p_extRegiccsinjecrateRegi(ext_regi),
   pm_ccsinjecrate(regi)$(regi_group(ext_regi,regi)) = p_extRegiccsinjecrateRegi(ext_regi);
 );
-pm_ccsinjecrate(regi) = s_ccsinjecrate;
 ;
 $endIf.c_ccsinjecrateRegi
 

--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -238,7 +238,7 @@ pm_ccsinjecrate(regi) = s_ccsinjecrate;
 $ifThen.c_ccsinjecrateRegi not "%c_ccsinjecrateRegi%" == "off"
 Parameter p_extRegiccsinjecrateRegi(ext_regi) "Regional CCS injection rate factor. 1/a. (extended regions)" / %c_ccsinjecrateRegi% /;
 loop((ext_regi)$p_extRegiccsinjecrateRegi(ext_regi),
-  pm_ccsinjecrate(regi)$(regi_group(ext_regi,regi)) = p_extRegiccsinjecrateRegi(ext_regi);
+  pm_ccsinjecrate(regi)$(regi_groupExt(ext_regi,regi)) = p_extRegiccsinjecrateRegi(ext_regi);
 );
 ;
 $endIf.c_ccsinjecrateRegi


### PR DESCRIPTION
## Purpose of this PR

Fix  c_ccsinjecrateRegi switch

* stop overwriting its values by default ones
* allow inclusion of sub EU regions like "DEU 0.003"

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix 
- [ ] Refactoring
- [ ] New feature 
- [ ] Minor change (default scenarios show only small differences)
- [ ] Fundamental change
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)

## Further information (optional):

* Test runs are here: 
``/p/tmp/schreyer/Modeling/remind/Current/output/Npi_testCCSRegi_fix_2023-07-10_18.44.16``

Check 
* Comparison of results (what changes by this PR?): 

