### PR TITLE
fix high taxCO2eq in SSA for NDC

### DIFF
--- a/modules/45_carbonprice/NDC/postsolve.gms
+++ b/modules/45_carbonprice/NDC/postsolve.gms
@@ -52,10 +52,9 @@ p45_factorRescaleCO2TaxLtd_iter(iteration,t,regi) = p45_factorRescaleCO2TaxLtd(t
 
 display p45_factorRescaleCO2TaxLtd_iter;
 
-*CB* special case SSA: maximum carbon price at 7.5$ in 2020, 30 in 2025, 45 in 2030, to reflect low energy productivity of region, and avoid high losses
-pm_taxCO2eq(t,regi)$(sameas(t,"2020") AND sameas(regi,"SSA")) = min(pm_taxCO2eq("2020",regi)$(sameas(regi,"SSA")),7.5 * sm_DptCO2_2_TDpGtC);
-pm_taxCO2eq(t,regi)$(sameas(t,"2020") AND sameas(regi,"SSA")) = min(pm_taxCO2eq("2025",regi)$(sameas(regi,"SSA")),30 * sm_DptCO2_2_TDpGtC);
-pm_taxCO2eq(t,regi)$(sameas(t,"2025") AND sameas(regi,"SSA")) = min(pm_taxCO2eq("2030",regi)$(sameas(regi,"SSA")),45 * sm_DptCO2_2_TDpGtC);
+*CB* special case SSA: cap carbon price at 30 in 2025, 45 in 2030, to reflect low energy productivity of region, and avoid high losses
+pm_taxCO2eq(t,regi)$(sameas(t,"2025") AND sameas(regi,"SSA")) = min(pm_taxCO2eq("2025",regi)$(sameas(regi,"SSA")),30 * sm_DptCO2_2_TDpGtC);
+pm_taxCO2eq(t,regi)$(sameas(t,"2030") AND sameas(regi,"SSA")) = min(pm_taxCO2eq("2030",regi)$(sameas(regi,"SSA")),45 * sm_DptCO2_2_TDpGtC);
 
 *** calculate tax path until NDC target year - linear increase
 p45_taxCO2eqFirstNDCyear(regi) = smax(t$(t.val = p45_firstNDCyear(regi)), pm_taxCO2eq(t,regi));

--- a/modules/45_carbonprice/NDC/preloop.gms
+++ b/modules/45_carbonprice/NDC/preloop.gms
@@ -6,9 +6,6 @@
 *** |  Contact: remind@pik-potsdam.de
 *** SOF ./modules/45_carbonprice/NDC/preloop.gms
 
-***CB* special case SSA: maximum carbon price (after adjustment below) at 7.5$ in 2020, 30 in 2025, 45 in 2030, to reflect low energy productivity of region, and avoid high losses
-pm_taxCO2eq(t,regi)$(sameas(t, "2020") and sameas(regi,"SSA")) = 15 * sm_DptCO2_2_TDpGtC;
-
 *** first calculate tax path until last NDC target year - linear increase
 pm_taxCO2eq(t,regi)$(t.val gt 2016 AND t.val le p45_lastNDCyear(regi)) = pm_taxCO2eq("2020",regi)*(t.val-2015)/5;
 


### PR DESCRIPTION
## Purpose of this PR

- I introduced an error [here](https://github.com/remindmodel/remind/commit/c41f50c897cfd81ce14f2e6d2fa56a3aa278ea5e#diff-cd992b694ef69f032333cd069b829dab284be44a0aee3dcadf1ebd9e5148cf28L56-R58) where I changed the year. Removed the 2020 allocation of prices because this is now handled by `NPi` module

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I compiled the NGFS NDC run and it worked. The automated tests would not even look into this file
