### PR TITLE
Add CAMPAIGNers scenarios

### DIFF
--- a/core/sets.gms
+++ b/core/sets.gms
@@ -74,6 +74,8 @@ gdp_SSP2EU_NAV_act "NAVIGATE demand scenarios: Activity reduction and activity s
 gdp_SSP2EU_NAV_tec "NAVIGATE demand scenarios: Technological improvements - energy efficiency"
 gdp_SSP2EU_NAV_lce "NAVIGATE demand scenarios: Low consumption energy (act + tec)"
 gdp_SSP2EU_NAV_all "NAVIGATE demand scenarios: All measures (ele + act + tec)"
+gdp_SSP2EU_CAMP_weak   "CAMPAIGNers scenario with low ambition lifestyle change"
+gdp_SSP2EU_CAMP_strong "CAMPAIGNers scenario with high ambition lifestyle change"
 /
 
 all_GDPpcScen    "all possible GDP per capita scenarios (GDP and Population from the same SSP-scenario"

--- a/modules/35_transport/edge_esm/sets.gms
+++ b/modules/35_transport/edge_esm/sets.gms
@@ -147,6 +147,8 @@ NAV_tec
 NAV_ele
 NAV_lce
 NAV_all
+CAMP_lscWeak
+CAMP_lscStrong
 /
 
 EDGE_scenario(EDGE_scenario_all) "Selected EDGE-T scenario"


### PR DESCRIPTION
## Purpose of this PR
Add two additional demand scenarios for CAMPAIGners with different levels of lifestyle changes

## Type of change


- [x] Minor change (default scenarios show only small differences)


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [ ] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
