### PR TITLE
Improve goxygen documentation of 47_regipol module

### DIFF
--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -22,6 +22,8 @@ vm_costTeCapital.fx(t,regi,teNoLearn)     = pm_inco0_t(t,regi,teNoLearn);
 *' @code{extrapage: "00_model_assumptions"}
 
 *' ### Model Bounds and Assumptions: 
+
+*' #### Model Bounds in Core
 *' Lower limit on all P2SE technologies capacities to 100 kW of all technologies and all time steps
 loop(pe2se(enty,enty2,te)$((not sameas(te,"biotr"))  AND (not sameas(te,"biodiesel")) AND (not sameas(te,"bioeths")) AND (not sameas(te,"gasftcrec")) AND (not sameas(te,"gasftrec"))
 AND (not sameas(te,"tnrs"))),

--- a/modules/47_regipol/module.gms
+++ b/modules/47_regipol/module.gms
@@ -8,24 +8,29 @@
 
 *' @title Regional Policies
 *'
-*' @description  The 47_regipol module includes region-specific policies and adjustments.
+*' @description  The 47_regipol module includes region-specific policies and adjustments on top of the generic parts in the core and other modules.
 *'
 *'
 *'               The `regiCarbonPrice` realization has two purposes. First, it allows to determine region specific year or budget targets for CO2 or GHG emissions.
-*'               Second, it comprises region-specific adjustments that are always active in this realization and policies that can be activated by specific switches (see bounds file).
+*'               Second, it comprises region-specific adjustments that are always active in this realization and policies that can be activated by specific switches (see modules/47_regipol/regiCarbonPrice/bounds.gms).
 *'               On the emissions targets: Emissions targets can be activated via the switch cm_emiMktTarget and there are number of options that can be chosen to specify them
 *'               like the type of target (annual target or budget), the target year, the regions the target should be applied to,
-*'               the emissions metric (CO2, GHG, CO2 excl. bunkers/LULUCF etc.) and the emissions market (all, ETS, ESR). For details on the options please see the description of the switch.
+*'               the emissions metric (CO2, GHG, CO2 excl. bunkers/LULUCF etc.) and the emissions market (all, ETS, ESR). For example, setting cm_emiMktTarget to
+*'               "2020.2030.EU27_regi.all.year.netGHG_noLULUCF_noBunkers 3.16, 2035.2050.EU27_regi.all.year.netCO2 0.001" will apply two emissions targets to the region group "EU27_regi"
+*'               which consists of all model regions in the EU27 (for the definition of region groups, please see definition of the set regi_group): The first is a target of 3.16 GtCO2eq/yr annual ("year") emissions by 2030
+*'               in the metric of net greenhouse gas emissions without LULUCF and bunkers ("netGHG_noLULUCF_noBunkers", for definition of emissions metrics see modules/47_regipol/regiCarbonPrice/postsolve.gms)
+*'               for all emissions markets ("all"). The second defines a target of 1 Mt CO2/yr annual ("year") emissions by 2050 in the metric of net CO2 emissions ("netCO2") for all emissions markets ("all").
+*'               For details on the options please see the description of the switch.
 *'               When an emissions target is set via this switch, the carbon price in the target years and regions, to which it is applied, is adjusted over nash iterations in REMIND
 *'               until the desired emissions target is reached within a certain margin of tolerance defined by cm_emiMktTarget_tolerance. Note that also multiple emissions targets can be specified for
 *'               different years (e.g. the EU's 2030 and 2050 targets). The carbon price trajectory up to the target years are linear and the carbon price
 *'               is assumed to still increase linearly at a small rate after the last target year. Please check the parameter pm_emiMktTarget_dev_iter to see the emissions target convergence over iterations.
-*'               Note that these regional emissions targets of the module only overwrite the carbon price trajectory for the regions their are applied to, while the other regions keep the carbon price trajectories
+*'               Note that these regional emissions targets of the module only overwrite the carbon price trajectory for the regions they are applied to, while the other regions keep the carbon price trajectories
 *'               that are adjusted in other parts of the model, in particular, from the global emissions target adjustment.
 *'               This means that these regional targets come on top of the global emissions target that REMIND aims to achieve.
 *'               On the regional bounds and adjustments: In the bounds file, there are a number of regionally hard-coded bounds to the model that aim to improve the representation of specific regions in REMIND.
 *'               They come on top of the bounds in the core of REMIND. The difference is that core defines bounds for all regions, while in this module region-specific adjustments are made which have not yet been generalized to all regions
-*'               and are not activated outside ot the realization "regiCarbonPrice".
+*'               and are not activated outside of the realization "regiCarbonPrice".
 *'               These bounds either serve to align REMIND with historic and near-term data in specific regions or represent regional policies (like national coal phase-out plans) that can be activated via switches.
 *'               Finally, there are some regional adjustments in the datainput file that modify input data for specific regions for cases which have not been generalized for all REMIND regions yet.
 *'

--- a/modules/47_regipol/module.gms
+++ b/modules/47_regipol/module.gms
@@ -8,11 +8,26 @@
 
 *' @title Regional Policies
 *'
-*' @description  The 47_regipol module includes region specific policies.
+*' @description  The 47_regipol module includes region-specific policies and adjustments.
 *'
 *'
-*'               The `regiCarbonPrice` realization allows to determine region specific year or budget targets for CO2 or GHG emissions.
-*'               It overwrites all other carbon prices for selected regions (for example those implemented by 45_carbonprice or 46_carbonpriceRegi).
+*'               The `regiCarbonPrice` realization has two purposes. First, it allows to determine region specific year or budget targets for CO2 or GHG emissions.
+*'               Second, it comprises region-specific adjustments that are always active in this realization and policies that can be activated by specific switches (see bounds file).
+*'               On the emissions targets: Emissions targets can be activated via the switch cm_emiMktTarget and there are number of options that can be chosen to specify them
+*'               like the type of target (annual target or budget), the target year, the regions the target should be applied to,
+*'               the emissions metric (CO2, GHG, CO2 excl. bunkers/LULUCF etc.) and the emissions market (all, ETS, ESR). For details on the options please see the description of the switch.
+*'               When an emissions target is set via this switch, the carbon price in the target years and regions, to which it is applied, is adjusted over nash iterations in REMIND
+*'               until the desired emissions target is reached within a certain margin of tolerance defined by cm_emiMktTarget_tolerance. Note that also multiple emissions targets can be specified for
+*'               different years (e.g. the EU's 2030 and 2050 targets). The carbon price trajectory up to the target years are linear and the carbon price
+*'               is assumed to still increase linearly at a small rate after the last target year. Please check the parameter pm_emiMktTarget_dev_iter to see the emissions target convergence over iterations.
+*'               Note that these regional emissions targets of the module only overwrite the carbon price trajectory for the regions their are applied to, while the other regions keep the carbon price trajectories
+*'               that are adjusted in other parts of the model, in particular, from the global emissions target adjustment.
+*'               This means that these regional targets come on top of the global emissions target that REMIND aims to achieve.
+*'               On the regional bounds and adjustments: In the bounds file, there are a number of regionally hard-coded bounds to the model that aim to improve the representation of specific regions in REMIND.
+*'               They come on top of the bounds in the core of REMIND. The difference is that core defines bounds for all regions, while in this module region-specific adjustments are made which have not yet been generalized to all regions
+*'               and are not activated outside ot the realization "regiCarbonPrice".
+*'               These bounds either serve to align REMIND with historic and near-term data in specific regions or represent regional policies (like national coal phase-out plans) that can be activated via switches.
+*'               Finally, there are some regional adjustments in the datainput file that modify input data for specific regions for cases which have not been generalized for all REMIND regions yet.
 *'
 *' @authors Renato Rodrigues, Felix Schreyer
 

--- a/modules/47_regipol/regiCarbonPrice/bounds.gms
+++ b/modules/47_regipol/regiCarbonPrice/bounds.gms
@@ -6,107 +6,143 @@
 *** |  Contact: remind@pik-potsdam.de
 *** SOF ./modules/47_regipol/regiCarbonPrice/bounds.gms
 
-***---------------------------------------------------------------------------
-*** region-specific bounds (with hard-coded regions)
-***---------------------------------------------------------------------------
+*' @code{extrapage: "00_model_assumptions"}
 
-** Force historical bounds on nuclear
+*' #### Model Bounds in Regipol Module (region-specific bounds with hard-coded regions)
+
+*' These bounds are only active if in 47_regipol module the realization is regiCarbonPrice. They mostly refer 
+*' to region-specific fixings of the model in European subregions to better represent historic or near-term values
+*' or specific policies of regions (e.g. national coal phase-out plans etc.). 
+*'
+*' ##### Bounds for Germany
+*'
+*' ###### Bounds for Historic and Near-term Alignment
+
+*' These bounds account for historic nuclear power development.
 vm_cap.fx("2015",regi,"tnrs","1")$((cm_startyear le 2015) and (sameas(regi,"DEU"))) = 10.8/1000; 
 vm_cap.fx("2020",regi,"tnrs","1")$((cm_startyear le 2020) and (sameas(regi,"DEU"))) = 7.8/1000;
 
-$IFTHEN.NucRegiPol not "%cm_NucRegiPol%" == "off" 
-
-***Germany Nuclear phase-out
-    vm_cap.up(t,regi,"tnrs","1")$((t.val ge 2025) and (t.val ge cm_startyear) and (sameas(regi,"DEU"))) = 1E-6;
-
-*** ESC -> no new Nuclear capacity (Italy had a plebiscite for this and Greece should not have any new capacity)
-    vm_deltaCap.up(t,regi,"tnrs","1")$((t.val ge 2020) and (t.val ge cm_startyear) and (sameas(regi,"ESC"))) = 0;
-
-$ENDIF.NucRegiPol  
-
-$IFTHEN.proNucRegiPol not "%cm_proNucRegiPol%" == "off" 
-***Pro nuclear countries tend to keep nuclear production by political decision
-***assuming France would keep at least 80% of its 2015 nuclear capacity in the future
-vm_cap.lo(t,regi,"tnrs","1")$((t.val ge cm_startyear) and (sameas(regi,"FRA"))) = 0.8*pm_histCap("2015",regi,"tnrs");
-***assuming Czech Republic would keep at least its 2015 nuclear capacity in the future (CZE corresponds to 61.8% of nuclear capacity of ECE in 2015)
-vm_cap.lo(t,regi,"tnrs","1")$((t.val ge cm_startyear) and (sameas(regi,"ECE"))) = 0.618*pm_histCap("2015",regi,"tnrs");
-***assuming Finland would keep at least its 2015 nuclear capacity in the future (FIN corresponds to 21.6% of nuclear capacity of ENC in 2015)
-vm_cap.lo(t,regi,"tnrs","1")$((t.val ge cm_startyear) and (sameas(regi,"ENC"))) = 0.216*pm_histCap("2015",regi,"tnrs");
-***assuming Romania would keep at least its 2015 nuclear capacity in the future (ROU corresponds to 22.1% of nuclear capacity of ECS in 2015)
-vm_cap.lo(t,regi,"tnrs","1")$((t.val ge cm_startyear) and (sameas(regi,"ECS"))) = 0.221*pm_histCap("2015",regi,"tnrs");
-$ENDIF.proNucRegiPol 
-
-$IFTHEN.CCSinvestment not "%cm_CCSRegiPol%" == "off" 
-
-* earliest investment in Europe, with one timestep split between countries currently exploring - Norway (NEN), Netherlands (EWN) and UK (UKI) - and others
-vm_deltaCap.up(t,regi,teCCS,rlf)$( (t.val lt %cm_CCSRegiPol%) AND (sameas(regi,"NEN") OR sameas(regi,"EWN") OR sameas(regi,"UKI"))) = 1e-6; 
-vm_deltaCap.up(t,regi,teCCS,rlf)$( (t.val le %cm_CCSRegiPol%) AND (regi_group("EUR_regi",regi)) AND (NOT(sameas(regi,"NEN") OR sameas(regi,"EWN") OR sameas(regi,"UKI")))) = 1e-6;
-
-$ENDIF.CCSinvestment
-
-
-** Force historical bounds on coal
-vm_cap.up("2020",regi,"pc","1")$((cm_startyear le 2020) and (sameas(regi,"DEU"))) = 38.028/1000;
-*** 2019 capacity = 7TWh, capacity factor = 0.6 ->  ~1.35GW -> Assuming no new capacity -> average 2018-2022 = ~ 1GW
-vm_cap.up("2020",regi,"pc","1")$((cm_startyear le 2020) and (sameas(regi,"UKI"))) = 1.3/1000; 
-
-** European regions coal capacity phase-out based on Beyond Coal 2021 (https://beyond-coal.eu/2021/03/03/overview-of-national-phase-out-announcements-march-2021/), whith adjustment for possible delay in Italy
-$IFTHEN.CoalRegiPol not "%cm_CoalRegiPol%" == "off" 
-
-    vm_cap.up(t,regi,te,"1")$((t.val ge 2025) and (t.val ge cm_startyear) and (sameas(te,"igcc") or sameas(te,"pc") or sameas(te,"coalchp")) and (sameas(regi,"ESW") or sameas(regi,"FRA") )) = 1E-6;
-    vm_cap.up(t,regi,te,"1")$((t.val ge 2030) and (t.val ge cm_startyear) and (sameas(te,"igcc") or sameas(te,"pc") or sameas(te,"coalchp")) and (sameas(regi,"ENC") or sameas(regi,"ESC") or sameas(regi,"EWN") )) = 1E-6;
-
-*** DEU coal-power capacity phase-out, upper bounds following the Kohleausstiegsgesetz from 2020
-*** https://www.bmuv.de/themen/klimaschutz-anpassung/klimaschutz/nationale-klimapolitik/fragen-und-antworten-zum-kohleausstieg-in-deutschland
-    vm_capTotal.up("2025",regi,"pecoal","seel")$(sameas(regi,"DEU"))=25/1000;
-    vm_capTotal.up("2030",regi,"pecoal","seel")$(sameas(regi,"DEU"))=17/1000;
-    vm_capTotal.up("2035",regi,"pecoal","seel")$(sameas(regi,"DEU"))=6/1000;
-    vm_capTotal.up("2040",regi,"pecoal","seel")$(sameas(regi,"DEU"))=1E-6;
-*** UK coal capacity phase-out
-    vm_cap.up(t,regi,te,"1")$((t.val ge 2025) and (t.val ge cm_startyear) and (sameas(te,"igcc") or sameas(te,"pc") or sameas(te,"coalchp")) and (sameas(regi,"UKI"))) = 1E-6;
-
-$ENDIF.CoalRegiPol  
-
-*** further bounds for Germany
-*** upper bound on capacity additions for 2025 based on near-term trends
-*** for now only REMIND-EU/Germany, upper bound is double the historic maximum capacity addition in 2011-2020
+*' This limits wind and solar PV capacity additions for 2025 in light of recent slow developments as of 2023.
+*' Upper bound is double the historic maximum capacity addition in 2011-2020.
 loop(regi$(sameAs(regi,"DEU")),
   vm_deltaCap.up("2025",regi,"wind","1")=2*smax(tall$(tall.val ge 2011 and tall.val le 2020), pm_delta_histCap(tall,regi,"wind"));
   vm_deltaCap.up("2025",regi,"spv","1")=2*smax(tall$(tall.val ge 2011 and tall.val le 2020), pm_delta_histCap(tall,regi,"spv"));
 );
 
-*** bounds on historic gas capacities in Germany
+*' These bounds account for historic gas power development.
 vm_capTotal.up("2015",regi,"pegas","seel")$(sameas(regi,"DEU"))=30/1000;
 vm_capTotal.up("2020",regi,"pegas","seel")$(sameas(regi,"DEU"))=34/1000;
 
-*** limit coal-power capacity to at least 5 GW in 2030 to account for emissions from fossil waste (~20 MtCO2/yr as of 2020) in 2030 target as waste currently subsumed under coal-power in REMIND
-vm_capTotal.lo("2030",regi,"pecoal","seel")$(sameas(regi,"DEU"))=5/1000;
+*' These bounds account for historic coal power development.
+vm_cap.up("2020",regi,"pc","1")$((cm_startyear le 2020) and (sameas(regi,"DEU"))) = 38.028/1000;
 
-
-*** only small amount of co2 injection ccs until 2030 in Germany
-vm_co2CCS.up(t,regi,"cco2","ico2",te,rlf)$((t.val le 2030) AND (sameas(regi,"DEU"))) = 1e-3;
-*** no Pe2Se fossil CCS in Germany, if c_noPeFosCCDeu = 1 chosen 
-vm_emiTeDetail.up(t,regi,peFos,entySe,teFosCCS,"cco2")$((sameas(regi,"DEU")) AND (cm_noPeFosCCDeu = 1)) = 1e-4;
-*** limit German CDR amount (Energy system BECCS, DACCS, EW and negative Landuse Change emissions), conversion from MtCO2 to GtC
-vm_emiCdrAll.up(t,regi)$((cm_deuCDRmax ge 0) AND (sameas(regi,"DEU"))) = cm_deuCDRmax / 1000 / sm_c_2_co2;
-
-*** adaptation of power system for Germany in early years  to prevent coal to gas switch in Germany due to coal-phase out policies
+*' These bounds account for historic and near-term gas power development and prevent too sudden coal to gas switch in Germany by 2025.
 loop(regi$(sameAs(regi,"DEU")),
 vm_deltaCap.up("2015",regi,"ngcc","1") = 0.002;
 vm_deltaCap.up("2020",regi,"ngcc","1") = 0.0015;
 vm_deltaCap.up("2025",regi,"ngcc","1") = 0.0015;
-*** limit early retirement of coal power in Germany in 2020s to avoid extremly fast phase-out
+*' Along the same lines, this limits early retirement of coal power in Germany in 2020s to avoid extremly fast phase-out.
 vm_capEarlyReti.up('2025',regi,'pc') = 0.65; 
 );
 
-*** energy security policy for Germany: 5GW(el) electrolysis installed by 2030 in Germany at minimum
+
+*' This limits coal-power capacity to at least 5 GW in 2030 to account for emissions 
+*' from fossil waste (~20 MtCO2/yr as of 2020) in 2030 target as waste currently subsumed under coal-power in REMIND.
+*' Waste power plants will not be phase-out by 2030. 
+vm_capTotal.lo("2030",regi,"pecoal","seel")$(sameas(regi,"DEU"))=5/1000;
+
+
+*' This limits CO2 underground injection up to 2030 in line with recent developments as of 2023. 
+vm_co2CCS.up(t,regi,"cco2","ico2",te,rlf)$((t.val le 2030) AND (sameas(regi,"DEU"))) = 1e-3;
+
+*' ###### Bounds for Germany-specific Policies (activated by switches)
+
+*' If c_noPeFosCCDeu = 1 chosen, fossil CCS for energy system technologies (pe2se) is forbidden.   
+vm_emiTeDetail.up(t,regi,peFos,entySe,teFosCCS,"cco2")$((sameas(regi,"DEU")) AND (cm_noPeFosCCDeu = 1)) = 1e-4;
+
+*' If cm_deuCDRmax > 0, limit German CDR amount (Energy system BECCS, DACCS, EW and negative Landuse Change emissions) to cm_deuCDRmax.
+*' Convert cm_deuCDRmax from MtCO2/yr to model unit of GtC/yr. 
+vm_emiCdrAll.up(t,regi)$((cm_deuCDRmax ge 0) AND (sameas(regi,"DEU"))) = cm_deuCDRmax / 1000 / sm_c_2_co2;
+
+*' Policy in energy security scenario for Germany: 5GW(el) electrolysis installed by 2030 in Germany at minimum.
 $ifThen.ensec "%cm_Ger_Pol%" == "ensec"
     vm_cap.lo("2030",regi,"elh2","1")$(sameAs(regi,"DEU"))=5*pm_eta_conv("2030",regi,"elh2")/1000;
 $endIf.ensec
 
-***---------------------------------------------------------------------------
-*** per region minimun variable renewables share in electricity:
-***---------------------------------------------------------------------------
+*' Policy in energy security scenario for Germany: increase coal power capacity factors and decrease gas power capacity factors until 2030
+*' to account for short-term gas to coal switch under the assumption of a continued gas crisis.
+$ifThen.ensec "%cm_Ger_Pol%" == "ensec"
+    vm_capFac.up("2025",regi,"pc")$sameas(regi,"DEU") = 0.6;
+    vm_capFac.up("2030",regi,"pc")$sameas(regi,"DEU") = 0.6;
+    vm_capFac.fx("2025",regi,"ngcc")$sameas(regi,"DEU") = 0.2;
+    vm_capFac.lo("2030",regi,"ngcc")$sameas(regi,"DEU") = 0.2;
+$endIf.ensec
+
+*' Policy in energy security scenario for Germany activated by cm_EnSecScen_limit: 
+*' Limit PE gas demand from 2025 on to cm_EnSecScen_limit (in EJ/yr) gas imports + domestic gas in Germany.
+if (cm_EnSecScen_limit gt 0,
+    vm_prodPe.up(t,regi,"pegas")$((t.val ge 2025) AND (sameas(regi,"DEU"))) = cm_EnSecScen_limit/pm_conv_TWa_EJ;
+);
+
+*' ##### Bounds for EU subregions
+
+*' ###### Bounds for historic and near-term Alignment
+
+*' This account for historic coal power developments.
+*' Bounds for UKI region: 2019 capacity = 7TWh, 
+*' capacity factor = 0.6 ->  ~1.35GW -> Assuming no new capacity -> average 2018-2022 = ~ 1GW
+vm_cap.up("2020",regi,"pc","1")$((cm_startyear le 2020) and (sameas(regi,"UKI"))) = 1.3/1000; 
+
+*' ###### Bounds for EU-specific policies (activated by switches)
+
+*' This accounts for different nuclear power policies that can be chosen for the EU subregions. 
+*' Basic nuclear policies: 
+$IFTHEN.NucRegiPol not "%cm_NucRegiPol%" == "off" 
+*' Germany Nuclear phase-out
+    vm_cap.up(t,regi,"tnrs","1")$((t.val ge 2025) and (t.val ge cm_startyear) and (sameas(regi,"DEU"))) = 1E-6;
+*' ESC -> no new Nuclear capacity (Italy had a plebiscite for this and Greece should not have any new capacity)
+    vm_deltaCap.up(t,regi,"tnrs","1")$((t.val ge 2020) and (t.val ge cm_startyear) and (sameas(regi,"ESC"))) = 0;
+$ENDIF.NucRegiPol  
+
+*' Extended nuclear policies:
+$IFTHEN.proNucRegiPol not "%cm_proNucRegiPol%" == "off" 
+*' Pro nuclear countries tend to keep nuclear production by political decision
+*' assuming France would keep at least 80% of its 2015 nuclear capacity in the future.
+vm_cap.lo(t,regi,"tnrs","1")$((t.val ge cm_startyear) and (sameas(regi,"FRA"))) = 0.8*pm_histCap("2015",regi,"tnrs");
+*' Assuming Czech Republic would keep at least its 2015 nuclear capacity in the future (CZE corresponds to 61.8% of nuclear capacity of ECE in 2015)
+vm_cap.lo(t,regi,"tnrs","1")$((t.val ge cm_startyear) and (sameas(regi,"ECE"))) = 0.618*pm_histCap("2015",regi,"tnrs");
+*' Assuming Finland would keep at least its 2015 nuclear capacity in the future (FIN corresponds to 21.6% of nuclear capacity of ENC in 2015)
+vm_cap.lo(t,regi,"tnrs","1")$((t.val ge cm_startyear) and (sameas(regi,"ENC"))) = 0.216*pm_histCap("2015",regi,"tnrs");
+*' Assuming Romania would keep at least its 2015 nuclear capacity in the future (ROU corresponds to 22.1% of nuclear capacity of ECS in 2015)
+vm_cap.lo(t,regi,"tnrs","1")$((t.val ge cm_startyear) and (sameas(regi,"ECS"))) = 0.221*pm_histCap("2015",regi,"tnrs");
+$ENDIF.proNucRegiPol 
+
+*' This accounts for different CCS policies that can be chosen for the EU subregions.
+$IFTHEN.CCSinvestment not "%cm_CCSRegiPol%" == "off" 
+*' earliest investment in Europe, with one timestep split between countries currently exploring - Norway (NEN), Netherlands (EWN) and UK (UKI) - and others
+vm_deltaCap.up(t,regi,teCCS,rlf)$( (t.val lt %cm_CCSRegiPol%) AND (sameas(regi,"NEN") OR sameas(regi,"EWN") OR sameas(regi,"UKI"))) = 1e-6; 
+vm_deltaCap.up(t,regi,teCCS,rlf)$( (t.val le %cm_CCSRegiPol%) AND (regi_group("EUR_regi",regi)) AND (NOT(sameas(regi,"NEN") OR sameas(regi,"EWN") OR sameas(regi,"UKI")))) = 1e-6;
+$ENDIF.CCSinvestment
+
+*' This accounts for different coal power phase-out policies that can be chosen for the EU subregions. 
+*' It is based on Beyond Coal 2021 (https://beyond-coal.eu/2021/03/03/overview-of-national-phase-out-announcements-march-2021/), whith adjustment for possible delay in Italy.
+$IFTHEN.CoalRegiPol not "%cm_CoalRegiPol%" == "off" 
+    vm_cap.up(t,regi,te,"1")$((t.val ge 2025) and (t.val ge cm_startyear) and (sameas(te,"igcc") or sameas(te,"pc") or sameas(te,"coalchp")) and (sameas(regi,"ESW") or sameas(regi,"FRA") )) = 1E-6;
+    vm_cap.up(t,regi,te,"1")$((t.val ge 2030) and (t.val ge cm_startyear) and (sameas(te,"igcc") or sameas(te,"pc") or sameas(te,"coalchp")) and (sameas(regi,"ENC") or sameas(regi,"ESC") or sameas(regi,"EWN") )) = 1E-6;
+
+*' DEU coal-power capacity phase-out, upper bounds following the Kohleausstiegsgesetz from 2020.
+*' https://www.bmuv.de/themen/klimaschutz-anpassung/klimaschutz/nationale-klimapolitik/fragen-und-antworten-zum-kohleausstieg-in-deutschland
+    vm_capTotal.up("2025",regi,"pecoal","seel")$(sameas(regi,"DEU"))=25/1000;
+    vm_capTotal.up("2030",regi,"pecoal","seel")$(sameas(regi,"DEU"))=17/1000;
+    vm_capTotal.up("2035",regi,"pecoal","seel")$(sameas(regi,"DEU"))=6/1000;
+    vm_capTotal.up("2040",regi,"pecoal","seel")$(sameas(regi,"DEU"))=1E-6;
+*' UK coal capacity phase-out
+    vm_cap.up(t,regi,te,"1")$((t.val ge 2025) and (t.val ge cm_startyear) and (sameas(te,"igcc") or sameas(te,"pc") or sameas(te,"coalchp")) and (sameas(regi,"UKI"))) = 1E-6;
+
+$ENDIF.CoalRegiPol  
+
+
+*' Represent region-specific renewable power policies with minimum VRE shares over time. 
 $ifthen.cm_VREminShare not "%cm_VREminShare%" == "off"
   loop((ttot,ext_regi)$(p47_VREminShare(ttot,ext_regi)),
     loop(regi$(regi_group(ext_regi,regi)),
@@ -115,25 +151,15 @@ $ifthen.cm_VREminShare not "%cm_VREminShare%" == "off"
   )
 ;
 $endIf.cm_VREminShare
-*** provide range for gas and coal power CF in EnSec scenario in 2025 and 2030 for subsitution
-$ifThen.ensec "%cm_Ger_Pol%" == "ensec"
-    vm_capFac.up("2025",regi,"pc")$sameas(regi,"DEU") = 0.6;
-    vm_capFac.up("2030",regi,"pc")$sameas(regi,"DEU") = 0.6;
 
-*** fix gas power to lower value in 2025 for short-term substitution
-    vm_capFac.fx("2025",regi,"ngcc")$sameas(regi,"DEU") = 0.2;
-    vm_capFac.lo("2030",regi,"ngcc")$sameas(regi,"DEU") = 0.2;
-$endIf.ensec
-
-*** PW: limit PE gas demand from 2025 on to cm_EnSecScen_limit EJ/yr gas imports + domestic gas in Germany
-if (cm_EnSecScen_limit gt 0,
-    vm_prodPe.up(t,regi,"pegas")$((t.val ge 2025) AND (sameas(regi,"DEU"))) = cm_EnSecScen_limit/pm_conv_TWa_EJ;
-);
-
-*** Fix CES function quantity trajectories to exogenous data if cm_exogDem_scen is activated
+*' This fixes Fix CES function quantity trajectories to exogenous data if cm_exogDem_scen is activated.
+*' It is used, for example, to hit specific, steel and cement production trajectories in policy scenarios
+*' for project-specific scenarios. It is not necessarily a policy but a different (exogenuous) assumption 
+*' about future production trajectories than what REMIND produces endogenuously. 
 $ifthen.ExogDemScen NOT "%cm_exogDem_scen%" == "off"
 vm_cesIO.fx(t,regi,in)$(pm_exogDemScen(t,regi,"%cm_exogDem_scen%",in))=pm_exogDemScen(t,regi,"%cm_exogDem_scen%",in);
 $endif.ExogDemScen
 
+*' @stop
 
 *** EOF ./modules/47_regipol/regiCarbonPrice/bounds.gms

--- a/modules/47_regipol/regiCarbonPrice/bounds.gms
+++ b/modules/47_regipol/regiCarbonPrice/bounds.gms
@@ -49,6 +49,8 @@ vm_capEarlyReti.up('2025',regi,'pc') = 0.65;
 *' This limits coal-power capacity to at least 5 GW in 2030 to account for emissions 
 *' from fossil waste (~20 MtCO2/yr as of 2020) in 2030 target as waste currently subsumed under coal-power in REMIND.
 *' Waste power plants will not be phase-out by 2030. 
+*' Rough calculation with REMIND parameters:
+*' 5 GW * 8760 (hours per year) * 0.5 (capacity factor) / 0.4 (conversion efficiency) * 1e-3 * 0.35 MtCO2/TWh (emissions factor coal) ~ 20 Mt CO2/yr.
 vm_capTotal.lo("2030",regi,"pecoal","seel")$(sameas(regi,"DEU"))=5/1000;
 
 
@@ -60,9 +62,17 @@ vm_co2CCS.up(t,regi,"cco2","ico2",te,rlf)$((t.val le 2030) AND (sameas(regi,"DEU
 *' If c_noPeFosCCDeu = 1 chosen, fossil CCS for energy system technologies (pe2se) is forbidden.   
 vm_emiTeDetail.up(t,regi,peFos,entySe,teFosCCS,"cco2")$((sameas(regi,"DEU")) AND (cm_noPeFosCCDeu = 1)) = 1e-4;
 
-*' If cm_deuCDRmax > 0, limit German CDR amount (Energy system BECCS, DACCS, EW and negative Landuse Change emissions) to cm_deuCDRmax.
+*' If cm_deuCDRmax >= 0, limit German CDR amount (Energy system BECCS, DACCS, EW and negative Landuse Change emissions) to cm_deuCDRmax.
 *' Convert cm_deuCDRmax from MtCO2/yr to model unit of GtC/yr. 
 vm_emiCdrAll.up(t,regi)$((cm_deuCDRmax ge 0) AND (sameas(regi,"DEU"))) = cm_deuCDRmax / 1000 / sm_c_2_co2;
+
+
+*' ####### Bounds for German Energy Security Scenario (activated by switches)
+
+*' Background: The energy security scenario used for the Ariadne Report on energy sovereignity in 2022 assumes that there is a continued gas crisis after 2022/23 in Germany
+*' with higher gas prices (see cm_EnSecScen_price) or limits to gas consumption (see cm_EnSecScen_limit switch) in the medium-term.
+*' Moreover, this scenario is characterized by a more pronounced role of coal power in the short-term as well as a greater role of
+*' industrial relocation and behavioral and energy efficiency transformations in demand sectors. Bounds in this section refer to energy supply technologies only. 
 
 *' Policy in energy security scenario for Germany: 5GW(el) electrolysis installed by 2030 in Germany at minimum.
 $ifThen.ensec "%cm_Ger_Pol%" == "ensec"
@@ -152,7 +162,7 @@ $ifthen.cm_VREminShare not "%cm_VREminShare%" == "off"
 ;
 $endIf.cm_VREminShare
 
-*' This fixes Fix CES function quantity trajectories to exogenous data if cm_exogDem_scen is activated.
+*' This bounds fixes CES function quantity trajectories to exogenous data if cm_exogDem_scen is activated.
 *' It is used, for example, to hit specific, steel and cement production trajectories in policy scenarios
 *' for project-specific scenarios. It is not necessarily a policy but a different (exogenuous) assumption 
 *' about future production trajectories than what REMIND produces endogenuously. 

--- a/modules/47_regipol/regiCarbonPrice/bounds.gms
+++ b/modules/47_regipol/regiCarbonPrice/bounds.gms
@@ -67,12 +67,12 @@ vm_emiTeDetail.up(t,regi,peFos,entySe,teFosCCS,"cco2")$((sameas(regi,"DEU")) AND
 vm_emiCdrAll.up(t,regi)$((cm_deuCDRmax ge 0) AND (sameas(regi,"DEU"))) = cm_deuCDRmax / 1000 / sm_c_2_co2;
 
 
-*' ####### Bounds for German Energy Security Scenario (activated by switches)
+*' ###### Bounds for German Energy Security Scenario (activated by switches)
 
 *' Background: The energy security scenario used for the Ariadne Report on energy sovereignity in 2022 assumes that there is a continued gas crisis after 2022/23 in Germany
 *' with higher gas prices (see cm_EnSecScen_price) or limits to gas consumption (see cm_EnSecScen_limit switch) in the medium-term.
 *' Moreover, this scenario is characterized by a more pronounced role of coal power in the short-term as well as a greater role of
-*' industrial relocation and behavioral and energy efficiency transformations in demand sectors. Bounds in this section refer to energy supply technologies only. 
+*' industrial relocation and behavioral and energy efficiency transformations in demand sectors. Bounds in this section refer to energy supply technologies only. \ \
 
 *' Policy in energy security scenario for Germany: 5GW(el) electrolysis installed by 2030 in Germany at minimum.
 $ifThen.ensec "%cm_Ger_Pol%" == "ensec"

--- a/modules/47_regipol/regiCarbonPrice/realization.gms
+++ b/modules/47_regipol/regiCarbonPrice/realization.gms
@@ -6,15 +6,13 @@
 *** |  Contact: remind@pik-potsdam.de
 *** SOF ./modules/47_regipol/regiCarbonPrice/realization.gms
 
-*' @description  
+*' @description
 *'
-*'The `regiCarbonPrice` realization allow to determine region specific year or budget targets for CO2 or GHG emissions.
-*'
-*'This allows to determine regions with more (or less) stringent carbon policies than the World targets.
-*'
-*'Ex.: EU emission targets are tipically more stringent than other World regions. 
-*'
-*' @authors Renato Rodrigues, Felix Schreyer 
+*' The `regiCarbonPrice` realization has two purposes. First, it allows to determine region specific year or budget targets for CO2 or GHG emissions.
+*' Second, it comprises region-specific adjustments that are always active in this realization and policies that can be activated by specific switches (see bounds file).
+*' Please see module description for details. 
+
+*' @authors Renato Rodrigues, Felix Schreyer
 
 *####################### R SECTION START (PHASES) ##############################
 $Ifi "%phase%" == "sets" $include "./modules/47_regipol/regiCarbonPrice/sets.gms"


### PR DESCRIPTION
## Purpose of this PR

Improves the documentation as a follow-up to the last REMIND cleaning session with Chris. 

## Type of change


- [x] Documentation Update



## Checklist:
[regipol_goxygen_change.zip](https://github.com/remindmodel/remind/files/13726660/regipol_goxygen_change.zip)



- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)


## Further information (optional):

The goxygen html output can be found attached. 

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

