### PR TITLE
fix 45/exogenous bug, enable use of different outputfolder

### DIFF
--- a/output.R
+++ b/output.R
@@ -126,7 +126,12 @@ if (! exists("outputdir")) {
   modulesNeedingMif <- c("compareScenarios2", "xlsx_IIASA", "policyCosts", "Ariadne_output",
                          "plot_compare_iterations", "varListHtml", "fixOnRef")
   needingMif <- any(modulesNeedingMif %in% output)
-  dir_folder <- if (exists("remind_dir")) c(file.path(remind_dir, "output"), remind_dir) else "./output"
+  if (exists("remind_dir")) {
+    dir_folder <- c(file.path(remind_dir, "output"), remind_dir)
+  } else {
+    defaultcfg <- readDefaultConfig(".")
+    dir_folder <- unique(c("output", dirname(defaultcfg$results_folder)))
+  }
   dirs <- dirname(Sys.glob(file.path(dir_folder, "*", "fulldata.gdx")))
   if (needingMif) dirs <- intersect(dirs, unique(dirname(Sys.glob(file.path(dir_folder, "*", "REMIND_generic_*.mif")))))
   dirnames <- if (length(dir_folder) == 1) basename(dirs) else dirs

--- a/scripts/input/create_input_for_45_carbonprice_exogenous.R
+++ b/scripts/input/create_input_for_45_carbonprice_exogenous.R
@@ -6,21 +6,23 @@
 # |  Contact: remind@pik-potsdam.de
 
 create_input_for_45_carbonprice_exogenous<-function(gdx){
-  
+ 
   library(luplot,quietly=TRUE,warn.conflicts =FALSE)
   library(gms,quietly=TRUE,warn.conflicts =FALSE)
   require(remind2,quietly = TRUE,warn.conflicts =FALSE)
-  
+ 
   p_fpath <- "./modules/45_carbonprice/exogenous/input/p45_tau_co2_tax.inc"
-  
+ 
   # ---- Read data ----
-  
+ 
   if (file.exists(gdx)) {
     pr <- reportPrices(gdx)
   } else {
     stop("No gdx file found to take the carbon price from - please provide gdx from a reference run in path_gdx_carbonprice in scenario_config file.")
   }
-  
+
+  if (! dir.exists(dirname(p_fpath))) dir.create(dirname(p_fpath), recursive = TRUE)
+ 
   # ---- Convert data ----
   
   #select right temporal/variable scope 

--- a/scripts/start/configureCfg.R
+++ b/scripts/start/configureCfg.R
@@ -66,7 +66,7 @@ configureCfg <- function(icfg, iscen, iscenarios, verboseGamsCompile = TRUE) {
           if (! str_sub(iscenarios[iscen, path_to_gdx], -4, -1) == ".gdx") {
             # search for fulldata.gdx in output directories starting with the path_to_gdx cell content.
             # may include folders that only _start_ with this string. They are sorted out later.
-            dirfolders <- c("./output", icfg$modeltests_folder)
+            dirfolders <- unique(c(dirname(icfg$results_folder), "output", icfg$modeltests_folder))
             for (dirfolder in dirfolders) {
               dirs <- Sys.glob(file.path(dirfolder, paste0(iscenarios[iscen, path_to_gdx], "*/fulldata.gdx")))
               # if path_to_gdx cell content exactly matches folder name, use this one


### PR DESCRIPTION
## Purpose of this PR

- don't fail if `modules/45_carbonprice/exogenous/input` folder does not exist, but rather create it if missing
- if you adjust `cfg$outputfolder`, search for reference runs and folders for output.R also there, not only in `output`

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
