### PR TITLE
fix bug calculating temperature convergence criterium 

### DIFF
--- a/modules/15_climate/magicc/postsolve.gms
+++ b/modules/15_climate/magicc/postsolve.gms
@@ -41,13 +41,14 @@ display s15_tempOffset2010;
 pm_globalMeanTemperature(tall) = pm_globalMeanTemperature(tall) - s15_tempOffset2010 + 0.97;
 display pm_globalMeanTemperature;
 
+$endif.cm_magicc_calibrateTemperature2000
+
 *** temperature convergence indicator
 pm_gmt_conv = 100*smax(t,abs(pm_globalMeanTemperature(t)/max(p15_gmt0(t),1e-8) -1));
 display pm_gmt_conv;
 *** save temp from last iteration
 p15_gmt0(tall) = pm_globalMeanTemperature(tall);
 
-$endif.cm_magicc_calibrateTemperature2000
 
 *** offset from HADCRUT4 to zero temperature in 1900, instead of the default 1870 (20 year averages each).
 pm_globalMeanTemperatureZeroed1900(tall)  = pm_globalMeanTemperature(tall) + 0.092; 


### PR DESCRIPTION


## Purpose of this PR
the temperature convergence criterium is now also calculated when the temperature is uncalibrated

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [ ] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

