### PR TITLE
update calibration revision

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -30,7 +30,7 @@ cfg$extramappings_historic <- ""
 cfg$inputRevision <- "6.609"
 
 #### Current CES parameter and GDX revision (commit hash) ####
-cfg$CESandGDXversion <- "9affecd97b6d34c294eca6571885263e1bb1de90"
+cfg$CESandGDXversion <- "cf0ef3b7c4c24f6be3b877779d310a40ee337d4d"
 
 #### Force the model to download new input data ####
 cfg$force_download <- FALSE


### PR DESCRIPTION
## Purpose of this PR

Update to [new calibration revision](https://github.com/remindmodel/CESparameters/commit/cf0ef3b7c4c24f6be3b877779d310a40ee337d4d), which only adds additional files for process-based steel implementation. 

Will run tests as part of #1547.

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Minor change (default scenarios show only small differences)

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

