### PR TITLE
add missing "declarations" phase in  51_internalizeDamages/off/realization.gms so gamscompile won't stumble

### DIFF
--- a/modules/51_internalizeDamages/off/realization.gms
+++ b/modules/51_internalizeDamages/off/realization.gms
@@ -9,6 +9,7 @@
 *' @description The off-realization of the internalizeDamages module sets the parameter pm_taxCO2eqSCC to zero, meaning no social costs of carbon are included in the optimization.
 
 *####################### R SECTION START (PHASES) ##############################
+$Ifi "%phase%" == "declarations" $include "./modules/51_internalizeDamages/off/declarations.gms"
 $Ifi "%phase%" == "datainput" $include "./modules/51_internalizeDamages/off/datainput.gms"
 *######################## R SECTION END (PHASES) ###############################
 *** EOF ./modules/51_internalizeDamages/off/realization.gms


### PR DESCRIPTION
## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
