### PR TITLE
fix cm_implicitPriceTarget regexp matching

### DIFF
--- a/main.gms
+++ b/main.gms
@@ -1287,8 +1287,8 @@ $setGlobal cm_loadFromGDX_implicitQttyTargetTax  off  !! def = off  !! regexp = 
 ***      option 3 should only be used if the target is defined for a region that has its carbon pricing controlled by cm_emiMktTarget in the 47_regipol module.
 $setGlobal cm_implicitQttyTarget_delay  iteration 3  !! def = iteration 3, quantity targets only start after iteration 3  
 *** cm_implicitPriceTarget "define tax/subsidies to match FE prices defined in the pm_implicitPriceTarget parameter."
-***   Acceptable values: "off", "Initial", "HighElectricityPrice", "HighGasandLiquidsPrice", "HighPrice", "LowPrice", "LowElectricityPrice"
-$setGlobal cm_implicitPriceTarget  off  !! def = off  !! regexp = off|Initial|HighElectricityPrice|HighGasandLiquidsPrice|HighPrice|LowPrice|LowElectricityPrice"
+***   Acceptable values: "off", "initial", "elecPrice", "H2Price", "highElec", "highGasandLiq", "highPrice", "lowElec", "lowPrice"
+$setGlobal cm_implicitPriceTarget  off  !! def = off  !! regexp = off|initial|elecPrice|H2Price|highElec|highGasandLiq|highPrice|lowElec|lowPrice
 *** cm_implicitPePriceTarget "define tax/subsidies to match PE prices defined in the pm_implicitPePriceTarget parameter."
 ***   Acceptable values: "off", "highFossilPrice".
 $setGlobal cm_implicitPePriceTarget  off  !! def = off  !! regexp = off|highFossilPrice

--- a/tests/testthat/test_01-start.R
+++ b/tests/testthat/test_01-start.R
@@ -39,8 +39,7 @@ test_that("start.R --test succeeds on all configs", {
                            file.path("../../config", "*", "scenario_config*.csv")))
   }
   csvfiles <- normalizePath(grep("scenario_config_coupled", csvfiles, invert = TRUE, value = TRUE))
-  skipfiles <- c("scenario_config_21_EU11_ECEMF",
-                 "scenario_config_EDGE-T_NDC_NPi_pkbudget",
+  skipfiles <- c("scenario_config_EDGE-T_NDC_NPi_pkbudget",
                  "scenario_config_NAVIGATE_300")
   csvfiles <- grep(paste(skipfiles, collapse = "|"), csvfiles, invert = TRUE, value = TRUE)
   expect_true(length(csvfiles) > 0)


### PR DESCRIPTION
## Purpose of this PR

- for `cm_implicitPriceTarget`, I noticed the description of allowed names did not match reality in [this file](https://github.com/remindmodel/remind/blob/fce4495d5c2a9f87ca586258a5581dd7ff8d2285/modules/47_regipol/regiCarbonPrice/input/exogenousFEprices.cs3r#L196), therefore I adjusted description and regexp match
- with that change, the file ECEMF config does not fail the test anymore and need not be skipped

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
