### PR TITLE
cleaning and refactoring, use pm_taxCO2eqSum where possible, delete pm_pvpRegi

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -59,7 +59,7 @@ Imports:
     raster,
     readr,
     readxl,
-    remind2 (>= 1.112.0),
+    remind2 (>= 1.122.0),
     renv,
     reshape2,
     reticulate,

--- a/core/declarations.gms
+++ b/core/declarations.gms
@@ -19,7 +19,6 @@ parameters
 ***prices
 pm_pvp(ttot,all_enty)                                "Price on commodity markets",
 p_pvpRef(ttot,all_enty)                              "Price on commodity markets - imported from REF gdx",
-pm_pvpRegi(ttot,all_regi,all_enty)                   "prices of traded commodities - regional. only used for permit trade"
 
 p_pvpRegiBeforeStartYear(ttot,all_regi,all_enty)     "prices of traded commodities before start year - regional. only used for permit trade"
 

--- a/core/postsolve.gms
+++ b/core/postsolve.gms
@@ -19,7 +19,7 @@ $else.neg
     pm_taxCO2eqSum(ttot,regi) = abs( abs(q_co2eq.m(ttot,regi)) / (abs(qm_budget.m(ttot,regi))+ sm_eps) );
 $endif.neg 
    elseif (cm_emiscen eq 1),  !! even in a BAU scenario without other climate policies, the 2010/2015/2020 CO2 prices should be reported (that still needs to be fixed, I guess, maybe by adding the historic prices to the 45/carbonprice/off variation
-    pm_taxCO2eqSum(ttot,regi)$(ttot.val < 2025) = abs( pm_taxCO2eq(ttot,regi)); 
+    pm_taxCO2eqSum(ttot,regi)$(ttot.val < 2025) = pm_taxCO2eq(ttot,regi); 
 );
 
 if(cm_iterative_target_adj eq 4,

--- a/core/postsolve.gms
+++ b/core/postsolve.gms
@@ -12,7 +12,7 @@
 p_taxCO2eq_iteration(iteration,ttot,regi) = pm_taxCO2eq(ttot,regi);
 pm_taxemiMkt_iteration(iteration,ttot,regi,emiMkt) = pm_taxemiMkt(ttot,regi,emiMkt);
 
-if (cm_emiscen eq 6), 
+if( (cm_emiscen eq 6), 
 $ifthen.neg %optimization% == 'negishi'     
     pm_taxCO2eqSum(ttot,regi) = abs((abs(q_co2eq.m(ttot,regi)) / pm_ts(ttot)) / (pm_pvp(ttot,"good") + sm_eps));
 $else.neg

--- a/core/postsolve.gms
+++ b/core/postsolve.gms
@@ -14,7 +14,7 @@ pm_taxemiMkt_iteration(iteration,ttot,regi,emiMkt) = pm_taxemiMkt(ttot,regi,emiM
 
 *RP* added the historic 2010/2015 CO2 prices 
 if (cm_emiscen eq 9,
- pm_pvpRegi(ttot,regi,"perm") = (pm_taxCO2eq(ttot,regi) + pm_taxCO2eqRegi(ttot,regi) + pm_taxCO2eqSCC(ttot,regi))* pm_pvp(ttot,"good");
+ pm_pvpRegi(ttot,regi,"perm") = pm_taxCO2eqSum(ttot,regi)* pm_pvp(ttot,"good");
 elseif (cm_emiscen eq 6), !! the 2010/2015 CO2 prices do not need to be individually included, as they already influence the marginal of the q_co2eq equation (empirically tested) 
 
 $ifthen.neg %optimization% == 'negishi'     

--- a/core/postsolve.gms
+++ b/core/postsolve.gms
@@ -12,36 +12,6 @@
 p_taxCO2eq_iteration(iteration,ttot,regi) = pm_taxCO2eq(ttot,regi);
 pm_taxemiMkt_iteration(iteration,ttot,regi,emiMkt) = pm_taxemiMkt(ttot,regi,emiMkt);
 
-*RP* added the historic 2010/2015 CO2 prices 
-if (cm_emiscen eq 9,
- pm_pvpRegi(ttot,regi,"perm") = pm_taxCO2eqSum(ttot,regi)* pm_pvp(ttot,"good");
-elseif (cm_emiscen eq 6), !! the 2010/2015 CO2 prices do not need to be individually included, as they already influence the marginal of the q_co2eq equation (empirically tested) 
-
-$ifthen.neg %optimization% == 'negishi'     
- pm_pvpRegi(ttot,regi,"perm") = abs(q_co2eq.m(ttot,regi)) / pm_ts(ttot) ;
-$else.neg
-pm_pvpRegi(ttot,regi,"perm") = abs(q_co2eq.m(ttot,regi)) / (abs(qm_budget.m(ttot,regi) )+ sm_eps) * pm_pvp(ttot,"good") ; 
-$endif.neg 
-   
-elseif (cm_emiscen eq 1),  !! even in a BAU scenario without other climate policies, the 2010/2015/2020 CO2 prices should be reported (that still needs to be fixed, I guess, maybe by adding the historic prices to the 45/carbonprice/off variation
- pm_pvpRegi(ttot,regi,"perm")$(ttot.val < 2025) = ( pm_taxCO2eq(ttot,regi) * pm_pvp(ttot,"good") );
-    
-);
-*** if the bau or ref gdx has been run with a carbon tax (e.g. cm_emiscen=9), overwrite values before cm_startyear  
-if ( (cm_startyear gt 2005),
-  Execute_Loadpoint 'input_ref' p_pvpRegiBeforeStartYear = pm_pvpRegi;
-  pm_pvpRegi(ttot,regi,"perm")$((ttot.val gt 2005) AND (ttot.val lt cm_startyear)) = p_pvpRegiBeforeStartYear(ttot,regi,"perm");
-);
-
-*LB* use the global permit price as regional permit price if no regional permit price is calculated
-loop(ttot$(ttot.val ge 2005),
-  loop(regi,
-    if(pm_pvpRegi(ttot,regi,"perm") eq NA,
-      pm_pvpRegi(ttot,regi,"perm") = pm_pvp(ttot,"perm");
-    );
-  );
-);
-
 if(cm_iterative_target_adj eq 4,
 *JeS* Update tax levels/ multigasbudget values to reach the CO2 FF&I budget (s_actualbudgetco2 runs from 2020-2100)
 *KK* for a time step of 5 years, the budget is calculated as 3 * 2020 + ts(2025-2090) + 8 * 2100;

--- a/core/postsolve.gms
+++ b/core/postsolve.gms
@@ -12,6 +12,16 @@
 p_taxCO2eq_iteration(iteration,ttot,regi) = pm_taxCO2eq(ttot,regi);
 pm_taxemiMkt_iteration(iteration,ttot,regi,emiMkt) = pm_taxemiMkt(ttot,regi,emiMkt);
 
+if (cm_emiscen eq 6), 
+$ifthen.neg %optimization% == 'negishi'     
+    pm_taxCO2eqSum(ttot,regi) = abs((abs(q_co2eq.m(ttot,regi)) / pm_ts(ttot)) / (pm_pvp(ttot,"good") + sm_eps));
+$else.neg
+    pm_taxCO2eqSum(ttot,regi) = abs( abs(q_co2eq.m(ttot,regi)) / (abs(qm_budget.m(ttot,regi))+ sm_eps) );
+$endif.neg 
+   elseif (cm_emiscen eq 1),  !! even in a BAU scenario without other climate policies, the 2010/2015/2020 CO2 prices should be reported (that still needs to be fixed, I guess, maybe by adding the historic prices to the 45/carbonprice/off variation
+    pm_taxCO2eqSum(ttot,regi)$(ttot.val < 2025) = abs( pm_taxCO2eq(ttot,regi)); 
+);
+
 if(cm_iterative_target_adj eq 4,
 *JeS* Update tax levels/ multigasbudget values to reach the CO2 FF&I budget (s_actualbudgetco2 runs from 2020-2100)
 *KK* for a time step of 5 years, the budget is calculated as 3 * 2020 + ts(2025-2090) + 8 * 2100;

--- a/core/preloop.gms
+++ b/core/preloop.gms
@@ -38,6 +38,7 @@ vm_co2eqMkt.l(ttot,regi,emiMkt) = 0;
 v_shfe.l(t,regi,enty,sector) = 0;
 v_shGasLiq_fe.l(t,regi,sector) = 0;  
 pm_share_CCS_CCO2(t,regi) = 0; 
+pm_taxCO2eqSum(t,regi) = 0;
 
 *** overwrite default targets with gdx values if wanted
 Execute_Loadpoint 'input' p_emi_budget1_gdx = sm_budgetCO2eqGlob;

--- a/core/preloop.gms
+++ b/core/preloop.gms
@@ -38,7 +38,6 @@ vm_co2eqMkt.l(ttot,regi,emiMkt) = 0;
 v_shfe.l(t,regi,enty,sector) = 0;
 v_shGasLiq_fe.l(t,regi,sector) = 0;  
 pm_share_CCS_CCO2(t,regi) = 0; 
-pm_pvpRegi(ttot,regi,enty) = 0;
 
 *** overwrite default targets with gdx values if wanted
 Execute_Loadpoint 'input' p_emi_budget1_gdx = sm_budgetCO2eqGlob;

--- a/core/preloop.gms
+++ b/core/preloop.gms
@@ -45,6 +45,7 @@ Execute_Loadpoint 'input' p_emi_budget1_gdx = sm_budgetCO2eqGlob;
 Execute_Loadpoint 'input' vm_demPe.l = vm_demPe.l;
 Execute_Loadpoint 'input' q_balPe.m = q_balPe.m;
 Execute_Loadpoint 'input' qm_budget.m = qm_budget.m;
+Execute_Loadpoint 'input' q_co2eq.m = q_co2eq.m;
 Execute_Loadpoint 'input' pm_pvp = pm_pvp;
 Execute_Loadpoint 'input' vm_demFeSector.l = vm_demFeSector.l;
 

--- a/core/presolve.gms
+++ b/core/presolve.gms
@@ -112,25 +112,7 @@ loop(regi,
           );
     );
 
-  if (cm_emiscen eq 9 or (cm_emiscen eq 10),
-*** TODO: take care, this means that the SCC are only priced into MAC-curve
-*** abatement if emiscen = 9 and for emiscen = 10 for CBA runs. Might want to change this.
-    p_priceCO2(ttot,regi) = pm_taxCO2eqSum(ttot,regi) * 1000;
-  elseif (cm_emiscen eq 6), 
-$ifthen.neg %optimization% == 'negishi'     
-    p_priceCO2(ttot,regi) 
-    = abs((abs(q_co2eq.m(ttot,regi)) / pm_ts(ttot)) / (pm_pvp(ttot,"good") + sm_eps))
-     * 1000;
-$else.neg
-    p_priceCO2(ttot,regi) 
-    = abs( abs(q_co2eq.m(ttot,regi)) / (abs(qm_budget.m(ttot,regi))+ sm_eps)  )
-     * 1000;
-$endif.neg 
-   elseif (cm_emiscen eq 1),  !! even in a BAU scenario without other climate policies, the 2010/2015/2020 CO2 prices should be reported (that still needs to be fixed, I guess, maybe by adding the historic prices to the 45/carbonprice/off variation
-    p_priceCO2(ttot,regi)$(ttot.val < 2025) 
-    = abs( pm_taxCO2eq(ttot,regi))
-     * 1000; 
-);
+p_priceCO2(ttot,regi) = pm_taxCO2eqSum(ttot,regi) * 1000;
 
 *** Define co2 price for entities that are used in MAC. 
 loop((enty,enty2)$emiMac2mac(enty,enty2), !! make sure that both mac sectors and mac curves have prices asigned as both sets are used in calculations below

--- a/core/presolve.gms
+++ b/core/presolve.gms
@@ -115,7 +115,7 @@ loop(regi,
   if (cm_emiscen eq 9 or (cm_emiscen eq 10),
 *** TODO: take care, this means that the SCC are only priced into MAC-curve
 *** abatement if emiscen = 9 and for emiscen = 10 for CBA runs. Might want to change this.
-    p_priceCO2(ttot,regi) = (pm_taxCO2eq(ttot,regi) + pm_taxCO2eqRegi(ttot,regi) + pm_taxCO2eqSCC(ttot,regi) )* 1000;
+    p_priceCO2(ttot,regi) = pm_taxCO2eqSum(ttot,regi) * 1000;
   else
     p_priceCO2(ttot,regi) 
     = abs(pm_pvpRegi(ttot,regi,"perm") / (pm_pvp(ttot,"good") + sm_eps))

--- a/core/presolve.gms
+++ b/core/presolve.gms
@@ -116,11 +116,21 @@ loop(regi,
 *** TODO: take care, this means that the SCC are only priced into MAC-curve
 *** abatement if emiscen = 9 and for emiscen = 10 for CBA runs. Might want to change this.
     p_priceCO2(ttot,regi) = pm_taxCO2eqSum(ttot,regi) * 1000;
-  else
+  elseif (cm_emiscen eq 6), 
+$ifthen.neg %optimization% == 'negishi'     
     p_priceCO2(ttot,regi) 
-    = abs(pm_pvpRegi(ttot,regi,"perm") / (pm_pvp(ttot,"good") + sm_eps))
-    * 1000;
-  );
+    = abs((abs(q_co2eq.m(ttot,regi)) / pm_ts(ttot)) / (pm_pvp(ttot,"good") + sm_eps))
+     * 1000;
+$else.neg
+    p_priceCO2(ttot,regi) 
+    = abs( abs(q_co2eq.m(ttot,regi)) / (abs(qm_budget.m(ttot,regi))+ sm_eps)  )
+     * 1000;
+$endif.neg 
+   elseif (cm_emiscen eq 1),  !! even in a BAU scenario without other climate policies, the 2010/2015/2020 CO2 prices should be reported (that still needs to be fixed, I guess, maybe by adding the historic prices to the 45/carbonprice/off variation
+    p_priceCO2(ttot,regi)$(ttot.val < 2025) 
+    = abs( pm_taxCO2eq(ttot,regi))
+     * 1000; 
+);
 
 *** Define co2 price for entities that are used in MAC. 
 loop((enty,enty2)$emiMac2mac(enty,enty2), !! make sure that both mac sectors and mac curves have prices asigned as both sets are used in calculations below

--- a/modules/21_tax/on/postsolve.gms
+++ b/modules/21_tax/on/postsolve.gms
@@ -15,7 +15,7 @@ OPTION decimals =5;
 display p21_deltarev;
 OPTION decimals =3;
 
-*** sum all 4 CO2eq tax components
+*** sum all 3 CO2eq tax components
 pm_taxCO2eqSum(ttot,regi) = pm_taxCO2eq(ttot,regi) + pm_taxCO2eqRegi(ttot,regi) + pm_taxCO2eqSCC(ttot,regi);
 
 *GL* save reference level value of taxes for revenue recycling

--- a/modules/80_optimization/nash/not_used.txt
+++ b/modules/80_optimization/nash/not_used.txt
@@ -7,7 +7,6 @@
 name,                type,        reason
 cm_solver_try_max,   switch,      not needed
 pm_prtp,             parameter,   ???
-pm_pvpRegi,          parameter,   ???
 pm_taxCO2eq,         parameter,   ???
 pm_ttot_val,         parameter,   ???
 pm_welf,             parameter,   ???

--- a/modules/80_optimization/negishi/postsolve.gms
+++ b/modules/80_optimization/negishi/postsolve.gms
@@ -76,7 +76,7 @@ p80_nw(iteration+1,regi) = pm_w(regi);
 p80_defic_sum(iteration+1) = sum(regi, abs(p80_defic(iteration,regi)));
 p80_defic_sumLast = p80_defic_sum(iteration+1);
 
-display p80_alpha_nw, s80_alpha_avg, pm_pvpRegi, pm_pvp, pm_w, p80_defic, p80_defic_sum, p80_defic_sumLast;
+display p80_alpha_nw, s80_alpha_avg, pm_pvp, pm_w, p80_defic, p80_defic_sum, p80_defic_sumLast;
 OPTION decimals =5;
 display p80_nw;
 OPTION decimals =3;

--- a/modules/80_optimization/testOneRegi/not_used.txt
+++ b/modules/80_optimization/testOneRegi/not_used.txt
@@ -34,7 +34,6 @@ sm_fadeoutPriceAnticip,         scalar,     ???
 vm_co2eq,                       variable,   ???
 pm_taxCO2eq,                    parameter,  ???
 cm_emiscen,                     switch,     ???
-pm_pvpRegi,                     parameter,  ???
 pm_nfa_start,                   input,      questionnaire
 vm_dummyBudget,                 input,      questionnaire
 vm_cesIO,                       variable,   ???


### PR DESCRIPTION
## Purpose of this PR
Cleaning and refactoring to ensure exact same values for year before startyear of ref secenario and current scenario. Use pm_taxCO2eqSum where possible and delete pm_pvpRegi.

## Type of change

- [x] Refactoring


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

