### PR TITLE
modify Makefile to skip Python stuff if 3.7 <= Python version < 3.11 is not satisfied

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,15 +22,27 @@ update-renv:     ## Upgrade all pik-piam packages in your renv to the respective
 update-renv-all: ## Upgrade all packages (including CRAN packages) in your renv
                  ## to the respective latest release, write renv.lock archive
                  ## Upgrade all packages in python venv, if python venv exists
-	Rscript -e 'renv::update(exclude = "renv"); piamenv::archiveRenv()'
-	[ -e ".venv/bin/python" ] && .venv/bin/python -mpip install --upgrade pip wheel
-	[ -e ".venv/bin/python" ] && .venv/bin/python -mpip install --upgrade --upgrade-strategy eager -r requirements.txt
+	@Rscript -e 'renv::update(exclude = "renv"); piamenv::archiveRenv()'
+	@if [ -e "./venv/bin/python" ]; then \
+		pv_maj=$$( .venv/bin/python -V | sed 's/^Python \([0-9]\).*/\1/' ); \
+		pv_min=$$( .venv/bin/python -V | sed 's/^Python [0-9]\.\([0-9]\+\).*/\1/' ); \
+		if (( 3 == $$pv_maj )) && (( 7 <= $$pv_min )) && (( $pv_min < 11 )); then \
+			.venv/bin/python -mpip install --upgrade pip wheel; \
+			.venv/bin/python -mpip install --upgrade --upgrade-strategy eager -r requirements.txt; \
+		fi \
+	fi
 
 ensure-reqs:     ## Ensure the REMIND library requirements are fulfilled
                  ## by installing updates and new libraries as necessary. Does not
                  ## install updates unless it is required.
 	@Rscript -e 'source("scripts/start/ensureRequirementsInstalled.R"); ensureRequirementsInstalled(rerunPrompt="make ensure-reqs")'
-	@[ -e ".venv/bin/python" ] && .venv/bin/python -mpip -qq install -r requirements.txt
+	@if [ -e "./venv/bin/python" ]; then \
+		pv_maj=$$( .venv/bin/python -V | sed 's/^Python \([0-9]\).*/\1/' ); \
+		pv_min=$$( .venv/bin/python -V | sed 's/^Python [0-9]\.\([0-9]\+\).*/\1/' ); \
+		if (( 3 == $$pv_maj )) && (( 7 <= $$pv_min )) && (( $pv_min < 11 )); then \
+			.venv/bin/python -mpip -qq install -r requirements.txt; \
+		fi \
+	fi
 
 archive-renv:    ## Write renv.lock into archive.
 	Rscript -e 'piamenv::archiveRenv()'


### PR DESCRIPTION
- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
