### PR TITLE
Improvment of traditional representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     [[#1414](https://github.com/remindmodel/remind/pull/1414)]
 - correctly report `Tech|*|Capital Costs|w/ Adj Costs` for t < cm_startyear
     [[#1429](https://github.com/remindmodel/remind/pull/1429), [#1476](https://github.com/remindmodel/remind/pull/1476)]
+- prevent tradtional biomass spillover to other sectors than buildings
+    [[#1519](https://github.com/remindmodel/remind/pull/1519)]
 
 ### removed
 - **45_carbonprice** remove outdated realizations:

--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -80,28 +80,28 @@ vm_deltaCap.fx(t,regi,"biotr",rlf)$(t.val gt 2005) = 0;
 *BS/DK* Developing regions (defined by GDP PPP threshold) phase out more slowly ( + varied by SSP)
 loop(regi,
   if ( (pm_gdp("2005",regi)/pm_pop("2005",regi) / pm_shPPPMER(regi)) lt 4,
-    vm_deltaCap.fx("2010",regi,"biotr","1") = 1.3  * vm_deltaCap.lo("2005",regi,"biotr","1");
-    vm_deltaCap.fx("2015",regi,"biotr","1") = 0.9  * vm_deltaCap.lo("2005",regi,"biotr","1");
-    vm_deltaCap.fx("2020",regi,"biotr","1") = 0.7  * vm_deltaCap.lo("2005",regi,"biotr","1");
+    vm_deltaCap.up("2010",regi,"biotr","1") = 1.3  * vm_deltaCap.lo("2005",regi,"biotr","1");
+    vm_deltaCap.up("2015",regi,"biotr","1") = 0.9  * vm_deltaCap.lo("2005",regi,"biotr","1");
+    vm_deltaCap.up("2020",regi,"biotr","1") = 0.7  * vm_deltaCap.lo("2005",regi,"biotr","1");
 $ifthen NOT %cm_tradbio_phaseout% == "fast"   !! cm_tradbio_phaseout
-    vm_deltaCap.fx("2025",regi,"biotr","1") = 0.5  * vm_deltaCap.lo("2005",regi,"biotr","1");
-    vm_deltaCap.fx("2030",regi,"biotr","1") = 0.4  * vm_deltaCap.lo("2005",regi,"biotr","1");
-    vm_deltaCap.fx("2035",regi,"biotr","1") = 0.3  * vm_deltaCap.lo("2005",regi,"biotr","1");
-    vm_deltaCap.fx("2040",regi,"biotr","1") = 0.2  * vm_deltaCap.lo("2005",regi,"biotr","1");
-    vm_deltaCap.fx("2045",regi,"biotr","1") = 0.15 * vm_deltaCap.lo("2005",regi,"biotr","1");
-    vm_deltaCap.fx("2050",regi,"biotr","1") = 0.1  * vm_deltaCap.lo("2005",regi,"biotr","1");
-    vm_deltaCap.fx("2055",regi,"biotr","1") = 0.1  * vm_deltaCap.lo("2005",regi,"biotr","1");
+    vm_deltaCap.up("2025",regi,"biotr","1") = 0.5  * vm_deltaCap.lo("2005",regi,"biotr","1");
+    vm_deltaCap.up("2030",regi,"biotr","1") = 0.4  * vm_deltaCap.lo("2005",regi,"biotr","1");
+    vm_deltaCap.up("2035",regi,"biotr","1") = 0.3  * vm_deltaCap.lo("2005",regi,"biotr","1");
+    vm_deltaCap.up("2040",regi,"biotr","1") = 0.2  * vm_deltaCap.lo("2005",regi,"biotr","1");
+    vm_deltaCap.up("2045",regi,"biotr","1") = 0.15 * vm_deltaCap.lo("2005",regi,"biotr","1");
+    vm_deltaCap.up("2050",regi,"biotr","1") = 0.1  * vm_deltaCap.lo("2005",regi,"biotr","1");
+    vm_deltaCap.up("2055",regi,"biotr","1") = 0.1  * vm_deltaCap.lo("2005",regi,"biotr","1");
 $endif
   );
 );
 
 * quickest phaseout in SDP scenarios (no new capacities allowed), quick phaseout in SSP1 und SSP5
-$if %cm_GDPscen% == "gdp_SDP" vm_deltaCap.fx(t,regi,"biotr","1")$(t.val gt 2020) = 0;
-$if %cm_GDPscen% == "gdp_SDP_EI" vm_deltaCap.fx(t,regi,"biotr","1")$(t.val gt 2020) = 0;
-$if %cm_GDPscen% == "gdp_SDP_MC" vm_deltaCap.fx(t,regi,"biotr","1")$(t.val gt 2020) = 0;
-$if %cm_GDPscen% == "gdp_SDP_RC" vm_deltaCap.fx(t,regi,"biotr","1")$(t.val gt 2020) = 0;
-$if %cm_GDPscen% == "gdp_SSP1" vm_deltaCap.fx(t,regi,"biotr","1")$(t.val gt 2020) = 0.5 * vm_deltaCap.lo(t,regi,"biotr","1");
-$if %cm_GDPscen% == "gdp_SSP5" vm_deltaCap.fx(t,regi,"biotr","1")$(t.val gt 2020) = 0.5 * vm_deltaCap.lo(t,regi,"biotr","1");
+$if %cm_GDPscen% == "gdp_SDP" vm_deltaCap.up(t,regi,"biotr","1")$(t.val gt 2020) = 0;
+$if %cm_GDPscen% == "gdp_SDP_EI" vm_deltaCap.up(t,regi,"biotr","1")$(t.val gt 2020) = 0;
+$if %cm_GDPscen% == "gdp_SDP_MC" vm_deltaCap.up(t,regi,"biotr","1")$(t.val gt 2020) = 0;
+$if %cm_GDPscen% == "gdp_SDP_RC" vm_deltaCap.up(t,regi,"biotr","1")$(t.val gt 2020) = 0;
+$if %cm_GDPscen% == "gdp_SSP1" vm_deltaCap.up(t,regi,"biotr","1")$(t.val gt 2020) = 0.5 * vm_deltaCap.lo(t,regi,"biotr","1");
+$if %cm_GDPscen% == "gdp_SSP5" vm_deltaCap.up(t,regi,"biotr","1")$(t.val gt 2020) = 0.5 * vm_deltaCap.lo(t,regi,"biotr","1");
 
 
 *** ------------------------------------------------------------------------------------------

--- a/modules/36_buildings/services_putty/not_used.txt
+++ b/modules/36_buildings/services_putty/not_used.txt
@@ -20,3 +20,4 @@ vm_costCESMkup,input,questionnaire
 sm_trillion_2_non,input,questionnaire
 sm_TWa_2_kWh,input,questionnaire
 pm_tau_ces_tax,input,questionnaire
+vm_prodSe,input,questionnaire

--- a/modules/36_buildings/services_with_capital/not_used.txt
+++ b/modules/36_buildings/services_with_capital/not_used.txt
@@ -26,3 +26,4 @@ sm_trillion_2_non,input,questionnaire
 sm_TWa_2_kWh,input,questionnaire
 pm_tau_ces_tax,input,questionnaire
 pm_dt,parameter,???
+vm_prodSe,input,questionnaire

--- a/modules/36_buildings/simple/declarations.gms
+++ b/modules/36_buildings/simple/declarations.gms
@@ -37,6 +37,7 @@ Equations
   q36_costAddH2PhaseIn(ttot,all_regi)               "additional industry H2 t&d cost at low H2 penetration in buildings" 
   q36_costCESmarkup(ttot,all_regi,all_in)           "calculation of additional CES markup cost that are accounted in the budget (GDP) to represent demand-side technology cost of end-use transformation, for example, cost of heat pumps"
   q36_costAddTeInv(ttot,all_regi,all_te)            "summation of sector-specific demand-side cost"
+  q36_biotrBound(ttot,all_regi)                     "enforce that solid biomass demand is be at least as was transformed via biotr to prevent spillover to other sectors"
 ;
 
 *** EOF ./modules/36_buildings/simple/declarations.gms

--- a/modules/36_buildings/simple/declarations.gms
+++ b/modules/36_buildings/simple/declarations.gms
@@ -37,7 +37,7 @@ Equations
   q36_costAddH2PhaseIn(ttot,all_regi)               "additional industry H2 t&d cost at low H2 penetration in buildings" 
   q36_costCESmarkup(ttot,all_regi,all_in)           "calculation of additional CES markup cost that are accounted in the budget (GDP) to represent demand-side technology cost of end-use transformation, for example, cost of heat pumps"
   q36_costAddTeInv(ttot,all_regi,all_te)            "summation of sector-specific demand-side cost"
-  q36_biotrBound(ttot,all_regi)                     "enforce that solid biomass demand is be at least as was transformed via biotr to prevent spillover to other sectors"
+  q36_biotrBound(ttot,all_regi)                     "enforce that solid biomass demand in buildings is at least as much as what is transformed via biotr to prevent spillover to other sectors"
 ;
 
 *** EOF ./modules/36_buildings/simple/declarations.gms

--- a/modules/36_buildings/simple/equations.gms
+++ b/modules/36_buildings/simple/equations.gms
@@ -85,5 +85,14 @@ q36_costCESmarkup(t,regi,in)$(ppfen_buildings_dyn36(in))..
      + pm_cesdata(t,regi,in,"offset_quantity"))
 ;
 
+***---------------------------------------------------------------------------
+*' Use at least as much solids from biomass in buildings as was transformed
+*' via biotr in order to prevent that traditionally used biomass is also used
+*' in other sectors. This only applies to regions that still have trational
+*' biomass use, which is defined via a gdp criteria.
+***---------------------------------------------------------------------------
+q36_biotrBound(t,regi)$((pm_gdp("2005",regi)/pm_pop("2005",regi) / pm_shPPPMER(regi)) lt 4)..
+  vm_demFeSector_afterTax(t,regi,'sesobio','fesos','build',emiMkt)$(sector2emiMkt('build',emiMkt))
+  =g= vm_prodSe(t,regi,"pebiolc","sesobio","biotr")
 
 *** EOF ./modules/36_buildings/simple/equations.gms

--- a/modules/36_buildings/simple/equations.gms
+++ b/modules/36_buildings/simple/equations.gms
@@ -91,8 +91,12 @@ q36_costCESmarkup(t,regi,in)$(ppfen_buildings_dyn36(in))..
 *' in other sectors. This only applies to regions that still have trational
 *' biomass use, which is defined via a gdp criteria.
 ***---------------------------------------------------------------------------
-q36_biotrBound(t,regi)$((pm_gdp("2005",regi)/pm_pop("2005",regi) / pm_shPPPMER(regi)) lt 4)..
-  vm_demFeSector_afterTax(t,regi,'sesobio','fesos','build',emiMkt)$(sector2emiMkt('build',emiMkt))
-  =g= vm_prodSe(t,regi,"pebiolc","sesobio","biotr")
+q36_biotrBound(t,regi)$(t.val ge 2010 AND (pm_gdp("2005",regi)/pm_pop("2005",regi) / pm_shPPPMER(regi)) lt 4)..
+  sum(sector2emiMkt('build',emiMkt),
+    vm_demFeSector_afterTax(t,regi,'sesobio','fesos','build',emiMkt)
+  )
+  =g=
+  vm_prodSe(t,regi,"pebiolc","sesobio","biotr")
+;
 
 *** EOF ./modules/36_buildings/simple/equations.gms

--- a/modules/36_buildings/simple/equations.gms
+++ b/modules/36_buildings/simple/equations.gms
@@ -88,7 +88,7 @@ q36_costCESmarkup(t,regi,in)$(ppfen_buildings_dyn36(in))..
 ***---------------------------------------------------------------------------
 *' Use at least as much solids from biomass in buildings as was transformed
 *' via biotr in order to prevent that traditionally used biomass is also used
-*' in other sectors. This only applies to regions that still have trational
+*' in other sectors. This only applies to regions that still have traditional
 *' biomass use, which is defined via a gdp criteria.
 ***---------------------------------------------------------------------------
 q36_biotrBound(t,regi)$(t.val ge 2010 AND (pm_gdp("2005",regi)/pm_pop("2005",regi) / pm_shPPPMER(regi)) lt 4)..

--- a/modules/36_buildings/simple/not_used.txt
+++ b/modules/36_buildings/simple/not_used.txt
@@ -19,9 +19,6 @@ sm_DpGJ_2_TDpTWa,input,questionnaire
 sm_D2015_2_D2005,input,questionnaire
 sm_tmp,input,questionnaire
 vm_effGr,input,questionnaire
-pm_shPPPMER,input,questionnaire
-pm_pop,input,questionnaire
-pm_gdp,input,questionnaire
 pm_esCapCost,input,questionnaire
 pm_fe2es,input,questionnaire
 pm_shFeCes,input,questionnaire


### PR DESCRIPTION
## Purpose of this PR

This PR prevents a spillover of traditional biomass into other sectors (i.e. the industry sector), by ensuring that not more `pebiolc` is transformed into `sesobio` via `biotr` than there is demand for solid biomass in buildings. This applies only to regions that still have a traditional biomass demand. 

In order to do that, the phase-out trajectory of `vm_deltaCap(t ,regi, "biotr","1")` is relaxed from a fixed value to an upper bound. This works, because `biotr` is by definition the cheapest and most efficient technology, so REMIND will always use that technology if not constrained otherwise.

The effect is, that `IND` and `SSA` now have lower levels of `vm_prodSe(t,regi,"pebiolc","sesobio","biotr")` and the solids demand is instead fulfilled with coal (`coaltr`) and modern solid biomass (`biotrmod`).

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix 
- [ ] Refactoring
- [ ] New feature 
- [x] Minor change (default scenarios show only small differences)
- [ ] Fundamental change
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed (not needed)
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches (not needed)
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Test runs are here: 
  `/p/tmp/merfort/REMIND_update_residues/remind`
* Comparison of results (what changes by this PR?): 
You find a compare scenarios PDF here:
`/p/tmp/merfort/REMIND_update_residues/remind/compScen-orig_vs_relax_biotr_supply_v2-2024-01-11_08.50.31-H12.pdf`
Differences between the previous version ("orig") and the new version ("relax_biotr_supply_v2") are small. Biggest difference is that some of the solids that came from traditional biomass before is now coming from coal or (modern) biomass in IND and SSA:
![image](https://github.com/remindmodel/remind/assets/58845874/7b0e3f6d-45c3-4271-aedc-305d1970bf97)
![image](https://github.com/remindmodel/remind/assets/58845874/7467debb-c738-4387-8aeb-9d69f1874ade)
![image](https://github.com/remindmodel/remind/assets/58845874/f102a446-c653-4cb5-bf45-89f501a3db83)
![image](https://github.com/remindmodel/remind/assets/58845874/3c1fee6d-3590-418d-8ef6-9b2260322efa)

