### PR TITLE
catch and count checkConfig errors

### DIFF
--- a/scripts/start/checkFixCfg.R
+++ b/scripts/start/checkFixCfg.R
@@ -8,14 +8,23 @@
 #' @author Oliver Richters
 #' @return updated cfg
 checkFixCfg <- function(cfg, remindPath = ".", testmode = FALSE) {
-  refcfg <- gms::readDefaultConfig(remindPath)
-  gms::check_config(cfg, reference_file = refcfg, modulepath = file.path(remindPath, "modules"),
-                    settings_config = file.path(remindPath, "config", "settings_config.csv"),
-                    extras = c("backup", "remind_folder", "pathToMagpieReport", "cm_nash_autoconverge_lastrun",
-                               "gms$c_expname", "restart_subsequent_runs", "gms$c_GDPpcScen",
-                               "gms$cm_CES_configuration", "gms$c_description", "model"))
-
   errorsfound <- 0
+  red   <- "\033[0;31m"
+  NC    <- "\033[0m"   # No Color
+
+  refcfg <- gms::readDefaultConfig(remindPath)
+  remindextras <- c("backup", "remind_folder", "pathToMagpieReport", "cm_nash_autoconverge_lastrun",
+                               "gms$c_expname", "restart_subsequent_runs", "gms$c_GDPpcScen",
+                               "gms$cm_CES_configuration", "gms$c_description", "model")
+  fail <- tryCatch(gms::check_config(cfg, reference_file = refcfg, modulepath = file.path(remindPath, "modules"),
+                     settings_config = file.path(remindPath, "config", "settings_config.csv"),
+                     extras = remindextras),
+                     error = function(x) { paste0(red, "Error", NC, ": ", gsub("^Error: ", "", x)) } )
+  if (is.character(fail) && length(fail) == 1 && grepl("Error", fail)) {
+    message(fail, appendLF = FALSE)
+    if (testmode) warning(fail)
+    errorsfound <- errorsfound + 1
+  }
 
   ## regexp check
   # extract all instances of 'regexp' from main.gms
@@ -69,7 +78,7 @@ checkFixCfg <- function(cfg, remindPath = ".", testmode = FALSE) {
 
   # Check for compatibility with subsidizeLearning
   if ((cfg$gms$optimization != "nash") && (cfg$gms$subsidizeLearning == "globallyOptimal") ) {
-    message("Only optimization='nash' is compatible with subsidizeLearning='globallyOptimal'. Switching subsidizeLearning to 'off' now.\n")
+    message("Only optimization='nash' is compatible with subsidizeLearning='globallyOptimal'. Switching subsidizeLearning to 'off' now.")
     cfg$gms$subsidizeLearning <- "off"
   }
 
@@ -87,10 +96,12 @@ checkFixCfg <- function(cfg, remindPath = ".", testmode = FALSE) {
   } else {
     if (!is.na(cfg$files2export$start["input_bau.gdx"])) {
       message("Neither 'carbonprice' nor 'carbonpriceRegi' is set to 'NDC' but 'path_gdx_bau' ",
-              "is not empty introducing an unnecessary dependency to another run. Setting 'path_gdx_bau' to NA")
-      cfg$files2export$start["input_bau.gdx"] <- NA        
+              "is not empty introducing an unnecessary dependency to another run. Setting 'path_gdx_bau' to NA.")
+      cfg$files2export$start["input_bau.gdx"] <- NA
     }
+  }
+  if (errorsfound > 0) {
+    cfg$errorsfoundInCheckFixCfg <- errorsfound
   }  
-  
   return(cfg)
 }

--- a/start.R
+++ b/start.R
@@ -327,7 +327,10 @@ if (any(c("--reprepare", "--restart") %in% flags)) {
     # abort on too long paths ----
     cfg$gms$cm_CES_configuration <- calculate_CES_configuration(cfg, check = TRUE)
 
-    cfg <- checkFixCfg(cfg)
+    cfg <- checkFixCfg(cfg, testmode = "--test" %in% flags)
+    if ("errorsfoundInCheckFixCfg" %in% names(cfg)) {
+      errorsfound <- errorsfound + cfg$errorsfoundInCheckFixCfg
+    }
 
     # save the cfg object for the later automatic start of subsequent runs (after preceding run finished)
     if (! "--gamscompile" %in% flags) {

--- a/start_bundle_coupled.R
+++ b/start_bundle_coupled.R
@@ -550,7 +550,10 @@ for(scen in common){
       numberOfTasks <- 1
     }
 
-    cfg_rem <- checkFixCfg(cfg_rem, remindPath = path_remind)
+    cfg_rem <- checkFixCfg(cfg_rem, remindPath = path_remind, testmode = "--test" %in% flags)
+    if ("errorsfoundInCheckFixCfg" %in% names(cfg_rem)) {
+      errorsfound <- errorsfound + cfg_rem$errorsfoundInCheckFixCfg
+    }
 
     Rdatafile <- paste0(fullrunname, ".RData")
     message("Save settings to ", Rdatafile)

--- a/tutorials/13_Submit_to_IIASA_database.md
+++ b/tutorials/13_Submit_to_IIASA_database.md
@@ -87,7 +87,7 @@ yourfilter <- function(x) {
 }
 d <- quitte::read.snapshot("snapshot.csv", list(region = "World"), filter.function = yourfilter)
 ```
-If your computer supports the system commands `grep`, `head`, `sed` and `tail` (as the PIK cluster does), the
+If your computer supports the system commands `grep`, `head` and `tail` (as the PIK cluster does),
 using the list-based filtering reduces loading times, as the file size can be reduced _before_ reading the data into `R`.
 
 The following functions from `piamInterfaces` might be helpful for further analysis:


### PR DESCRIPTION
## Purpose of this PR

- if gms::check_config creates errors, the start script now stops immediatly
- in testmode, catch these errors and print them, but continue counting them so you get an overview about all the existing failures in your config file
- not in testmode, the script fails some lines later now, [here](https://github.com/remindmodel/remind/blob/a31cc3d907178fdc46ae6eba0bf46646b40aa6b4/scripts/start/checkFixCfg.R#L67), but that is fine
- typos in IIASA tutorial

## Type of change

- [x] Refactoring

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
