### PR TITLE
match all names(cfg) to scenario config columns

### DIFF
--- a/scripts/start/configureCfg.R
+++ b/scripts/start/configureCfg.R
@@ -16,9 +16,7 @@ configureCfg <- function(icfg, iscen, iscenarios, verboseGamsCompile = TRUE) {
     if (verboseGamsCompile) message("   Configuring cfg for ", iscen)
 
     # Edit main model file, region settings and input data revision based on scenarios table, if cell non-empty
-    for (switchname in intersect(c("model", "regionmapping", "extramappings_historic", "action",
-                                   "inputRevision", "slurmConfig", "results_folder", "force_replace", "pythonEnabled"),
-                                 names(iscenarios))) {
+    for (switchname in intersect(c("model", setdiff(names(icfg), "gms")), names(iscenarios))) {
       if ( ! is.na(iscenarios[iscen, switchname] )) {
         icfg[[switchname]] <- iscenarios[iscen, switchname]
       }

--- a/scripts/start/readCheckScenarioConfig.R
+++ b/scripts/start/readCheckScenarioConfig.R
@@ -120,9 +120,8 @@ readCheckScenarioConfig <- function(filename, remindPath = ".", testmode = FALSE
   errorsfound <- sum(toolong) + sum(regionname) + sum(nameisNA) + sum(illegalchars) + whitespaceErrors + copyConfigFromErrors + pathgdxerrors
 
   # check column names
-  knownColumnNames <- c(names(cfg$gms), names(path_gdx_list), "start", "output", "description", "model",
-                        "regionmapping", "extramappings_historic", "inputRevision", "slurmConfig",
-                        "results_folder", "force_replace", "action", "pythonEnabled", "copyConfigFrom")
+  knownColumnNames <- c(names(cfg$gms), setdiff(names(cfg), "gms"), names(path_gdx_list),
+                        "start", "model", "copyConfigFrom")
   if (grepl("scenario_config_coupled", filename)) {
     knownColumnNames <- c(knownColumnNames, "cm_nash_autoconverge_lastrun", "oldrun", "path_report", "magpie_scen",
                           "no_ghgprices_land_until", "qos", "sbatch", "path_mif_ghgprice_land", "max_iterations",
@@ -166,7 +165,7 @@ readCheckScenarioConfig <- function(filename, remindPath = ".", testmode = FALSE
               basename(filename), ":")
       message("  ", paste(unknownColumnNames, collapse = ", "))
       message("This check was added Jan. 2022. ",
-              "If you find false positives, add them to knownColumnNames in start/scripts/readCheckScenarioConfig.R.\n")
+              "If you find false positives, add them to knownColumnNames in scripts/start/readCheckScenarioConfig.R.\n")
       unknownColumnNamesNoComments <- unknownColumnNames[! grepl("^\\.", unknownColumnNames)]
       if (length(unknownColumnNamesNoComments) > 0) {
         if (testmode) {

--- a/start.R
+++ b/start.R
@@ -244,7 +244,7 @@ if (any(c("--reprepare", "--restart") %in% flags)) {
   # ask for slurmConfig if not specified for every run
   if ("--gamscompile" %in% flags) {
     slurmConfig <- "direct"
-    message("\nTrying to compile the selected runs...")
+    message("\nTrying to compile ", nrow(scenarios), " selected runs...")
     lockID <- gms::model_lock()
   }
   if (! exists("slurmConfig") & (any(c("--debug", "--quick", "--testOneRegi") %in% flags)

--- a/tests/testthat/test_01-readDefaultConfig.R
+++ b/tests/testthat/test_01-readDefaultConfig.R
@@ -1,0 +1,5 @@
+test_that("readDefaultConfig works", {
+  expect_no_warning(cfg <- gms::readDefaultConfig("../.."))
+  # make sure that no identical names are used to guarantee unique matching of scenario_config data
+  expect_identical(intersect(names(cfg), names(cfg$gms)), character(0))
+})


### PR DESCRIPTION
## Purpose of this PR

- until now, a hand-curated list of elements of `names(cfg)` were accepted as column names of scenario config and mapped to the cfg values
- Jakob noticed specifying `CESandGDXversion` in a scenario config did not work
- with this PR, accept and map every name of cfg. As `cfg$model` is currently not defined in `default.cfg` it needs an Extrawurst
- add a test to make sure that all elements `names(cfg)` and `names(cfg$gms)` are distinct to avoid a mess
- minor stuff: tell how many scenarios will be gamscompiled

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)

