### PR TITLE
output.R defaults to "direct" locally, does not offer "direct" on the cluster

### DIFF
--- a/output.R
+++ b/output.R
@@ -45,8 +45,8 @@ helpText <- "
 #'   remind_dir=       path to remind or output folder(s) where runs can be found.
 #'                     Defaults to ./output but can also be used to specify multiple
 #'                     folders, comma-separated, such as remind_dir=.,../otherremind
-#'   slurmConfig=      use slurmConfig=direct, priority, short or standby to specify
-#'                     slurm selection. You may also pass complicated arguments such as
+#'   slurmConfig=      use slurmConfig=priority, short or standby to specify slurm
+#'                     selection. You may also pass complicated arguments such as
 #'                     slurmConfig='--qos=priority --mem=8000'
 "
 
@@ -67,6 +67,8 @@ library(lucode2)
 library(gms)
 require(stringr, quietly = TRUE)
 
+source("scripts/start/isSlurmAvailable.R")
+
 flags <- NULL
 ### Define arguments that can be read from command line
 if (!exists("source_include")) {
@@ -84,9 +86,13 @@ if ("--help" %in% flags) {
 choose_slurmConfig_output <- function(slurmExceptions = NULL) {
   slurm_options <- c("--qos=priority", "--qos=short", "--qos=standby",
                      "--qos=priority --mem=8000", "--qos=short --mem=8000",
-                     "--qos=standby --mem=8000", "--qos=priority --mem=32000", "direct")
+                     "--qos=standby --mem=8000", "--qos=priority --mem=32000")
+
+  if (!isSlurmAvailable())
+    return("direct")
+
   if (!is.null(slurmExceptions)) {
-    slurm_options <- unique(c(grep(slurmExceptions, slurm_options, value = TRUE), "direct"))
+    slurm_options <- grep(slurmExceptions, slurm_options, value = TRUE)
   }
   if (length(slurm_options) == 1) {
     return(slurm_options[[1]])


### PR DESCRIPTION
- [x] New feature 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)