### PR TITLE
in start_bundle_coupled, log which runs were started, which qos etc.

### DIFF
--- a/scripts/start/readCheckScenarioConfig.R
+++ b/scripts/start/readCheckScenarioConfig.R
@@ -100,7 +100,8 @@ readCheckScenarioConfig <- function(filename, remindPath = ".", testmode = FALSE
     BAUbutNotNeeded <- ! is.na(scenConf$path_gdx_bau) & ! (scenNeedsBau)
     if (sum(BAUbutNotNeeded) > 0) {
       msg <- paste0("In ", sum(BAUbutNotNeeded), " scenarios, 'path_gdx_bau' is not empty although no realization is selected that needs it.\n",
-                    "To avoid unnecessary dependencies to other runs, setting 'path_gdx_bau' to NA.")
+                    "To avoid unnecessary dependencies to other runs, setting 'path_gdx_bau' to NA for:\n",
+                    paste(rownames(scenConf)[BAUbutNotNeeded], collapse = ", "))
       message(msg)
       scenConf$path_gdx_bau[BAUbutNotNeeded] <- NA
     }


### PR DESCRIPTION
## Purpose of this PR
- show which scenarios have `path_gdx_bau` set to `NA`
- in `start_bundle_coupled.R`, log which runs were finished, which were started, which were waiting, which qos etc., instead of just counting them

old:
```
- 0 runs already finished.
- 0 folders deleted.
- 1 runs started.
- 8 runs are waiting.
qos statistics: auto: 9.
```
new
``` 
- 0 runs already finished:
- 0 folders deleted:
- 1 runs started: C_SSP2-Base-rem-1
- 8 runs are waiting: C_h_ndc_preUkraine-rem-1, C_h_ndc-rem-1, C_h_cpol-rem-1, C_o_1p5c-rem-1, C_o_lowdem-rem-1, C_o_2c-rem-1, C_d_delfrag-rem-1, C_d_strain-rem-1
- qos statistics: auto: 9.
```

## Type of change

- [x] Minor new feature 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
