### PR TITLE
run gms::codeCheck() for make test, too

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ check-fix:       ## Check if the GAMS code follows the coding etiquette
 test:            ## Test if the model compiles and runs without running a full
                  ## scenario. Tests take about 10 minutes to run.
 	$(info Tests take about 10 minutes to run, please be patient)
-	@R_PROFILE_USER= Rscript -e 'testthat::test_dir("tests/testthat")'
+	@R_PROFILE_USER= Rscript -e 'invisible(gms::codeCheck(strict = TRUE)); testthat::test_dir("tests/testthat")'
 
 test-coupled:    ## Test if the coupling with MAgPIE works. Takes significantly
                  ## longer than 60 minutes to run and needs slurm and magpie
@@ -69,4 +69,4 @@ test-full:       ## Run all tests, including coupling tests and a default
 	@R_PROFILE_USER= TESTTHAT_RUN_SLOW=TRUE Rscript -e 'testthat::test_dir("tests/testthat")'
 test-validation: ## Run validation tests, requires a full set of runs in the output folder
 	$(info Run validation tests, requires a full set of runs in the output folder)
-	@R_PROFILE_USER= TESTTHAT_RUN_SLOW=TRUE Rscript -e 'testthat::test_dir("tests/testthat/validation")'	
+	@R_PROFILE_USER= TESTTHAT_RUN_SLOW=TRUE Rscript -e 'testthat::test_dir("tests/testthat/validation")'


### PR DESCRIPTION
This way, REMIND users that [prepare their merge requests properly](https://github.com/remindmodel/remind/blob/06d3f6171df5b4097930cdfb41fc4fc85d80eb8f/pull_request_template.md?plain=1#L24) will get advanced notification of problems with module realisation interfaces.

- [x] New feature 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)