### PR TITLE
fix automatic path_gdx_bau correction

### DIFF
--- a/modules/02_welfare/ineqLognormal/datainput.gms
+++ b/modules/02_welfare/ineqLognormal/datainput.gms
@@ -47,7 +47,7 @@ if ((cm_emiscen ne 1),
     Execute_Loadpoint 'input_ref' p02_damageFactor_ref=vm_damageFactor.l;
  
 * if energy system costs are used:
-*    Execute_Loadpoint 'input_bau' p02_energyExp_ref=vm_costEnergySys.l;
+*    Execute_Loadpoint 'input_ref' p02_energyExp_ref=vm_costEnergySys.l;
    
 );
 

--- a/scripts/start/checkFixCfg.R
+++ b/scripts/start/checkFixCfg.R
@@ -87,19 +87,21 @@ checkFixCfg <- function(cfg, remindPath = ".", testmode = FALSE) {
     cfg$output <- setdiff(cfg$output, "reportCEScalib")
   }
   
-  # Make sure that an input_bau.gdx has been specified if an NDC is to be calculated.
-  if (isTRUE(cfg$gms$carbonprice == "NDC") | isTRUE(cfg$gms$carbonpriceRegi == "NDC")) {
+  # Make sure that an input_bau.gdx has been specified if and only if needed.
+  isBauneeded <- isTRUE(length(unlist(lapply(names(needBau), function(x) intersect(cfg$gms[[x]], needBau[[x]])))) > 0)
+  if (isBauneeded) {
     if (is.na(cfg$files2export$start["input_bau.gdx"])) {
-      errormsg <- "'carbonprice' or 'carbonpriceRegi' is set to 'NDC' which requires a reference gdx in 'path_gdx_bau' but it is empty."
+      errormsg <- "A module requires a reference gdx in 'path_gdx_bau', but it is empty."
       if (testmode) warning(errormsg) else stop(errormsg)
     }
   } else {
-    if (!is.na(cfg$files2export$start["input_bau.gdx"])) {
-      message("Neither 'carbonprice' nor 'carbonpriceRegi' is set to 'NDC' but 'path_gdx_bau' ",
-              "is not empty introducing an unnecessary dependency to another run. Setting 'path_gdx_bau' to NA.")
+    if (! is.na(cfg$files2export$start["input_bau.gdx"])) {
+      message("You have specified no realization that requires 'path_gdx_bau' but you have specified it. ",
+              "To avoid an unnecessary dependency to another run, setting 'path_gdx_bau' to NA.")
       cfg$files2export$start["input_bau.gdx"] <- NA
     }
   }
+
   if (errorsfound > 0) {
     cfg$errorsfoundInCheckFixCfg <- errorsfound
   }  

--- a/scripts/start/needBau.R
+++ b/scripts/start/needBau.R
@@ -1,0 +1,13 @@
+# |  (C) 2006-2023 Potsdam Institute for Climate Impact Research (PIK)
+# |  authors, and contributors see CITATION.cff file. This file is part
+# |  of REMIND and licensed under AGPL-3.0-or-later. Under Section 7 of
+# |  AGPL-3.0, you are granted additional permissions described in the
+# |  REMIND License Exception, version 1.0 (see LICENSE file).
+# |  Contact: remind@pik-potsdam.de
+# This vector contains the module as name,
+# and the realizations that require a 'path_gdx_bau' as elements
+# This allows readCheckScenarioConfig and checkFixConfig to set it to NA
+# if not needed, and complain if it is missing.
+needBau <- list(carbonprice = c("NDC", "diffPriceSameCost"),
+                carbonpriceRegi = "NDC",
+                emicapregi = "AbilityToPay")

--- a/scripts/start/readCheckScenarioConfig.R
+++ b/scripts/start/readCheckScenarioConfig.R
@@ -83,6 +83,7 @@ readCheckScenarioConfig <- function(filename, remindPath = ".", testmode = FALSE
   }
   if ("path_gdx_bau" %in% names(scenConf)) {
     # fix if bau given despite not needed. needBau is defined in needBau.R
+    # initialize vector with FALSE everywhere and turn elements to TRUE if a scenario config row setting matches a needBau element
     scenNeedsBau <- rep(FALSE, nrow(scenConf))
     for (n in intersect(names(needBau), names(scenConf))) {
       scenNeedsBau <- scenNeedsBau | scenConf[[n]] %in% needBau[[n]]

--- a/scripts/start/readCheckScenarioConfig.R
+++ b/scripts/start/readCheckScenarioConfig.R
@@ -82,20 +82,10 @@ readCheckScenarioConfig <- function(filename, remindPath = ".", testmode = FALSE
     message(msg)
   }
   if ("path_gdx_bau" %in% names(scenConf)) {
-    # fix if bau given despite not needed
-    needBau <- list(welfare = "ineqLognormal",
-                    carbonprice = c("NDC", "diffPriceSameCost"),
-                    carbonpriceRegi = "NDC",
-                    emicapregi = "AbilityToPay")
+    # fix if bau given despite not needed. needBau is defined in needBau.R
     scenNeedsBau <- rep(FALSE, nrow(scenConf))
-    for (n in names(needBau)) {
-      if (n %in% names(scenConf)) {
-        if (n == "welfare" && "cm_emiscen" %in% names(scenConf)) {
-          scenNeedsBAU <- scenNeedsBau | (scenConf[[n]] %in% needBau[[n]] & scenConf[["cm_emiscen"]] != 1)
-        } else {
-          scenNeedsBau <- scenNeedsBau | scenConf[[n]] %in% needBau[[n]]
-        }
-      }
+    for (n in intersect(names(needBau), names(scenConf))) {
+      scenNeedsBau <- scenNeedsBau | scenConf[[n]] %in% needBau[[n]]
     }
     BAUbutNotNeeded <- ! is.na(scenConf$path_gdx_bau) & ! (scenNeedsBau)
     if (sum(BAUbutNotNeeded) > 0) {

--- a/tutorials/03_RunningBundleOfRuns.md
+++ b/tutorials/03_RunningBundleOfRuns.md
@@ -47,7 +47,7 @@ Example with comments and different ways to specify subsequent runs.
 The columns to implement subsequent runs are usually found at the end, starting with `path_gdx`:
 
 * `path_gdx` allows to specify initial conditions for the run, overwriting the usual initial conditions taken from the calibration files found in [`./config/gdx-files/`](../config/gdx-files/files). If it points to an unconverged run, this can be used to restart runs, similar to `Rscript start.R --restart`.
-* `path_gdx_bau` points to the run used as business as usual (BAU) scenario, for example for runs using [`45_carbonprice/NDC`](../modules/45_carbonprice/NDC), where some countries specify emission as percentage reduction compared to BAU.
+* `path_gdx_bau` points to the run used as business as usual (BAU) scenario, for example for runs using [`45_carbonprice/NDC`](../modules/45_carbonprice/NDC), where some countries specify emission as percentage reduction compared to BAU. All realizations needing it have to be summarized in [`scripts/start/needBau.R`](../scripts/start/needBau.R).
 * `path_gdx_carbonprice` can be used to use a carbon tax path from an earlier run with realization [`45_carbonprice/exogenous`](../modules/45_carbonprice/exogenous).
 * `path_gdx_ref` points to the run used for all `t < cm_startyear`, which can be used for example for delayed transition scenarios.
 * `path_gdx_refpolicycost` points to the run that is used as a comparison for the policy cost calculation. If no such column exists, `path_gdx_ref` is used instead.


### PR DESCRIPTION
## Purpose of this PR
- the inequality module does not need `path_gdx_bau` anymore, the last occurence was removed by @piontek, except for one that was commented out
- adjust second check in `checkFixConfig` that might remove the path_gdx_bau despite it being needed

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
