### PR TITLE
set import trade costs for peur for numerical reasons

### DIFF
--- a/modules/24_trade/capacity/datainput.gms
+++ b/modules/24_trade/capacity/datainput.gms
@@ -29,6 +29,7 @@ $offdelim
 ;
 pm_costsTradePeFinancial(regi,"XportElasticity", tradePe(enty)) = 100;
 pm_costsTradePeFinancial(regi, "tradeFloor", tradePe(enty))     = 0.0125;
+pm_costsTradePeFinancial(regi,"Mport","peur")                   = 1e-06;
 
 *** Adjust tradecosts based on switch
 pm_costsTradePeFinancial(regi,"Xport", "pebiolc") = pm_costsTradePeFinancial(regi,"Xport", "pebiolc") * cm_tradecostBio;

--- a/modules/24_trade/se_trade/datainput.gms
+++ b/modules/24_trade/se_trade/datainput.gms
@@ -29,6 +29,7 @@ $offdelim
 ;
 pm_costsTradePeFinancial(regi,"XportElasticity", tradePe(enty)) = 100;
 pm_costsTradePeFinancial(regi, "tradeFloor", tradePe(enty))     = 0.0125;
+pm_costsTradePeFinancial(regi,"Mport","peur")                   = 1e-06;
 
 *** Adjust tradecosts based on switch
 pm_costsTradePeFinancial(regi,"Xport", "pebiolc") = pm_costsTradePeFinancial(regi,"Xport", "pebiolc") * cm_tradecostBio;

--- a/modules/24_trade/standard/datainput.gms
+++ b/modules/24_trade/standard/datainput.gms
@@ -29,6 +29,7 @@ $offdelim
 ;
 pm_costsTradePeFinancial(regi,"XportElasticity", tradePe(enty)) = 100;
 pm_costsTradePeFinancial(regi, "tradeFloor", tradePe(enty))     = 0.0125;
+pm_costsTradePeFinancial(regi,"Mport","peur")                   = 1e-06;
 
 *** Adjust tradecosts based on switch
 pm_costsTradePeFinancial(regi,"Xport", "pebiolc") = pm_costsTradePeFinancial(regi,"Xport", "pebiolc") * cm_tradecostBio;


### PR DESCRIPTION


## Purpose of this PR
Avoid INFES: set import trade costs for peur for numerical reasons to avoid import and export at same time step

## Type of change

- [x] Minor change (default scenarios show only small differences)

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

