### PR TITLE
don't let cs2 fail if outputdirs are not unique

### DIFF
--- a/scripts/cs2/run_compareScenarios2.R
+++ b/scripts/cs2/run_compareScenarios2.R
@@ -31,7 +31,8 @@ run_compareScenarios2 <- function(
   # folder.
   system(paste0("mkdir ", outFileName)) 
   outDir <- normalizePath(outFileName, mustWork = TRUE)
-  
+
+  outputDirs <- unique(normalizePath(outputDirs, mustWork = TRUE))
   mifPath <- getMifScenPath(outputDirs, mustWork = TRUE)
   histPath <- getMifHistPath(outputDirs[1], mustWork = TRUE)
   scenConfigPath <- getCfgScenPath(outputDirs, mustWork = TRUE)


### PR DESCRIPTION
## Purpose of this PR

If you accidentally pass an output directory multiple times to cs2, then it fails to find the correct files and fails, because [`lucode2::getScenNames()`](https://github.com/pik-piam/lucode2/blob/master/R/getScenNames.R) returns the scenario name only once, leading with
```
outputDirs <- ../remind-2023-06-12/output/C_h_cpol-rem-6, ../remind-2023-06-12/output/C_h_cpol-rem-6, 
output/C_h_cpol_d50-rem-5, output/C_h_cpol_d95high-rem-15
```
to this error:
```
Error in `normalizePath()`:
! path[2]="../remind-2023-06-12/output/C_h_cpol-rem-6/REMIND_generic_C_h_cpol_d50-rem-5.mif": No such file or directory
```

After normalizing the path, `unique` is applied, avoiding the problem.

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] No need for adjusting the changelog `CHANGELOG.md`
