### PR TITLE
make sure NDC run has not lower taxes than BAU

### DIFF
--- a/modules/45_carbonprice/NDC/datainput.gms
+++ b/modules/45_carbonprice/NDC/datainput.gms
@@ -6,13 +6,20 @@
 *** |  Contact: remind@pik-potsdam.de
 *** SOF ./modules/45_carbonprice/NDC/datainput.gms
 
-*** CO2 tax level is calculated at a 5% exponential increase from the 2020 tax level exogenously defined until 2030, then a linear tax, plus regional convergence
-*** convert tax value from $/t CO2eq to T$/GtC
-pm_taxCO2eq(t,regi)$(sameas(t, "2020")) = 5 * sm_DptCO2_2_TDpGtC;
+*** CO2 tax level from business as usual run, serves as minimal tax in NDC
+Execute_Loadpoint "input_ref" p45_taxCO2eq_bau = pm_taxCO2eq;
 
-*** set ETS price in 2015 for EUR
-pm_taxCO2eq(t,regi)$(sameas(t, "2015")) = 0;
-pm_taxCO2eq(t,regi)$(sameas(t, "2015") and regi_group("EUR_regi",regi)) = 5 * sm_DptCO2_2_TDpGtC;
+pm_taxCO2eq(t,regi) = p45_taxCO2eq_bau(t,regi)
+
+*** Carbon prices defined in $/t CO2, has to be rescaled to right unit
+parameter f45_taxCO2eqHist(ttot,all_regi)       "historic CO2 prices ($/tCO2)"
+/
+$ondelim
+$include "./modules/45_carbonprice/NDC/input/pm_taxCO2eqHist.cs4r"
+$offdelim
+/
+;
+pm_taxCO2eq(t,regi)$(t.val < 2025) = f45_taxCO2eqHist(t,regi) * sm_DptCO2_2_TDpGtC;
 
 *** parameters for exponential increase after NDC targets
 Scalar p45_taxCO2eqGlobal2030 "startprice in 2030 (unit TDpGtC) of global CO2eq taxes towards which countries converge";

--- a/modules/45_carbonprice/NDC/declarations.gms
+++ b/modules/45_carbonprice/NDC/declarations.gms
@@ -17,6 +17,7 @@ p45_taxCO2eqFirstNDCyear(all_regi)                       "CO2eq tax in p45_first
 p45_taxCO2eqLastNDCyear(all_regi)                        "CO2eq tax in p45_lastNDCyear"
 p45_CO2eqwoLU_actual_iter(iteration,ttot,all_regi)       "actual level of regional GHG emissions p45_CO2eqwoLU_actual tracked over iterations"
 p45_taxCO2eq_iter(iteration,ttot,all_regi)               "CO2eq tax non-regi tracked over iterations"
+p45_taxCO2eq_bau(ttot,all_regi)                          "level of CO2 taxes in business as usual run"
 ;
 
 Scalar    p45_adjustExponent                             "exponent in tax adjustment process";

--- a/modules/45_carbonprice/NDC/input/files
+++ b/modules/45_carbonprice/NDC/input/files
@@ -1,3 +1,4 @@
 fm_2005shareTarget.cs3r
 fm_factorTargetyear.cs3r
 fm_histShare.cs3r
+pm_taxCO2eqHist.cs4r

--- a/modules/45_carbonprice/NDC/postsolve.gms
+++ b/modules/45_carbonprice/NDC/postsolve.gms
@@ -75,11 +75,16 @@ pm_taxCO2eq(t,regi)$(t.val gt p45_lastNDCyear(regi))
       + p45_taxCO2eqGlobal2030        * p45_taxCO2eqYearlyIncrease**(t.val-2030)                  * (min(t.val,p45_taxCO2eqConvergenceYear) - p45_lastNDCyear(regi))
       )/(p45_taxCO2eqConvergenceYear - p45_lastNDCyear(regi));
 
-***as a minimum, have linear price increase starting from 1$ in 2030
-pm_taxCO2eq(t,regi)$(t.val gt 2030) = max(pm_taxCO2eq(t,regi),1*sm_DptCO2_2_TDpGtC * (1+(t.val-2030)*9/7));
+***as a minimum, use BAU and have linear price increase starting from 1$ in 2030
+pm_taxCO2eq(t,regi)$(t.val gt 2030) = max(
+                 pm_taxCO2eq(t,regi),
+                 p45_taxCO2eq_bau(t,regi),
+                 1 * sm_DptCO2_2_TDpGtC * (1+(t.val-2030)*9/7), p45_taxCO2eq_bau(t,regi)
+  );
 
-        display pm_taxCO2eq;
+display pm_taxCO2eq;
 
+*** end if from beginning of file (cm_iterative_target_adj eq 3)
 );
 
 *** EOF ./modules/45_carbonprice/NDC/postsolve.gms

--- a/modules/45_carbonprice/NDC/preloop.gms
+++ b/modules/45_carbonprice/NDC/preloop.gms
@@ -19,6 +19,8 @@ pm_taxCO2eq(t,regi)$(t.val gt p45_lastNDCyear(regi))
       + p45_taxCO2eqGlobal2030          * p45_taxCO2eqYearlyIncrease**(t.val-2030)                    * (min(p45_taxCO2eqConvergenceYear,t.val) - p45_lastNDCyear(regi))
       )/(p45_taxCO2eqConvergenceYear - p45_lastNDCyear(regi));
 
+pm_taxCO2eq(t,regi) = max(pm_taxCO2eq(t,regi), p45_taxCO2eq_bau(t,regi));
+
 display pm_taxCO2eq;
 
 *#' @equations 


### PR DESCRIPTION
## Purpose of this PR

- close https://github.com/remindmodel/development_issues/issues/236
- NDC always has a BAU run in order to calculate an emission target for those countries that have no NDC at all. It makes no sense if NDC has lower carbon prices than BAU
- Load bau prices and use them as a minimum value
- also load historical data in case someone uses NDC module for <= 2020

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)

## Further information (optional):

* Test runs are here: `/p/tmp/oliverr/remind/output/SSP2EU-NDC_2024-02-22_13.35.12`: just one iteration to see whether everything works
