### PR TITLE
make sure lower bound on vm_cesIO is at least the offset_quantity, to prevent negative net energy consumption

### DIFF
--- a/modules/01_macro/singleSectorGr/bounds.gms
+++ b/modules/01_macro/singleSectorGr/bounds.gms
@@ -8,7 +8,8 @@
 
 *nb* lower bounds on CES values
 vm_cons.lo(t,regi)     = 1e-3;
-vm_cesIO.lo(t,regi,in)$( NOT in_industry_dyn37(in) ) = 1e-6;
+vm_cesIO.lo(t,regi,in)$( NOT in_industry_dyn37(in) ) 
+  = max(1e-6, abs(pm_cesdata(t,regi,in,"offset_quantity")));
 vm_cesIOdelta.lo(t,regi,in_putty) = 1e-6;
 
 *** fix energy inputs to CES structure in t0 to the parameter values

--- a/modules/29_CES_parameters/calibrate/bounds.gms
+++ b/modules/29_CES_parameters/calibrate/bounds.gms
@@ -42,9 +42,13 @@ if (smax((t,regi_dyn29(regi),ipf)$(    t.val gt 2005
 sm_tmp = 5;  !! last iteration with bounds on industry
 loop (pf_industry_relaxed_bounds_dyn37(in),
   vm_cesIO.lo(t_29(t),regi_dyn29(regi),in)
-  = pm_cesdata(t,regi,in,"quantity")
-  !! goes from 0.95 to 1e-12 in -0.2 steps
-  * max(1e-12, 0.95 + min(0, (1 - sm_CES_calibration_iteration) / sm_tmp));
+  = max(
+      ( pm_cesdata(t,regi,in,"quantity")
+        !! goes from 0.95 to 1e-12 in -0.2 steps
+      * max(1e-12, 0.95 + min(0, (1 - sm_CES_calibration_iteration) / sm_tmp))
+      ),
+      abs(pm_cesdata(t,regi,in,"offset_quantity"))
+    );
 
   vm_cesIO.up(t,regi_dyn29(regi),in)
   = ( pm_cesdata(t,regi,in,"quantity")

--- a/modules/36_buildings/services_putty/bounds.gms
+++ b/modules/36_buildings/services_putty/bounds.gms
@@ -9,7 +9,13 @@ vm_enerSerAdj.fx("2005",regi,in) = 0;
 
 if ((cm_noReboundEffect eq 1 ), !! Fix the upper bound of vm_cesIO to the level of input_ref if no rebound is allowed
 vm_cesIO.up(t,regi,in)$(sameAs(in,"esswb") OR sameAs(in,"uealb") OR sameAs(in,"uecwb")) = (1 + 1e-14) * p36_cesIONoRebound(t,regi,in);
-vm_cesIO.lo(t,regi,in)$(sameAs(in,"esswb") OR sameAs(in,"uealb") OR sameAs(in,"uecwb")) = (1 - 1e-14) * p36_cesIONoRebound(t,regi,in);
+vm_cesIO.lo(t,regi,in)$(    sameAs(in,"esswb") 
+                        OR sameAs(in,"uealb")
+			OR sameAs(in,"uecwb")  )
+  = max(
+      (1 - 1e-14) * p36_cesIONoRebound(t,regi,in),
+      abs(pm_cesdata(t,regi,in,"offset_quantity"))
+    );
 vm_cesIOdelta.up(t,regi,in)$(sameAs(in,"esswb") OR sameAs(in,"uealb") OR sameAs(in,"uecwb")) = (1 + 1e-14) * p36_cesIONoRebound_putty(t,regi,in);
 vm_cesIOdelta.lo(t,regi,in)$(sameAs(in,"esswb") OR sameAs(in,"uealb") OR sameAs(in,"uecwb")) = (1 - 1e-14) * p36_cesIONoRebound_putty(t,regi,in);
 );

--- a/modules/36_buildings/services_with_capital/bounds.gms
+++ b/modules/36_buildings/services_with_capital/bounds.gms
@@ -6,8 +6,14 @@
 *** |  Contact: remind@pik-potsdam.de
 *** SOF ./modules/36_buildings/services_with_capital/bounds.gms
 if ((cm_noReboundEffect eq 1 ), !! Fix the upper bound of vm_cesIO to the level of input_ref if no rebound is allowed
-vm_cesIO.up(t,regi,in)$(sameAs(in,"esswb") OR sameAs(in,"uealb") OR sameAs(in,"uecwb")) = (1 + 1e-14) * p36_cesIONoRebound(t,regi,in);
-vm_cesIO.lo(t,regi,in)$(sameAs(in,"esswb") OR sameAs(in,"uealb") OR sameAs(in,"uecwb")) = (1 - 1e-14) * p36_cesIONoRebound(t,regi,in);
+  vm_cesIO.up(t,regi,in)$(sameAs(in,"esswb") OR sameAs(in,"uealb") OR sameAs(in,"uecwb")) = (1 + 1e-14) * p36_cesIONoRebound(t,regi,in);
+  vm_cesIO.lo(t,regi,in)$(    sameAs(in,"esswb")
+                           OR sameAs(in,"uealb") 
+                           OR sameAs(in,"uecwb") ) 
+    = max(
+        (1 - 1e-14) * p36_cesIONoRebound(t,regi,in),
+        abs(pm_cesdata(t,regi,in,"offset_quantity"))
+      );
 );
 
 

--- a/modules/37_industry/fixed_shares/bounds.gms
+++ b/modules/37_industry/fixed_shares/bounds.gms
@@ -14,7 +14,8 @@ loop ((secInd37,enty)$( NOT macBaseInd37(enty,secInd37) ),
   vm_macBaseInd.fx(ttot,regi,enty,secInd37)$( ttot.val ge 2005 ) = 0;
 );
 
-vm_cesIO.lo(t,regi,in_industry_dyn37(in)) = 1e-6;
+vm_cesIO.lo(t,regi,in_industry_dyn37(in))
+  = max(1e-6, abs(pm_cesdata(t,regi,in,"offset_quantity")));
 
 *** Upper bound for exponent to avoid exponential gams overflow (if > 20 -> 3^20 > 1e10 what would cause GAMS to get an overflow x**y error) 
 v37_costExponent.up(t,regi) = 20; 

--- a/modules/37_industry/subsectors/bounds.gms
+++ b/modules/37_industry/subsectors/bounds.gms
@@ -87,7 +87,10 @@ $endif.secondary_steel_bound
 $endif.CES_parameters
 
 vm_cesIO.fx("2005",regi,ppfkap_industry_dyn37(in))
-  = pm_cesdata("2005",regi,in,"quantity");
+  = max(
+      pm_cesdata("2005",regi,in,"quantity"),
+      abS(pm_cesdata("2005",regi,in,"offset_quantity"))
+    );
 
 *** Set lower bound for secondary steel electricity to 1 % of the lowest
 *** existing lower bound (should be far above sm_eps) to avoid CONOPT getting
@@ -101,14 +104,15 @@ loop (in$( sameas(in,"feel_steel_secondary") ),
       * smax(ttot$( vm_cesIO.lo(ttot,regi,in) gt sm_eps),
           vm_cesIO.lo(ttot,regi,in)
 	)
-      )
+      ),
+      abs(pm_cesdata(t,regi,in,"offset_quantity"))
     );
 );
 
 *** Default lower bounds on all industry pfs
 vm_cesIO.lo(t,regi_dyn29(regi),in_industry_dyn37(in))$( 
                                                   0 eq vm_cesIO.lo(t,regi,in) )
-  = sm_eps;
+  = max(sm_eps, abs(pm_cesdata(t,regi,in,"offset_quantity")));
 
 *' Limit biomass solids use in industry to 25% (or historic shares, if they are higher)
 *' of baseline solids


### PR DESCRIPTION
Net `vm_cesIO` (i.e. `vm_cesIO + pm_cesdata("offset_quantity")`, the latter being negative) was not limited at zero on the `pf` level, only on the `pf`-sum.  Specifically, while the sum of all hydrogen net consumption in industry would be 0 in 2010 (so equal production of 0), individual industry subsectors would consume more `feh2_` than indicated by their offset quantity (and others less), resulting in (very small) negative net consumption, which showed up when looking into a industry reporting issue (#1399).
I extended this to all lower bounds on `vm_cesIO`.  Other modules probably are not affected, but this was faster then checking all production factors individually.

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Test runs are here: `/p/tmp/pehl/Remind/output/SSP2EU-Base_2023-09-07_11.37.01`
* Comparison of results (what changes by this PR?): `/p/tmp/pehl/Remind/compScen-2023-09-11_12.42.07-H12.pdf`

