### PR TITLE
Rename grindrock to weathering

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -27,7 +27,7 @@ cfg$regionmapping <- "config/regionmappingH12.csv"
 ### Additional (optional) region mapping, so that those validation data can be loaded that contain the corresponding additional regions.
 cfg$extramappings_historic <- ""
 #### Current input data revision (<mainrevision>.<subrevision>) ####
-cfg$inputRevision <- "6.543"
+cfg$inputRevision <- "6.544"
 
 #### Current CES parameter and GDX revision (commit hash) ####
 cfg$CESandGDXversion <- "ce96f1f97389c0b49757726259a40754a3c930b3"

--- a/core/input/generisdata_tech.prn
+++ b/core/input/generisdata_tech.prn
@@ -165,7 +165,7 @@ incolearn          19000        0.00       29000
 ccap0              0.003                   0.003
 learn               0.10                    0.10
 
-+              rockgrind         dac
++             weathering         dac
 tech_stat                          4
 inco0               0.01       18800
 mix0                   0           0

--- a/core/input/generisdata_tech_SSP1.prn
+++ b/core/input/generisdata_tech_SSP1.prn
@@ -163,7 +163,7 @@ incolearn          20000        0.00       29000
 ccap0              0.003                   0.003
 learn               0.10                    0.10
 
-+              rockgrind         dac
++             weathering         dac
 tech_stat                          4
 inco0               0.01       18800
 mix0                   0           0

--- a/core/input/generisdata_tech_SSP5.prn
+++ b/core/input/generisdata_tech_SSP5.prn
@@ -162,7 +162,7 @@ incolearn          18400        0.00       29000
 ccap0              0.003                   0.003
 learn               0.10                    0.10
 
-+              rockgrind         dac
++             weathering         dac
 tech_stat                          4
 inco0               0.01       18800
 mix0                   0           0

--- a/core/sets.gms
+++ b/core/sets.gms
@@ -275,7 +275,8 @@ $ENDIF.WindOff
         apCarElT        "Cars using final energy electricity (FEELT) to produce useful energy as electricity for transport (UEELT)"
         apTrnElT        "Trains using final energy electricity (FEELT) to produce useful energy as electricity for transport (UEELT)"
 ***  appCarGaT  "Cars using FEGAT to produce ESGAT."  ???
-        rockgrind       "grinding rock for enhanced weathering"
+        rockgrind       "grinding rock for enhanced weathering" !! deprecated, will be removed with CDR module refactoring
+        weathering      "enhanced weathering"
         dac             "direct air capture"
         x_gas2elec
         d_bio2elec      "d_* transmission and distribution losses"

--- a/modules/33_CDR/all/equations.gms
+++ b/modules/33_CDR/all/equations.gms
@@ -21,7 +21,7 @@ q33_demFeCDR(t,regi,entyFe)$(entyFe2Sector(entyFe,"cdr")) ..
 q33_capconst_grindrock(t,regi)..
 	sum(rlf2,sum(rlf, v33_grindrock_onfield(t,regi,rlf,rlf2)))
 	=l=
-	sum(teNoTransform2rlf_dyn33("rockgrind",rlf2), vm_capFac(t,regi,"rockgrind") * vm_cap(t,regi,"rockgrind",rlf2))
+	sum(teNoTransform2rlf_dyn33("weathering",rlf2), vm_capFac(t,regi,"weathering") * vm_cap(t,regi,"weathering",rlf2))
 	;
 	
 ***---------------------------------------------------------------------------

--- a/modules/33_CDR/all/sets.gms
+++ b/modules/33_CDR/all/sets.gms
@@ -9,20 +9,20 @@ sets
 
 te_dyn33(all_te)  "all technologies"
 /
-		rockgrind		"grinding rock for enhanced weathering"
-		dac		"direct air capture"
+	weathering  "enhanced weathering"
+	dac		"direct air capture"
 /
 
 teNoTransform_dyn33(all_te) "all technologies that do not transform energy but still have investment and O&M costs (like storage or grid)"
 /
-       rockgrind       "grinding rock for enhanced weathering"
-	   dac       "grinding rock for enhanced weathering"
+      weathering  "enhanced weathering"
+	dac       "direct air capture"
 /
 
 teNoTransform2rlf_dyn33(all_te,rlf)      "mapping for final energy to grades"
 /
-      (rockgrind) . 1
-	  (dac) . 1
+      (weathering) . 1
+      (dac) . 1
 /
 
 adjte_dyn33(all_te)           "technologies with linearly growing constraint on control variable"

--- a/modules/33_CDR/off/bounds.gms
+++ b/modules/33_CDR/off/bounds.gms
@@ -6,7 +6,7 @@
 *** |  Contact: remind@pik-potsdam.de
 *** SOF ./modules/33_CDR/off/bounds.gms
 vm_otherFEdemand.fx(t,regi,entyFe) = 0;
-vm_cap.fx(t,regi,"rockgrind",rlf) = 0;
+vm_cap.fx(t,regi,"weathering",rlf) = 0;
 vm_emiCdr.fx(t,regi,enty) = 0;   
 vm_omcosts_cdr.fx(t,regi) = 0;
 vm_ccs_cdr.fx(t,regi,enty,enty2,te,rlf)$ccs2te(enty,enty2,te) = 0;

--- a/modules/33_CDR/weathering/equations.gms
+++ b/modules/33_CDR/weathering/equations.gms
@@ -32,7 +32,7 @@ q33_otherFEdemand(t,regi,entyFe)$(sameas(entyFe,"feels") OR sameas(entyFe,"fedie
 q33_capconst_grindrock(t,regi)..
 	sum(rlf2,sum(rlf$(rlf.val le 2), v33_grindrock_onfield(t,regi,rlf,rlf2)))
 	=l=
-	sum(teNoTransform2rlf_dyn33(te,rlf2), vm_capFac(t,regi,"rockgrind") * vm_cap(t,regi,"rockgrind",rlf2))
+	sum(teNoTransform2rlf_dyn33(te,rlf2), vm_capFac(t,regi,"weathering") * vm_cap(t,regi,"weathering",rlf2))
 	;
 	
 ***---------------------------------------------------------------------------

--- a/modules/33_CDR/weathering/sets.gms
+++ b/modules/33_CDR/weathering/sets.gms
@@ -9,17 +9,17 @@ sets
 
 te_dyn33(all_te)   "all technologies"
 /
-		rockgrind		"grinding rock for enhanced weathering"
+		weathering		"grinding rock for enhanced weathering"
 /
 
 teNoTransform_dyn33(all_te) "all technologies that do not transform energy but still have investment and O&M costs (like storage or grid)"
 /
-       rockgrind       "grinding rock for enhanced weathering"
+       weathering       "grinding rock for enhanced weathering"
 /
 
 teNoTransform2rlf_dyn33(all_te,rlf)      "mapping for final energy to grades"
 /
-      (rockgrind) . 1
+      (weathering) . 1
 /
 ;
 


### PR DESCRIPTION
## Purpose of this PR
Renaming of technology `rockgrind` to `weathering` and updating the data revision version to the data with the renamed technology [mrremind PR#407](https://github.com/pik-piam/mrremind/pull/407).

## Type of change

- [x] Refactoring
- [x] Minor change (default scenarios show only small differences)

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date