### PR TITLE
Fix event for version increment action

### DIFF
--- a/.github/workflows/auto-dev-version.yaml
+++ b/.github/workflows/auto-dev-version.yaml
@@ -1,5 +1,5 @@
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - develop
     types: [ closed ]


### PR DESCRIPTION
## Purpose of this PR

Sets event to trigger increment of dev version to `pull_request_target` instead of `pull_request` so that secrets in the REMIND repository can be accessed from within the workflow.

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
