### PR TITLE
accounting of emissions of natural gas vehicles in transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **scripts** MAgPIE coupling interface: remove filtering of negative LU emissions
 - **core** MAgPIE coupling: tolerate negative values for `n2ofertsom` and deactivate its MAC
 - **05_initialCap** fix overwriting of investment cost changes from cm_inco0Factor switch
+- **core** fix bug that emissions from gas use in transport were not accounted
 
 ### added
 - **45_carbonprice** added realization `NPi` (National Policies Implemented)

--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -1461,6 +1461,7 @@ pm_emifac(ttot,regi,"sesofos","fesos","tdfossos","co2") = p_ef_dem(regi,"fesos")
 pm_emifac(ttot,regi,"seliqfos","fehos","tdfoshos","co2") = p_ef_dem(regi,"fehos") / (sm_c_2_co2*1000*sm_EJ_2_TWa); !! GtC/TWa
 pm_emifac(ttot,regi,"seliqfos","fepet","tdfospet","co2") = p_ef_dem(regi,"fepet") / (sm_c_2_co2*1000*sm_EJ_2_TWa); !! GtC/TWa
 pm_emifac(ttot,regi,"seliqfos","fedie","tdfosdie","co2") = p_ef_dem(regi,"fedie") / (sm_c_2_co2*1000*sm_EJ_2_TWa); !! GtC/TWa
+pm_emifac(ttot,regi,"segafos","fegat","tdfosgat","co2") = p_ef_dem(regi,"fegas") / (sm_c_2_co2*1000*sm_EJ_2_TWa); !! GtC/TWa
 
 *** some balances are not matching by small amounts;
 *** the differences are cancelled out here!!!

--- a/core/sets.gms
+++ b/core/sets.gms
@@ -2644,6 +2644,7 @@ emi2te(all_enty,all_enty,all_te,all_enty)    " map emissions to technologies"
         sesofos.fesos.tdfossos.co2
         seliqfos.fepet.tdfospet.co2
         seliqfos.fedie.tdfosdie.co2
+        segafos.fegat.tdfosgat.co2
 /
 
 emi2fuel(all_enty,all_enty) "map emissions to fuel extraction"


### PR DESCRIPTION
## Purpose of this PR

This adds an emissions factor to fossil gas in transport and accounts the resulting emissions. 

I stumbled across this when I checked how deep REMIND can reduce fossil energy. Seems like we forgot about this when we moved to edge_esm realization (as fegat did not exist in complex)?

## Type of change


- [x] Bug fix 



## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`) (did not pass due to infes in quick mode, fine for now but communicated to RSE)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Test runs are here: 

``/p/tmp/schreyer/Modeling/remind/Current/output/Npi_fegatfix_2023-09-19_10.59.46``

PDF: ``/p/tmp/schreyer/Modeling/remind/Current/compScen-Npi_EmiFegat_Comp-2023-10-09_12.28.18-H12.pdf``

Check ``vm_emiTeDetailMkt`` entry for ``tdfosgat`` technology for the corresponding emissions that were zero before. 

* Comparison of results (what changes by this PR?): 

