### PR TITLE
adjust geohdr costs to be consistent with region specific 2015-2040 values

### DIFF
--- a/core/input/generisdata_tech.prn
+++ b/core/input/generisdata_tech.prn
@@ -57,7 +57,7 @@ lifetime              35         35          40          40          40         
 
 +                geohdr       geohe       hydro        wind         windoff     spv       solhe         csp
 tech_stat            1
-inco0               3600        1200        2700        2400         5000       5160        9999       10320
+inco0               1950        1200        2700        2400         5000       5160        9999       10320
 constrTme            4           1           5            1            4          1           1          3
 mix0
 eta                 1.00        1.00        1.00        1.00         1.00       1.00        1.00        1.00

--- a/core/input/generisdata_tech_SSP1.prn
+++ b/core/input/generisdata_tech_SSP1.prn
@@ -57,7 +57,7 @@ lifetime              35         35          40          40          40         
 
 +                geohdr       geohe       hydro        wind         windoff     spv       solhe         csp
 tech_stat            1
-inco0               3600        1200        2700        2400         5000       5160        9999       10320
+inco0               1950        1200        2700        2400         5000       5160        9999       10320
 constrTme            4           1           5            1            4          1           1          3
 mix0
 eta                 1.00        1.00        1.00        1.00         1.00       1.00        1.00        1.00

--- a/core/input/generisdata_tech_SSP5.prn
+++ b/core/input/generisdata_tech_SSP5.prn
@@ -56,7 +56,7 @@ lifetime              35         35          40          40          40         
 
 +                geohdr       geohe       hydro        wind       windoff        spv       solhe         csp
 tech_stat            1
-inco0               3600        1200        2700        2400       5000         5160        9999       10320
+inco0               1950        1200        2700        2400       5000         5160        9999       10320
 constrTme            4           1           5            1          4            1           1          3
 mix0                
 eta                 1.00        1.00        1.00        1.00       1.00         1.00        1.00        1.00


### PR DESCRIPTION


## Purpose of this PR
This fixes an issue with Capital Costs for Geothermal electricity falling in the near-term but then rising until 2070 by lowering the value they are converging towards: the `inco0` of `geohdr` in the `generisdata_tech.prn` files.

Due to very limited resource potentials, this will likely not have a strong effect on geothermal electricity generation.

## Type of change

- [x] Bug fix 
- [x] Minor change (default scenarios show only small differences)


## Checklist:

- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information:

* Test runs are here: 
* Comparison of results: 

