### PR TITLE
require testthat (>= 3.1.10)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -69,7 +69,7 @@ Imports:
     SPEI,
     stringr,
     terra,
-    testthat (>= 3.1.5),
+    testthat (>= 3.1.10),
     tibble,
     tidyr,
     tidyverse,


### PR DESCRIPTION
## Purpose of this PR

to make sure `with_mocked_bindings` exist already

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
