### PR TITLE
Remove four asterisks in code comments (reserved for GAMS error messages)

### DIFF
--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -130,9 +130,9 @@ pm_shGasLiq_fe_up(ttot,regi,sector)=0;
 pm_shGasLiq_fe_lo(ttot,regi,sector)=0;
 
 
-*******************************************************************************
-**************     Technology data input read-in and manipulation       *******
-*******************************************************************************
+*------------------------------------------------------------------------------------
+***          Technology data input read-in and manipulation
+*------------------------------------------------------------------------------------
 *** Note: future to be its own module perhaps
 *** Note: in module 5 there are more cost manipulation after initial capacities are calculated, be aware those can overwrite your technology values for policy runs if you set them here in the core
 ***---------------------------------------------------------------------------
@@ -182,7 +182,7 @@ $offdelim
 pm_esCapCost(tall,all_regi,all_teEs) = 0;
 
 ***---------------------------------------------------------------------------
-****** Manipulating technology data
+*** Manipulating technology data
 ***---------------------------------------------------------------------------
 *** Manipulating global or regional technology data - absolute value
 ***---------------------------------------------------------------------------
@@ -244,16 +244,16 @@ fm_dataglob("inco0","csp")              = 0.7 * fm_dataglob("inco0","csp");
 fm_dataglob("incolearn","csp")          = 0.7 * fm_dataglob("incolearn","csp");
 
 
-*** --------------------------------------------------------------------------------
-****** Regionalize investment cost data
-*** -------------------------------------------------------------------------------
+***---------------------------------------------------------------------------
+*** Regionalize investment cost data
+***---------------------------------------------------------------------------
 
 *** initialize regionalized data using global data
 pm_data(all_regi,char,te) = fm_dataglob(char,te);
 
-*** -------------------------------------------------------------------------------
-****** Regional risk premium during building time
-*** -------------------------------------------------------------------------------
+***---------------------------------------------------------------------------
+*** Regional risk premium during building time
+***---------------------------------------------------------------------------
 
 *RP* calculate turnkey costs (which are the sum of the overnight costs in generisdata_tech and the "interest during construction” (IDC) )
 
@@ -406,12 +406,13 @@ loop (teNoLearn(te)$( sameas(te,"igcc") ),
 $endif.REG_techcosts
 
 
-****************************************************************************************************
-*************************END of Technology data input read-in and manipulation in core *************
+*------------------------------------------------------------------------------------
+*   END of Technology data input read-in and manipulation in core
+*------------------------------------------------------------------------------------
 *** Note: in modules/05_initialCap/on/preloop.gms, there are additional adjustment to investment
 *** cost in the near term due to calibration of historical energy conversion efficiencies based on
 *** initial capacities
-****************************************************************************************************
+*------------------------------------------------------------------------------------
 
 
 *JH* Determine CCS injection rates


### PR DESCRIPTION
## Purpose of this PR

Sequences of four asterisks are reserved for GAMS error messages, but were inserted in code comments in https://github.com/remindmodel/remind/commit/cede734af3ffebddffca407f91c670289d3b885a, https://github.com/remindmodel/remind/commit/bace67b30366578b720a3a5fed1822f5da6c1ff2 and https://github.com/remindmodel/remind/commit/06f746c99df5a6a6b09ce5c091053522a030353b. This replaces them.

## Type of change

Only changing comments, not code.

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [ ] I explained my changes within the PR, particularly in hard-to-understand areas
- [ ] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)