### PR TITLE
better error messages for failed tests

### DIFF
--- a/tests/testthat/helper_localSystem2.R
+++ b/tests/testthat/helper_localSystem2.R
@@ -21,5 +21,10 @@ localSystem2 <- function(command, args = character(),
     if (is.null(attr(output, 'status', exact = TRUE))) {
         attr(output, 'status') <- 0
     }
+
+    # include command and arguments in output for pretty errors
+    attr(output, 'command') <- command
+    attr(output, 'args') <- args
+
     return(output)
 }

--- a/tests/testthat/helper_skipFailed.R
+++ b/tests/testthat/helper_skipFailed.R
@@ -6,19 +6,59 @@
 # |  Contact: remind@pik-potsdam.de
 helperSkipFailed <- FALSE
 
-expectSuccessStatus <- function(output) {
-    status <- attr(output, "status", exact = TRUE)
-    if (0 != status) {
-        helperSkipFailed <<- TRUE
+expect_exit_status_n <- function(object, n = 0, invert = FALSE) {
+    act <- quasi_label(rlang::enquo(object), arg = 'object')
+
+    status <- attr(act[['val']], 'status', exact = TRUE)
+
+    if (all(c('command', 'args') %in% names(attributes(act[['val']])))) {
+        label <- paste0('`', attr(act[['val']], 'command', exact = TRUE), ' ',
+                        paste(attr(act[['val']], 'args', exact = TRUE),
+                              collapse = ' '),
+                        '`')
     }
-    expect_equal(status, 0)
+    else {
+        label <- act[['lab']]
+    }
+
+    # empty trace to suppress testthat backtrace
+    empty_trace <- structure(
+        list(call      = list(),
+             parent    = integer(0),
+             visible   = logical(0),
+             namespace = character(0),
+             scope     = character(0)),
+        row.names = integer(0),
+        version   = 2L,
+        class     = c('rlang_trace', 'rlib_trace', 'tbl', 'data.frame'))
+
+    if (isFALSE(invert)) {
+        if (n != status)
+            helperSkipFailed <<- TRUE
+
+        expect(n == status,
+               sprintf('%s returned exit status %i, not %i', label, status, n),
+               trace = empty_trace)
+    }
+    else {
+        if (n == status)
+            helperSkipFailed <<- TRUE
+
+        expect(n != status,
+               sprintf('%s returned exit status %i, which it should not',
+                       label, status),
+               trace = empty_trace)
+    }
+
+    invisible(act[['val']])
 }
+
+expectSuccessStatus <- function(output) {
+    expect_exit_status_n(output, 0, FALSE)
+}
+
 expectFailStatus <- function(output) {
-    status <- attr(output, "status", exact = TRUE)
-    if (1 != status) {
-        helperSkipFailed <<- TRUE
-    }
-    expect_equal(status, 1)
+    expect_exit_status_n(output, 0, TRUE)
 }
 
 skipIfPreviousFailed <- function() {


### PR DESCRIPTION
close #1119

- [x] New feature 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

Tail of the output (on a manually introduced compilation error) looks like
```
…
Creating full.gms
Error in prepare() : Compiling main_testOneRegi.gms failed, stopping.
Use `less -j 4 --pattern='^\*\*\*\*' output/testOneRegi/main.lst` to investigate compilation errors.
Calls: prepareAndRun -> prepare
2023-09-28 11:56:56: unlocked model.
Execution halted
Error in submit(cfg) : Executing prepareAndRun failed, stopping.
Execution halted
✖ | 1       0 | 02-compile [60.2s]                                                                                                      
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Failure (test_02-compile.R:11:3): remind compiles
`Rscript start.R config/tests/scenario_config_compile.csv` returned exit status 1, not 0
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
✔ |     1   0 | 03-quick                                                                                                                
✔ |     2   0 | 04-gamscompile                                                                                                          
✔ |     1   0 | 05-default                                                                                                              
✔ |     1   0 | 06-output                                                                                                               
✔ |     1   0 | 20-coupled                                                                                                              
✔ |     1   0 | 99-codeCheck                                                                                                            

══ Results ═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
Duration: 89.5 s

── Skipped tests (9) ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────
• A previous test failed. (3): test_03-quick.R:8:3, test_04-gamscompile.R:11:3, test_99-codeCheck.R:10:3
• Not run in default tests, use `make test-full` to run (takes significantly longer than 10 minutes). (5): test_01-start.R:34:3,
  test_04-gamscompile.R:25:3, test_05-default.R:8:3, test_06-output.R:7:1, test_20-coupled.R:8:1
• standalone models aren't consistent at the moment (1): test_01-gms_readSettings.R:12:3

── Failed tests ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Failure (test_02-compile.R:11:3): remind compiles
`Rscript start.R config/tests/scenario_config_compile.csv` returned exit status 1, not 0

[ FAIL 1 | WARN 0 | SKIP 9 | PASS 79 ]
Error: Test failures
Execution halted
make: *** [Makefile:54: test] Error 1
```