### PR TITLE
let preempted and resumed runs start their subsequent runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     [[#1354](https://github.com/remindmodel/remind/pull/1354)]
 - switch off MAgPIE emission abatement for 45/NPi realization
     [[#1401](https://github.com/remindmodel/remind/pull/1401)]
+- let preempted and resumed runs start their subsequent runs
 
 ## [3.2.1] - 2023-07-13 (incomplete)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - switch off MAgPIE emission abatement for 45/NPi realization
     [[#1401](https://github.com/remindmodel/remind/pull/1401)]
 - let preempted and resumed runs start their subsequent runs
+    [[#1414](https://github.com/remindmodel/remind/pull/1414)]
 
 ## [3.2.1] - 2023-07-13 (incomplete)
 

--- a/scripts/start/prepareAndRun.R
+++ b/scripts/start/prepareAndRun.R
@@ -22,8 +22,6 @@ prepareAndRun <- function() {
   } else {
     # If "full.gms" exists, the script assumes that a full.gms has been generated before and you want
     # to restart REMIND in the same folder using the gdx that it eventually previously produced.
-    message("\nRestarting REMIND, find old log in 'log_beforeRestart.txt'.")
-    if (file.exists("log.txt")) file.copy("log.txt", "log_beforeRestart.txt", overwrite = TRUE)
     if (file.exists("fulldata.gdx")) file.copy("fulldata.gdx", "input.gdx", overwrite = TRUE)
   }
 

--- a/scripts/start/prepareAndRun.R
+++ b/scripts/start/prepareAndRun.R
@@ -19,17 +19,16 @@ prepareAndRun <- function() {
     # If no "full.gms" exists, the script assumes that REMIND did not run before and
     # prepares all inputs before starting the run.
     prepare()
-    start_subsequent_runs <- TRUE
   } else {
     # If "full.gms" exists, the script assumes that a full.gms has been generated before and you want
     # to restart REMIND in the same folder using the gdx that it eventually previously produced.
     message("\nRestarting REMIND, find old log in 'log_beforeRestart.txt'.")
-    if(file.exists("fulldata.gdx")) file.copy("fulldata.gdx", "input.gdx", overwrite = TRUE)
-    start_subsequent_runs <- FALSE
+    if (file.exists("log.txt")) file.copy("log.txt", "log_beforeRestart.txt", overwrite = TRUE)
+    if (file.exists("fulldata.gdx")) file.copy("fulldata.gdx", "input.gdx", overwrite = TRUE)
   }
 
   # Run REMIND, start subsequent runs (if applicable), and produce output.
-  run(start_subsequent_runs)
+  run()
 }
 
 # Only if this file is run directly via Rscript prepareAndRun.R, but not if this file

--- a/scripts/start/run.R
+++ b/scripts/start/run.R
@@ -5,7 +5,7 @@
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
 
-run <- function(start_subsequent_runs = TRUE) {
+run <- function() {
 
   load("config.Rdata")
 
@@ -175,7 +175,7 @@ run <- function(start_subsequent_runs = TRUE) {
   # Use the name to check whether it is a coupled run (TRUE if the name ends with "-rem-xx")
   coupled_run <- grepl("-rem-[0-9]{1,2}$",cfg$title)
   # Don't start subsequent runs form here if REMIND runs coupled. They are started in start_coupled.R instead.
-  start_subsequent_runs <- (start_subsequent_runs | isTRUE(cfg$restart_subsequent_runs)) & !coupled_run
+  start_subsequent_runs <- ! isFALSE(cfg$restart_subsequent_runs) && ! coupled_run
 
   if (start_subsequent_runs & (length(rownames(cfg$RunsUsingTHISgdxAsInput)) > 0)) {
     # track whether any subsequent run was actually started

--- a/scripts/start/submit.R
+++ b/scripts/start/submit.R
@@ -130,7 +130,7 @@ submit <- function(cfg, restart = FALSE, stopOnFolderCreateError = TRUE) {
   } else {
     exitCode <- system(paste0("sbatch --job-name=",
                               cfg$title,
-                              " --output=log.txt",
+                              " --output=log.txt --open-mode=append", # append for requeued jobs
                               " --mail-type=END",
                               " --comment=REMIND",
                               " --wrap=\"Rscript prepareAndRun.R \" ",

--- a/start_bundle_coupled.R
+++ b/start_bundle_coupled.R
@@ -629,7 +629,7 @@ for (scen in common) {
           runEnv$qos <- if (is.null(attr(sq, "status")) && sum(grepl("^priority ", sq)) < 4) "priority" else "short"
         }
         slurmOptions <- combine_slurmConfig(paste0("--qos=", runEnv$qos, " --job-name=", fullrunname, " --output=", logfile,
-          " --mail-type=END --comment=REMIND-MAgPIE --tasks-per-node=", runEnv$numberOfTasks,
+          " --open-mode=append --mail-type=END --comment=REMIND-MAgPIE --tasks-per-node=", runEnv$numberOfTasks,
           if (runEnv$numberOfTasks == 1) " --mem=8000"), runEnv$sbatch)
         slurmCommand <- paste0("sbatch ", slurmOptions, " --wrap=\"Rscript start_coupled.R coupled_config=", Rdatafile, "\"")
         message(slurmCommand)

--- a/start_coupled.R
+++ b/start_coupled.R
@@ -256,7 +256,7 @@ start_coupled <- function(path_remind, path_magpie, cfg_rem, cfg_mag, runname, m
           subseq.env$qos <- if (is.null(attr(sq, "status")) && sum(grepl("^priority ", sq)) < 4) "priority" else "short"
         }
         slurmOptions <- combine_slurmConfig(paste0("--qos=", subseq.env$qos, " --job-name=", subseq.env$fullrunname, " --output=", logfile,
-           " --mail-type=END --comment=REMIND-MAgPIE --tasks-per-node=", subseq.env$numberOfTasks,
+           " --open-mode=append --mail-type=END --comment=REMIND-MAgPIE --tasks-per-node=", subseq.env$numberOfTasks,
           if (subseq.env$numberOfTasks == 1) " --mem=8000"), subseq.env$sbatch)
         subsequentcommand <- paste0("sbatch ", slurmOptions, " --wrap=\"Rscript start_coupled.R coupled_config=", RData_file, "\"")
         message(subsequentcommand)

--- a/tests/testthat/test_04-gamscompile.R
+++ b/tests/testthat/test_04-gamscompile.R
@@ -37,7 +37,6 @@ test_that("start.R --gamscompile works on all configs and scenarios", {
                  "scenario_config_EDGE-T_NDC_NPi_pkbudget",
                  "scenario_config_NAVIGATE_300",
                  "scenario_config_tradeCap_standalone",
-                 "scenario_config_DeepEl",
                  "scenario_config_SHAPE",
                  "scenario_config_GCS")
   csvfiles <- grep(paste(skipfiles, collapse = "|"), csvfiles, invert = TRUE, value = TRUE)


### PR DESCRIPTION
## Purpose of this PR

- see #1413
- it is meanwhile [asked in `start.R`](https://github.com/remindmodel/remind/blob/c2174b3b8831e087d26da0f32023850c1131b283/start.R#L151C31-L169) whether a restarted run should start its subsequent runs as well
- therefore, the automatic detection based on existence of `full.gms` is misleading, always leading to `FALSE` for preempted and resumed runs
- so always start subsequent runs here, expect for coupled runs and if it was selected in `start.R` not to
- make sure old log is saved also in case of preemption (I don't think that works the way I implemented it, as the file is probably already overwritten here)

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
