### PR TITLE
Fix bug with switch cm_inco0Factor for scaling investment cost of technologies, investment cost in policy runs are not overwritten by reference gdx in 05_initialCap anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **scripts** MAgPIE coupling interface: replace old MAgPIE cost variable
 - **scripts** MAgPIE coupling interface: remove filtering of negative LU emissions
 - **core** MAgPIE coupling: tolerate negative values for `n2ofertsom` and deactivate its MAC
+- **05_initialCap** fix overwriting of investment cost changes from cm_inco0Factor switch
 
 ### added
 - **45_carbonprice** added realization `NPi` (National Policies Implemented)

--- a/main.gms
+++ b/main.gms
@@ -1479,10 +1479,12 @@ $setglobal cm_adj_coeff_multiplier  off
 *** cm_inco0Factor "change investment costs. [factor]."
 ***   def <- "off" = use default inco0 values.
 ***   or list of techs with respective factor to change inco0 value by a multiplication factor. (ex. "ccsinje=0.5,bioigccc=0.66,bioh2c=0.66,biogas=0.66,bioftrec=0.66,bioftcrec=0.66,igccc=0.66,coalh2c=0.66,coalgas=0.66,coalftrec=0.66,coalftcrec=0.66,ngccc=0.66,gash2c=0.66,gasftrec=0.66,gasftcrec=0.66,tnrs=0.66")
+*** (note: if %cm_techcosts% == "GLO", switch will not work for policy runs, i.e. cm_startyear > 2005, for pc, ngt and ngcc as this gets overwritten in 05_initialCap module)
 $setglobal cm_inco0Factor  off !! def = off
 *** cm_inco0RegiFactor "change investment costs regionalized technology values. [factor]."
 ***   def <- "off" = use default p_inco0 values.
 ***   or list of techs with respective factor to change p_inco0 value by a multiplication factor. (ex. "wind=0.33, spv=0.33" makes investment costs for wind and spv 3 times cheaper)
+*** (note: if %cm_techcosts% == "GLO", switch will not work for policy runs, i.e. cm_startyear > 2005, for pc, ngt and ngcc as this gets overwritten in 05_initialCap module)
 $setglobal cm_inco0RegiFactor  off  !! def = off
 *** cm_CCS_markup "multiplicative factor for CSS cost markup"
 ***   def <- "off" = use default CCS pm_inco0_t values.

--- a/main.gms
+++ b/main.gms
@@ -1322,6 +1322,8 @@ $setglobal cm_CES_calibration_default_prices  0.01  !!  def  =  0.01
 *** cm_calibration_string "def = off, else = additional string to include in the calibration name to be used" label for your calibration run to keep calibration files with different setups apart (e.g. with low elasticities, high elasticities)
 $setglobal cm_calibration_string  off    !!  def  =  off
 *** cm_techcosts -     use regionalized or globally homogenous technology costs for certain technologies
+*** (REG) regionalized technology costs
+*** (GLO) globally homogenous technology costs
 $setglobal cm_techcosts  REG       !! def = REG
 *** cm_regNetNegCO2 -    default "on" allows for regionally netNegative CO2 emissions, setting "off" activates bound in core/bounds.gms that disallows net negative CO2 emissions at the regional level
 $setglobal cm_regNetNegCO2  on       !! def = on

--- a/modules/05_initialCap/on/declarations.gms
+++ b/modules/05_initialCap/on/declarations.gms
@@ -24,7 +24,10 @@ Parameter
   p05_aux_cap_distr(all_regi,all_te,rlf)             "auxiliary calculation parameter for the calculation of initial capacities, distributed to grades"
   p05_aux_cap(all_regi,all_te)                       "auxiliary calculation parameter for the calculation of initial capacities"
   pm_aux_capLowerLimit(all_te,all_regi,tall)         "auxiliary calculation parameter for the calculation of the lowest possible capacities in the first time steps"
-  p05_aux_calccapLowerLimitSwitch(tall)              "auxiliary calculation parameter to allow the calculation of the lowest possible capacities in the first time steps"    
+  p05_aux_calccapLowerLimitSwitch(tall)              "auxiliary calculation parameter to allow the calculation of the lowest possible capacities in the first time steps"
+$ifThen %cm_techcosts% == "GLO"
+  p05_inco0_t_ref(ttot,all_regi,all_te)              "auxiliary parameter to load pm_inco0_t from reference run if cm_startyear > 2005 and initialCap is therefore not run"
+$endIf
 ;
 
 Variables

--- a/modules/05_initialCap/on/preloop.gms
+++ b/modules/05_initialCap/on/preloop.gms
@@ -512,14 +512,23 @@ if (cm_startyear gt 2005,
   Execute_Loadpoint 'input_ref' pm_emifac = pm_emifac;
   Execute_Loadpoint 'input_ref' pm_EN_demand_from_initialcap2 = pm_EN_demand_from_initialcap2;
   Execute_Loadpoint 'input_ref' pm_pedem_res = pm_pedem_res;
-  Execute_Loadpoint 'input_ref' pm_inco0_t = pm_inco0_t;
   Execute_Loadpoint 'input_ref' pm_dataeta = pm_dataeta;
   Execute_Loadpoint 'input_ref' pm_data = pm_data;
   Execute_Loadpoint 'input_ref' pm_aux_capLowerLimit = pm_aux_capLowerLimit;
   Execute_Loadpoint 'input_ref' vm_deltaCap.l = vm_deltaCap.l;
   Execute_Loadpoint 'input_ref' vm_deltaCap.lo = vm_deltaCap.lo;
   Execute_Loadpoint 'input_ref' vm_deltaCap.up = vm_deltaCap.up;
-);
 
+*** if %cm_techcosts% == "GLO", load pm_inco0_t from input_ref.gdx and overwrite values
+*** only for pc, ngt, ngcc since they have been adapted in initialCap routine above
+*** This is to avoid overwriting changes to pm_inco0_t by scenario switches
+$ifThen %cm_techcosts% == "GLO"
+  Execute_Loadpoint 'input_ref' p05_inco0_t_ref = pm_inco0_t;
+  pm_inco0_t(t,regi,te)$( teEtaIncr(te)
+                          AND (sameas(te,"pc")
+                            OR sameas(te,"ngt")
+                            OR sameas(te,"ngcc") ) ) = p05_inco0_t_ref(t,regi,te);
+$endIf
+);
 
 *** EOF ./modules/05_initialCap/on/preloop.gms


### PR DESCRIPTION
## Purpose of this PR
This fixes a bug for changing the investment cost in core/datainput with switches like ``cm_inco0Factor``. Those changes were overwritten in policy runs at the end of the 05_initialCap module since the earlier change that initialCap is not run in policy runs anymore. Now, pm_inco0_t is not loaded from the input_ref.gdx anymore in policy runs. It is only loaded in case of cm_techcost = GLO where initialCap has an actual influence on pm_inco0_t. In this case, only the technologies modified by initialCap code are overwritten (ngcc etc.). I added a note to the above switches that those technologies are in this case still not affected by the switches. In all other cases, the switch should work as expected. 

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix 


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Test runs are here: 
/p/tmp/schreyer/Modeling/remind/Current/output/test_inco0_switch_glo_2023-08-29_11.42.31

* Comparison of results (what changes by this PR?): 

