### PR TITLE
add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+
+# Changelog
+
+All notable changes to this project will be documented in this file.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+
+## [Unreleased]
+
+
+## [3.2.1] - 2023-07-13
+
+### changed
+- **documentation** MAgPIE coupling, DIETER coupling, input changes
+- **config** NGFS, SHAPE
+- **scripts** re-enable summation checks for IIASA submission
+
+### added
+- **45_carbonprice** added realization for National Policies Implemented 
+- **47_carbonpriceRegi** now supports BECCS quantity targets
+- **MAgPIE coupling** added `qos=auto` mode for MAgPIE coupling
+- **MAgPIE coupling** added renv support mode for MAgPIE coupling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **47_carbonpriceRegi** now supports BECCS quantity targets
 - **MAgPIE coupling** added `qos=auto` mode for MAgPIE coupling
 - **MAgPIE coupling** added renv support mode for MAgPIE coupling
+
+
+
+[Unreleased]: https://github.com/remindmodel/remind/compare/v3.2.1...HEAD
+[3.2.1]: https://github.com/remindmodel/remind/compare/v3.2.0...v3.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 
-## [3.2.1] - 2023-07-13
+## [3.2.1] - 2023-07-13 (incomplete)
 
 ### changed
 - **documentation** MAgPIE coupling, DIETER coupling, input changes
@@ -18,10 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### added
 - **45_carbonprice** added realization for National Policies Implemented 
 - **47_carbonpriceRegi** now supports BECCS quantity targets
-- **MAgPIE coupling** added `qos=auto` mode for MAgPIE coupling
-- **MAgPIE coupling** added renv support mode for MAgPIE coupling
-
-
+- **MAgPIE coupling** added `qos=auto` mode
+- **MAgPIE coupling** added renv support mode
 
 [Unreleased]: https://github.com/remindmodel/remind/compare/v3.2.1...HEAD
 [3.2.1]: https://github.com/remindmodel/remind/compare/v3.2.0...v3.2.1

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -22,6 +22,7 @@
 - [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
 - [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
 - [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)
+- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
 
 ## Further information (optional):
 


### PR DESCRIPTION
## Purpose of this PR

Add a CHANGELOG.md file with some changes for Release 3.2.1 and a corresponding reminder to update the changelog to the PR template.

Rules for changelog format can be found [here](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Type of change

- [x]  New feature 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x]  I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)

