### PR TITLE
limit industry CCS scale-up

### DIFF
--- a/core/declarations.gms
+++ b/core/declarations.gms
@@ -587,7 +587,7 @@ sm_DpGJ_2_TDpTWa                                      "multipl. factor to conver
 s_gwpCH4                                              "Global Warming Potentials of CH4, AR5 WG1 CH08 Table 8.7"     /28/
 s_gwpN2O                                              "Global Warming Potentials of N2O, AR5 WG1 CH08 Table 8.7"     /265/
 sm_dmac                                               "step in MAC functions [US$]"                                                                   /5/
-s_macChange                                           "maximum yearly increase of relative abatement in percentage points of maximum abatement. [0..1]"      /0.05/
+sm_macChange                                           "maximum yearly increase of relative abatement in percentage points of maximum abatement. [0..1]"      /0.05/
 sm_tgn_2_pgc                                           "conversion factor 100-yr GWP from TgN to PgCeq"
 sm_tgch4_2_pgc                                         "conversion factor 100-yr GWP from TgCH4 to PgCeq"
 

--- a/core/presolve.gms
+++ b/core/presolve.gms
@@ -301,12 +301,12 @@ pm_macStep(ttot,regi,"ch4gas")
 pm_macStep(ttot,regi,"ch4coal")
   = min(801, ceil(max(pm_priceCO2forMAC(ttot,regi,"ch4coal") * (25/s_gwpCH4), 0.5 * max(0,(p_priceGas(ttot,regi)-p_priceGas("2005",regi))) ) / sm_dmac) + 1);    
   
-*** limit yearly increase of MAC usage to s_macChange
+*** limit yearly increase of MAC usage to sm_macChange
 p_macAbat_lim(ttot,regi,enty)
   = sum(steps$(ord(steps) eq pm_macStep(ttot-1,regi,enty)),
       pm_macAbat(ttot-1,regi,enty,steps)
     )
-  + s_macChange * pm_ts(ttot)
+  + sm_macChange * pm_ts(ttot)
 ;
 
 *** if intended abatement pm_macAbat is higher than this limit, pm_macStep has to 
@@ -383,20 +383,14 @@ pm_macAbatLev(ttot,regi,enty)$( ttot.val gt 2015 )
 pm_macAbatLev("2015",regi,"co2luc") = 0;
 pm_macAbatLev("2020",regi,"co2luc") = 0;
 
-*** Limit MAC abatement level increase to 5 % p.a., or 2 % p.a. for cement
-*** before 2050
+*** Limit MAC abatement level increase to sm_macChange (default: 5 % p.a.)
 loop (ttot$( ttot.val ge 2015 ),
   pm_macAbatLev(ttot,regi,MACsector(enty))
     = min(
         pm_macAbatLev(ttot,regi,enty),
 
-        ( pm_macAbatLev(ttot-1,regi,enty)
-        + ( ( s_macChange$( NOT sameas(enty,"co2cement") OR  ttot.val gt 2050 )
-            + 0.02$(            sameas(enty,"co2cement") AND ttot.val le 2050 )
-  	    )
-          * pm_ts(ttot)
-          )
-        )
+          pm_macAbatLev(ttot-1,regi,enty)
+        + (sm_macChange * pm_ts(ttot))
       );
 );
 

--- a/modules/37_industry/fixed_shares/not_used.txt
+++ b/modules/37_industry/fixed_shares/not_used.txt
@@ -17,3 +17,4 @@ vm_Mport,                variable,   not needed
 pm_tau_ces_tax,          input,      questionnaire
 pm_secBioShare,          parameter,  not needed
 pm_exogDemScen,input,added by codeCheck
+pm_dt,                   parameter,  not needed

--- a/modules/37_industry/fixed_shares/not_used.txt
+++ b/modules/37_industry/fixed_shares/not_used.txt
@@ -17,4 +17,5 @@ vm_Mport,                variable,   not needed
 pm_tau_ces_tax,          input,      questionnaire
 pm_secBioShare,          parameter,  not needed
 pm_exogDemScen,input,added by codeCheck
-pm_dt,                   parameter,  not needed
+pm_ts,                   parameter,  not needed
+sm_macChange,            parameter,  not needed

--- a/modules/37_industry/subsectors/declarations.gms
+++ b/modules/37_industry/subsectors/declarations.gms
@@ -66,6 +66,7 @@ $endif.no_calibration
   q37_macBaseInd(ttot,all_regi,all_enty,secInd37)         "gross industry emissions before CCS"
   q37_emiIndCCSmax(ttot,all_regi,emiInd37)                "maximum abatable industry emissions at current CO2 price"
   q37_IndCCS(ttot,all_regi,emiInd37)                      "limit industry emissions abatement"
+  q37_limit_IndCCS_growth(ttot,all_regi,emiInd37)	  "limit industry CCS scale-up"
   q37_cementCCS(ttot,all_regi)                            "link cement fuel and process abatement"
   q37_IndCCSCost                                          "Calculate industry CCS costs"
   q37_demFeIndst(ttot,all_regi,all_enty,all_emiMkt)       "industry final energy demand (per emission market)"

--- a/modules/37_industry/subsectors/equations.gms
+++ b/modules/37_industry/subsectors/equations.gms
@@ -164,17 +164,15 @@ q37_IndCCS(ttot,regi,emiInd37)$( ttot.val ge cm_startyear ) ..
   v37_emiIndCCSmax(ttot,regi,emiInd37)
 ;
 
-*' Limit industry CCS scale-up to 5 % p.a., or 2 % p.a. for cement before 2050
+*' Limit industry CCS scale-up to sm_macChange (default: 5 % p.a.)
 q37_limit_IndCCS_growth(ttot,regi,emiInd37) ..
   vm_emiIndCCS(ttot,regi,emiInd37)
   =l=
     vm_emiIndCCS(ttot-1,regi,emiInd37)
   + sum(secInd37_2_emiInd37(secInd37,emiInd37),
       v37_emiIndCCSmax(ttot,regi,emiInd37)
-    * ( 0.02$( sameas(secInd37,"cement") AND ttot.val le 2050 )
-      + 0.05$( NOT sameas(secInd37,"cement") OR ttot.val gt 2050 )
-      )
-    * pm_dt(ttot)
+    * sm_macChange
+    * pm_ts(ttot)
     )
 ;
 

--- a/modules/37_industry/subsectors/equations.gms
+++ b/modules/37_industry/subsectors/equations.gms
@@ -164,6 +164,20 @@ q37_IndCCS(ttot,regi,emiInd37)$( ttot.val ge cm_startyear ) ..
   v37_emiIndCCSmax(ttot,regi,emiInd37)
 ;
 
+*' Limit industry CCS scale-up to 5 % p.a., or 2 % p.a. for cement before 2050
+q37_limit_IndCCS_growth(ttot,regi,emiInd37) ..
+  vm_emiIndCCS(ttot,regi,emiInd37)
+  =l=
+    vm_emiIndCCS(ttot-1,regi,emiInd37)
+  + sum(secInd37_2_emiInd37(secInd37,emiInd37),
+      v37_emiIndCCSmax(ttot,regi,emiInd37)
+    * ( 0.02$( sameas(secInd37,"cement") AND ttot.val le 2050 )
+      + 0.05$( NOT sameas(secInd37,"cement") OR ttot.val gt 2050 )
+      )
+    * pm_dt(ttot)
+    )
+;
+
 *' Fix cement fuel and cement process emissions to the same abatement level.
 q37_cementCCS(ttot,regi)$(    ttot.val ge cm_startyear
                           AND pm_macswitch("co2cement")


### PR DESCRIPTION
Included a lagged equation to limit industry CCS scale-up to 5 % p.a. (2 % p.a. for cement before 2050).  This is for the benefit of scenarios that (for unknown reasons) do not utilise CCS when it is available and then jump to the maximum possible abatement rate at a later period, showing very large CCS growth rates.

- [x] New feature 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
