### PR TITLE
some updates from NGFS runs

### DIFF
--- a/modules/45_carbonprice/NDC/postsolve.gms
+++ b/modules/45_carbonprice/NDC/postsolve.gms
@@ -45,20 +45,20 @@ p45_factorRescaleCO2TaxLtd(p45_NDCyearSet(t,regi)) =
   min(max(0.1**p45_adjustExponent, p45_factorRescaleCO2Tax(t,regi)), max(2-iteration.val/15,1.01-iteration.val/10000));
 *** use max(0.1, ...) to make sure that negative emission values cause no problem, use +0.0001 such that net zero targets cause no problem
 
-pm_taxCO2eq(t,regi)$(t.val gt 2016 AND t.val ge cm_startyear AND t.val le p45_lastNDCyear(regi)) = max(1* sm_DptCO2_2_TDpGtC,pm_taxCO2eq(t,regi) * p45_factorRescaleCO2TaxLtd(t,regi) );
+pm_taxCO2eq(t,regi)$(t.val gt 2021 AND t.val le p45_lastNDCyear(regi)) = max(1* sm_DptCO2_2_TDpGtC,pm_taxCO2eq(t,regi) * p45_factorRescaleCO2TaxLtd(t,regi) );
 
 p45_factorRescaleCO2Tax_iter(iteration,t,regi) = p45_factorRescaleCO2Tax(t,regi);
 p45_factorRescaleCO2TaxLtd_iter(iteration,t,regi) = p45_factorRescaleCO2TaxLtd(t,regi);
 
 display p45_factorRescaleCO2TaxLtd_iter;
 
-*CB* special case SSA: cap carbon price at 30 in 2025, 45 in 2030, to reflect low energy productivity of region, and avoid high losses
+*CB* special case SSA: maximum carbon price at 30 in 2025, 45 in 2030, to reflect low energy productivity of region, and avoid high losses
 pm_taxCO2eq(t,regi)$(sameas(t,"2025") AND sameas(regi,"SSA")) = min(pm_taxCO2eq("2025",regi)$(sameas(regi,"SSA")),30 * sm_DptCO2_2_TDpGtC);
 pm_taxCO2eq(t,regi)$(sameas(t,"2030") AND sameas(regi,"SSA")) = min(pm_taxCO2eq("2030",regi)$(sameas(regi,"SSA")),45 * sm_DptCO2_2_TDpGtC);
 
 *** calculate tax path until NDC target year - linear increase
 p45_taxCO2eqFirstNDCyear(regi) = smax(t$(t.val = p45_firstNDCyear(regi)), pm_taxCO2eq(t,regi));
-pm_taxCO2eq(t,regi)$(t.val > 2016 AND t.val < p45_firstNDCyear(regi)) = p45_taxCO2eqFirstNDCyear(regi)*(t.val-2015)/(p45_firstNDCyear(regi)-2015);
+pm_taxCO2eq(t,regi)$(t.val > 2021 AND t.val < p45_firstNDCyear(regi)) = (p45_taxCO2eqFirstNDCyear(regi) - pm_taxCO2eq("2020",regi))*(t.val-2020)/(p45_firstNDCyear(regi)-2020) + pm_taxCO2eq("2020",regi);
 
 *** replace taxCO2eq between NDC targets such that taxCO2eq between goals does not decrease
 loop( p45_NDCyearSet(t2,regi) ,
@@ -77,9 +77,6 @@ pm_taxCO2eq(t,regi)$(t.val gt p45_lastNDCyear(regi))
 
 ***as a minimum, have linear price increase starting from 1$ in 2030
 pm_taxCO2eq(t,regi)$(t.val gt 2030) = max(pm_taxCO2eq(t,regi),1*sm_DptCO2_2_TDpGtC * (1+(t.val-2030)*9/7));
-
-*** new 2020 carbon price definition: weighted average of 2015 and 2025, with triple weight for 2015 (which is zero for all non-eu regions).
-pm_taxCO2eq(t,regi)$sameas(t,"2020") = (3*pm_taxCO2eq("2015",regi)+pm_taxCO2eq("2025",regi))/4;
 
         display pm_taxCO2eq;
 

--- a/modules/45_carbonprice/NDC/preloop.gms
+++ b/modules/45_carbonprice/NDC/preloop.gms
@@ -7,7 +7,7 @@
 *** SOF ./modules/45_carbonprice/NDC/preloop.gms
 
 *** first calculate tax path until last NDC target year - linear increase
-pm_taxCO2eq(t,regi)$(t.val gt 2016 AND t.val le p45_lastNDCyear(regi)) = pm_taxCO2eq("2020",regi)*(t.val-2015)/5;
+pm_taxCO2eq(t,regi)$(t.val gt 2021 AND t.val le p45_lastNDCyear(regi)) = pm_taxCO2eq("2020",regi)*(t.val-2015)/5;
 
 *** convergence scheme after the last NDC target year: exponential increase with 1.25% AND regional convergence until p45_taxCO2eqConvergenceYear
 p45_taxCO2eqLastNDCyear(regi) = smax(t$(t.val = p45_lastNDCyear(regi)), pm_taxCO2eq(t,regi));
@@ -21,14 +21,6 @@ pm_taxCO2eq(t,regi)$(t.val gt p45_lastNDCyear(regi))
 
 display pm_taxCO2eq;
 
-***as a minimum, have linear price increase starting from 1$ in 2030
-pm_taxCO2eq(t,regi)$(t.val gt p45_lastNDCyear(regi)) = max(pm_taxCO2eq(t,regi),1*sm_DptCO2_2_TDpGtC * (1+(t.val-2030)*9/7));
-
-*** new 2020 carbon price definition: weighted average of 2015 and 2025, with triple weight for 2015 (which is zero for all non-eu regions).
-pm_taxCO2eq(t,regi)$sameas(t, "2020") = (3*pm_taxCO2eq("2015",regi)+pm_taxCO2eq("2025",regi))/4;
-
-display pm_taxCO2eq;
-
 *#' @equations 
 *#'  calculate level of emission target that it should converge to, composed of:
 *#'  emission target relative to 2005 emissions (factor_targetyear) for part of region with NDC target
@@ -38,4 +30,5 @@ p45_CO2eqwoLU_goal(p45_NDCyearSet(t,regi)) =
         + (1-p45_2005shareTarget(t,regi)) * p45_BAU_reg_emi_wo_LU_bunkers(t,regi);            !! baseline for share of countries without NDC target
 
 display pm_taxCO2eq,p45_CO2eqwoLU_goal;
+
 *** EOF ./modules/45_carbonprice/NDC/preloop.gms

--- a/modules/46_carbonpriceRegi/NDC/datainput.gms
+++ b/modules/46_carbonpriceRegi/NDC/datainput.gms
@@ -35,7 +35,7 @@ $onlisting
 ;
 
 Parameter p46_2005shareTarget(ttot,all_regi) "2005 GHG emission share of countries with quantifyable emissions under NDC in particular region, time dimension specifies alternative future target years";
-p46_2005shareTarget(ttot,all_regi) = f46_2005shareTarget(ttot,all_regi,"%cm_NDC_version%","%cm_GDPscen%");
+p46_2005shareTarget(t,all_regi) = f46_2005shareTarget(t,all_regi,"%cm_NDC_version%","%cm_GDPscen%");
 
 display p46_2005shareTarget;
 
@@ -71,19 +71,38 @@ $offdelim
 *** 0.2 is a rounded value valid for all except 2018_uncond, because Brazil had no unconditional target then.
 
 if (not sameas("%cm_NDC_version%","2018_uncond"),
-    p46_factorTargetyear(ttot,regi)$(sameas(regi,"LAM") AND sameas(ttot,"2030")) = p46_factorTargetyear(ttot,regi) + 0.2;
+    p46_factorTargetyear(t,regi)$(sameas(regi,"LAM") AND sameas(t,"2030")) = p46_factorTargetyear(t,regi) + 0.2;
 );
 
 *** add 2060 GHG net zero target for China, not yet in the UNFCCC_NDC database
-p46_factorTargetyear(ttot,regi)$(sameas(regi,"CHA") AND sameas(ttot,"2060")) = 0;
-p46_2005shareTarget(ttot,regi)$(sameas(regi,"CHA") AND sameas(ttot,"2060")) = 1;
+p46_factorTargetyear(t,regi)$(sameas(regi,"CHA") AND sameas(t,"2060")) = 0;
+p46_2005shareTarget(t,regi)$(sameas(regi,"CHA") AND sameas(t,"2060")) = 1;
+
+$ifthen.p46_netZero "%cm_netZeroScen%" == "NGFS_v4_20pc"
+  p46_factorTargetyear(t,regi)$(sameas(regi,"CAZ") AND sameas(t,"2050")) = 0;
+   p46_2005shareTarget(t,regi)$(sameas(regi,"CAZ") AND sameas(t,"2050")) = 0.8;
+  p46_factorTargetyear(t,regi)$(sameas(regi,"EUR") AND sameas(t,"2050")) = 0;
+   p46_2005shareTarget(t,regi)$(sameas(regi,"EUR") AND sameas(t,"2050")) = 0.8;
+  p46_factorTargetyear(t,regi)$(sameas(regi,"JPN") AND sameas(t,"2050")) = 0;
+   p46_2005shareTarget(t,regi)$(sameas(regi,"JPN") AND sameas(t,"2050")) = 0.8;
+  p46_factorTargetyear(t,regi)$(sameas(regi,"LAM") AND sameas(t,"2050")) = 0;
+   p46_2005shareTarget(t,regi)$(sameas(regi,"LAM") AND sameas(t,"2050")) = 0.8;
+  p46_factorTargetyear(t,regi)$(sameas(regi,"USA") AND sameas(t,"2050")) = 0;
+   p46_2005shareTarget(t,regi)$(sameas(regi,"USA") AND sameas(t,"2050")) = 0.8;
+  p46_factorTargetyear(t,regi)$(sameas(regi,"CHA") AND sameas(t,"2060")) = 0;
+   p46_2005shareTarget(t,regi)$(sameas(regi,"CHA") AND sameas(t,"2060")) = 0.8;
+  p46_factorTargetyear(t,regi)$(sameas(regi,"REF") AND sameas(t,"2060")) = 0;
+   p46_2005shareTarget(t,regi)$(sameas(regi,"REF") AND sameas(t,"2060")) = 0.8;
+  p46_factorTargetyear(t,regi)$(sameas(regi,"IND") AND sameas(t,"2070")) = 0;
+   p46_2005shareTarget(t,regi)$(sameas(regi,"IND") AND sameas(t,"2070")) = 0.8;
+$endif.p46_netZero
 
 
 *** parameters for selecting NDC years
 Scalar p46_ignoreNDCbefore          "NDC targets before this years are ignored, for example to exclude 2030 targets" /2028/;
 p46_ignoreNDCbefore = max(p46_ignoreNDCbefore, cm_startyear)
-Scalar p46_ignoreNDCafter           "NDC targets after  this years are ignored, for example to exclude 2050 net zero targets" /2070/;
-Scalar p46_minRatioOfCoverageToMax  "only targets whose coverage is this times p46_bestNDCcoverage are considered. Use 1 for only best." /0.2/;
+Scalar p46_ignoreNDCafter           "NDC targets after  this years are ignored, for example to exclude 2050 net zero targets" /2100/;
+Scalar p46_minRatioOfCoverageToMax  "only targets whose coverage is this times p46_bestNDCcoverage are considered. Use 1 for only best." /0.7/;
 Scalar p46_useSingleYearCloseTo     "if 0: use all. If > 0: use only one single NDC target per country closest to this year (use 2030.4 to prefer 2030 over 2035 over 2025)" /0/;
 
 Set p46_NDCyearSet(ttot,all_regi)               "YES for years whose NDC targets is used";

--- a/modules/46_carbonpriceRegi/NDC/declarations.gms
+++ b/modules/46_carbonpriceRegi/NDC/declarations.gms
@@ -23,7 +23,7 @@ p46_taxCO2eqLast(tall,all_regi)                          "general carbon price i
 ;
 
 Scalar    p46_adjustExponent                             "exponent in tax adjustment process";
-Scalar    p46_startInIteration                           "first iteration to start adapting pm_taxCO2eqRegi" / 10 /;
+Scalar    p46_startInIteration                           "first iteration to start adapting pm_taxCO2eqRegi" / 5 /;
 Scalar    p46_previousYearInLoop                         "previous year in loop, required for linear interpolation in postsolve";
 Scalar    p46_taxPreviousYearInLoop                      "tax of previous year in loop, required for linear interpolation in postsolve";
 

--- a/modules/46_carbonpriceRegi/NDC/not_used.txt
+++ b/modules/46_carbonpriceRegi/NDC/not_used.txt
@@ -5,6 +5,3 @@
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
 name,type,reason
-vm_emiTe,variable,only used for CO2 targets
-vm_emiCdr,variable,only used for CO2 targets
-vm_emiMac,variable,only used for CO2 targets

--- a/modules/46_carbonpriceRegi/NDC/postsolve.gms
+++ b/modules/46_carbonpriceRegi/NDC/postsolve.gms
@@ -22,13 +22,13 @@ p46_CO2eqwoLU_actual(p46_NDCyearSet(t,regi)) =
         * vm_demFeSector.l(t,regi,enty,enty2,"trans","other") * sm_c_2_co2 * 1000
       );
 
-*** there is some debate whether Chinas net zero goal is not CO2eq, but CO2. Then use CO2 emissions minus substract bunker emissions
-*** p46_CO2eqwoLU_actual(p46_NDCyearSet(t,regi))$(sameas(regi,"CHA") AND sameas(t,"2055")) =
-***  (vm_emiTe.l(t,regi,"co2") + vm_emiMac.L(t,regi,"co2") + vm_emiCdr.L(t,regi,"co2"))*sm_c_2_co2*1000
-***    - sum(se2fe(enty,enty2,te),
-***        pm_emifac(t,regi,enty,enty2,te,"co2")
-***        * vm_demFeSector.l(t,regi,enty,enty2,"trans","other") * sm_c_2_co2 * 1000
-***      );
+*** Indias 2070 target is not CO2eq, but CO2. Then use CO2 emissions minus substract bunker emissions
+p46_CO2eqwoLU_actual(p46_NDCyearSet(t,regi))$(sameas(regi,"IND") AND sameas(t,"2070")) =
+  (vm_emiTe.l(t,regi,"co2") + vm_emiMac.L(t,regi,"co2") + vm_emiCdr.L(t,regi,"co2"))*sm_c_2_co2*1000
+    - sum(se2fe(enty,enty2,te),
+        pm_emifac(t,regi,enty,enty2,te,"co2")
+        * vm_demFeSector.l(t,regi,enty,enty2,"trans","other") * sm_c_2_co2 * 1000
+      );
 
 display vm_co2eq.l;
 display p46_CO2eqwoLU_actual;

--- a/modules/46_carbonpriceRegi/NDC/preloop.gms
+++ b/modules/46_carbonpriceRegi/NDC/preloop.gms
@@ -10,7 +10,7 @@
 pm_taxCO2eqRegi(t,regi)$(t.val gt 2016 AND t.val le p46_lastNDCyear(regi))
   = max(
         0.1 * sm_DptCO2_2_TDpGtC,
-        (30 * p46_bestNDCcoverage(regi) - pm_taxCO2eq(t,regi)) * sm_DptCO2_2_TDpGtC
+        (30 * p46_bestNDCcoverage(regi) * sm_DptCO2_2_TDpGtC - pm_taxCO2eq(t,regi))
        )*(t.val-2015)/5;
 
 *** convergence scheme after the last NDC target year: exponential increase AND regional convergence until p46_taxCO2eqConvergenceYear
@@ -21,13 +21,10 @@ pm_taxCO2eqRegi(t,regi)$(t.val gt p46_lastNDCyear(regi))
    = (  !! regional, weight going from 1 in last NDC target year to 0 in 2100
         p46_taxCO2eqLastNDCyear(regi) * p46_taxCO2eqYearlyIncrease**(t.val-p46_lastNDCyear(regi)) * (max(p46_taxCO2eqConvergenceYear,t.val) - t.val)
         !! global, weight going from 0 in NDC target year to 1 in and after 2100
-      + p46_taxCO2eqGlobal2030          * p46_taxCO2eqYearlyIncrease**(t.val-2030)                    * (min(p46_taxCO2eqConvergenceYear,t.val) - p46_lastNDCyear(regi))
+      + p46_taxCO2eqGlobal2030          * p46_taxCO2eqYearlyIncrease**(t.val-2030)                * (min(p46_taxCO2eqConvergenceYear,t.val) - p46_lastNDCyear(regi))
       )/(p46_taxCO2eqConvergenceYear - p46_lastNDCyear(regi));
 
 display pm_taxCO2eqRegi;
-
-*** new 2020 carbon price definition: weighted average of 2015 and 2025, with triple weight for 2015 (which is zero for all non-eu regions).
-pm_taxCO2eqRegi("2020",regi) = (3*pm_taxCO2eqRegi("2015",regi)+pm_taxCO2eqRegi("2025",regi))/4;
 
 *#' @equations
 *#'  calculate level of emission target that it should converge to, composed of:

--- a/modules/46_carbonpriceRegi/netZero/datainput.gms
+++ b/modules/46_carbonpriceRegi/netZero/datainput.gms
@@ -11,6 +11,12 @@ $ifthen.p46_zeroYear "%cm_netZeroScen%" == "ENGAGE4p5_GlP"
   p46_zeroYear = 2200;
 $endif.p46_zeroYear
 
+$ifthen.p46_zeroYear "%cm_netZeroScen%" == "NGFS_v4_20pc"
+  p46_zeroYear = 2200;
+$endif.p46_zeroYear
+$ifthen.p46_zeroYear "%cm_netZeroScen%" == "NGFS_v4"
+  p46_zeroYear = 2200;
+$endif.p46_zeroYear
 
 ***profile for countries with 2050 target
 pm_taxCO2eqRegi(t,nz_reg2050)$sameas(t,"2035")=5;


### PR DESCRIPTION
## Purpose of this PR

some bug fixes and improvements copied from [this branch](https://github.com/orichters/remind/tree/NGFS-2023-06-12).

- With new NPi realization, 45/NDC module should now be run from 2025 onwards only.
- Remove recalculation of 2020 values
- add option to run netZero scenarios with 46/NDC module
- start calculate 46 markups earlier to improve convergence

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
