### PR TITLE
in start_bundle_coupled fail on missing files/dirs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ test-coupled:    ## Test if the coupling with MAgPIE works. Takes significantly
 
 test-coupled-slurm: ## test-coupled, but on slurm
 	$(info Coupling tests take around 75 minutes to run. Sent to slurm, find log in test-coupled.log)
-	@sbatch --qos=priority --wrap="make test-coupled" --job-name=test-coupled --mail-type=END --output=test-coupled.log
+	@sbatch --qos=priority --wrap="make test-coupled" --job-name=test-coupled --mail-type=END --output=test-coupled.log --comment="test-coupled.log"
 
 test-full:       ## Run all tests, including coupling tests and a default
                  ## REMIND scenario. Takes significantly longer than 10 minutes to run.

--- a/output.R
+++ b/output.R
@@ -133,6 +133,9 @@ if (! exists("outputdir")) {
   dirnames <- if (length(dir_folder) == 1) basename(dirs) else dirs
   names(dirnames) <- stringr::str_extract(dirnames, "rem-[0-9]+$")
   names(dirnames)[is.na(names(dirnames))] <- ""
+  if (length(dirnames) == 0) {
+    stop("No directories found containing gdx", if (needingMif) " and mif", " files. Aborting.")
+  }
   selectedDirs <- chooseFromList(dirnames, type = "runs to be used for output generation",
                     userinfo = paste0(if ("policyCosts" %in% output) "The reference run will be selected separately! " else NULL,
                                       if (needingMif) "Do you miss a run? Check if .mif exists and rerun reporting. " else NULL),

--- a/start_bundle_coupled.R
+++ b/start_bundle_coupled.R
@@ -155,16 +155,6 @@ if (length(argv) > 0) {
   message("")
 }
 
-message("path_remind:           ", if (dir.exists(path_remind)) green else red, path_remind, NC)
-message("path_magpie:           ", if (dir.exists(path_magpie)) green else red, path_magpie, NC)
-message("path_settings_coupled: ", if (file.exists(path_settings_coupled)) green else red, path_settings_coupled, NC)
-message("path_settings_remind:  ", if (file.exists(path_settings_remind)) green else red, path_settings_remind, NC)
-message("path_remind_oldruns:   ", if (dir.exists(path_remind_oldruns)) green else red, path_remind_oldruns, NC)
-message("path_magpie_oldruns:   ", if (dir.exists(path_magpie_oldruns)) green else red, path_magpie_oldruns, NC)
-message("prefix_runname:        ", prefix_runname)
-message("n600_iterations:       ", n600_iterations)
-message("run_compareScenarios:  ", run_compareScenarios)
-
 if (! file.exists("output")) dir.create("output")
 
 ensureRequirementsInstalled(rerunPrompt = "start_bundle_coupled.R")
@@ -177,6 +167,21 @@ qosRuns <- NULL
 deletedFolders <- 0
 
 stamp <- format(Sys.time(), "_%Y-%m-%d_%H.%M.%S")
+
+message("path_remind:           ", if (dir.exists(path_remind)) green else red, path_remind, NC)
+message("path_magpie:           ", if (dir.exists(path_magpie)) green else red, path_magpie, NC)
+message("path_settings_coupled: ", if (file.exists(path_settings_coupled)) green else red, path_settings_coupled, NC)
+message("path_settings_remind:  ", if (file.exists(path_settings_remind)) green else red, path_settings_remind, NC)
+message("path_remind_oldruns:   ", if (dir.exists(path_remind_oldruns)) green else red, path_remind_oldruns, NC)
+message("path_magpie_oldruns:   ", if (dir.exists(path_magpie_oldruns)) green else red, path_magpie_oldruns, NC)
+message("prefix_runname:        ", prefix_runname)
+message("n600_iterations:       ", n600_iterations)
+message("run_compareScenarios:  ", run_compareScenarios)
+
+if (any(! file.exists(c(path_settings_coupled, path_settings_remind))) ||
+    any(! dir.exists(c(path_remind, path_magpie, path_remind_oldruns, path_magpie_oldruns)))) {
+  stop("Missing files or directories, see in red above.")
+}
 
 if ("--gamscompile" %in% flags && ! file.exists("input/source_files.log")) {
   message("\n### Input data missing, need to compile REMIND first (2 min.)\n")


### PR DESCRIPTION
## Purpose of this PR

- If you somehow misspecified the files / folders, `start_bundle_coupled` broke quite late with unclear message. Rather fail early.
- in `output.R`, if no folder contains gdx files (and mif if needed), fail and tell the user instead of printing this nonsense:

```
Please choose runs to be used for output generation:

1,a: all
2,p: Search pattern by regular expression...
3,f: Search by fixed pattern...
```

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test-coupled-slurm`)

