### PR TITLE
in xlsx_IIASA export, improve project-specific settings

### DIFF
--- a/scripts/output/export/xlsx_IIASA.R
+++ b/scripts/output/export/xlsx_IIASA.R
@@ -27,41 +27,37 @@ iiasatemplate <- NULL                          # provided for each project, can 
 # note: you can also pass all these options to output.R, so 'Rscript output.R logFile=mylogfile.txt' works.
 lucode2::readArgs("project")
 
+projects <- list(
+  ELEVATE    = list(mapping = "NAVIGATE",
+                    iiasatemplate = "2023-05-26_template_ELEVATE.xlsx"),
+  ENGAGE_4p5 = list(mapping = c("AR6", "AR6_NGFS"),
+                    iiasatemplate = "ENGAGE_CD-LINKS_template_2019-08-22.xlsx",
+                    removeFromScen = "_diff|_expoLinear|-all_regi"),
+  NAVIGATE_coupled = list(mapping = c("NAVIGATE", "NAVIGATE_coupled")),
+  NGFS       = list(model = "REMIND-MAgPIE 3.2-4.6",
+                    mapping = c("AR6", "AR6_NGFS"),
+                    iiasatemplate = "../ngfs-phase-4-internal-workflow/definitions/variable/variables.yaml",
+                    removeFromScen = "C_|_bIT|_bit|_bIt"),
+  SHAPE      = list(mapping = c("NAVIGATE", "SHAPE")),
+  TESTTHAT   = list(mapping = "AR6")
+)
+
+# add pure mapping from piamInterfaces
+mappings <- setdiff(names(piamInterfaces::templateNames()), c(names(projects), "AR6_NGFS"))
+projects <- c(projects,
+              do.call(c, lapply(mappings, function(x) stats::setNames(list(list(mapping = x)), x))))
+
 ### Load project-specific settings
 if (! exists("project")) {
-  project <- gms::chooseFromList(c("ECEMF", "ENGAGE_4p5", "ELEVATE", "ESABCC", "NAVIGATE", "NGFS_v4", "SHAPE"), type = "project", multiple = FALSE,
+  project <- gms::chooseFromList(sort(setdiff(names(projects), "TESTTHAT")), type = "project", multiple = FALSE,
                                  userinfo = paste0("Select project settings or leave empty.\n",
-                                                   "You can add your own project by editing 'scripts/output/export/xlsx_IIASA.R'"))
+                                                   "You can adjust project settings by editing 'scripts/output/export/xlsx_IIASA.R'"))
 }
-if (! is.null(project)) {
-  message("# Overwrite settings with project settings for '", project, "'.")
-  if ("TESTTHAT" %in% project) {
-    mapping <- "AR6"
-  } else if ("AR6" %in% project) {
-    mapping <- "AR6"
-  } else if ("NGFS_v4" %in% project) {
-    model <- "REMIND-MAgPIE 3.2-4.6"
-    mapping <- c("AR6", "AR6_NGFS")
-    iiasatemplate <- "../ngfs-phase-4-internal-workflow/definitions/variable/variables.yaml"
-    removeFromScen <- "C_|_bIT|_bit|_bIt"
-  } else if ("ENGAGE_4p5" %in% project) {
-    mapping <- c("AR6", "AR6_NGFS")
-    iiasatemplate <- "ENGAGE_CD-LINKS_template_2019-08-22.xlsx"
-    removeFromScen <- "_diff|_expoLinear|-all_regi"
-  } else if ("ELEVATE" %in% project) {
-    mapping <- "NAVIGATE"
-    iiasatemplate <- "2023-05-26_template_ELEVATE.xlsx"
-  } else if ("ECEMF" %in% project) {
-    mapping <- "ECEMF"
-  } else if ("ESABCC" %in% project) {
-    mapping <- "ESABCC"
-  } else if ("NAVIGATE" %in% project) {
-    mapping <- "NAVIGATE"
-  } else if ("SHAPE" %in% project) {
-    mapping <- c("NAVIGATE", "SHAPE")
-  } else {
-    stop("# Command line argument project='", project, "' defined, but not understood.")
-  }
+projectdata <- projects[[project]]
+message("# Overwrite settings with project settings for '", project, "'.")
+varnames <- c("mapping", "iiasatemplate", "addToScen", "removeFromScen", "model", "outputFilename", "logFile")
+for (p in intersect(varnames, names(projectdata))) {
+  assign(p, projectdata[[p]])
 }
 
 # overwrite settings with those specified as command-line arguments

--- a/tests/testthat/test_06-output.R
+++ b/tests/testthat/test_06-output.R
@@ -32,5 +32,6 @@ test_that("output.R -> export -> xlsx_IIASA works", {
 test_that("cleanup output.R", {
   skipIfPreviousFailed()
   exportfiles <- Sys.glob(file.path("..", "..", "output", "export", "*TESTTHAT*"))
+  expect_true(length(exportfiles) > 1)
   unlink(exportfiles)
 })


### PR DESCRIPTION
## Purpose of this PR

- improve how project-specific settings can be entered
- if no `project` is supplied via command line, the user is asked which one (s)he wants
- specify settings for ELEVATE, plus SHAPE and NAVIGATE_coupled as they need more than one template

## Type of change

- [x] Refactoring

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
