### PR TITLE
initialize pm_pvpRegi = 0 instead of loading those values from the input.gdx file

### DIFF
--- a/core/preloop.gms
+++ b/core/preloop.gms
@@ -38,13 +38,13 @@ vm_co2eqMkt.l(ttot,regi,emiMkt) = 0;
 v_shfe.l(t,regi,enty,sector) = 0;
 v_shGasLiq_fe.l(t,regi,sector) = 0;  
 pm_share_CCS_CCO2(t,regi) = 0; 
-  
+pm_pvpRegi(ttot,regi,enty) = 0;
+
 *** overwrite default targets with gdx values if wanted
 Execute_Loadpoint 'input' p_emi_budget1_gdx = sm_budgetCO2eqGlob;
 Execute_Loadpoint 'input' vm_demPe.l = vm_demPe.l;
 Execute_Loadpoint 'input' q_balPe.m = q_balPe.m;
 Execute_Loadpoint 'input' qm_budget.m = qm_budget.m;
-Execute_Loadpoint 'input' pm_pvpRegi = pm_pvpRegi;
 Execute_Loadpoint 'input' pm_pvp = pm_pvp;
 Execute_Loadpoint 'input' vm_demFeSector.l = vm_demFeSector.l;
 

--- a/tutorials/06_Advanced_ChangeInputs.md
+++ b/tutorials/06_Advanced_ChangeInputs.md
@@ -41,7 +41,7 @@ If you want to peek inside the archive to debug something or out of curiosity yo
 
 1. Run the helper tool `lastrev` (`/p/projects/rd3mod/tools/lastrev`) to get a list of the last five `revX.XXX*_remind.tgz` items in the default madrat output directory. Alternatively, you can also check by hand in the `/p/projects/rd3mod/inputdata/output` folder on the PIK cluster.
 
-2. Clone the [remind-preprocessing repo](https://github.com/remindmodel/pre-processing) to your tmp folder on the cluster and edit its `config/default.cfg` file by inserting the next revision number. Use at least 4 decimal places for development/testing or use the additional argument `dev` to specify your test. If an old revision number is used, the input data will not be recalculated. Input data for a new regional resolution will be recalculated based on the existing cache information in the PUC file.
+2. Clone the [remind-preprocessing repo](https://github.com/remindmodel/pre-processing) to your tmp folder on the cluster and edit its `config/default.cfg` file by inserting the next revision number. Use the additional argument `dev` for testing. If an old revision number is used, the input data will not be recalculated. Input data for a new regional resolution will be recalculated based on the existing cache information in the PUC file.
 
 3. Start the script with `Rscript submit_preprocessing.R`.
 The .log file lists the progress and potential errors. This process might take a while (currently >8 hours).


### PR DESCRIPTION
## Purpose of this PR
Not load in pm_pvpRegi values from input.gdx avoids CO2 prices for time steps if they are not overwritten later in code (e.g. baseline scenarios after NPi caliration and using an input.gdx from an NPi calibration run)

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix 


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)

## Further information (optional):

* Test runs are here: /p/tmp/lavinia/MO/test_pm_pvpRegi/remind
* Comparison of results (what changes by this PR?): 

