### PR TITLE
fix pm_sccConvergenceMaxDeviation bug for module 51

### DIFF
--- a/modules/51_internalizeDamages/KWlikeItrCPnash/declarations.gms
+++ b/modules/51_internalizeDamages/KWlikeItrCPnash/declarations.gms
@@ -14,7 +14,7 @@ p51_sccLastItr(tall,all_regi) "Social cost of carbon (due to GDP damages) from l
 p51_sccParts(tall,tall,all_regi) "Social cost of carbon components (time, region)"
 
 
-pm_sccConvergenceMaxDeviation(all_regi) "max deviation of SCC from last iteration [percent]"
+pm_sccConvergenceMaxDeviation "max deviation of SCC from last iteration [percent]"
 ;
 
 *** EOF ./modules/51_internalizeDamages/KWlikeItrCPnash/declarations.gms

--- a/modules/51_internalizeDamages/KWlikeItrCPnash/postsolve.gms
+++ b/modules/51_internalizeDamages/KWlikeItrCPnash/postsolve.gms
@@ -55,7 +55,7 @@ display p51_scc,pm_taxCO2eqSCC;
 
 
 * convergence indicator:
-pm_sccConvergenceMaxDeviation(regi) = 100 * smax(tall$(tall.val ge cm_startyear and tall.val lt 2150),abs(p51_scc(tall,regi)/max(p51_sccLastItr(tall,regi),1e-8) - 1) );
+pm_sccConvergenceMaxDeviation = 100 * smax(regi, smax(tall$(tall.val ge cm_startyear and tall.val lt 2150),abs(p51_scc(tall,regi)/max(p51_sccLastItr(tall,regi),1e-8) - 1) ));
 display pm_sccConvergenceMaxDeviation;
 
 

--- a/modules/51_internalizeDamages/KWlikeItrCPreg/declarations.gms
+++ b/modules/51_internalizeDamages/KWlikeItrCPreg/declarations.gms
@@ -14,7 +14,7 @@ p51_sccLastItr(tall,all_regi) "Social cost of carbon (due to GDP damages) from l
 p51_sccParts(tall,tall,all_regi) "Social cost of carbon components (time, region)"
 
 
-pm_sccConvergenceMaxDeviation(all_regi) "max deviation of SCC from last iteration [percent]"
+pm_sccConvergenceMaxDeviation "max deviation of SCC from last iteration [percent]"
 ;
 
 *** EOF ./modules/51_internalizeDamages/KWlikeItrCPreg/declarations.gms

--- a/modules/51_internalizeDamages/KWlikeItrCPreg/postsolve.gms
+++ b/modules/51_internalizeDamages/KWlikeItrCPreg/postsolve.gms
@@ -57,7 +57,7 @@ display p51_scc,pm_taxCO2eqSCC;
 
 
 * convergence indicator:
-pm_sccConvergenceMaxDeviation(regi) = 100 * smax(tall$(tall.val ge cm_startyear and tall.val lt 2150),abs(p51_scc(tall,regi)/max(p51_sccLastItr(tall,regi),1e-8) - 1) );
+pm_sccConvergenceMaxDeviation = 100 * smax(regi, smax(tall$(tall.val ge cm_startyear and tall.val lt 2150),abs(p51_scc(tall,regi)/max(p51_sccLastItr(tall,regi),1e-8) - 1) ));
 display pm_sccConvergenceMaxDeviation;
 
 


### PR DESCRIPTION
## Purpose of this PR

- 80_optimization/nash/postsolve.gms expects pm_sccConvergenceMaxDeviation to be a scalar
- in two 51 realizations, replace the regi-dependent version by smax(regi)
- avoid compilation errors in NGFS pricereg scenarios

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)
