### PR TITLE
enable management of local calibration results

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -114,4 +114,14 @@ if (use_cluster_defaults &&
     "/p/projects/remind/inputdata/CESparametersAndGDX" = NULL))
 }
 
+# Include local calibration results, if they exist, from either the main
+# directory or output directories.
+path <- file.path(
+    c('.', file.path('..', '..')),
+    'calibration_results', '.Rprofile_calibration_results')
+
+path <- head(path[file.exists(path)], 1)
+
+if (!rlang::is_empty(path))
+    source(path)
 })

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,4 @@ runtime.rds
 # ignore slurm logs
 slurm-[0-9]*.log
 slurm-[0-9]*.out
+calibration_results/

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,15 @@
 .DEFAULT_GOAL := help
 
 # extracts the help text and formats it nicely
-HELP_PARSING = 'm <- readLines("Makefile");\
-				m <- grep("\#\#", m, value=TRUE);\
-				command <- sub("^([^ ]*) *\#\#(.*)", "\\1", m);\
-				help <- sub("^([^ ]*) *\#\#(.*)", "\\2", m);\
-				cat(sprintf("%-18s%s", command, help), sep="\n")'
+HELP_PARSING = 'm <- grep("\#\#", readLines("Makefile"), value = TRUE);\
+                parse <- "^([^[[:space:]]*)[[:space:]]*\#\#[[:space:]]*(.*)";\
+                command <- sub(parse, "\\1", m, perl = TRUE);\
+                help <- sub(parse, "\\2",  m, perl = TRUE);\
+                i <- grep("^$$", command, invert = TRUE)[-1];\
+                command[i] <- paste0("\n", command[i]);\
+                help[i] <- paste0(" ", help[i]);\
+                cat(sprintf("%-*s%s", max(nchar(command)), command, help),\
+                    sep = "\n")'
 
 help:            ## Show this help.
 	@Rscript -e $(HELP_PARSING)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-.PHONY: help docs update-renv update-renv-all archive-renv restore-renv check check-fix test test-coupled test-full
+.PHONY: help docs update-renv update-renv-all archive-renv restore-renv check \
+	check-fix test test-coupled test-full set-local-calibration
 .DEFAULT_GOAL := help
 
 # extracts the help text and formats it nicely
@@ -86,3 +87,7 @@ test-full:       ## Run all tests, including coupling tests and a default
 test-validation: ## Run validation tests, requires a full set of runs in the output folder
 	$(info Run validation tests, requires a full set of runs in the output folder)
 	@TESTTHAT_RUN_SLOW=TRUE Rscript -e 'testthat::test_dir("tests/testthat/validation")'	
+
+set-local-calibration:		## set up local calibration results directory
+	@./scripts/utils/set-local-calibration.sh
+	$(info use `collect_calibration` script in calibration_results/ directory )

--- a/scripts/utils/set-local-calibration.sh
+++ b/scripts/utils/set-local-calibration.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+caldir="calibration_results"
+
+# stop if calibration results directory already exists
+test -d "$caldir" && echo "$caldir directory already exists" && exit 1
+
+# create directory, ignore it,  initialise git in it, get hooks and set up 
+# the collection script
+mkdir "$caldir"
+grep -q "^$caldir/$" .gitignore || echo "$caldir/" >> .gitignore
+
+cd "$caldir"
+
+git init > /dev/null
+cp ../scripts/utils/set-local-calibration/collect_calibration ./
+cp ../scripts/utils/set-local-calibration/gitignore .gitignore
+chmod u+x collect_calibration
+
+git add collect_calibration .gitignore
+git commit --no-verify --quiet -m "set up local calibration results directory"
+
+cp ../scripts/utils/set-local-calibration/pre-commit .git/hooks
+cp ../scripts/utils/set-local-calibration/post-commit .git/hooks
+chmod u+x .git/hooks/pre-commit .git/hooks/post-commit
+
+cd "$OLDPWD"
+
+# create additional .Rprofile (sourced through default .Rprofile)
+echo -e "options(remind_repos = c(\n" \
+	"    getOption(\"remind_repos\"),\n" \
+	"    stats::setNames(list(x = NULL), \"$PWD/$caldir/\")))" \
+	> calibration_results/.Rprofile_calibration_results

--- a/scripts/utils/set-local-calibration/collect_calibration
+++ b/scripts/utils/set-local-calibration/collect_calibration
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+help="Usage: collect_calibration <path>
+Copy calibration .inc and .gdx files from REMIND calibration directories <path>,
+stage them, include their source in the commit message and initialise the
+commit.  The commit message can be amended in the editor."
+
+# show help and quit
+if [ -z "$*" ] || [ '-h' == "$1" ] || [ '--help' == "$1" ]
+then
+	echo "$help"
+	exit
+fi
+
+# unstage any files left that are not committed
+git reset --quiet HEAD
+
+# prepare commit message template
+echo "\
+new CES parameters and GDX files
+
+# add descriptions for parameter sources as needed
+# comments starting with '#' are ignored
+# quit the editor without saving to abort the commit (use \`:cq\` in vim)
+
+parameters based on calibrations:" > commit-message.txt
+
+# cycle through directories in parameters
+for d in "$@"
+do
+	# skip if not a directory
+	if [ ! -d "$d" ]
+	then
+		echo "skipping $d"
+		continue
+	fi
+
+	cd "$d"
+
+	# get CES configuration as base for file names
+	CES_config=$( sed -n 's/ *cm_CES_configuration: *//p' cfg.txt 2>/dev/null )
+
+	# get designated last calibration iteration
+	CES_itr=$( sed -n 's/ *c_CES_calibration_iterations:[^0-9]*\([0-9]\+\).*/\1/p' cfg.txt 2>/dev/null )
+
+	# skip if configuration is missing
+	if [ -z "$CES_config" ]
+	then
+		echo "Can't find cm_CES_configuration in cfg.txt, skipping $PWD"
+		all_errors+=1
+		cd $OLDPWD
+		continue
+	fi
+
+	# count errors while copying
+	error=0
+
+	cp "$CES_config"_ITERATION_"$CES_itr".inc "$OLDPWD"/"$CES_config".inc
+	error+="$?"
+	cp "$CES_config".gdx "$OLDPWD"/
+	error+="$?"
+
+	cd "$OLDPWD"
+	    
+	# if no errors during file copy
+	if [ "$error" -eq 0 ]
+	then
+		# stage copied files and add source to commit message template
+		git add "$CES_config".inc "$CES_config".gdx
+		readlink -e "$d" >> commit-message.txt
+	else
+		all_errors+="$error"
+	fi
+done
+
+# if there where errors during copying, show the user the files that where
+# staged
+if [ 0 -ne $(( all_errors )) ]
+then
+	echo " "
+	git status
+	echo " "
+	read -p "Please review repository status.  (Press enter)"
+	echo " "
+fi
+
+# if there are any staged files to commit
+if [ ! $( git status --short | grep -q "^[AM].*gdx$" ) ]
+then
+	# commit and delete commit-message.txt if the commit was successful
+	# commit-message.txt is used as a commit message template as per
+	# local git configuration
+	git commit -eqF commit-message.txt && rm commit-message.txt
+else
+	# if not, delete unused commit message
+	rm commit-message.txt
+fi

--- a/scripts/utils/set-local-calibration/gitignore
+++ b/scripts/utils/set-local-calibration/gitignore
@@ -1,0 +1,4 @@
+*.tgz
+git_info
+commit-message.txt
+.Rprofile_calibration_results

--- a/scripts/utils/set-local-calibration/post-commit
+++ b/scripts/utils/set-local-calibration/post-commit
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+# Check for staged, modified, untracked, and ignored .inc|.gdx files
+staged_files=$( git status | \
+    sed -n '
+    /^Changes to be committed:$/,/^[^ 	]/ {
+      s/^\s*[^:]\+:\s*\(.*\.inc\)$/\1/p;
+      s/^\s*[^:]\+:\s*\(.*\.gdx\)$/\1/p }
+    ' )
+
+modified_files=$( git status | \
+    sed -n '
+    /^Changes not staged for commit:$/,/^[^ 	]/ {
+      s/^\s*[^:]\+:\s*\(.*\.inc\)$/\1/p;
+      s/^\s*[^:]\+:\s*\(.*\.gdx\)$/\1/p }
+    ' )
+
+untracked_files=$( git status | \
+    sed -n '
+    /^Untracked files:$/,/^[^ 	]/ {
+      s/^\s*\(.*\.inc\)$/\1/p;
+      s/^\s*\(.*\.gdx\)$/\1/p }
+    ' )
+
+ignored_files=$( git status --ignored -- *.inc *.gdx | \
+    sed -n '
+    /^Untracked files:$/,/^[^ 	]/ {
+      s/^\s*\(.*\.inc\)$/\1/p;
+      s/^\s*\(.*\.gdx\)$/\1/p }
+    ' )
+
+# exclude "normal" untracked from ignored files
+ignored_files=$( comm -23 <( echo "$ignored_files" | sort ) \
+                          <( echo "$untracked_files" | sort ) )
+
+error=0
+
+if test 0 -ne `echo "$staged_files" | grep -v "^$" | wc -l`
+then
+    echo "There are uncommited .inc or .gdx files"
+    echo "$staged_files"
+    echo ""
+    error=`expr "$error" + 1`
+fi
+
+if test 0 -ne `echo "$modified_files" | grep -v "^$" | wc -l`
+then
+    echo "There are modified .inc or .gdx files"
+    echo "$modified_files" | cat -A
+    echo ""
+    error=`expr "$error" + 2`
+fi
+
+if test 0 -ne `echo "$untracked_files" | grep -v "^$" | wc -l `
+then
+    echo "There are untracked .inc or .gdx files"
+    echo "$untracked_files"
+    echo ""
+    error=`expr "$error" + 4`
+fi
+
+if test 0 -ne `echo "$ignored_files" | grep -v "^$" | wc -l `
+then
+    echo "There are ignored .inc or .gdx files"
+    echo "$ignored_files"
+    echo ""
+    error=`expr "$error" + 8`
+fi
+
+if test 0 -ne "$error"
+then
+    echo "no action was taken"
+    exit "$error"
+else
+    # generate git commit info
+    git log --format=full -1 HEAD > git_info
+
+    # pack all .inc and .gdx files and git_info
+    echo "packing into CESparametersAndGDX archive:"
+    commit_hash=$( git --no-pager log --format="%H" -1 HEAD )
+    archive_name="CESparametersAndGDX_""$commit_hash"".tgz"
+    tar --create --file "$archive_name" --gzip --verbose *.inc *.gdx  git_info
+
+    # push updates, if we are tracking a remote branch
+    git branch -vv | grep -q "^\* .* [0-9a-f]\+ \[.*\]" && git push 
+    
+    # report hash
+    echo -e "\n'CESandGDXversion' to include in REMIND configuration:" \
+	    "$commit_hash\n"
+fi

--- a/scripts/utils/set-local-calibration/pre-commit
+++ b/scripts/utils/set-local-calibration/pre-commit
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# .inc files without .gdx file
+orphan_inc=$( comm -23 \
+  <( git status -s | sed -n 's/^[AMR].*\s\([^ ]\)\.inc$/\1/p' | sort ) \
+  <( git status -s | sed -n 's/^[AMR].*\s\([^ ]\)\.gdx$/\1/p' | sort ) )
+
+# .gdx files without .inc file
+orphan_gdx=$( comm -13 \
+  <( git status -s | sed -n 's/^[AMR].*\s\([^ ]\)\.inc$/\1/p' | sort ) \
+  <( git status -s | sed -n 's/^[AMR].*\s\([^ ]\)\.gdx$/\1/p' | sort ) )
+
+error=0
+
+if test 0 -ne `echo "$orphan_inc" | grep -cv "^$" `; then
+	echo "There are .inc files without corresponding .gdx file:"
+	echo "$orphan_inc" | sed 's/.*/&.inc/'
+	error=`expr "$error" + 1`
+fi
+
+if test 0 -ne `echo "$orphan_gdx" | grep -cv "^$" `; then
+	echo "There are .gdx files without corresponding .inc file:"
+	echo "$orphan_gdx" | sed 's/.*/&.gdx/'
+	error=`expr "$error" + 2`
+fi
+
+if test 0 -ne "$error"; then
+	echo "Commit aborted."
+fi
+
+exit "$error"
+

--- a/tutorials/12_Calibrating_CES_Parameters.md
+++ b/tutorials/12_Calibrating_CES_Parameters.md
@@ -128,19 +128,39 @@ used.
 
 ## Results
 
-The main output of the CES calibration are a .gdx file and a .inc files with all
+The main output of the CES calibration are a .gdx file and an .inc file with all
 the CES parameters.  They are named based on the CES configuration, the
 GDP/population scenarios, the capital market module realisation and the region
 configuration (e.g. `indu_subsectors-buil_simple-tran_edge_esm-POP_pop_SSP2EU-GDP_gdp_SSP2EU-En_gdp_SSP2EU-Kap_debt_limit-Reg_62eff8f7`).
 You don't need to change these names, they are matched automatically using the
 switch `cm_CES_configuration`.  The parameter files also include a counter for
-the calibration iteration they resulted from (e.g. `_ITERATION_10.inc`).  To
-use the calibration results, copy the parameter (`.inc`) file (without the
-iteration counter) to the directory `./modules/29_CES_parameters/load/input/`
-and the .gdx file to the directory `./config/gdx-files/`.  At PIK, this is done
-automatically using the RSE support scripts.  See [this wiki
-page](https://gitlab.pik-potsdam.de/REMIND/wiki/-/wikis/Handling-of-Gdx-and-Ces-Parameter-Files-in-Remind)
-for details.
+the calibration iteration they resulted from (e.g. `_ITERATION_10.inc`).
+
+Calibration results can be included the PIK calibration repository (for use by
+all REMIND users), or used in a local directory (e.g. for project work).
+
+- To include calibration results in the PIK calibration repository, navigate to
+  `/p/projects/remind/inputdata/CESparametersAndGDX/` on the PIK cluster and use
+  the `collect_calibration` script with one ore more paths to the completed
+  calibration run directories as a parameter (e.g.
+  `./collect_calibration /p/tmp/pehl/Remind/output/SSP2EU-calibrate_2022-09-06_08.48.56/`). \
+  The script will copy the necessary .inc and .gdx files to the repository,
+  (adjusting the file names as needed) stage and commit them.  It will also add
+  the directories the parameter files originated from to the commit message.
+  You can review and amend the message before committing.  (If after reviewing
+  you decide not to commit, use `:cq` in vim to abort.) \
+  The commit will trigger the generation of new `.tgz` archive, which is what
+  the REMIND model will be looking for in order to run.  Finally it will display
+  the commit hash that has to be included as the `CESandGDXrevision` in the
+  REMIND configuration.
+
+- For use in a local directory, use `make set-local-calibration` to set up a
+  `calibration_results/` directory inside the REMIND directory and add it as a
+  repository for `.gdx` files to the REMIND configuration (the `remind_repos` R
+  option).  From there on, proceed inside the local `calibration_results/`
+  directory as you would in the PIK calibration repository on the cluster, i.e.
+  call the `collect_calibration` script on your local calibration results (e.g.
+  `./collect_calibration ../output/SSP2EU-calibrate_2022-09-06_08.48.56/`).
 
 If the specific calibration settings (e.g. `cm_CES_configuration`) have not been
 calibrated and used in REMIND before, the names of the .gdx and .inc files have
@@ -151,10 +171,11 @@ new calibration results are copied into these directories during run setup.
 As for diagnostic output, there are the `full.log` and `full.lst` files for each
 calibration iteration (`full_01.log` …), the file `CES_calibration.csv`
 containing all the relevant calibration parameters (inputs and outputs) for all
-iterations for automated analysis and a `CES_calibration_report` .pdf file with
-plots of quantities, prices, and efficiency parameters over regions, production
-factors, and time.  This .pdf file can also be generated manually using the
-`output.R` script (option "reportCEScalib").
+iterations for automated analysis and a
+`CES_calibration_report_<scenario_name>.pdf` file with plots of quantities,
+prices, and efficiency parameters over regions, production factors, and time.
+This .pdf file can also be generated manually using the `output.R` script
+(option "reportCEScalib").
 
 
 ## Validity


### PR DESCRIPTION
For production runs it is generally advisable to calibrate first, since establishing what exactly went into a given calibration results is an inherently manual process that is not guaranteed to yield definitive results.
This merge request adds a `set-local-calibration` target to the Makefile that implements [this tutorial](https://gitlab.pik-potsdam.de/pehl/tuts/-/blob/master/Using_local_REMIND_calibrations.md) (with some improvements).
Users will get a `calibration_results/` directory with a `collect_calibration` script that can be used to create `.tgz` files from calibration results (just like at `/p/projects/remind/inputdata/CESparametersAndGDX/`) and will have the directory included as a `remind_repos` option in their R session.  Use of local calibration results in REMIND from there on is identical to that of provided calibration results – simply set the `CESandGDXversion` accordingly.

- [x] New feature 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
