### PR TITLE
allow runs to reference runs of the same name (i.e. earlier versions of themselve) for the path_gdx

### DIFF
--- a/scripts/start/configureCfg.R
+++ b/scripts/start/configureCfg.R
@@ -57,12 +57,12 @@ configureCfg <- function(icfg, iscen, iscenarios, verboseGamsCompile = TRUE) {
     if (verboseGamsCompile) {
       # for columns path_gdx…, check whether the cell is non-empty, and not the title of another run with start = 1
       # if not a full path ending with .gdx provided, search for most recent folder with that title
-      if (any(iscen %in% iscenarios[iscen, names(path_gdx_list)])) {
+      if (any(iscen %in% iscenarios[iscen, setdiff(names(path_gdx_list), "path_gdx")])) {
         stop("Self-reference: ", iscen , " refers to itself in a path_gdx... column.")
       }
       # if a scenario is referenced that is not in the list of scenarios to be started, try to find a gdx automatically
       for (path_to_gdx in names(path_gdx_list)) {
-        if (!is.na(iscenarios[iscen, path_to_gdx]) & ! iscenarios[iscen, path_to_gdx] %in% row.names(iscenarios)) {
+        if (!is.na(iscenarios[iscen, path_to_gdx]) & ! iscenarios[iscen, path_to_gdx] %in% setdiff(row.names(iscenarios), iscen)) {
           if (! str_sub(iscenarios[iscen, path_to_gdx], -4, -1) == ".gdx") {
             # search for fulldata.gdx in output directories starting with the path_to_gdx cell content.
             # may include folders that only _start_ with this string. They are sorted out later.
@@ -102,7 +102,7 @@ configureCfg <- function(icfg, iscen, iscenarios, verboseGamsCompile = TRUE) {
         }
       }
     }
-    
+
     # Define path where the GDXs will be taken from
     gdxlist <- unlist(iscenarios[iscen, names(path_gdx_list)])
     names(gdxlist) <- path_gdx_list
@@ -113,6 +113,6 @@ configureCfg <- function(icfg, iscen, iscenarios, verboseGamsCompile = TRUE) {
     # add table with information about runs that need the fulldata.gdx of the current run as input
     icfg$RunsUsingTHISgdxAsInput <- iscenarios %>% select(contains("path_gdx")) %>%              # select columns that have "path_gdx" in their name
                                                    filter(rowSums(. == iscen, na.rm = TRUE) > 0) # select rows that have the current scenario in any column
-    
+
     return(icfg)
 }

--- a/scripts/start/configureCfg.R
+++ b/scripts/start/configureCfg.R
@@ -94,10 +94,15 @@ configureCfg <- function(icfg, iscen, iscenarios, verboseGamsCompile = TRUE) {
           }
           # if the above has not created a path to a valid gdx, stop
           if (!file.exists(iscenarios[iscen, path_to_gdx])) {
-            icfg$errorsfoundInConfigureCfg <- sum(icfg$errorsfoundInConfigureCfg, 1)
-            message(red, "Error", NC, ": Can't find a gdx specified as '", iscenarios[iscen, path_to_gdx], "' in column ",
-                    path_to_gdx, ".\nPlease specify full path to gdx or name of output subfolder that contains a ",
-                    "fulldata.gdx from a previous normally completed run.")
+            if (   path_to_gdx == "path_gdx"
+                && iscenarios[iscen, path_to_gdx] == iscen) {
+              iscenarios[iscen, path_to_gdx] <- NA
+            } else {
+              icfg$errorsfoundInConfigureCfg <- sum(icfg$errorsfoundInConfigureCfg, 1)
+              message(red, "Error", NC, ": Can't find a gdx specified as '", iscenarios[iscen, path_to_gdx], "' in column ",
+                      path_to_gdx, ".\nPlease specify full path to gdx or name of output subfolder that contains a ",
+                      "fulldata.gdx from a previous normally completed run.")
+            }
           }
         }
       }


### PR DESCRIPTION
close #1423

- [x] New feature 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
