### PR TITLE
fix max potential for CCS to 0 for t < 2020

### DIFF
--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -396,7 +396,7 @@ $endif
 *** -------------------------------------------------------------------------------------------------------------
 
 if ( c_ccsinjecratescen gt 0,
-        vm_co2CCS.up(ttot,regi,"cco2","ico2","ccsinje","1")$(ttot.val lt 2020) = 0;
+        vm_co2CCS.up(ttot,regi,"cco2","ico2","ccsinje","1")$(ttot.val ge 2005 AND ttot.val lt 2020) = 0;
 	vm_co2CCS.up("2020",regi,"cco2","ico2","ccsinje","1") = pm_boundCapCCS(regi);
 	vm_co2CCS.up("2025",regi,"cco2","ico2","ccsinje","1") = pm_boundCapCCS(regi);
 );


### PR DESCRIPTION
## Purpose of this PR

- bugfix for #1563 
- variables should are usually not define over whole ttot, but instead just for t

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
