### PR TITLE
in plot_compare_iterations correctly find mifs

### DIFF
--- a/scripts/output/comparison/plot_compare_iterations.R
+++ b/scripts/output/comparison/plot_compare_iterations.R
@@ -62,8 +62,8 @@ plot_iterations <- function(runname) {
   # ---- Read REMIND reportings for all scenarios ----
   
   message("Searching for REMIND_generic_*.mif files for ", runname)
-  report_path <- Sys.glob(paste0(runname,"-rem-*/REMIND_generic_*.mif"))
-  report_path <- report_path[!grepl("with|adj",report_path)]
+  report_path <- Sys.glob(paste0(runname,"-rem-*/REMIND_generic_", runname, "-rem-*.mif"))
+  report_path <- grep(paste0(runname, "-rem-[0-9]+\\.mif$"), report_path, value = TRUE)
   
   message("Reading ", length(report_path), " REMIND reports.")
   reports <- NULL


### PR DESCRIPTION
## Purpose of this PR

avoid that `REMIND_generic_C_SSP2EU-Npi-BECCSonly-rem-3_summation_errors.mif` etc. are found.

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
