### PR TITLE
make sure requirements are really satisfied after update

### DIFF
--- a/scripts/start/ensureRequirementsInstalled.R
+++ b/scripts/start/ensureRequirementsInstalled.R
@@ -22,6 +22,7 @@ ensureRequirementsInstalled <- function(
   if (requireNamespace("piamenv", quietly = TRUE) && packageVersion("piamenv") >= "0.3.4") {
     installedPackages <- piamenv::fixDeps(ask = ask)
     piamenv::stopIfLoaded(names(installedPackages))
+    piamenv::checkDeps()
   } else {
     stop(paste0("REMIND requires piamenv >= 0.3.4, please run the following to update it:\n",
                 "renv::install('piamenv')\n", "and re-run ", rerunPrompt, "."))


### PR DESCRIPTION
## Purpose of this PR

- close https://github.com/remindmodel/remind/issues/1498
- after update, simply check a second time whether requirements are satisfied

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)

This is how `make test` looks:
```
/p/tmp/oliverr/remind-smallfix (checkdeps)$ make test
Tests take about 20 minutes to run, please be patient
Global .Rprofile loaded! (R version 4.1.2 (2021-11-01))
Loading required package: gdx
Loading required package: gdxrrw
Loading required package: magclass

Attaching package: 'magclass'

The following object is masked from 'package:dplyr':

    where

make[1]: Entering directory '/p/tmp/oliverr/remind-smallfix'
Global .Rprofile loaded! (R version 4.1.2 (2021-11-01))
  remind2 >= 2.122.0 is required, but 1.125.0 is installed - please update: remind2
Try to fix automatically? (Y/n): Y
Installing remind2 [1.125.0] ...
        OK [linked cache]
Error in `piamenv::checkDeps()`:
! remind2 >= 2.122.0 is required, but 1.125.0 is installed - please update: remind2
Backtrace:
    ▆
 1. └─global ensureRequirementsInstalled(rerunPrompt = "make ensure-reqs")
 2.   └─piamenv::checkDeps()
Execution halted
make[1]: *** [Makefile:43: ensure-reqs] Error 1
make[1]: Leaving directory '/p/tmp/oliverr/remind-smallfix'
Error in `FUN()`:
! In path: "/p/tmp/oliverr/remind-smallfix/tests/testthat/setup_updateRenv.R"
Caused by error:
! Not all requirements installed. Follow instructions above and re-start tests.
Backtrace:
     ▆
  1. ├─testthat::test_dir("tests/testthat")
  2. │ └─testthat:::test_files(...)
  3. │   └─testthat:::test_files_serial(...)
  4. │     └─testthat:::test_files_setup_state(...)
  5. │       └─testthat::source_test_setup(".", env)
  6. │         └─testthat::source_dir(path, "^setup.*\\.[rR]$", env = env, wrap = FALSE)
  7. │           └─base::lapply(...)
  8. │             └─testthat (local) FUN(X[[i]], ...)
  9. │               └─testthat::source_file(path, env = env, chdir = chdir, wrap = wrap)
 10. │                 ├─base::withCallingHandlers(...)
 11. │                 └─base::eval(exprs, env)
 12. │                   └─base::eval(exprs, env)
 13. │                     └─base::stop("Not all requirements installed. Follow instructions above and re-start tests.") at tests/testthat/setup_updateRenv.R:15:3
 14. └─base::.handleSimpleError(...)
 15.   └─testthat (local) h(simpleError(msg, call))
 16.     └─rlang::abort(...)
Execution halted
make: *** [Makefile:71: test] Error 1
```

This is how start.R looks:
```
/p/tmp/oliverr/remind-smallfix (checkdeps)$ ./start.R -t
Global .Rprofile loaded! (R version 4.1.2 (2021-11-01))
Loading required package: gdx
Loading required package: gdxrrw
Loading required package: magclass

Attaching package: 'magclass'

The following object is masked from 'package:dplyr':

    where

  remind2 >= 2.122.0 is required, but 1.125.0 is installed - please update: remind2
Try to fix automatically? (Y/n): y
Installing remind2 [1.125.0] ...
        OK [linked cache]
Error in `piamenv::checkDeps()`:
! remind2 >= 2.122.0 is required, but 1.125.0 is installed - please update: remind2
Backtrace:
    ▆
 1. └─global ensureRequirementsInstalled()
 2.   └─piamenv::checkDeps()
Execution halted
```