### PR TITLE
set pm_macSwitch(emiMacMagpie) = 0 also for 45/NPi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### fixed
 - fixed weights of energy carriers in `pm_IndstCO2Captured`
     [[#1354](https://github.com/remindmodel/remind/pull/1354)]
+- switch off MAgPIE emission abatement for 45/NPi realization
+    [[#1401](https://github.com/remindmodel/remind/pull/1401)]
 
 ## [3.2.1] - 2023-07-13 (incomplete)
 

--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -1351,7 +1351,8 @@ if(c_macscen eq 1,
 *pm_macCostSwitch(enty)=pm_macSwitch(enty);
 
 *** for NDC and NPi switch off landuse MACs
-$if %carbonprice% == "NDC"  pm_macSwitch(emiMacMagpie) = 0;
+$if %carbonprice% == "NDC"      pm_macSwitch(emiMacMagpie) = 0;
+$if %carbonprice% == "NPi"      pm_macSwitch(emiMacMagpie) = 0;
 $if %carbonprice% == "NPi2018"  pm_macSwitch(emiMacMagpie) = 0;
 
 *DK* LU emissions are abated in MAgPIE in coupling mode

--- a/main.gms
+++ b/main.gms
@@ -831,7 +831,7 @@ parameter
   cm_iterative_target_adj  = 0;      !! def = 0  !! regexp = 0|2|3|4|5|6|7|9
 *' * (0): no iterative adjustment
 *' * (2): iterative adjustment II based on magicc calculated forcing (for both budget and tax runs), see modules/ 0 /magicc/postsolve.gms for direct algorithms of adjustment
-*' * (3): [requires 45_carbonprice = "NDC" and emiscen = 9] iterative adjustment III for tax based on 2025 or 2030 regionally differentiated emissions, see module/45_carbonprice/<NDC/NPi2018>/postsolve.gms for algorithm of adjustment
+*' * (3): [requires 45_carbonprice = "NDC" and emiscen = 9] iterative adjustment III for tax based on 2025 or 2030 regionally differentiated emissions, see module/45_carbonprice/NDC/postsolve.gms for algorithm of adjustment
 *' * (4): iterative adjustment IV for both budget and tax runs based on CO2 FF&I emissions 2020-2100, see core/postsolve.gms for direct algorithms of adjustment
 *' * (5): iterative adjustment V for both budget and tax runs based on CO2 emissions 2020-2100, see core/postsolve.gms for direct algorithms of adjustment
 *' * (6): iterative adjustment VI for both budget and tax runs based on peak CO2 emissions budget, without changing temporal profile (i.e. with overshoot), see core/postsolve.gms for direct algorithms of adjustment


### PR DESCRIPTION
## Purpose of this PR

-  when running REMIND standalone with the MAgPIE emulator, `Emi|GHG|Agriculture` grows if I switch on NDC carbon pricing
![image](https://github.com/remindmodel/remind/assets/90761609/147933c7-5262-4fe8-93c6-cc83e4349153)
- reason: While adding `45/NPi` realization, we forgot to switch off that emissions are being abated for `emiMacMagpie`. But in NDC, there was abatement switched off, so emissions in NDC were higher
 
## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] `gamscompile` works and I'm certain all automated model tests would pass (`FAIL 0` in the output of `make test`) if renv wasn't corrupted given the very minor code changes
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
