### PR TITLE
Bugfix average CO2 tax calculation

### DIFF
--- a/modules/47_regipol/regiCarbonPrice/postsolve.gms
+++ b/modules/47_regipol/regiCarbonPrice/postsolve.gms
@@ -315,6 +315,13 @@ loop(ext_regi$regiEmiMktTarget(ext_regi),
   );
 );
 
+***  Assuming that other emissions outside the ESR and ETS see prices equal to the ESR prices
+loop((ttot,ttot2,ext_regi,emiMktExt,target_type_47,emi_type_47)$(pm_emiMktTarget(ttot,ttot2,ext_regi,"ESR",target_type_47,emi_type_47) or pm_emiMktTarget(ttot,ttot2,ext_regi,"all",target_type_47,emi_type_47)),
+  loop(regi$regi_groupExt(ext_regi,regi),
+    pm_taxemiMkt(t,regi,"other") = pm_taxemiMkt(t,regi,"ES");
+  );
+);
+
 *** updating periods after current target
 loop(ext_regi$regiEmiMktTarget(ext_regi),
   if(not(p47_allTargetsConverged(ext_regi) eq 1), !!no rescale need if all targets already converged
@@ -345,13 +352,6 @@ loop(ext_regi$regiEmiMktTarget(ext_regi),
         );
       );
     );
-  );
-);
-
-***  Assuming that other emissions outside the ESR and ETS see prices equal to the ESR prices
-loop((ttot,ttot2,ext_regi,emiMktExt,target_type_47,emi_type_47)$(pm_emiMktTarget(ttot,ttot2,ext_regi,"ESR",target_type_47,emi_type_47) or pm_emiMktTarget(ttot,ttot2,ext_regi,"all",target_type_47,emi_type_47)),
-  loop(regi$regi_groupExt(ext_regi,regi),
-    pm_taxemiMkt(t,regi,"other") = pm_taxemiMkt(t,regi,"ES");
   );
 );
 

--- a/modules/47_regipol/regiCarbonPrice/postsolve.gms
+++ b/modules/47_regipol/regiCarbonPrice/postsolve.gms
@@ -283,6 +283,7 @@ loop((ttot,ttot2,ext_regi,emiMktExt,target_type_47,emi_type_47)$pm_emiMktTarget(
 p47_factorRescaleSlope_iter(iteration,ttot,ttot2,ext_regi,emiMktExt) = p47_factorRescaleSlope(ttot,ttot2,ext_regi,emiMktExt);
 p47_factorRescaleemiMktCO2Tax_iter(iteration,ttot,ttot2,ext_regi,emiMktExt) = pm_factorRescaleemiMktCO2Tax(ttot,ttot2,ext_regi,emiMktExt); !!save rescale factor across iterations for debugging of target convergence issues
 
+*** updating periods under current target
 loop(ext_regi$regiEmiMktTarget(ext_regi),
 *** solving targets sequentially, i.e. only apply target convergence algorithm if previous yearly targets were already achieved
   if(not(p47_allTargetsConverged(ext_regi) eq 1), !!no rescale need if all targets already converged
@@ -308,6 +309,18 @@ loop(ext_regi$regiEmiMktTarget(ext_regi),
           loop(ttot3$(ttot3.val eq s47_prefreeYear), !! ttot3 = beginning of slope; ttot2 = end of slope
             pm_taxemiMkt(t,regi,emiMkt)$((t.val ge s47_firstFreeYear) AND (t.val lt ttot2.val))  = pm_taxemiMkt(ttot3,regi,emiMkt) + ((pm_taxemiMkt(ttot2,regi,emiMkt) - pm_taxemiMkt(ttot3,regi,emiMkt))/(ttot2.val-ttot3.val))*(t.val-ttot3.val); 
           );
+        );
+      );
+    );
+  );
+);
+
+*** updating periods after current target
+loop(ext_regi$regiEmiMktTarget(ext_regi),
+  if(not(p47_allTargetsConverged(ext_regi) eq 1), !!no rescale need if all targets already converged
+    loop((ttot,ttot2,emiMktExt,target_type_47,emi_type_47)$(pm_emiMktTarget(ttot,ttot2,ext_regi,emiMktExt,target_type_47,emi_type_47) AND (ttot2.val eq p47_currentConvergencePeriod(ext_regi))),
+      loop(emiMkt$emiMktGroup(emiMktExt,emiMkt),
+        loop(regi$regiEmiMktTarget2regi_47(ext_regi,regi),
 ***       if last year target, fixed year increase after terminal year price (cm_postTargetIncrease €/tCO2 increase per year)
           if((ttot2.val eq p47_lastTargetYear(ext_regi)),
             pm_taxemiMkt(t,regi,emiMkt)$(t.val gt ttot2.val) = pm_taxemiMkt(ttot2,regi,emiMkt) + (cm_postTargetIncrease*sm_DptCO2_2_TDpGtC)*(t.val-ttot2.val);


### PR DESCRIPTION
## Purpose of this PR

Bugfix.

### Issue:

- Average CO2 emission market tax was wrongly calculated before because it was being calculated in the same loop statement that the CO2 emission market tax was being updated.

### Solution:

- Move CO2 tax definition for periods after the current target to an independent loop.

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)

## Further information (optional):

* Test runs are here: 
`/p/projects/ecemf/REMIND/2040_scenarios/v04_2023_06_02_WP5/output/new_04_Nzero_57_bio7p5_EU27_2023-10-16_15.02.05`

* Comparison of results (what changes by this PR?):
`/p/projects/ecemf/REMIND/2040_scenarios/v04_2023_06_02_WP5/compScen-NZero57_fixBug-2023-10-17_11.40.27-EU27.pdf`

