### PR TITLE
new input data 6.609 and CES parameters and gdx files

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -27,10 +27,10 @@ cfg$regionmapping <- "config/regionmappingH12.csv"
 ### Additional (optional) region mapping, so that those validation data can be loaded that contain the corresponding additional regions.
 cfg$extramappings_historic <- ""
 #### Current input data revision (<mainrevision>.<subrevision>) ####
-cfg$inputRevision <- "6.607"
+cfg$inputRevision <- "6.609"
 
 #### Current CES parameter and GDX revision (commit hash) ####
-cfg$CESandGDXversion <- "878ac5d69254efb4eba5c1fa39aba64000307bb1"
+cfg$CESandGDXversion <- "6fd80d4748d4715e9f71da31d9d5494ccf2a3cbe"
 
 #### Force the model to download new input data ####
 cfg$force_download <- FALSE


### PR DESCRIPTION

## Purpose of this PR
new input data 6.609 and CES parameters and gdx files for SSP2EU, SSP2EU-EU21, SSP1, SSP5, SPD_MC, SDP_EI_SDP_RC and SSP2EU_lowEn; 
calibration runs: /p/tmp/lavinia/REMIND/REMIND_calibration_2023_12_14/remind## Type of change

- [x] Minor change (default scenarios show only small differences)


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code


## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

