### PR TITLE
count failing regions correctly

### DIFF
--- a/modules/80_optimization/nash/declarations.gms
+++ b/modules/80_optimization/nash/declarations.gms
@@ -57,7 +57,7 @@ p80_repy_iteration(all_regi,solveinfo80,iteration) "summary report from solver i
 p80_repyLastOptim(all_regi,solveinfo80)    "p80_repy from last iteration"
 p80_messageFailedMarket(tall,all_enty)     "nash display helper"
 p80_messageShow(convMessage80)             "nash display helper"
-p80_trackConsecFail(all_regi)              "Parameter to keep track of consecutive solve failurs of regions in Nash mode."
+p80_trackConsecFail(all_regi)              "Parameter to keep track of consecutive solve failures of regions in Nash mode."
 
 p80_curracc(ttot,all_regi)                 "current account"
 

--- a/modules/80_optimization/nash/postsolve.gms
+++ b/modules/80_optimization/nash/postsolve.gms
@@ -572,10 +572,11 @@ if(cm_abortOnConsecFail, !! execute only if consecutive failures switch is non-z
         else
             p80_trackConsecFail(regi) = p80_trackConsecFail(regi) + 1;
         );
-
+    );
+    loop(regi,
         if(p80_trackConsecFail(regi) >= cm_abortOnConsecFail,
             execute_unload "abort.gdx";
-
+            display p80_trackConsecFail;
             abort "Run was aborted because the maximum number of consecutive failures was reached in at least one region!";
         );
     )


### PR DESCRIPTION
## Purpose of this PR

- the scripts was aborting after the first region that reached the fail limit was found
- so you could end up thinking one region failed while it were multiple
- now, count them correctly, then print the current status, and fail then

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
