### PR TITLE
fix Internal/CES values on reference run

### DIFF
--- a/modules/01_macro/singleSectorGr/postsolve.gms
+++ b/modules/01_macro/singleSectorGr/postsolve.gms
@@ -23,38 +23,38 @@ pm_consPC(tall,regi)$(tall.val gt 2150) = pm_consPC("2150",regi);
 *** output parameter for diagnostics
 
 *** Compute ppf prices from CES derivatives
-o01_CESderivatives(t,regi,cesOut2cesIn(out,in))$( vm_cesIO.l(t,regi,in) gt 1e-6 AND
-                                                  vm_cesIO.l(t,regi,out) gt 1e-6 )
+o01_CESderivatives(ttot,regi,cesOut2cesIn(out,in))$( vm_cesIO.l(ttot,regi,in) gt 1e-6 AND
+                                                     vm_cesIO.l(ttot,regi,out) gt 1e-6 )
   =
-    pm_cesdata(t,regi,in,"xi")
-  * pm_cesdata(t,regi,in,"eff")
-  * vm_effGr.l(t,regi,in)
+    pm_cesdata(ttot,regi,in,"xi")
+  * pm_cesdata(ttot,regi,in,"eff")
+  * vm_effGr.l(ttot,regi,in)
 
-  * vm_cesIO.l(t,regi,out)
- ** (1 - pm_cesdata(t,regi,out,"rho"))
+  * vm_cesIO.l(ttot,regi,out)
+ ** (1 - pm_cesdata(ttot,regi,out,"rho"))
 
-  * ( pm_cesdata(t,regi,in,"eff")
-    * vm_effGr.l(t,regi,in)
-    * vm_cesIO.l(t,regi,in)
+  * ( pm_cesdata(ttot,regi,in,"eff")
+    * vm_effGr.l(ttot,regi,in)
+    * vm_cesIO.l(ttot,regi,in)
     )
- ** (pm_cesdata(t,regi,out,"rho") - 1)
+ ** (pm_cesdata(ttot,regi,out,"rho") - 1)
 ;
 
 loop ((cesLevel2cesIO(counter,in),cesOut2cesIn(in,in2),cesOut2cesIn2(in2,in3)),
-  o01_CESderivatives(t,regi,"inco",in3)
-  = o01_CESderivatives(t,regi,"inco",in2)
-  * o01_CESderivatives(t,regi,in2,in3);
+  o01_CESderivatives(ttot,regi,"inco",in3)
+  = o01_CESderivatives(ttot,regi,"inco",in2)
+  * o01_CESderivatives(ttot,regi,in2,in3);
 );
 
 
 *** compute marginal rate of substitution between primary production factors as
 *** ratio of CES prices provides the amount of in2 needed to subsitute one unit
 *** of in to generate the same economic value
-loop ((t,regi,cesOut2cesIn(out,ppfen(in)),cesOut2cesIn2(out,in2))$( 
-                                        o01_CESderivatives(t,regi,"inco",in2) ),
-  o01_CESmrs(t,regi,in,in2)$(o01_CESderivatives(t,regi,"inco",in2) gt 0)
-  = o01_CESderivatives(t,regi,"inco",in)
-  / o01_CESderivatives(t,regi,"inco",in2)
+loop ((ttot,regi,cesOut2cesIn(out,ppfen(in)),cesOut2cesIn2(out,in2))$(
+                                        o01_CESderivatives(ttot,regi,"inco",in2) ),
+  o01_CESmrs(ttot,regi,in,in2)$(o01_CESderivatives(ttot,regi,"inco",in2) gt 0)
+  = o01_CESderivatives(ttot,regi,"inco",in)
+  / o01_CESderivatives(ttot,regi,"inco",in2)
   );
 
 *** total CES efficiency as diagnostic output parameter

--- a/modules/36_buildings/simple/datainput.gms
+++ b/modules/36_buildings/simple/datainput.gms
@@ -99,24 +99,24 @@ $endif.feShareScenario
 *` are given by the marginal rate of subsitution (MRS) in the parameter o01_CESmrs.
 
 *` There are two types of CES mark-up cost:
-*` (a) Mark-up cost on inputs in ppfen_MkupCost37: Those are counted as expenses in the budget and set by the parameter p37_CESMkup. 
+*` (a) Mark-up cost on inputs in ppfen_MkupCost36: Those are counted as expenses in the budget and set by the parameter p36_CESMkup.
 *` (b) Mark-up cost on other inputs: Those are budget-neutral and implemented as a tax. They are set by the parameter pm_tau_ces_tax. 
 
 *` Mark-up cost in buildings are modeled with budget-effect (a).
 
 *` default values of CES mark-up with budget effect:
-p36_CESMkup(t,regi,in) = 0;
+p36_CESMkup(ttot,regi,in) = 0;
 *` mark-up cost on heat pumps and district heating are incurred as actual cost to the budget (see option (a) above)
 *` place markup cost on heat pumps electricity of 200 USD/MWh(el) to represent demand-side cost of electrification
 *` and reach higher efficiency during calibration to model higher energy efficiency of heat pumps
-p36_CESMkup(t,regi,"feelhpb") = 200 * sm_TWa_2_MWh * 1e-12;
+p36_CESMkup(ttot,regi,"feelhpb") = 200 * sm_TWa_2_MWh * 1e-12;
 *` place markup cost on district heating of 25 USD/MWh(heat) to represent additional t&d cost of expanding district heating networks for buildings
 *` which makes district heating in buildings more expensive than in industry
-p36_CESMkup(t,regi,"feheb") = 25 * sm_TWa_2_MWh * 1e-12;
+p36_CESMkup(ttot,regi,"feheb") = 25 * sm_TWa_2_MWh * 1e-12;
 
 *` overwrite or extent CES markup cost if specified by switch
 $ifThen.CESMkup not "%cm_CESMkup_build%" == "standard"
-  p36_CESMkup(t,regi,in)$(p36_CESMkup_input(in)
+  p36_CESMkup(ttot,regi,in)$(p36_CESMkup_input(in)
                           AND ppfen_MkupCost36(in)) =
     p36_CESMkup_input(in);
   pm_tau_ces_tax(t,regi,in)$(p36_CESMkup_input(in)

--- a/modules/37_industry/fixed_shares/datainput.gms
+++ b/modules/37_industry/fixed_shares/datainput.gms
@@ -151,14 +151,14 @@ $endif.feShareScenario
 $ENDIF.feShare
 
 *** FS: CES markup cost industry
-p37_CESMkup(t,regi,in) = 0;
+p37_CESMkup(ttot,regi,in) = 0;
 *** in standard case, apply markup-cost of 0.5 trUSD/TWa to feeli to represent demand-side cost of electrification and 
 *** obtain a higher efficiency in calibration to mimic energy efficiency gains with increasing electricity share
-p37_CESMkup(t,regi,"feeli") = 0.5;
+p37_CESMkup(ttot,regi,"feeli") = 0.5;
 
 *** overwrite or extent CES markup cost if specified by switch
 $ifThen.CESMkup not "%cm_CESMkup_ind%" == "standard" 
-  p37_CESMkup(t,regi,in)$(p37_CESMkup_input(in)) = p37_CESMkup_input(in);
+  p37_CESMkup(ttot,regi,in)$(p37_CESMkup_input(in)) = p37_CESMkup_input(in);
 $endIf.CESMkup
 
 display p37_CESMkup;

--- a/modules/37_industry/subsectors/datainput.gms
+++ b/modules/37_industry/subsectors/datainput.gms
@@ -430,7 +430,7 @@ pm_ue_eff_target("ue_otherInd")         = 0.008;
 *` Mark-up cost in industry are modeled without budget-effect (b).
 
 *` Default industry mark-up cost with budget effect:
-p37_CESMkup(t,regi,in) = 0;
+p37_CESMkup(ttot,regi,in) = 0;
 
 *` Default industry mark-up cost without budget effect:
 *` mark-up cost on electrification (hth_electricity inputs), to reach >1 MRS to gas/liquids as technical efficiency gains from electrification
@@ -447,8 +447,8 @@ pm_tau_ces_tax(t,regi,"feh2_cement") = 100* sm_TWa_2_MWh * 1e-12;
 
 *` overwrite or extent CES markup cost if specified by switch
 $ifThen.CESMkup not "%cm_CESMkup_ind%" == "standard"
-  p37_CESMkup(t,regi,in)$(p37_CESMkup_input(in) AND ppfen_MkupCost37(in)) = p37_CESMkup_input(in);
-  pm_tau_ces_tax(t,regi,in)$(p37_CESMkup_input(in) AND (NOT ppfen_MkupCost37(in))) = p37_CESMkup_input(in);
+  p37_CESMkup(ttot,regi,in)$(p37_CESMkup_input(in) AND ppfen_MkupCost37(in)) = p37_CESMkup_input(in);
+  pm_tau_ces_tax(ttot,regi,in)$(p37_CESMkup_input(in) AND (NOT ppfen_MkupCost37(in))) = p37_CESMkup_input(in);
 $endIf.CESMkup
 
 display p37_CESMkup;


### PR DESCRIPTION
## Purpose of this PR

- part of https://github.com/remindmodel/development_issues/issues/220
- fixes the values for `Internal|CES Markup Cost|*` and `Internal|Price|CES` to the reference run

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)

## Further information (optional):

* Test runs are here: 
* `/p/tmp/oliverr/remind/output/SSP2EU-NPi_2023-10-12_17.07.50`, `/p/tmp/oliverr/remind/output/SSP2EU-NDC_2023-10-13_12.46.21`

