### PR TITLE
Removing German specific nuclear capacity bounds

### DIFF
--- a/modules/47_regipol/regiCarbonPrice/bounds.gms
+++ b/modules/47_regipol/regiCarbonPrice/bounds.gms
@@ -18,10 +18,6 @@
 *'
 *' ###### Bounds for Historic and Near-term Alignment
 
-*' These bounds account for historic nuclear power development.
-vm_cap.fx("2015",regi,"tnrs","1")$((cm_startyear le 2015) and (sameas(regi,"DEU"))) = 10.8/1000; 
-vm_cap.fx("2020",regi,"tnrs","1")$((cm_startyear le 2020) and (sameas(regi,"DEU"))) = 7.8/1000;
-
 *' This limits wind and solar PV capacity additions for 2025 in light of recent slow developments as of 2023.
 *' Upper bound is double the historic maximum capacity addition in 2011-2020.
 loop(regi$(sameAs(regi,"DEU")),


### PR DESCRIPTION
## Purpose of this PR

- A recent update to the historical data made the previous German capacity fixing located in the regipol module incompatible with the historical data.

- REMIND equation `q_PE_histCap` enforces nuclear capacity in 2010, 2015 and 2020 to be at least 90% of the historical data input calculated at `mrremind` `calcCapacity` function.
- The regipol module had extra code to enforce 2015 and 2020 German nuclear capacities to be `10.8/1000` and `7.8/1000`, respectively.

- `q_PE_histCap` sets a lower bound equal to `90% of 8.93/1000 = 8.037/1000` which is lower than the previous enforced capacity value in the regipol module `7.8/1000` for `vm_cap.fx("2020","DEU","tnrs","1")`.

- This PR removes the German specific code fixing the nuclear capacitites, and relies on the core equation to reflect the historical behavior instead.

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
