### PR TITLE
for outdated technologies "pcc" and "pco" set capacities to 0

### DIFF
--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -59,6 +59,12 @@ vm_deltaCap.up(t,regi,"solhe",rlf) = 0;
 vm_cap.fx(t,regi,"fnrs",rlf)     = 0;
 vm_deltaCap.up(t,regi,"fnrs",rlf) = 0;
 
+vm_cap.fx(t,regi,"pcc",rlf)     = 0;
+vm_deltaCap.up(t,regi,"pcc",rlf) = 0;
+
+vm_cap.fx(t,regi,"pco",rlf)     = 0;
+vm_deltaCap.up(t,regi,"pco",rlf) = 0;
+
 *** -----------------------------------------------------------------------------------------------------------------
 *** Traditional biomass use is phased out on an exogeneous time path
 *** -----------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Purpose of this PR
avoid misinterpretation of model results via loading outdated information for outdated technologies

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)


## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

