### PR TITLE
add lower bound for feel_steel_secondary that is markedly higher than sm_eps to improve CONOPT convergence

### DIFF
--- a/modules/37_industry/subsectors/bounds.gms
+++ b/modules/37_industry/subsectors/bounds.gms
@@ -89,6 +89,23 @@ $endif.CES_parameters
 vm_cesIO.fx("2005",regi,ppfkap_industry_dyn37(in))
   = pm_cesdata("2005",regi,in,"quantity");
 
+*** Set lower bound for secondary steel electricity to 1 % of the lowest
+*** existing lower bound (should be far above sm_eps) to avoid CONOPT getting
+*** lost in the woods.
+loop (in$( sameas(in,"feel_steel_secondary") ),
+  vm_cesIO.lo(t,regi,in)$(    t.val ge cm_startyear 
+                          AND vm_cesIO.lo(t,regi,in) le sm_eps )
+  = max(
+      sm_eps, 
+      (  0.01 
+      * smax(ttot$( vm_cesIO.lo(ttot,regi,in) gt sm_eps),
+          vm_cesIO.lo(ttot,regi,in)
+	)
+      )
+    );
+);
+
+*** Default lower bounds on all industry pfs
 vm_cesIO.lo(t,regi_dyn29(regi),in_industry_dyn37(in))$( 
                                                   0 eq vm_cesIO.lo(t,regi,in) )
   = sm_eps;


### PR DESCRIPTION
close https://github.com/remindmodel/development_issues/issues/206

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)