### PR TITLE
fix Tech|*|Capital Costs|w/ Adj Costs to reference run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     [[#1401](https://github.com/remindmodel/remind/pull/1401)]
 - let preempted and resumed runs start their subsequent runs
     [[#1414](https://github.com/remindmodel/remind/pull/1414)]
+- correctly report `Tech|*|Capital Costs|w/ Adj Costs` for t < cm_startyear
+    [[#1429](https://github.com/remindmodel/remind/pull/1429)]
 
 ## [3.2.1] - 2023-07-13 (incomplete)
 

--- a/core/postsolve.gms
+++ b/core/postsolve.gms
@@ -625,7 +625,7 @@ o_margAdjCostInv(ttot,regi,te)$(ttot.val ge max(2010, cm_startyear) AND teAdj(te
 ;
 
 *** CG: calculate average adjustment cost for capacity investment: v_costInvTeAdj / vm_deltaCap
-o_avgAdjCostInv(ttot,regi,te)$(ttot.val ge max(2010, cm_startyear) AND teAdj(te) AND (sum(te2rlf(te,rlf),vm_deltaCap.l(ttot,regi,te,rlf)) ne 0 )) 
+o_avgAdjCostInv(ttot,regi,te)$(ttot.val ge 2010 AND teAdj(te) AND (sum(te2rlf(te,rlf),vm_deltaCap.l(ttot,regi,te,rlf)) ne 0 ))
     = v_costInvTeAdj.l(ttot,regi,te) / sum(te2rlf(te,rlf),vm_deltaCap.l(ttot,regi,te,rlf));
 *** and ratio between average adjCost and direct investment cost
 o_avgAdjCost_2_InvCost_ratioPc(ttot,regi,te)$(v_costInvTeDir.l(ttot,regi,te) ge 1E-22) = v_costInvTeAdj.l(ttot,regi,te)/v_costInvTeDir.l(ttot,regi,te) * 100;


### PR DESCRIPTION
## Purpose of this PR

- fix `Tech|*|Capital Costs|w/ Adj Costs` on reference run
- for `t <= cm_startyear`, the paramater `o_avgAdjCostInv` was just 0 which caused `remind2::reportTechnology` to forget about adjustment costs. See longer problem description here: https://github.com/remindmodel/development_issues/issues/226
- I did not run a full remind to check whether that fixes it, as the error seems obvious and I checked that the variables used to calculate the output parameter remain unchanged between `fulldata.gdx` and `input_ref.gdx`, so that must work :)

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

