### PR TITLE
Fix bug that overwrote changes of floor cost from the switch cm_incolearn in policy scenarios, fix overwriting in the 05_initialCap module

### DIFF
--- a/modules/05_initialCap/on/declarations.gms
+++ b/modules/05_initialCap/on/declarations.gms
@@ -28,6 +28,7 @@ Parameter
 $ifThen %cm_techcosts% == "GLO"
   p05_inco0_t_ref(ttot,all_regi,all_te)              "auxiliary parameter to load pm_inco0_t from reference run if cm_startyear > 2005 and initialCap is therefore not run"
 $endIf
+  p05_pmdata_ref(all_regi,char,all_te)               "auxiliary parameter to load pm_data from reference run if cm_startyear > 2005 and initialCap is therefore not run"
 ;
 
 Variables

--- a/modules/05_initialCap/on/preloop.gms
+++ b/modules/05_initialCap/on/preloop.gms
@@ -532,11 +532,23 @@ if (cm_startyear gt 2005,
   Execute_Loadpoint 'input_ref' pm_EN_demand_from_initialcap2 = pm_EN_demand_from_initialcap2;
   Execute_Loadpoint 'input_ref' pm_pedem_res = pm_pedem_res;
   Execute_Loadpoint 'input_ref' pm_dataeta = pm_dataeta;
-  Execute_Loadpoint 'input_ref' pm_data = pm_data;
   Execute_Loadpoint 'input_ref' pm_aux_capLowerLimit = pm_aux_capLowerLimit;
   Execute_Loadpoint 'input_ref' vm_deltaCap.l = vm_deltaCap.l;
   Execute_Loadpoint 'input_ref' vm_deltaCap.lo = vm_deltaCap.lo;
   Execute_Loadpoint 'input_ref' vm_deltaCap.up = vm_deltaCap.up;
+
+
+
+*** load pm_data from input_ref.gdx and overwrite values
+*** only for eta of chp technologies since they have been adapted in initialCap routine above
+*** This is to avoid overwriting changes to pm_data by scenario switches
+  Execute_Loadpoint 'input_ref' p05_pmdata_ref = pm_data;
+  pm_data(regi,char,te)$( (sameas(te,"coalchp")  
+                              OR sameas(te,"gaschp")
+                              OR sameas(te,"biochp") )
+                            AND sameas(char,"eta") ) = p05_pmdata_ref(regi,char,te);
+
+
 
 *** if %cm_techcosts% == "GLO", load pm_inco0_t from input_ref.gdx and overwrite values
 *** only for pc, ngt, ngcc since they have been adapted in initialCap routine above

--- a/modules/05_initialCap/on/preloop.gms
+++ b/modules/05_initialCap/on/preloop.gms
@@ -539,9 +539,9 @@ if (cm_startyear gt 2005,
 
 
 
-*** load pm_data from input_ref.gdx and overwrite values
-*** only for eta of chp technologies since they have been adapted in initialCap routine above
-*** This is to avoid overwriting changes to pm_data by scenario switches
+*** load pm_data from input_ref.gdx and overwrite values only for eta of chp technologies
+*** Only the eta values of chp technologies have been adapted by initialCap script above.
+*** This is to avoid overwriting all of pm_data and make sure that scenario switches which adapt pm_data before this module work as intended.
   Execute_Loadpoint 'input_ref' p05_pmdata_ref = pm_data;
   pm_data(regi,char,te)$( (sameas(te,"coalchp")  
                               OR sameas(te,"gaschp")


### PR DESCRIPTION
Fix bug that overwrote changes of floor cost from the switch cm_incolearn in policy scenarios. I removed overwriting all values of ``pm_data`` in the 05_initialCap module. Now only values of pm_data are overwritten that are actually changed by module 5. This is related to #1390. 

Please let me know if you know of other parameters that are overwritten at the end of module 5 where this might be relevant. 

Tagging @cchrisgong, who also works on technology cost. 

## Purpose of this PR


## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix 


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [ ] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Test runs are here: 
``/p/tmp/schreyer/Modeling/remind/FossilFree/output/EU27_NZ_CCS050_opt_2023-12-04_22.40.08``
* Comparison of results (what changes by this PR?): 

