### PR TITLE
add new demand scenario names for industry to all_demScen (new low material and moderate efficiency scenarios)

### DIFF
--- a/core/sets.gms
+++ b/core/sets.gms
@@ -77,6 +77,9 @@ gdp_SSP2EU_NAV_all "NAVIGATE demand scenarios: All measures (ele + act + tec)"
 gdp_SSP2EU_CAMP_weak   "CAMPAIGNers scenario with low ambition lifestyle change"
 gdp_SSP2EU_CAMP_strong "CAMPAIGNers scenario with high ambition lifestyle change"
 gdp_SSP2EU_demRedWeak
+gdp_SSP2EU_ECEMF_modEffInd      "ECEMF scenario where the industry has moderated efficiency gains (less efficient than default)"
+gdp_SSP2EU_ECEMF_IndLMD         "ECEMF scenario where bahavioral changes lead to reduced material demand (only de-materialization from sharing economy based on Gruebler et.al., for now)"
+gdp_SSP2EU_GCS_IndLMD           "Global Commons scenario whith reduced material output in the industry sector (from de-materialization and material efficiency)"
 /
 
 all_GDPpcScen    "all possible GDP per capita scenarios (GDP and Population from the same SSP-scenario"


### PR DESCRIPTION


## Purpose of this PR

add new demand scenario names for industry to all_demScen (new low material and moderate efficiency scenarios) in `core/sets.gms`

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Minor change (default scenarios show only small differences)

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed (not needed)
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches (not needed)
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (not necessary)


