### PR TITLE
fix max potential for CCS to 0 for t < 2020

### DIFF
--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -396,6 +396,7 @@ $endif
 *** -------------------------------------------------------------------------------------------------------------
 
 if ( c_ccsinjecratescen gt 0,
+        vm_co2CCS.up(ttot,regi,"cco2","ico2","ccsinje","1")$(ttot.val lt 2020) = 0;
 	vm_co2CCS.up("2020",regi,"cco2","ico2","ccsinje","1") = pm_boundCapCCS(regi);
 	vm_co2CCS.up("2025",regi,"cco2","ico2","ccsinje","1") = pm_boundCapCCS(regi);
 );

--- a/core/declarations.gms
+++ b/core/declarations.gms
@@ -397,7 +397,7 @@ v_costInv(ttot,all_regi)                             "investment costs"
 vm_costTeCapital(ttot,all_regi,all_te)               "investment costs"
 vm_costAddTeInv(tall,all_regi,all_te,emi_sectors)    "additional sector-specific investment cost of demand-side transformation"
 
-vm_co2CCS(ttot,all_regi,all_enty,all_enty,all_te,rlf)       "all differenct ccs. [GtC/a]"
+vm_co2CCS(ttot,all_regi,all_enty,all_enty,all_te,rlf)       "all different ccs. [GtC/a]"
 
 vm_co2capture(ttot,all_regi,all_enty,all_enty,all_te,rlf)   "all captured CO2. [GtC/a]"
 v_co2capturevalve(ttot,all_regi)                            "CO2 emitted right after capture [GtC/a] (in q_balCCUvsCCS to account for different lifetimes of capture and CCU/CCS te and capacities)"


### PR DESCRIPTION
## Purpose of this PR

Avoid the following:
```
scenario  variable                                                       unit      period value
NPi       Carbon Management|Storage|Maximum annual CO2 storage potential Mt CO2/yr   2005 19646.
NPi       Carbon Management|Storage|Maximum annual CO2 storage potential Mt CO2/yr   2010 19646.
NPi       Carbon Management|Storage|Maximum annual CO2 storage potential Mt CO2/yr   2015 19646.
```

The levels were 0 anyway, so just affects this new variable

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
