### PR TITLE
Automatically assign development version

### DIFF
--- a/.github/GitVersion.yml
+++ b/.github/GitVersion.yml
@@ -1,0 +1,16 @@
+mode: ContinuousDelivery
+assembly-versioning-format: '{Major}.{Minor}.{Patch}.dev{CommitsSinceVersionSource}'
+branches:
+  develop:
+    regex: ^dev(elop)?(ment)?$
+    mode: ContinuousDeployment
+    tag: dev
+    increment: None
+    prevent-increment-of-merged-branch-version: false
+    track-merge-target: true
+    source-branches: []
+    tracks-release-branches: true
+    is-release-branch: false
+    is-mainline: false
+    pre-release-weight: 0
+

--- a/.github/workflows/auto-dev-version.yaml
+++ b/.github/workflows/auto-dev-version.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          token: ${{ secrets.AUTO_DEV_VERSION }}
+          token: ${{ secrets.AUTO_DEV_VERSION_REMIND }}
 
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v0.9.15

--- a/.github/workflows/auto-dev-version.yaml
+++ b/.github/workflows/auto-dev-version.yaml
@@ -1,0 +1,46 @@
+on:
+  push:
+    branches:
+      - develop
+
+name: auto-dev-version
+
+jobs:
+  auto-dev-version:
+    if: github.repository == 'remindmodel/remind'
+    runs-on: ubuntu-22.04
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install GitVersion
+        uses: gittools/actions/gitversion/setup@v0.9.15
+        with:
+          versionSpec: '5.x'
+
+      - name: Determine Version
+        id: gitversion
+        uses: gittools/actions/gitversion/execute@v0.9.15
+        with:
+          useConfigFile: true
+          configFilePath: .github/GitVersion.yml
+
+      - name: Update CITATION.cff and config/default.cfg with version and date
+        run: |
+          sed -i 's/^version:.*$/version: "${{ steps.gitversion.outputs.assemblySemVer }}"/' CITATION.cff
+          sed -i "s/^date-released:.*$/date-released: $(date --iso)/" CITATION.cff
+          sed -i 's/^cfg$model_version <-.*$/cfg$model_version <- "${{ steps.gitversion.outputs.assemblySemVer }}"/' config/default.cfg
+
+      - name: Commit changes to CITATION.cff
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: '["CITATION.cff", "config/default.cfg"]'
+          author_name: REMIND Research Software Engineering
+          author_email: rse@pik-potsdam.de
+          message: 'Release development version ${{ steps.gitversion.outputs.assemblySemVer }}'
+          tag: 'v${{ steps.gitversion.outputs.assemblySemVer }}'
+          pathspec_error_handling: exitImmediately

--- a/.github/workflows/auto-dev-version.yaml
+++ b/.github/workflows/auto-dev-version.yaml
@@ -1,21 +1,20 @@
 on:
-  push:
+  pull_request:
     branches:
       - develop
-
+    types: [ closed ]
 name: auto-dev-version
 
 jobs:
   auto-dev-version:
-    if: github.repository == 'remindmodel/remind'
+    if: github.repository == 'remindmodel/remind' && github.event.pull_request.merged == true
     runs-on: ubuntu-22.04
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          token: ${{ secrets.AUTO_DEV_VERSION }}
 
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v0.9.15
@@ -37,7 +36,7 @@ jobs:
 
       - name: Commit changes to CITATION.cff
         uses: EndBug/add-and-commit@v9
-        with:
+        with:          
           add: '["CITATION.cff", "config/default.cfg"]'
           author_name: REMIND Research Software Engineering
           author_email: rse@pik-potsdam.de

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -62,7 +62,7 @@ cfg$model_name <- "REMIND"
 cfg$validationmodel_name <- "VALIDATIONREMIND"
 
 #### model version of the overall model (used for run statistics only).
-# Use extension "-rc" for release candidate and "-dev" for developer version
+# automatically generated for development versions, updated by hand for releases
 cfg$model_version <- "3.2.2-dev"
 
 #### settings ####


### PR DESCRIPTION
## Purpose of this PR

Brings back an enhances the reverted PR https://github.com/remindmodel/remind/pull/1065

Enhancements: 
- uses a classic PAT to authorized the workflow to commit to `develop` branch
- update of dev version is triggered by a successful merge, not by a commit to `develop` branch, as the latter would trigger  an endless loop

## Type of change

- [x] New feature 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code

