### PR TITLE
respect different FE emission factors in pm_IndstCO2Captured calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **config** regex tests for many parameters
 - **testthat** test and compile all config files
 
+### fixed
+- fixed weights of energy carriers in `pm_IndstCO2Captured`
+    [[#1354](https://github.com/remindmodel/remind/pull/1354)]
+
 ## [3.2.1] - 2023-07-13 (incomplete)
 
 ### changed

--- a/core/sets.gms
+++ b/core/sets.gms
@@ -2315,7 +2315,7 @@ alias(te,te2,te3);
 alias(all_enty,all_enty2);
 alias(enty,enty2,enty3,enty4,enty5,enty6,enty7);
 alias(entyPE,entyPE2);
-alias(entySE,entySE2,entySE3);
+alias(entySE,entySE2);
 alias(entyFe,entyFe2);
 alias(teEs,teEs2);
 alias(esty,esty2);

--- a/core/sets.gms
+++ b/core/sets.gms
@@ -2315,7 +2315,7 @@ alias(te,te2,te3);
 alias(all_enty,all_enty2);
 alias(enty,enty2,enty3,enty4,enty5,enty6,enty7);
 alias(entyPE,entyPE2);
-alias(entySe,entySe2);
+alias(entySE,entySE2,entySE3);
 alias(entyFe,entyFe2);
 alias(teEs,teEs2);
 alias(esty,esty2);

--- a/modules/37_industry/subsectors/datainput.gms
+++ b/modules/37_industry/subsectors/datainput.gms
@@ -16,12 +16,12 @@ PARAMETERS
   p37_specMatsDem(mats,teMats,opModes)                                      "Specific materials demand of a production technology and operation mode [t_input/t_output]"
   /
     ironore.idr.(ng,h2)     1.5                                             !! Iron ore demand of iron direct-reduction (independent of fuel source)
-    
+
     dri.eaf.pri             1.0                                             !! DRI demand of EAF
     scrap.eaf.sec           1.0                                             !! Scrap demand of EAF
     dri.eaf.sec             0.0
     scrap.eaf.pri           0.0
-    
+
     ironore.bfbof.pri       1.5                                             !! Iron ore demand of BF-BOF
     scrap.bfbof.sec         1.0                                             !! Scrap demand of BF-BOF
     scrap.bfbof.pri         0.0
@@ -33,10 +33,10 @@ PARAMETERS
     feels.idr.(ng,h2)       0.33                                            !! Specific electric demand for both H2 and NG operation.
     fegas.idr.ng            2.94                                            !! Specific natural gas demand when operating with NG.
     feh2s.idr.h2            1.91                                            !! Specific hydrogen demand when operating with H2.
-    
+
     feels.eaf.pri           0.91                                            !! Specific electricy demand of EAF when operating with DRI.
     feels.eaf.sec           0.67                                            !! Specific electricy demand of EAF when operating with scrap.
-    
+
     fesos.bfbof.pri         2.0                                             !! Specific coal demand of BF-BOF when operating with DRI -- this number is just a guess
     fesos.bfbof.sec         0.5                                             !! Specific coal demand of BF-BOF when operating with scrap -- this number is just a guess
   /
@@ -175,7 +175,7 @@ loop (industry_ue_calibration_target_dyn37(out)$( pm_energy_limit(out) ),
 
 *** Specific energy demand limits for other industry and chemicals in TWa/trUSD
 *** exponential decrease of minimum specific energy demand per value added up to 90% by 2100
-sm_tmp2 = 0.9;   !! maximum "efficiency gain" relative to 2015 baseline value 
+sm_tmp2 = 0.9;   !! maximum "efficiency gain" relative to 2015 baseline value
 sm_tmp  = 2100;   !! period in which closing could be achieved
 
 loop (industry_ue_calibration_target_dyn37(out)$( sameas(out,"ue_chemicals") OR  sameas(out,"ue_otherInd")),
@@ -415,17 +415,17 @@ pm_ue_eff_target("ue_otherInd")         = 0.008;
 *` CES mark-up cost industry
 
 *` The Mark-up cost on primary production factors (final energy) of the CES tree have two functions. 
-*` (1) They represent sectoral end-use cost not captured by the energy system. 
-*` (2) As they alter prices to of the CES function inputs, they affect the CES efficiency parameters during calibration 
+*` (1) They represent sectoral end-use cost not captured by the energy system.
+*` (2) As they alter prices to of the CES function inputs, they affect the CES efficiency parameters during calibration
 *` and therefore influence the efficiency of different FE CES inputs. The resulting economic subsitution rates
 *` are given by the marginal rate of subsitution (MRS) in the parameter o01_CESmrs.
-*` Mark-up cost were tuned as to obtain similar or slightly higher marginal rate of substitution (MRS) to gas/liquids than technical subsitution rates and 
-*` obtain similar specific energy consumption per value added in chemicals and other industry across high and low electrification scenarios. 
+*` Mark-up cost were tuned as to obtain similar or slightly higher marginal rate of substitution (MRS) to gas/liquids than technical subsitution rates and
+*` obtain similar specific energy consumption per value added in chemicals and other industry across high and low electrification scenarios.
 
 
 *` There are two ways in which mark-up cost can be set:
-*` (a) Mark-up cost on inputs in ppfen_MkupCost37: Those are counted as expenses in the budget and set by the parameter p37_CESMkup. 
-*` (b) Mark-up cost on other inputs: Those are budget-neutral and implemented as a tax. They are set by the parameter pm_tau_ces_tax. 
+*` (a) Mark-up cost on inputs in ppfen_MkupCost37: Those are counted as expenses in the budget and set by the parameter p37_CESMkup.
+*` (b) Mark-up cost on other inputs: Those are budget-neutral and implemented as a tax. They are set by the parameter pm_tau_ces_tax.
 
 *` Mark-up cost in industry are modeled without budget-effect (b).
 

--- a/modules/37_industry/subsectors/declarations.gms
+++ b/modules/37_industry/subsectors/declarations.gms
@@ -16,7 +16,7 @@ Parameters
   p37_energy_limit_slope(tall,all_regi,all_in)                                 "limit for subsector specific energy demand that converges towards the thermodynamic/technical limit [GJ/t product]"
   p37_clinker_cement_ratio(ttot,all_regi)                                      "clinker content per unit cement used"                                         
   pm_ue_eff_target(all_in)                                                     "energy efficiency target trajectories [% p.a.]"                               
-  pm_IndstCO2Captured(ttot,all_regi,all_enty,all_enty,secInd37,all_emiMkt)     "Captured CO2 in industry by energy carrier, subsector and emissions market"   
+  pm_IndstCO2Captured(ttot,all_regi,all_enty,all_enty,secInd37,all_emiMkt)     "Captured CO2 in industry by energy carrier, subsector and emissions market [GtC/a]"
   p37_CESMkup(ttot,all_regi,all_in)                                            "parameter for those CES markup cost accounted as investment cost in the budget [trUSD/CES input]"                                  
   p37_cesIO_up_steel_secondary(tall,all_regi,all_GDPscen)                      "upper limit to secondary steel production based on scrap availability"        
   p37_steel_secondary_max_share(tall,all_regi)                                 "maximum share of secondary steel production"

--- a/modules/37_industry/subsectors/declarations.gms
+++ b/modules/37_industry/subsectors/declarations.gms
@@ -14,11 +14,11 @@ Parameters
   pm_abatparam_Ind(ttot,all_regi,all_enty,steps)                               "industry CCS MAC curves [ratio @ US$2005]"
   pm_energy_limit(all_in)                                                      "thermodynamic/technical limits of subsector energy use [GJ/t product]"
   p37_energy_limit_slope(tall,all_regi,all_in)                                 "limit for subsector specific energy demand that converges towards the thermodynamic/technical limit [GJ/t product]"
-  p37_clinker_cement_ratio(ttot,all_regi)                                      "clinker content per unit cement used"                                         
-  pm_ue_eff_target(all_in)                                                     "energy efficiency target trajectories [% p.a.]"                               
+  p37_clinker_cement_ratio(ttot,all_regi)                                      "clinker content per unit cement used"
+  pm_ue_eff_target(all_in)                                                     "energy efficiency target trajectories [% p.a.]"
   pm_IndstCO2Captured(ttot,all_regi,all_enty,all_enty,secInd37,all_emiMkt)     "Captured CO2 in industry by energy carrier, subsector and emissions market [GtC/a]"
-  p37_CESMkup(ttot,all_regi,all_in)                                            "parameter for those CES markup cost accounted as investment cost in the budget [trUSD/CES input]"                                  
-  p37_cesIO_up_steel_secondary(tall,all_regi,all_GDPscen)                      "upper limit to secondary steel production based on scrap availability"        
+  p37_CESMkup(ttot,all_regi,all_in)                                            "parameter for those CES markup cost accounted as investment cost in the budget [trUSD/CES input]"
+  p37_cesIO_up_steel_secondary(tall,all_regi,all_GDPscen)                      "upper limit to secondary steel production based on scrap availability"
   p37_steel_secondary_max_share(tall,all_regi)                                 "maximum share of secondary steel production"
   p37_BAU_industry_ETS_solids(tall,all_regi)                                   "industry solids demand in baseline scenario"
   p37_cesIO_baseline(tall,all_regi,all_in)                                     "vm_cesIO from the baseline scenario"
@@ -28,12 +28,12 @@ $ifthen.process_based_steel "%cm_process_based_steel%" == "on"                 !
 $endif.process_based_steel
 
 *** output parameters only for reporting
-  o37_emiInd(ttot,all_regi,all_enty,secInd37,all_enty)                   "industry CCS emissions [GtC/a]"                                                                                
-  o37_cementProcessEmissions(ttot,all_regi,all_enty)                     "cement process emissions [GtC/a]"                                                                              
+  o37_emiInd(ttot,all_regi,all_enty,secInd37,all_enty)                   "industry CCS emissions [GtC/a]"
+  o37_cementProcessEmissions(ttot,all_regi,all_enty)                     "cement process emissions [GtC/a]"
   o37_demFeIndTotEn(ttot,all_regi,all_enty,all_emiMkt)                   "total FE per energy carrier and emissions market in industry (sum over subsectors)"
-  o37_shIndFE(ttot,all_regi,all_enty,secInd37,all_emiMkt)                "share of subsector in FE industry energy carriers and emissions markets"                                       
-  o37_demFeIndSub(ttot,all_regi,all_enty,all_enty,secInd37,all_emiMkt)   "FE demand per industry subsector"                                                                              
-  o37_demFeIndSub_SecCC(ttot,all_regi,secInd37)                          "FE per subsector whose emissions can be captured, helper parameter for calculation of industry captured CO2"   
+  o37_shIndFE(ttot,all_regi,all_enty,secInd37,all_emiMkt)                "share of subsector in FE industry energy carriers and emissions markets"
+  o37_demFeIndSub(ttot,all_regi,all_enty,all_enty,secInd37,all_emiMkt)   "FE demand per industry subsector"
+  o37_demFeIndSub_SecCC(ttot,all_regi,secInd37)                          "FE per subsector whose emissions can be captured, helper parameter for calculation of industry captured CO2"
 
 $ifThen.CESMkup not "%cm_CESMkup_ind%" == "standard" 
   p37_CESMkup_input(all_in)  "markup cost parameter read in from config for CES levels in industry to influence demand-side cost and efficiencies in CES tree [trUSD/CES input]" / %cm_CESMkup_ind% /
@@ -81,4 +81,3 @@ $endif.process_based_steel
 ;
 
 *** EOF ./modules/37_industry/subsectors/declarations.gms
-

--- a/modules/37_industry/subsectors/equations.gms
+++ b/modules/37_industry/subsectors/equations.gms
@@ -10,8 +10,8 @@
 ***-------------------------------------------------------------------------------
 ***                         MATERIAL-FLOW IMPLEMENTATION
 ***-------------------------------------------------------------------------------
-* Balance equation: Demand of materials equals to production of those materials, 
-* accounting for trade. Demand of materials arises either due to external demand 
+* Balance equation: Demand of materials equals to production of those materials,
+* accounting for trade. Demand of materials arises either due to external demand
 * from the economy (i.e. steel) or due to internal demand of the processes modelled
 * in the materials-flow model (i.e. directly reduced iron).
 *
@@ -106,10 +106,10 @@ $ifthen.fixed_production "%cm_import_EU%" == "bal"   !! cm_import_EU
          !! do not limit steel production shares for fixed production
      AND p37_industry_quantity_targets(ttot,regi,"ue_steel_secondary") eq 0
 $endif.fixed_production
-$ifthen.exogDem_scen NOT "%cm_exogDem_scen%" == "off" 
+$ifthen.exogDem_scen NOT "%cm_exogDem_scen%" == "off"
          !! do not limit steel production shares for fixed production
      AND pm_exogDemScen(ttot,regi,"%cm_exogDem_scen%","ue_steel_secondary") eq 0
-$endif.exogDem_scen 
+$endif.exogDem_scen
 
                                                                             ) ..
   vm_cesIO(ttot,regi,"ue_steel_secondary")

--- a/modules/37_industry/subsectors/postsolve.gms
+++ b/modules/37_industry/subsectors/postsolve.gms
@@ -14,21 +14,21 @@ pm_FEPrice(ttot,regi,entyFE,"indst",emiMkt)$( abs(qm_budget.m(ttot,regi)) gt sm_
 
 *** calculate reporting parameters for FE per subsector and SE origin to make R
 *** reporting easier
-*** total FE per energy carrier and emissions market in industry (sum over 
+*** total FE per energy carrier and emissions market in industry (sum over
 *** subsectors)
 o37_demFeIndTotEn(ttot,regi,entyFe,emiMkt)
   = sum((fe2ppfEn37(entyFe,in),secInd37_2_pf(secInd37,in),
-                         secInd37_emiMkt(secInd37,emiMkt)), 
+                         secInd37_emiMkt(secInd37,emiMkt)),
       (vm_cesIO.l(ttot,regi,in)
       +pm_cesdata(ttot,regi,in,"offset_quantity"))
     );
 
 *** share of subsector in FE industry energy carriers and emissions markets
-o37_shIndFE(ttot,regi,entyFe,secInd37,emiMkt)$( 
+o37_shIndFE(ttot,regi,entyFe,secInd37,emiMkt)$(
                                     o37_demFeIndTotEn(ttot,regi,entyFe,emiMkt) )
   = sum(( fe2ppfEn37(entyFe,in),
           secInd37_2_pf(secInd37,in),
-          secInd37_emiMkt(secInd37,emiMkt)), 
+          secInd37_emiMkt(secInd37,emiMkt)),
       (vm_cesIO.l(ttot,regi,in)
       +pm_cesdata(ttot,regi,in,"offset_quantity"))
     )
@@ -47,16 +47,16 @@ o37_demFeIndSub(ttot,regi,entySe,entyFe,secInd37,emiMkt)
 *** NOTE: not used for pm_IndstCO2Captured anymore since it did not take into
 *** account the different emission factors of FE carriers.  But used in remind2,
 *** so kept for backwards compatibility.
-o37_demFeIndSub_SecCC(ttot,regi,secInd37) 
+o37_demFeIndSub_SecCC(ttot,regi,secInd37)
   = sum((se2fe(entySe,entyFe,te),macBaseInd37(entyFe,secInd37),
-                                 sector2emiMkt("indst",emiMkt)), 
+                                 sector2emiMkt("indst",emiMkt)),
       o37_demFeIndSub(ttot,regi,entySe,entyFe,secInd37,emiMkt)
     );
 
 *** industry captured fuel CO2
 pm_IndstCO2Captured(ttot,regi,entySE,entyFE(entyFEcc37),secInd37,emiMkt)$(
                   macBaseInd37(entyFE,secInd37)
-              AND sum(se2fe(entySE2,entyFE,te), 
+              AND sum(se2fe(entySE2,entyFE,te),
                     o37_demFEindsub(ttot,regi,entySE2,entyFE,secInd37,emiMkt)) )
   = ( o37_demFEindsub(ttot,regi,entySE,entyFE,secInd37,emiMkt)
     * sum(se2fe(entySE2,entyFE,te),

--- a/modules/37_industry/subsectors/postsolve.gms
+++ b/modules/37_industry/subsectors/postsolve.gms
@@ -55,9 +55,8 @@ o37_demFeIndSub_SecCC(ttot,regi,secInd37)
 
 *** industry captured fuel CO2
 pm_IndstCO2Captured(ttot,regi,entySE,entyFE(entyFEcc37),secInd37,emiMkt)$(
-                  macBaseInd37(entyFE,secInd37)
-              AND sum(se2fe(entySE2,entyFE,te),
-                    o37_demFEindsub(ttot,regi,entySE2,entyFE,secInd37,emiMkt)) )
+                     macBaseInd37(entyFE,secInd37)
+                 AND sum(entyFE2, vm_macBaseInd.l(ttot,regi,entyFE2,secInd37)) )
   = ( o37_demFEindsub(ttot,regi,entySE,entyFE,secInd37,emiMkt)
     * sum(se2fe(entySE2,entyFE,te),
         !! collapse entySE dimension, so emission factors apply to all entyFE
@@ -71,15 +70,9 @@ pm_IndstCO2Captured(ttot,regi,entySE,entyFE(entyFEcc37),secInd37,emiMkt)$(
         vm_emiIndCCS.l(ttot,regi,emiInd37)
       ) !! subsector captured energy emissions
 
-    / sum(se2fe(entySE2,entyFE2,te),
-        o37_demFEindsub(ttot,regi,entySE2,entyFE2,secInd37,emiMkt)
-      * sum(se2fe2(entySE3,entyFE2,te2),
-          !! collapse entySE dimension, so emission factors apply to all entyFE2
-          !! regardless or origin, and therefore entySEbio and entySEsyn have
-          !! non-zero emission factors
-          pm_emifac(ttot,regi,entySE3,entyFE,te2,"co2")
-	)
-      )  !! subsector total emissions
+    / sum(entyFE2,
+        vm_macBaseInd.l(ttot,regi,entyFE2,secInd37)
+      ) !! subsector total energy emissions
     ) !! subsector capture share
 ;
 

--- a/modules/37_industry/subsectors/postsolve.gms
+++ b/modules/37_industry/subsectors/postsolve.gms
@@ -64,7 +64,7 @@ pm_IndstCO2Captured(ttot,regi,entySE,entyFE(entyFEcc37),secInd37,emiMkt)$(
 	!! non-zero emission factors
         pm_emifac(ttot,regi,entySE2,entyFE,te,"co2")
       )
-    ) !! subsector emissions
+    ) !! subsector emissions (smokestack, i.e. including biomass & synfuels)
 
   * ( sum(secInd37_2_emiInd37(secInd37,emiInd37(emiInd37_fuel)),
         vm_emiIndCCS.l(ttot,regi,emiInd37)

--- a/modules/37_industry/subsectors/preloop.gms
+++ b/modules/37_industry/subsectors/preloop.gms
@@ -10,4 +10,3 @@
 pm_IndstCO2Captured(t,regi,entySe,entyFe,secInd37,emiMkt) = 0;
 
 *** EOF ./modules/37_industry/subsectors/preloop.gms
-

--- a/modules/37_industry/subsectors/presolve.gms
+++ b/modules/37_industry/subsectors/presolve.gms
@@ -7,12 +7,12 @@
 *** SOF ./modules/37_industry/subsectors/presolve.gms
 
 *' The process emissions from cement production are calculated using a fixed
-*' CO2-to-clinker ratio (0.5262 kg CO2/kg clinker), region-specific 
-*' clinker-to-cement ratios, and the cement production from the production 
+*' CO2-to-clinker ratio (0.5262 kg CO2/kg clinker), region-specific
+*' clinker-to-cement ratios, and the cement production from the production
 *' function.
 *' Last iteration's cement production value is used, since the MAC mechanism is
 *' outside of the optimisation loop.
-vm_macBaseInd.fx(ttot,regi,"co2cement_process","cement")$( ttot.val ge 2005 ) 
+vm_macBaseInd.fx(ttot,regi,"co2cement_process","cement")$( ttot.val ge 2005 )
   = s37_clinker_process_CO2
   * p37_clinker_cement_ratio(ttot,regi)
   * vm_cesIO.l(ttot,regi,"ue_cement")
@@ -22,4 +22,3 @@ vm_macBaseInd.fx(ttot,regi,"co2cement_process","cement")$( ttot.val ge 2005 )
 ***p37_emiFac(ttot,regi,entyFe) = sum((entySe,te)$(se2fe(entySe,entyFe,te) and entySeFos(entySe)), pm_emifac(ttot,regi,entySe,entyFe,te,"co2"));
 
 *** EOF ./modules/37_industry/subsectors/presolve.gms
-

--- a/modules/37_industry/subsectors/realization.gms
+++ b/modules/37_industry/subsectors/realization.gms
@@ -20,4 +20,3 @@ $Ifi "%phase%" == "presolve" $include "./modules/37_industry/subsectors/presolve
 $Ifi "%phase%" == "postsolve" $include "./modules/37_industry/subsectors/postsolve.gms"
 *######################## R SECTION END (PHASES) ###############################
 *** EOF ./modules/37_industry/subsectors/realization.gms
-

--- a/modules/37_industry/subsectors/sets.gms
+++ b/modules/37_industry/subsectors/sets.gms
@@ -15,14 +15,14 @@ $ifthen.process_based_steel "%cm_process_based_steel%" == "on"                 !
     scrap               "Steel scrap"
     ironore             "Iron ore"
   /
-  
+
   teMats(all_te)        "Technologies used in material-flow model"
   /
     idr                 "Iron direct reduction"
     eaf                 "Electric-arc furnace"
     bfbof               "Blast furnace/basic-oxygen furnace"
   /
-  
+
   opModes               "Operation modes for technologies in material-flow model"
   /
     ng                  "Direct reduction using natural gas"
@@ -30,21 +30,21 @@ $ifthen.process_based_steel "%cm_process_based_steel%" == "on"                 !
     pri                 "Primary production of steel (based on iron ore or DRI)"
     sec                 "Secondary production of steel (based on scrap)"
   /
-  
+
   teMats2matsIn(teMats,mats)    "Mapping of technologies onto input materials"
   /
     idr . ironore
     eaf . (dri,scrap)
     bfbof . (ironore,scrap)
   /
-  
+
   teMats2opModes(teMats,opModes)    "Mapping of technologies onto available operation modes"
   /
     idr . (ng,h2)
     eaf . (pri,sec)
     bfbof . (pri,sec)
   /
-  
+
   matsOut2teMats(mats,teMats)       "Mapping of output materials onto technologies producing these"
   /
     dri . idr


### PR DESCRIPTION
Fixes #1353

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)

## Further information (optional):

-  Test runs are here: `/p/tmp/pehl/Remind/` (running)
  `new` and `old` should have different weights but identical totals for CCS in industry subsectors, save for gdx effects due to `pm_IndstCO2Captured` feeding back into the solver.

