### PR TITLE
add info about model version to full.gms 

### DIFF
--- a/scripts/start/prepare.R
+++ b/scripts/start/prepare.R
@@ -153,10 +153,12 @@ prepare <- function() {
   manipulateConfig(tmpModelFile, cfg$gms)
 
   ######## declare functions for updating information ####
-  update_info <- function(regionscode, revision) {
+  update_info <- function(regionscode, revision, model_version) {
 
     subject <- "VERSION INFO"
     content <- c("",
+      paste("Modelversion:", model_version),
+      "",
       paste("Regionscode:", regionscode),
       "",
       paste("Input data revision:", revision),
@@ -270,7 +272,7 @@ prepare <- function() {
 
   ############ update information ########################
   # update_info, which regional resolution and input data revision in tmpModelFile
-  update_info(madrat::regionscode(cfg$regionmapping), cfg$inputRevision)
+  update_info(madrat::regionscode(cfg$regionmapping), cfg$inputRevision, cfg$model_version)
   # update_sets, which is updating the region-depending sets in core/sets.gms
   #-- load new mapping information
   map <- read.csv(cfg$regionmapping, sep=";")


### PR DESCRIPTION
## Purpose of this PR
add info about model version to full.gms 

## Type of change
- [x] Refactoring

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)


## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

