### PR TITLE
adjust test-code workflow to avoid timeout when installing gms

### DIFF
--- a/.github/workflows/test-code.yaml
+++ b/.github/workflows/test-code.yaml
@@ -18,20 +18,19 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Remove .Rprofile
         run: rm .Rprofile
 
       - uses: r-lib/actions/setup-r@v2
         with:
-          extra-repositories: https://cloud.r-project.org https://rse.pik-potsdam.de/r/packages/
+          extra-repositories: https://rse.pik-potsdam.de/r/packages/
 
       - name: Install R dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          packages: gms
-          extra-packages: gms
+          packages: any::gms
         
       - name: codeCheck
         run: null <- gms::codeCheck(strict=TRUE)


### PR DESCRIPTION
## Purpose of this PR

- With the current settings, installation of gms using pak was hanging until aborted (new issue since 30th October)
- I removed "https://cloud.r-project.org" from extra-repositiories, as for gms and its dependencies CRAN and the pik repo should suffice
- I removed `gms` from `extra-packages`, as gms should be installed as specified in the DESCRIPTION file 
- I added `any::` as a prefix to gms, since this seems to be the right way to do it
- I updated the checkout version to v3, since it is also used in current examples
- [Reference](https://github.com/r-lib/actions/tree/v2/setup-r-dependencies)


## Type of change

- [x] Bug fix 

