### PR TITLE
new input data rev6.606 and new CES parameter and gdx files 

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -27,10 +27,10 @@ cfg$regionmapping <- "config/regionmappingH12.csv"
 ### Additional (optional) region mapping, so that those validation data can be loaded that contain the corresponding additional regions.
 cfg$extramappings_historic <- ""
 #### Current input data revision (<mainrevision>.<subrevision>) ####
-cfg$inputRevision <- "6.605"
+cfg$inputRevision <- "6.606"
 
 #### Current CES parameter and GDX revision (commit hash) ####
-cfg$CESandGDXversion <- "8a227c12c2690ee45bd9a278a51fca9e7162b1b4"
+cfg$CESandGDXversion <- "878ac5d69254efb4eba5c1fa39aba64000307bb1"
 
 #### Force the model to download new input data ####
 cfg$force_download <- FALSE

--- a/core/sets.gms
+++ b/core/sets.gms
@@ -76,6 +76,7 @@ gdp_SSP2EU_NAV_lce "NAVIGATE demand scenarios: Low consumption energy (act + tec
 gdp_SSP2EU_NAV_all "NAVIGATE demand scenarios: All measures (ele + act + tec)"
 gdp_SSP2EU_CAMP_weak   "CAMPAIGNers scenario with low ambition lifestyle change"
 gdp_SSP2EU_CAMP_strong "CAMPAIGNers scenario with high ambition lifestyle change"
+gdp_SSP2EU_demRedWeak
 /
 
 all_GDPpcScen    "all possible GDP per capita scenarios (GDP and Population from the same SSP-scenario"


### PR DESCRIPTION
## Purpose of this PR
* new input data rev6.606 including new energy demand scenarios `gdp_SSP2EU_CAMP_weak`, `gdp_SSP2EU_CAMP_strong`and `gdp_SSP2EU_demRedWeak` 
* new CES parameter and gdx files for input…data rev6.606 for SSP2EU, SSPEU_EU21, SSP1, SSP5, SDP_MC, SDP_RC, SDP_EI, calibration files are here: /p/tmp/lavinia/REMIND/REMIND_calibration_2023_11_30/remind


## Type of change

- [x] Minor change (default scenarios show only small differences)

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code


## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

