### PR TITLE
new intput data 6.605 and CES parameters and gdx files

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -27,10 +27,10 @@ cfg$regionmapping <- "config/regionmappingH12.csv"
 ### Additional (optional) region mapping, so that those validation data can be loaded that contain the corresponding additional regions.
 cfg$extramappings_historic <- ""
 #### Current input data revision (<mainrevision>.<subrevision>) ####
-cfg$inputRevision <- "6.544"
+cfg$inputRevision <- "6.605"
 
 #### Current CES parameter and GDX revision (commit hash) ####
-cfg$CESandGDXversion <- "216c0ede4f08158971a8aa8a80de94387e031809"
+cfg$CESandGDXversion <- "3537cf56348074a4065c61c981abca0cbc753d6d"
 
 #### Force the model to download new input data ####
 cfg$force_download <- FALSE


### PR DESCRIPTION
## Purpose of this PR
new input data rev. 6.605 including new biomass emulators
new CES parameter and gdx files for inptu data rev. 6.605 for SSP2EU, SSP1, SSP5, SDP_MC, SDP_EI, SDP_RC, SSP2EU_lowEn; calibration runs: /p/tmp/lavinia/MO/test_newInputData/remind/output

## Type of change

- [x] Minor change (default scenarios show only small differences)


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code


## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

