### PR TITLE
Bug Report and Feature Request Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,75 @@
+name: Bug Report
+description: This template is for reporting bugs found in the REMIND model
+title: "[BUG]: "
+labels: ["bug", "remind"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        :warning: **Please note:** We welcome bug reports and will address them promptly. However, support for setting up and running REMIND outside of PIK is limited.
+  - type: textarea
+    id: user-environment
+    attributes:
+      label: Your environment
+      description: Tell us a bit about your computing environment. Please include the following information. You can copy and paste the output of the commands into the text box. Run all commands in a terminal/PowerShell session in your REMIND root directory.
+      value: |
+        **REMIND version**
+        Run `cat CITATION.cff | grep ^version`
+
+        **R version**
+        On Linux/Mac run `R --version`
+        On Windows run `R.exe --version`
+
+        **Operating System**
+        On Linux run `lsb_release -a` or `cat /etc/os-release`
+        On Mac run `sw_vers`
+        On Windows run `systeminfo | findstr /B /C:"OS Name" /B /C:"OS Version"`
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual Behavior
+      description: What did happen?
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce the Problem
+      description: Please provide detailed steps for reproducing the problem.
+      placeholder: |
+        e.g.:
+        1. Configured REMIND for run `SSP2-EU` ...
+        2. Started REMIND via `R start.R` ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Log Output
+      description: |
+        Any log output that will give us more context about the issue you are encountering is much appreciated. Tip: You can attach screenshots or log files by clicking this area to highlight it and then dragging files in.
+    validations:
+      required: false
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Please confirm the following
+      description: Please check the relevant boxes.
+      options:
+        - label: I have access to the PIK cluster
+        - label: I have access to the REMIND input data
+        - label: I have searched the existing issues
+        - label: I have provided detailed information about the bug
+        - label: I have provided steps to reproduce the issue
+        - label: I have provided information about my environment (OS)
+

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,44 @@
+---
+name: Feature Request
+description: Suggest a new feature or enhancement for the REMIND model.
+title: '[FEATURE REQUEST]'
+labels: enhancement
+body:
+- type: markdown
+  attributes:
+    value: |
+      Thanks for taking the time to suggest a new feature or enhancement!
+- type: input
+  id: feature-summary
+  attributes:
+    label: Feature Summary
+    description: Provide a brief summary of the feature or enhancement.
+    placeholder: 'e.g., Add a new model parameter to handle X...'
+  validations:
+    required: true
+- type: textarea
+  id: feature-benefit
+  attributes:
+    label: Benefit
+    description: Please explain the benefit of this feature.
+    placeholder: 'This feature would improve...'
+  validations:
+    required: true
+- type: textarea
+  id: feature-details
+  attributes:
+    label: Feature Details
+    description: Please provide any additional details or context about the feature.
+    placeholder: 'The feature works by...'
+  validations:
+    required: true
+- type: checkboxes
+  id: terms
+  attributes:
+    label: Agreement
+    options:
+      - label: I have searched to see if this feature has been requested before.
+        required: true
+      - label: I have provided details and context for the feature.
+        required: true
+---


### PR DESCRIPTION
## Purpose of this PR

This PR completes [Baseer's original PR](https://github.com/remindmodel/remind/pull/1438). To quote Baseer

> This pull request introduces standardized issue templates to streamline the issue creation and resolution process in our REMIND repository. The templates cover Feature Requests, Bug Reports and we can add more custom templates if needed.

I substantially revised the bug template from Baseers draft since I liked the structure of [this bug report template](https://github.com/angular-translate/angular-translate/blob/master/.github/ISSUE_TEMPLATE.md), but still wanted to keep the versatility provided by Baseers yaml-based approach. The feature request template remains basically the same as in the original PR. 

You can test the templates in the [Issue section of my personal REMIND repo](https://github.com/tonnrueter/remind/issues/new/choose). Fake issues show the rendered [feature request](https://github.com/tonnrueter/remind0/issues/6) and [bug report](https://github.com/tonnrueter/remind/issues/5) templates. Your feedback on the template drafts is welcome!
