### PR TITLE
fix path_gdx_bau checks, some more realizations need it

### DIFF
--- a/tests/testthat/test_01-readCheckScenarioConfig.R
+++ b/tests/testthat/test_01-readCheckScenarioConfig.R
@@ -34,10 +34,10 @@ test_that("readCheckScenarioConfig fails on error-loaden config", {
   expect_match(w, "contain whitespaces", all = FALSE, fixed = TRUE)
   expect_match(w, "scenario names indicated in copyConfigFrom column were not found", all = FALSE, fixed = TRUE)
   expect_match(w, "specify in copyConfigFrom column a scenario name defined below in the file", all = FALSE, fixed = TRUE)
-  expect_match(w, "which requires a reference gdx", all = FALSE, fixed = TRUE)
+  expect_match(w, "a reference gdx in 'path_gdx_bau'", all = FALSE, fixed = TRUE)
   expect_match(w, "Do not use 'NA' as scenario name", all = FALSE, fixed = TRUE)
   expect_match(m, "no column path_gdx_refpolicycost for policy cost comparison found, using path_gdx_ref instead", all = FALSE, fixed = TRUE)
-  expect_match(m, "In 1 scenarios, neither 'carbonprice'", all = FALSE, fixed = TRUE)
+  expect_match(m, "is not empty although no realization is selected that needs it", all = FALSE, fixed = TRUE)
   copiedFromPBS <- c("c_budgetCO2", "path_gdx", "path_gdx_ref")
   expect_identical(unlist(scenConf["PBS", copiedFromPBS]),
                    unlist(scenConf["PBScopy", copiedFromPBS]))


### PR DESCRIPTION
## Purpose of this PR

- we forgot in #1366 that three other realizations actually read from the input_bau.gdx.
- I first implemented it in a straightforward manner, but then the NAVIGATE config failed because this file is needed only if cm_emiscen = 1, so it all became a bit more complicated.
- without this change, the start scripts would set `path_gdx_bau` to `NA` and then the realizations lack this file and fail

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
