### PR TITLE
remove unused variable vm_invRD

### DIFF
--- a/modules/01_macro/singleSectorGr/declarations.gms
+++ b/modules/01_macro/singleSectorGr/declarations.gms
@@ -32,7 +32,6 @@ vm_cons(ttot,all_regi)                                          "Consumption"
 vm_cesIO(tall,all_regi,all_in)                                  "Production factor" 
 vm_invMacro(ttot,all_regi,all_in)                               "Investment for capital for ttot"
 v01_invMacroAdj(ttot,all_regi,all_in)                           "Adjustment costs of macro economic investments"
-vm_invRD(ttot,all_regi,all_in)                                  "R&D investments"
 vm_invInno(ttot,all_regi,all_in)                                "Investment into innovation"
 vm_invImi(ttot, all_regi,all_in)                                "Investment into imitation"     
 

--- a/modules/01_macro/singleSectorGr/equations.gms
+++ b/modules/01_macro/singleSectorGr/equations.gms
@@ -25,7 +25,6 @@ qm_budget(ttot,regi)$( ttot.val ge cm_startyear ) ..
     vm_cons(ttot,regi)
   + sum(ppfKap(in), vm_invMacro(ttot,regi,in))
   + sum(ppfKap(in), v01_invMacroAdj(ttot,regi,in))  
-  + sum(in, vm_invRD(ttot,regi,in))
   + sum(in, vm_invInno(ttot,regi,in))
   + sum(in, vm_invImi(ttot,regi,in))
   + sum(tradePe(enty)$(NOT tradeCap(enty)), pm_costsTradePeFinancial(regi,"Mport",enty) * vm_Mport(ttot,regi,enty))

--- a/modules/20_growth/exogenous/not_used.txt
+++ b/modules/20_growth/exogenous/not_used.txt
@@ -11,4 +11,3 @@ pm_ttot_val, parameter, ???
 pm_ts, parameter, ???
 cm_startyear, switch, ???
 pm_cumEff, parameter, ???
-vm_invRD,input,questionnaire

--- a/modules/20_growth/spillover/bounds.gms
+++ b/modules/20_growth/spillover/bounds.gms
@@ -18,6 +18,5 @@ display pm_cesdata;
 
    vm_effGr.fx(t,regi,"feelt") = 1;
    vm_effGR.lo(t,regi,inRD20(in)) = 1;    
-   vm_invRD.fx(t,regi,in) = 0; 
 
 *** EOF ./modules/20_growth/spillover/bounds.gms


### PR DESCRIPTION
- left over from https://gitlab.pik-potsdam.de/REMIND/REMIND/-/commit/eed4558
- shortens qm_budget by 66 entries

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)