### PR TITLE
update deep el vre assumption switch to match current data, and also …

### DIFF
--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -138,37 +138,37 @@ $include "./core/input/generisdata_trade.prn"
 !! Modify spv and storspv parameters for optimistic VRE supply assumptions
 if (cm_VRE_supply_assumptions eq 1,
   if (fm_dataglob("learn","spv") ne 0.207,
-    abort "input data in core/input/generisdata_tech.prn has been externally changed, so fm_dataglob("learn","spv") specified here no longer matches the data there; code here needs to be updated to the new input data";
+    abort "input data in core/input/generisdata_tech.prn has been externally changed, so fm_dataglob('learn','spv') specified here no longer matches the data there; code here needs to be updated to the new input data";
   else
     fm_dataglob("learn","spv") = 0.257;
   );
 
   if (fm_dataglob("inco0","storspv") ne 7720,
-    abort "input data in core/input/generisdata_tech.prn has been externally changed, so fm_dataglob("inco0","storspv") specified here no longer matches the data there; code here needs to be updated to the new input data";
+    abort "input data in core/input/generisdata_tech.prn has been externally changed, so fm_dataglob('inco0','storspv') specified here no longer matches the data there; code here needs to be updated to the new input data";
   else
     fm_dataglob("inco0","storspv") = 6470;
   );
 
   if (fm_dataglob("incolearn","storspv") ne 5440,
-    abort "input data in core/input/generisdata_tech.prn has been externally changed, so fm_dataglob("incolearn","storspv") specified here no longer matches the data there; code here needs to be updated to the new input data";
+    abort "input data in core/input/generisdata_tech.prn has been externally changed, so fm_dataglob('incolearn','storspv') specified here no longer matches the data there; code here needs to be updated to the new input data";
   else
     fm_dataglob("incolearn","storspv") = 4040;
   );
 
   if (fm_dataglob("learn","storspv") ne 0.10,
-    abort "input data in core/input/generisdata_tech.prn has been externally changed, so fm_dataglob("learn","storspv") specified here no longer matches the data there; code here needs to be updated to the new input data";
+    abort "input data in core/input/generisdata_tech.prn has been externally changed, so fm_dataglob('learn','storspv') specified here no longer matches the data there; code here needs to be updated to the new input data";
   else
     fm_dataglob("learn","storspv") = 0.12;
   );
 elseif cm_VRE_supply_assumptions eq 2,
   if (fm_dataglob("incolearn","spv") ne 5060,
-    abort "input data in core/input/generisdata_tech.prn has been externally changed, so fm_dataglob("incolearn","spv") specified here no longer matches the data there; code here needs to be updated to the new input data";
+    abort "input data in core/input/generisdata_tech.prn has been externally changed, so fm_dataglob('incolearn','spv') specified here no longer matches the data there; code here needs to be updated to the new input data";
   else
     fm_dataglob("incolearn","spv") = 5010;
   );
 elseif cm_VRE_supply_assumptions eq 3,
   if (fm_dataglob("incolearn","spv") ne 5060,
-    abort "input data in core/input/generisdata_tech.prn has been externally changed, so fm_dataglob("incolearn","spv") specified here no longer matches the data there; code here needs to be updated to the new input data";
+    abort "input data in core/input/generisdata_tech.prn has been externally changed, so fm_dataglob('incolearn','spv') specified here no longer matches the data there; code here needs to be updated to the new input data";
   else
     fm_dataglob("incolearn","spv") = 4960;
   );

--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -138,8 +138,8 @@ $include "./core/input/generisdata_trade.prn"
 !! Modify spv and storspv parameters for optimistic VRE supply assumptions
 if (cm_VRE_supply_assumptions eq 1,
     fm_dataglob("learn","spv") = 0.257;
-    fm_dataglob("inco0","storspv") = 6470;
-    fm_dataglob("incolearn","storspv") = 4040;
+    fm_dataglob("inco0","storspv") = 7000;
+    fm_dataglob("incolearn","storspv") = 4240;
     fm_dataglob("learn","storspv") = 0.12;
     fm_dataglob("incolearn","spv") = 5010;
     fm_dataglob("incolearn","spv") = 4960;

--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -137,41 +137,12 @@ $include "./core/input/generisdata_trade.prn"
 
 !! Modify spv and storspv parameters for optimistic VRE supply assumptions
 if (cm_VRE_supply_assumptions eq 1,
-  if (fm_dataglob("learn","spv") ne 0.207,
-    abort "input data in core/input/generisdata_tech.prn has been externally changed, so fm_dataglob('learn','spv') specified here no longer matches the data there; code here needs to be updated to the new input data";
-  else
     fm_dataglob("learn","spv") = 0.257;
-  );
-
-  if (fm_dataglob("inco0","storspv") ne 7720,
-    abort "input data in core/input/generisdata_tech.prn has been externally changed, so fm_dataglob('inco0','storspv') specified here no longer matches the data there; code here needs to be updated to the new input data";
-  else
     fm_dataglob("inco0","storspv") = 6470;
-  );
-
-  if (fm_dataglob("incolearn","storspv") ne 5440,
-    abort "input data in core/input/generisdata_tech.prn has been externally changed, so fm_dataglob('incolearn','storspv') specified here no longer matches the data there; code here needs to be updated to the new input data";
-  else
     fm_dataglob("incolearn","storspv") = 4040;
-  );
-
-  if (fm_dataglob("learn","storspv") ne 0.10,
-    abort "input data in core/input/generisdata_tech.prn has been externally changed, so fm_dataglob('learn','storspv') specified here no longer matches the data there; code here needs to be updated to the new input data";
-  else
     fm_dataglob("learn","storspv") = 0.12;
-  );
-elseif cm_VRE_supply_assumptions eq 2,
-  if (fm_dataglob("incolearn","spv") ne 5060,
-    abort "input data in core/input/generisdata_tech.prn has been externally changed, so fm_dataglob('incolearn','spv') specified here no longer matches the data there; code here needs to be updated to the new input data";
-  else
     fm_dataglob("incolearn","spv") = 5010;
-  );
-elseif cm_VRE_supply_assumptions eq 3,
-  if (fm_dataglob("incolearn","spv") ne 5060,
-    abort "input data in core/input/generisdata_tech.prn has been externally changed, so fm_dataglob('incolearn','spv') specified here no longer matches the data there; code here needs to be updated to the new input data";
-  else
     fm_dataglob("incolearn","spv") = 4960;
-  );
 );
 
 parameter p_inco0(ttot,all_regi,all_te)     "regionalized technology costs Unit: USD$/KW"

--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -138,37 +138,37 @@ $include "./core/input/generisdata_trade.prn"
 !! Modify spv and storspv parameters for optimistic VRE supply assumptions
 if (cm_VRE_supply_assumptions eq 1,
   if (fm_dataglob("learn","spv") ne 0.207,
-    abort "fm_dataglob('learn','spv') is to be modified, but changed externally";
+    abort "input data in core/input/generisdata_tech.prn has been externally changed, so fm_dataglob("learn","spv") specified here no longer matches the data there; code here needs to be updated to the new input data";
   else
     fm_dataglob("learn","spv") = 0.257;
   );
 
-  if (fm_dataglob("inco0","storspv") ne 8350,
-    abort "fm_dataglob('inco0','storspv') is to be modified, but changed externally";
+  if (fm_dataglob("inco0","storspv") ne 7720,
+    abort "input data in core/input/generisdata_tech.prn has been externally changed, so fm_dataglob("inco0","storspv") specified here no longer matches the data there; code here needs to be updated to the new input data";
   else
-    fm_dataglob("inco0","storspv") = 7000;
+    fm_dataglob("inco0","storspv") = 6470;
   );
 
-  if (fm_dataglob("incolearn","storspv") ne 5710,
-    abort "fm_dataglob('incolearn','storspv') is to be modified, but changed externally";
+  if (fm_dataglob("incolearn","storspv") ne 5440,
+    abort "input data in core/input/generisdata_tech.prn has been externally changed, so fm_dataglob("incolearn","storspv") specified here no longer matches the data there; code here needs to be updated to the new input data";
   else
-    fm_dataglob("incolearn","storspv") = 4240;
+    fm_dataglob("incolearn","storspv") = 4040;
   );
 
   if (fm_dataglob("learn","storspv") ne 0.10,
-    abort "fm_dataglob('learn','storspv') is to be modified, but changed externally";
+    abort "input data in core/input/generisdata_tech.prn has been externally changed, so fm_dataglob("learn","storspv") specified here no longer matches the data there; code here needs to be updated to the new input data";
   else
     fm_dataglob("learn","storspv") = 0.12;
   );
 elseif cm_VRE_supply_assumptions eq 2,
   if (fm_dataglob("incolearn","spv") ne 5060,
-    abort "fm_dataglob('incolearn','spv') is to be modified, but changed externally";
+    abort "input data in core/input/generisdata_tech.prn has been externally changed, so fm_dataglob("incolearn","spv") specified here no longer matches the data there; code here needs to be updated to the new input data";
   else
     fm_dataglob("incolearn","spv") = 5010;
   );
 elseif cm_VRE_supply_assumptions eq 3,
   if (fm_dataglob("incolearn","spv") ne 5060,
-    abort "fm_dataglob('incolearn','spv') is to be modified, but changed externally";
+    abort "input data in core/input/generisdata_tech.prn has been externally changed, so fm_dataglob("incolearn","spv") specified here no longer matches the data there; code here needs to be updated to the new input data";
   else
     fm_dataglob("incolearn","spv") = 4960;
   );


### PR DESCRIPTION
…print a more helpful error message

## Purpose of this PR


## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [X ] Bug fix 

## Checklist:

- [ X] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ X] I performed a self-review of my own code
- [ X] I explained my changes within the PR, particularly in hard-to-understand areas
- [ X] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ X] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ X] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ X] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ X] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

