### PR TITLE
new input data rev. 6.70  and new CES parameters

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -27,10 +27,10 @@ cfg$regionmapping <- "config/regionmappingH12.csv"
 ### Additional (optional) region mapping, so that those validation data can be loaded that contain the corresponding additional regions.
 cfg$extramappings_historic <- ""
 #### Current input data revision (<mainrevision>.<subrevision>) ####
-cfg$inputRevision <- "6.609"
+cfg$inputRevision <- "6.70"
 
 #### Current CES parameter and GDX revision (commit hash) ####
-cfg$CESandGDXversion <- "cf0ef3b7c4c24f6be3b877779d310a40ee337d4d"
+cfg$CESandGDXversion <- "c1256714220e99250f791cc35e61ae51d3bdc7da"
 
 #### Force the model to download new input data ####
 cfg$force_download <- FALSE

--- a/modules/29_CES_parameters/calibrate/datainput.gms
+++ b/modules/29_CES_parameters/calibrate/datainput.gms
@@ -144,34 +144,12 @@ ipf_beyond_last(out) = YES;
 *** End of Sets calculation
 
 Parameter
-f29_esdemand(tall,all_regi,all_demScen,all_in)       "energy service demand"
-/
-$ondelim
-$include "./modules/29_CES_parameters/calibrate/input/f29_esdemand.cs4r"
-$offdelim
-/
-;
-*** change million m2.C to trillion m2.C
-p29_esdemand(t,regi,in) = f29_esdemand(t,regi,"%cm_demScen%",in)/sm_mega_2_non;
-
-Parameter
-$ifthen.transpmodule "%transport%" == "edge_esm"
 p29_trpdemand       "transport demand"
 /
 $ondelim
 $include "./modules/29_CES_parameters/calibrate/input/pm_trp_demand.cs4r"
 $offdelim
 /
-$endif.transpmodule
-
-f29_efficiency_growth(tall,all_regi,all_demScen,all_in)       "efficency growth for ppf beyond calibration"
-/
-$ondelim
-$include "./modules/29_CES_parameters/calibrate/input/f29_efficiency_growth.cs4r"
-$offdelim
-/
-;
-p29_efficiency_growth(t,regi,in) = f29_efficiency_growth(t,regi,"%cm_demScen%",in);
 
 parameter
 f29_capitalQuantity(tall,all_regi,all_demScen,all_in)          "capital quantities"
@@ -254,9 +232,6 @@ $ifthen.industry_subsectors "%industry%" == "subsectors"
 $else.industry_subsectors
   sm_EJ_2_TWa * pm_fedemand(t,regi,in)
 $endif.industry_subsectors
-
-*** Load exogenous ES trajectories
-pm_cesdata(t,regi,in,"quantity") $p29_esdemand(t,regi,in) = p29_esdemand(t,regi,in);
 
 *** Load exogenous transport demand - required for the EDGE transport module
 $ifthen.edgesm %transport% ==  "edge_esm"
@@ -359,14 +334,6 @@ p29_capitalPrice(t,regi) = 0.12;
 
 *** Load capital price assumption for the first iteration, otherwise take it from gdx prices
 if( sm_CES_calibration_iteration eq 1 AND s29_CES_calibration_new_structure eq 1,  pm_cesdata(t,regi,"kap","price") = p29_capitalPrice(t,regi));
-
-*** In case there is one capital variable together with an energy variable in a same CES, give them the same efficiency growth pathways
-
-loop (ue_fe_kap_29(out),
-        loop ((cesOut2cesIn(out,in),cesOut2cesIn2(out,in2))$(ppfKap(in) AND ppfen(in2)),
-        p29_efficiency_growth(t,regi,in) = p29_efficiency_growth(t,regi,in2);
-        );
-    );
 
 p29_esubGrowth = 0.3;
 

--- a/modules/29_CES_parameters/calibrate/declarations.gms
+++ b/modules/29_CES_parameters/calibrate/declarations.gms
@@ -18,10 +18,7 @@ Parameters
   p29_cesdata_load(tall,all_regi,all_in,cesParameter)  "pm_cesdata from the gdx file"
   p29_cesIO_load(tall,all_regi,all_in)                "production factor vm_cesIO from input.gdx"
   p29_effGr(tall,all_regi,all_in)                                   "growth of factor efficiency from input.gdx"
-$ifthen.transpmodule "%transport%" == "edge_esm"
   p29_trpdemand(tall,all_regi,all_GDPscen,all_demScen,EDGE_scenario_all,all_in) "transport demand for the edge_esm transport module, unit: trillion passenger/ton km"
-$endif.transpmodule
-  p29_esdemand(tall,all_regi,all_in)                  "energy service demand"
   p29_efficiency_growth(tall,all_regi,all_in)         "efficency level paths for ppf beyond calibration"
   p29_capitalQuantity(tall,all_regi,all_in)            "capital quantities"
   p29_capitalPrice(tall,all_regi)                "capital prices"

--- a/modules/29_CES_parameters/calibrate/input/files
+++ b/modules/29_CES_parameters/calibrate/input/files
@@ -1,5 +1,3 @@
 f29_capitalQuantity.cs4r
-f29_efficiency_growth.cs4r
-f29_esdemand.cs4r
 pm_trp_demand.cs4r
 pm_fe_demand_EDGETbased.cs4r

--- a/modules/29_CES_parameters/calibrate/preloop.gms
+++ b/modules/29_CES_parameters/calibrate/preloop.gms
@@ -878,15 +878,6 @@ loop ((t_29hist_last(t2),regi_dyn29(regi),cesOut2cesIn(out,in))$(
   = pm_cesdata(t2,regi,in, "effGr");
 );
 
-*** Second, change efficiencies for the variables which have exogenous pathways
-*** in case UE = f(FE,K)
-loop ((t_29hist_last(t2),cesOut2cesIn(out,in))$(    ue_fe_kap_29(out) ),
-  pm_cesdata(t_29,regi_dyn29(regi),in, "effGr")$( NOT t_29hist(t_29) )
-  = pm_cesdata(t2,regi,in, "effGr")
-  * p29_efficiency_growth(t_29,regi,in)
-  / p29_efficiency_growth(t2,regi,in);
-);
-
 ***_____________________________ END OF: 5 - PASS EFF TIME EVOLUTION TO EFFGR ________________________________________
 
 
@@ -1073,8 +1064,7 @@ $endif.subsectors
 
 ***_____________________________ END OF: BEYOND CALIBRATION PART II ________________________________________
 
-option p29_efficiency_growth:8;
-display "after long term efficiencies", pm_cesdata, p29_efficiency_growth;
+display "after long term efficiencies", pm_cesdata;
 
 *** All efficiences after t_29_last are set to their t_29_last values. This is
 *** done in order to avoid xi negative in the latest periods. Should not be


### PR DESCRIPTION
* new input data rev. 6.70
* delete files that are no longer part of input data
* CES parameters and gdx files for input data rev. 6.70 for SSP2EU, SDP2EU_EU21, SPP1, SSP5, SDP_MC, SDP_EI, SDP_RC, SSP2EU_PBS and SSP2EU_lowEn; 
* runs: /p/tmp/lavinia/REMIND/REMIND_calibration_2024_02_10/remind and /p/tmp/lavinia/REMIND/REMIND_calibration_2024_02_12/remind

## Purpose of this PR


## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Minor change (default scenarios show only small differences)

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas

## Further information (optional):

* Test runs are here: /p/tmp/lavinia/REMIND/REMIND_calibration_2024_02_10/remind and /p/tmp/lavinia/REMIND/REMIND_calibration_2024_02_12/remind
* Comparison of results (what changes by this PR?): 

