### PR TITLE
Fix v33-CDR variables to zero before 2025

### DIFF
--- a/modules/33_CDR/portfolio/bounds.gms
+++ b/modules/33_CDR/portfolio/bounds.gms
@@ -9,6 +9,12 @@
 vm_emiCdr.fx(t,regi,emi)$(not sameas(emi,"co2")) = 0.0;
 vm_emiCdr.l(t,regi,"co2")$(t.val ge 2025 AND cm_ccapturescen ne 2) = -sm_eps;
 
+*' Fix CDR-module variables to zero for early time steps t < 2025 (no CDR in the real-world)
+*' to reduce unnecessary freedom (and likelyhood of spontaneous solver infeasibilities)
+v33_emi.fx(t,regi,te_all33)$(t.val lt 2025) = 0.0;
+v33_FEdemand.fx(t,regi,entyFe,entyFe2,te_all33)$(t.val lt 2025) = 0.0;
+v33_EW_onfield.fx(t,regi,rlf_cz33,rlf)$(t.val lt 2025) = 0.0;
+
 *' Bounds if there are no technologies in the portfolio
 if(card(te_used33) eq 0,
     vm_emiCdr.fx(t,regi,"co2") = 0;

--- a/modules/33_CDR/portfolio/bounds.gms
+++ b/modules/33_CDR/portfolio/bounds.gms
@@ -29,7 +29,7 @@ v33_emi.fx(t,regi,te_used33)$(t.val lt 2025) = 0.0;
 v33_FEdemand.fx(t,regi,entyFe,entyFe2,te_used33)$(fe2cdr(entyFe,entyFe2,te_used33) AND (t.val lt 2025)) = 0.0;
 vm_emiCdr.fx(t,regi,"co2")$(t.val lt 2025) = 0;
 vm_omcosts_cdr.fx(t,regi)$((t.val lt 2025)) = 0;
-vm_cap.fx(t,regi,"weathering",rlf)(t.val lt 2025) = 0;
+vm_cap.fx(t,regi,"weathering",rlf)$(t.val lt 2025) = 0;
 *** vm_cap for dac is fixed for t<2025 in core/bounds.gms (tech_stat eq 4)
 vm_ccs_cdr.fx(t,regi,enty,enty2,te,rlf)$(ccs2te(enty,enty2,te) AND t.val lt 2025) = 0;
 

--- a/modules/33_CDR/portfolio/bounds.gms
+++ b/modules/33_CDR/portfolio/bounds.gms
@@ -12,7 +12,7 @@ vm_emiCdr.l(t,regi,"co2")$(t.val ge 2025 AND cm_ccapturescen ne 2) = -sm_eps;
 *' Fix CDR-module variables to zero for early time steps t < 2025 (no CDR in the real-world)
 *' to reduce unnecessary freedom (and likelyhood of spontaneous solver infeasibilities)
 v33_emi.fx(t,regi,te_all33)$(t.val lt 2025) = 0.0;
-v33_FEdemand.fx(t,regi,entyFe,entyFe2,te_all33)$(t.val lt 2025) = 0.0;
+v33_FEdemand.fx(t,regi,entyFe,entyFe2,te_all33)$(fe2cdr(entyFe,entyFe2,te_all33) AND (t.val lt 2025)) = 0.0;
 v33_EW_onfield.fx(t,regi,rlf_cz33,rlf)$(t.val lt 2025) = 0.0;
 
 *' Bounds if there are no technologies in the portfolio

--- a/modules/33_CDR/portfolio/bounds.gms
+++ b/modules/33_CDR/portfolio/bounds.gms
@@ -9,12 +9,6 @@
 vm_emiCdr.fx(t,regi,emi)$(not sameas(emi,"co2")) = 0.0;
 vm_emiCdr.l(t,regi,"co2")$(t.val ge 2025 AND cm_ccapturescen ne 2) = -sm_eps;
 
-*' Fix CDR-module variables to zero for early time steps t < 2025 (no CDR in the real-world)
-*' to reduce unnecessary freedom (and likelyhood of spontaneous solver infeasibilities)
-v33_emi.fx(t,regi,te_all33)$(t.val lt 2025) = 0.0;
-v33_FEdemand.fx(t,regi,entyFe,entyFe2,te_all33)$(fe2cdr(entyFe,entyFe2,te_all33) AND (t.val lt 2025)) = 0.0;
-v33_EW_onfield.fx(t,regi,rlf_cz33,rlf)$(t.val lt 2025) = 0.0;
-
 *' Bounds if there are no technologies in the portfolio
 if(card(te_used33) eq 0,
     vm_emiCdr.fx(t,regi,"co2") = 0;
@@ -29,9 +23,14 @@ if(card(te_ccs33) eq 0,
 v33_emi.fx(t,regi,te_all33)$(not te_used33(te_all33)) = 0;
 v33_FEdemand.fx(t,regi,entyFe,entyFe2,te_all33)$(not te_used33(te_all33) and fe2cdr(entyFe,entyFe2,te_all33)) = 0;
 
-*' Bounds for DAC (cm_emiscen ne 1 avoids setting the boundary for the business-as-usual scenario)
-if (te_used33("dac") and cm_emiscen ne 1,
-    vm_cap.lo(t,regi,"dac",rlf)$(teNoTransform2rlf33("dac",rlf) AND (t.val ge max(2025,cm_startyear))) = sm_eps;
+*' And fix negative emissions and FE demand to zero for early time steps t< 2025 (no CDR in the real world)
+*' to reduce unnecessary freedom (and likelyhood of spontaneous solver infeasibilities)
+v33_emi.fx(t,regi,te_all33)$(t.val lt 2025) = 0.0;
+v33_FEdemand.fx(t,regi,entyFe,entyFe2,te_all33)$(fe2cdr(entyFe,entyFe2,te_all33) AND (t.val lt 2025)) = 0.0;
+
+*' Set minimum DAC capacities (if available) to help the solver find the technology 
+if (te_used33("dac"),
+    vm_cap.lo(t,regi,"dac",rlf)$(teNoTransform2rlf33("dac",rlf) AND (t.val ge 2030)) = sm_eps;
 );
 
 *' Bounds for enhanced weathering

--- a/modules/33_CDR/portfolio/bounds.gms
+++ b/modules/33_CDR/portfolio/bounds.gms
@@ -23,10 +23,16 @@ if(card(te_ccs33) eq 0,
 v33_emi.fx(t,regi,te_all33)$(not te_used33(te_all33)) = 0;
 v33_FEdemand.fx(t,regi,entyFe,entyFe2,te_all33)$(not te_used33(te_all33) and fe2cdr(entyFe,entyFe2,te_all33)) = 0;
 
-*' And fix negative emissions and FE demand to zero for early time steps t< 2025 (no CDR in the real world)
+*' Fix all CDR-related variables to zero for early time steps t< 2025 (no CDR in the real world)
 *' to reduce unnecessary freedom (and likelyhood of spontaneous solver infeasibilities)
-v33_emi.fx(t,regi,te_all33)$(t.val lt 2025) = 0.0;
-v33_FEdemand.fx(t,regi,entyFe,entyFe2,te_all33)$(fe2cdr(entyFe,entyFe2,te_all33) AND (t.val lt 2025)) = 0.0;
+v33_emi.fx(t,regi,te_used33)$(t.val lt 2025) = 0.0;
+v33_FEdemand.fx(t,regi,entyFe,entyFe2,te_used33)$(fe2cdr(entyFe,entyFe2,te_used33) AND (t.val lt 2025)) = 0.0;
+vm_emiCdr.fx(t,regi,"co2")$(t.val lt 2025) = 0;
+vm_omcosts_cdr.fx(t,regi)$((t.val lt 2025)) = 0;
+vm_cap.fx(t,regi,"weathering",rlf)(t.val lt 2025) = 0;
+*** vm_cap for dac is fixed for t<2025 in core/bounds.gms (tech_stat eq 4)
+vm_ccs_cdr.fx(t,regi,enty,enty2,te,rlf)$(ccs2te(enty,enty2,te) AND t.val lt 2025) = 0;
+
 
 *' Set minimum DAC capacities (if available) to help the solver find the technology 
 if (te_used33("dac"),
@@ -38,8 +44,9 @@ if(te_used33("weathering"),
     v33_EW_onfield_tot.up(t,regi,rlf_cz33,rlf) = s33_step;
     v33_EW_onfield.fx(t,regi,rlf_cz33,rlf)$(rlf.val gt 10) = 0; !! rlfs that are not used
     v33_EW_onfield_tot.fx(t,regi,rlf_cz33,rlf)$(rlf.val gt 10) = 0; !! rlfs that are not used
-    v33_EW_onfield.fx(ttot,regi,rlf_cz33,rlf)$(ttot.val lt max(2025,cm_startyear)) = 0.0;
-    v33_EW_onfield_tot.fx(ttot,regi,rlf_cz33,rlf)$(ttot.val lt max(2025,cm_startyear)) = 0.0;
+    !! if cm_startyear > 2025 and input_ref.gdx used EW, this fixing will be overwritten in submit.R
+    v33_EW_onfield.fx(ttot,regi,rlf_cz33,rlf)$(ttot.val lt max(2025,cm_startyear)) = 0.0; !! 
+    v33_EW_onfield_tot.fx(ttot,regi,rlf_cz33,rlf)$(ttot.val lt max(2025,cm_startyear)) = 0.0; !! 
 );
 
 *' Bounds if enhanced weathering is not in the portfolio


### PR DESCRIPTION
## Purpose of this PR
Fix v33 CDR emissions and CDR fe-demand to zero before 2025, as there was no real-world deployment.
This reduces unnecessary flexibility of the model in the early years that led to solver-infeasibilities.
Furthermore, move technology deployment push to 2030 for DAC (if technology is available) to avoid any risk of 
inconsistencies between subsequent runs with different technology availability. 

This PR solves the issues discussed here:
https://github.com/remindmodel/development_issues/issues/239


## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix 
- [x] Minor change (default scenarios show only small differences)


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)

## Further information (optional):

* Test runs are here: /p/tmp/amerfort/remind/output/SSP2EU-NPi_2024-01-09_15.36.45/ (in comparison, the failed NPi-AMT run showing the infeasibility is here /p/projects/remind/modeltests/remind/output/SSP2EU-NPi-AMT_2023-12-22_22.08.15_debug/)
* Comparison of results (what changes by this PR?): Avoids infeasibilities with dac-FE-demand in early timesteps (t<2025)
* Even though the PR eliminates the risk of random solver infeasibilites in CDR variables in the early time steps, it does not reduce runtime, unfortunately.