### PR TITLE
fix literature.bib to work with current pandoc

### DIFF
--- a/doc/literature.bib
+++ b/doc/literature.bib
@@ -1,63 +1,79 @@
-
-
-@article{Mouratiadou2016,
-title = "The impact of climate change mitigation on water demand for energy and food: An integrated analysis based on the Shared Socioeconomic Pathways",
-journal = "Environmental Science & Policy",
-volume = "64",
-pages = "48 - 58",
-year = "2016",
-doi = "https://doi.org/10.1016/j.envsci.2016.06.007",
-url = "https://www.sciencedirect.com/science/article/pii/S146290111630301X",
-author = "Ioanna Mouratiadou and Anne Biewald and Michaja Pehl and Markus Bonsch and Lavinia Baumstark and David Klein and Alexander Popp and Gunnar Luderer and Elmar Kriegler",
-keywords = "Water demand, Climate change mitigation, Bioenergy, Electricity, Shared socioeconomic pathways, Water policy"
-}
-
-@unpublished{Schultes2020,
-title = "Persistent economic damages determine social costs of carbon",
-year = "2020",
-author = "Anselm Schultes and Gunnar Luderer and Franziska Piontek and Bjoern Soergel and Joeri Rogelj and Elmar Kriegler and Ottmar Edenhofer",
-note = "to be submitted"
-}
-
 @article{Burke2015,
-title = "Global non-linear effect of temperature on economic production",
-journal = "Nature",
-volume = "527",
-pages = "235 - 239",
-year = "2015",
-doi = "doi:10.1038/nature15725",
-url = "https://www.nature.com/articles/nature15725",
-author = "Marshall Burke and Solomon Hsiang and Edward Miguel"
-}
-
-@manual{DICEdocumentation,
-title = "DICE2013R: Introduction and User's Manual",
-year = "2013",
-url = "http://www.econ.yale.edu/~nordhaus/homepage/homepage/documents/DICE_Manual_100413r1.pdf",
-author = "William Nordhaus and Paul Sztorc"
+  title = {Global Non-Linear Effect of Temperature on Economic Production},
+  author = {Burke, Marshall and Hsiang, Solomon M. and Miguel, Edward},
+  year = {2015},
+  month = nov,
+  journal = {Nature},
+  volume = {527},
+  number = {7577},
+  pages = {235--239},
+  issn = {0028-0836},
+  doi = {10.1038/nature15725},
+  urldate = {2016-01-07},
+  abstract = {Growing evidence demonstrates that climatic conditions can have a profound impact on the functioning of modern human societies, but effects on economic activity appear inconsistent. Fundamental productive elements of modern economies, such as workers and crops, exhibit highly non-linear responses to local temperature even in wealthy countries. In contrast, aggregate macroeconomic productivity of entire wealthy countries is reported not to respond to temperature, while poor countries respond only linearly. Resolving this conflict between micro and macro observations is critical to understanding the role of wealth in coupled human\textendash natural systems and to anticipating the global impact of climate change. Here we unify these seemingly contradictory results by accounting for non-linearity at the macro scale. We show that overall economic productivity is non-linear in temperature for all countries, with productivity peaking at an annual average temperature of 13 \textdegree C and declining strongly at higher temperatures. The relationship is globally generalizable, unchanged since 1960, and apparent for agricultural and non-agricultural activity in both rich and poor countries. These results provide the first evidence that economic activity in all regions is coupled to the global climate and establish a new empirical foundation for modelling economic loss in response to climate change, with important implications. If future adaptation mimics past adaptation, unmitigated warming is expected to reshape the global economy by reducing average global incomes roughly 23\% by 2100 and widening global income inequality, relative to scenarios without climate change. In contrast to prior estimates, expected global losses are approximately linear in global mean temperature, with median losses many times larger than leading models indicate.},
+  copyright = {\textcopyright{} 2015 Nature Publishing Group, a division of Macmillan Publishers Limited. All Rights Reserved.},
+  langid = {english},
+  keywords = {Climate-change impacts},
+  annotation = {00001},
+  file = {/home/pehl/PIK/Zotero/storage/FG2TFXPE/Burke et al_2015_Global non-linear effect of temperature on economic production.pdf;/home/pehl/PIK/Zotero/storage/HANRVDPC/41586_2015_BFnature15725_MOESM56_ESM.pdf;/home/pehl/PIK/Zotero/storage/I8MCQG3T/nature15725.html}
 }
 
 @article{Howard2017,
-title = "Few and Not So Far Between: A Meta-analysis of Climate Damage Estimates",
-journal = "Environmental and Resource Economics",
-volume = "68",
-pages = "197 - 225",
-year = "2017",
-doi = "DOI 10.1007/s10640-017-0166-z",
-url = "https://link.springer.com/content/pdf/10.1007%2Fs10640-017-0166-z.pdf",
-author = "Peter H. Howard and Thomas Sterner",
-keywords = "Climate change, damage function, duplication bias, meta-analysis, social cost of carbon"
+  title = {Few and {{Not So Far Between}}: {{A Meta-analysis}} of {{Climate Damage Estimates}}},
+  shorttitle = {Few and {{Not So Far Between}}},
+  author = {Howard, Peter H. and Sterner, Thomas},
+  year = {2017},
+  month = sep,
+  journal = {Environmental and Resource Economics},
+  volume = {68},
+  number = {1},
+  pages = {197--225},
+  issn = {1573-1502},
+  doi = {10.1007/s10640-017-0166-z},
+  urldate = {2020-06-08},
+  abstract = {Given the vast uncertainty surrounding climate impacts, meta-analyses of global climate damage estimates are a key tool for determining the relationship between temperature and climate damages. Due to limited data availability, previous meta-analyses of global climate damages potentially suffered from multiple sources of coefficient and standard error bias: duplicate estimates, omitted variables, measurement error, overreliance on published estimates, dependent errors, and heteroskedasticity. To address and test for these biases, we expand on previous datasets to obtain sufficient degrees of freedom to make the necessary model adjustments, including dropping duplicate estimates and including methodological variables. Estimating the relationship between temperature and climate damages using weighted least squares with cluster-robust standard errors, we find strong evidence that duplicate and omitted variable biases flatten the relationship. However, the magnitude of the bias greatly depends on the treatment of speculative high-temperature ({$>$}4~\$\$\^\{\textbackslash circ \}\$\${$\circ$}C) damage estimates. Replacing the DICE-2013R damage function with our preferred estimate of the temperature\textendash damage relationship, we find a three- to four-fold increase in the 2015 SCC relative to DICE, depending on the treatment of productivity. When catastrophic impacts are also factored in, the SCC increases by four- to five-fold.},
+  langid = {english},
+  file = {/home/pehl/PIK/Zotero/storage/WUSAMTFB/Howard and Sterner - 2017 - Few and Not So Far Between A Meta-analysis of Cli.pdf}
+}
+
+@article{Mouratiadou2016,
+  title = {The Impact of Climate Change Mitigation on Water Demand for Energy and Food: {{An}} Integrated Analysis Based on the {{Shared Socioeconomic Pathways}}},
+  author = {Mouratiadou, Ioanna and Biewald, Anne and Pehl, Michaja and Bonsch, Markus and Baumstark, Lavinia and Klein, David and Popp, Alexander and Luderer, Gunnar and Kriegler, Elmar},
+  year = {2016},
+  month = oct,
+  journal = {Environmental Science \&amp\textbackslash mathsemicolon Policy},
+  volume = {64},
+  pages = {48--58},
+  publisher = {{Elsevier BV}},
+  doi = {10.1016/j.envsci.2016.06.007}
+}
+
+@article{Schultes2020,
+  title = {Economic Damages from On-Going Climate Change Imply Deeper near-Term Emission Cuts},
+  author = {Schultes, Anselm and Piontek, Franziska and Soergel, Bjoern and Rogelj, Joeri and Baumstark, Lavinia and Kriegler, Elmar and Edenhofer, Ottmar and Luderer, Gunnar},
+  year = {2021},
+  journal = {Environmental Research Letters},
+  issn = {1748-9326},
+  doi = {10.1088/1748-9326/ac27ce},
+  urldate = {2021-09-22},
+  abstract = {Pathways towards limiting global warming to well below 2\textdegree C, as used by the IPCC in the Fifth Assessment Report, do not consider the climate impacts already occurring below 2\textdegree C. Here we show that accounting for such damages significantly increases the near-term ambition of transformation pathways. We use econometric estimates of climate damages on GDP growth, and explicitly model the uncertainty in the persistence time of damages. The Integrated Assessment Model we use includes the climate system and mitigation technology detail required to derive near-term policies. We find an optimal carbon price of \$115 per tonne of CO2 in 2030. The long-term persistence of damages, while highly uncertain, is a main driver of the near-term carbon price. Accounting for damages on economic growth increases the gap between the currently pledged nationally determined contributions and the welfare-optimal 2030 emissions by two thirds, compared to pathways considering the 2\textdegree C limit only.},
+  langid = {english},
+  file = {/home/pehl/PIK/Zotero/storage/ZAUL95A2/Schultes et al. - 2021 - Economic damages from on-going climate change impl.pdf}
 }
 
 @phdthesis{strefler_challenges_2014,
-	address = {Berlin, Germany},
-	type = {{PhD} {Thesis}},
-	title = {Challenges for low stabilization of climate change: {The} complementarity of non-{CO}2 greenhouse gas and aerosol abatement to {CO}2 emission reductions},
-	url = {http://dx.doi.org/10.14279/depositonce-4231},
-	language = {English},
-	school = {Technische Universität Berlin},
-	author = {Strefler, Jessica},
-	month = jul,
-	year = {2014},
-	file = {Strefler_2014_Challenges_for_low_stabilization_of_climate_change.pdf:/home/pehl/PIK/Zotero/storage/3PVCSSNX/Strefler_2014_Challenges_for_low_stabilization_of_climate_change.pdf:application/pdf}
+  title = {Challenges for Low Stabilization of Climate Change: {{The}} Complementarity of Non-{{CO2}} Greenhouse Gas and Aerosol Abatement to {{CO2}} Emission Reductions},
+  author = {Strefler, Jessica},
+  year = {2014},
+  month = jul,
+  address = {{Berlin, Germany}},
+  langid = {english},
+  school = {Technische Universit\"at Berlin},
+  file = {/home/pehl/PIK/Zotero/storage/3PVCSSNX/Strefler_2014_Challenges_for_low_stabilization_of_climate_change.pdf}
+}
+
+@misc{DICEdocumentation,
+  title = {{{DICE2013R}}: {{Introduction}} and {{User}}'s {{Manual}}},
+  author = {{William Nordhaus} and {Paul Sztorc}},
+  year = {2013}
 }


### PR DESCRIPTION
Current pandoc releases (tested with 2.17.1.1) took exception to the formatting of `literature.bib`, failing 35 times with
```
Error reading bibliography file literature.bib:
(line 48, column 11):
unexpected 'P'
```
and producing no HTML output.

Exporting the file from Zotero again fixed this.

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)