### PR TITLE
suppress madrat standard config for start.R

### DIFF
--- a/scripts/start/readCheckScenarioConfig.R
+++ b/scripts/start/readCheckScenarioConfig.R
@@ -36,7 +36,7 @@ readCheckScenarioConfig <- function(filename, remindPath = ".", testmode = FALSE
   }
   nameisNA <- grepl("^NA$", rownames(scenConf))
   if (any(nameisNA)) {
-    warning("Don't use 'NA' as scenario name, you fool. Stopping now.")
+    warning("Do not use 'NA' as scenario name, you fool. Stopping now.")
   }
   illegalchars <- grepl("[^[:alnum:]_-]", rownames(scenConf))
   if (any(illegalchars)) {

--- a/start.R
+++ b/start.R
@@ -110,6 +110,9 @@ if (   'TRUE' != Sys.getenv('ignoreRenvUpdates')
   Sys.sleep(1)
 }
 
+# initialize madrat settings
+invisible(madrat::getConfig(verbose = FALSE))
+
 errorsfound <- 0 # counts ignored errors in --test mode
 startedRuns <- 0
 waitingRuns <- 0

--- a/start_bundle_coupled.R
+++ b/start_bundle_coupled.R
@@ -270,6 +270,9 @@ if (file.exists("/p") && sum(scenarios_coupled[common, "qos"] == "priority", na.
 ######## PREPARE AND START COUPLED RUNS ############
 ####################################################
 
+# initialize madrat settings
+invisible(madrat::getConfig(verbose = FALSE))
+
 # prepare runs: write RData files
 for(scen in common){
   message("\n################################\nPreparing run ", scen, "\n")

--- a/tests/testthat/test_01-readCheckScenarioConfig.R
+++ b/tests/testthat/test_01-readCheckScenarioConfig.R
@@ -35,6 +35,7 @@ test_that("readCheckScenarioConfig fails on error-loaden config", {
   expect_match(w, "scenario names indicated in copyConfigFrom column were not found", all = FALSE, fixed = TRUE)
   expect_match(w, "specify in copyConfigFrom column a scenario name defined below in the file", all = FALSE, fixed = TRUE)
   expect_match(w, "which requires a reference gdx", all = FALSE, fixed = TRUE)
+  expect_match(w, "Do not use 'NA' as scenario name", all = FALSE, fixed = TRUE)
   expect_match(m, "no column path_gdx_refpolicycost for policy cost comparison found, using path_gdx_ref instead", all = FALSE, fixed = TRUE)
   expect_match(m, "In 1 scenarios, neither 'carbonprice'", all = FALSE, fixed = TRUE)
   copiedFromPBS <- c("c_budgetCO2", "path_gdx", "path_gdx_ref")


### PR DESCRIPTION
## Purpose of this PR

1. Adding a test that I forgot in #1370

2. The first scenario to be started with `./start.R` always looks like that:

```
testOneRegi-Base
   Configuring cfg for testOneRegi-Base
   SLURM option 8 selected: qos=priority nodes=1 tasks-per-node=1 mem=8000
   Run can be started using 0 specified gdx file(s).

Initialize madrat config with default settings..
    regionmapping = regionmappingH12.csv
    extramappings = NULL
    packages = madrat
    globalenv = FALSE
    verbosity = 1
    mainfolder = /p/projects/rd3mod/inputdata
    sourcefolder = NA
    cachefolder = NA
    mappingfolder = NA
    outputfolder = NA
    pucfolder = NA
    tmpfolder = NA
    nolabels = NULL
    forcecache = FALSE
    ignorecache = NULL
    cachecompression = gzip
    hash = xxhash32
    diagnostics = FALSE
    debug = FALSE
    maxLengthLogMessage = 200
..done!

   Writing cfg to file testOneRegi-Base.RData
   If this wasn't --test mode, I would submit testOneRegi-Base.
```

I don't think that the madrat stuff contains any useful information, given it just reproduces [these lines](https://github.com/pik-piam/madrat/blob/master/R/initializeConfig.R#L16-L35) from `madrat::initializeConfig()`.

This is avoided by just calling `madrat::getConfig(verbose = FALSE)` before starting any scenarios.

## Type of change

- [x] Cleanup

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] I don't think that needs to be mentioned in the changelog.