### PR TITLE
fix negative fossil emissions in industry

### DIFF
--- a/core/equations.gms
+++ b/core/equations.gms
@@ -764,18 +764,22 @@ q_emiAll(t,regi,emi(enty))..
 ***------------------------------------------------------
 *mlb 8/2010* extension for multigas accounting/trading
 *cb only "static" equation to be active before cm_startyear, as multigasscen could be different from a scenario to another that is fixed on the first
-  q_co2eq(ttot,regi)$(ttot.val ge cm_startyear)..
-         vm_co2eq(ttot,regi)
-         =e=
-         sum(emiMkt, vm_co2eqMkt(ttot,regi,emiMkt));
+q_co2eq(ttot,regi)$(ttot.val ge cm_startyear)..
+  vm_co2eq(ttot,regi)
+  =e=
+  sum(emiMkt, vm_co2eqMkt(ttot,regi,emiMkt))
+;
 
-  q_co2eqMkt(ttot,regi,emiMkt)$(ttot.val ge cm_startyear)..
+q_co2eqMkt(ttot,regi,emiMkt)$(ttot.val ge cm_startyear)..
   vm_co2eqMkt(ttot,regi,emiMkt)
   =e=
-  vm_emiAllMkt(ttot,regi,"co2",emiMkt)
-  + (sm_tgn_2_pgc   * vm_emiAllMkt(ttot,regi,"n2o",emiMkt) +
-     sm_tgch4_2_pgc * vm_emiAllMkt(ttot,regi,"ch4",emiMkt)) $(cm_multigasscen eq 2 or cm_multigasscen eq 3)
-  - vm_emiMacSector(ttot,regi,"co2luc") $((cm_multigasscen eq 3) AND (sameas(emiMkt,"other")));
+    vm_emiAllMkt(ttot,regi,"co2",emiMkt)
+  + ( sm_tgn_2_pgc   * vm_emiAllMkt(ttot,regi,"n2o",emiMkt)
+    + sm_tgch4_2_pgc * vm_emiAllMkt(ttot,regi,"ch4",emiMkt)
+    )$( cm_multigasscen eq 2 or cm_multigasscen eq 3 )
+  - vm_emiMacSector(ttot,regi,"co2luc")$(
+                              cm_multigasscen eq 3 AND sameas(emiMkt,"other") )
+;
 
 ***------------------------------------------------------
 *' Total global emissions in CO2 equivalents that are part of the climate policy also take into account foreign emissions.
@@ -789,8 +793,12 @@ q_emiAll(t,regi,emi(enty))..
 ***------------------------------------
 *mh for each region and time step: emissions + permit trade balance < emission cap
 q_emiCap(t,regi) ..
-                vm_co2eq(t,regi) + vm_Xport(t,regi,"perm") - vm_Mport(t,regi,"perm")
-                =l= vm_perm(t,regi);
+    vm_co2eq(t,regi) 
+  + vm_Xport(t,regi,"perm")
+  - vm_Mport(t,regi,"perm")
+  =l=
+  vm_perm(t,regi)
+;
 
 ***-----------------------------------------------------------------
 *** Budgets on GHG emissions (single or two subsequent time periods)

--- a/core/equations.gms
+++ b/core/equations.gms
@@ -519,11 +519,11 @@ q_emiTeDetailMkt(t,regi,enty,enty2,te,enty3,emiMkt)$(
                         OR (pe2se(enty,enty2,te) AND sameas(enty3,"cco2")) ) ..
   vm_emiTeDetailMkt(t,regi,enty,enty2,te,enty3,emiMkt)
   =e=
-    sum(emi2te(enty,enty2,te,enty3),
-      ( sum(pe2se(enty,enty2,te),
-          pm_emifac(t,regi,enty,enty2,te,enty3)
-        * vm_demPE(t,regi,enty,enty2,te)
-      )
+  sum(emi2te(enty,enty2,te,enty3),
+    ( sum(pe2se(enty,enty2,te),
+        pm_emifac(t,regi,enty,enty2,te,enty3)
+      * vm_demPE(t,regi,enty,enty2,te)
+    )
     + sum((ccs2Leak(enty,enty2,te,enty3),teCCS2rlf(te,rlf)),
         pm_emifac(t,regi,enty,enty2,te,enty3)
       * vm_co2CCS(t,regi,enty,enty2,te,rlf)
@@ -531,16 +531,21 @@ q_emiTeDetailMkt(t,regi,enty,enty2,te,enty3,emiMkt)$(
     )$( sameas(emiMkt,"ETS") )
   + sum(se2fe(enty,enty2,te),
       pm_emifac(t,regi,enty,enty2,te,enty3)
-    * sum(sector$(    entyFe2Sector(enty2,sector)
-                  AND sector2emiMkt(sector,emiMkt) ),
-        vm_demFeSector(t,regi,enty,enty2,sector,emiMkt)
-        !! substract FE used for non-energy purposes (as feedstocks) so it does
-        !! not create energy-related emissions
-      - sum(entyFe2sector2emiMkt_NonEn(enty2,sector,emiMkt),
-          vm_demFENonEnergySector(t,regi,enty,enty2,sector,emiMkt))
-        )
+    * ( sum(sector$(    entyFe2Sector(enty2,sector)
+		    AND sector2emiMkt(sector,emiMkt) ),
+	  vm_demFeSector(t,regi,enty,enty2,sector,emiMkt)
+	  !! substract FE used for non-energy purposes (as feedstocks) so i
+	  !! does not create energy-related emissions
+	  !! FE from seXXbio, seXXsyn (not included in emi2te, therefore se2fe2)
+	  !! create negative emissions
+	- sum((se2fe2(entySe,enty2,te2),
+	       entyFe2sector2emiMkt_NonEn(entyFe,sector2emiMkt(sector,emiMkt))),
+	    vm_demFENonEnergySector(t,regi,entySe,enty2,sector,emiMkt)
+	  )
+	)
       )
     )
+  )
 ;
 
 ***--------------------------------------------------

--- a/core/sets.gms
+++ b/core/sets.gms
@@ -921,6 +921,7 @@ $endif.altFeEmiFac
 ***######################## R SECTION START (MODULES) ###############################
 *** THIS CODE IS CREATED AUTOMATICALLY, DO NOT MODIFY THESE LINES DIRECTLY
 *** ANY DIRECT MODIFICATION WILL BE LOST AFTER NEXT MODEL START
+*** CHANGES CAN BE DONE USING THE RESPECTIVE LINES IN scripts/start/prepare.R
 
 sets
 
@@ -960,7 +961,7 @@ sets
        codePerformance
        /
 
-      module2realisation(modules,*) "mapping of modules and active realisations" /
+module2realisation(modules,*) "mapping of modules and active realisations" /
        macro . %macro%
        welfare . %welfare%
        PE_FE_parameters . %PE_FE_parameters%

--- a/modules/37_industry/subsectors/declarations.gms
+++ b/modules/37_industry/subsectors/declarations.gms
@@ -104,6 +104,7 @@ $endif.no_calibration
   q37_nonIncineratedPlastics(ttot,all_regi,all_enty,all_enty,all_emiMkt)    "calculate carbon contained in plastics that are not incinerated [GtC]"
   q37_feedstockEmiUnknownFate(ttot,all_regi,all_enty,all_enty,all_emiMkt)   "calculate carbon contained in chemical feedstock with unknown fate [GtC]"
   q37_feedstocksLimit(ttot,all_regi,all_enty,all_enty,all_emiMkt)           "restrict feedstocks flow to total energy flows into industry"
+  q37_feedstocksShares(ttot,all_regi,all_enty,all_enty,all_emiMkt)   "identical fossil/biomass/synfuel shares for FE and feedstocks"
 
   !! process-based implementation
   q37_demMatPrc(tall,all_regi,mat)                        "Material demand of processes"

--- a/modules/37_industry/subsectors/equations.gms
+++ b/modules/37_industry/subsectors/equations.gms
@@ -242,6 +242,21 @@ q37_feedstocksLimit(ttot,regi,entySE,entyFE,emiMkt)$(
   vm_demFENonEnergySector(ttot,regi,entySE,entyFE,"indst",emiMkt)
 ;
 
+*' Feedstocks have identical fossil/biomass/synfuel shares as industry FE
+q37_feedstocksShares(t,regi,entySE,entyFE,emiMkt)$(
+                                          sum(te, se2fe(entySE,entyFE,te)) ) ..
+    vm_demFEsector_afterTax(t,regi,entySE,entyFE,"indst",emiMkt)
+  * sum(se2fe(entySE2,entyFE,te),
+      vm_demFENonEnergySector(t,regi,entySE2,entyFE,"indst",emiMkt)
+    )
+  =e=
+    vm_demFENonEnergySector(t,regi,entySE,entyFE,"indst",emiMkt)
+  * sum(se2fe2(entySE2,entyFE,te),
+      vm_demFEsector_afterTax(t,regi,entySE2,entyFE,"indst",emiMkt)
+    )
+;
+
+
 *' Calculate mass of carbon contained in chemical feedstocks
 q37_FeedstocksCarbon(ttot,regi,sefe(entySE,entyFE),emiMkt)$(
                          entyFE2sector2emiMkt_NonEn(entyFE,"indst",emiMkt) ) ..


### PR DESCRIPTION
This does ~two things~:
1. ~Subtract `vm_demFENonEnergySector` for `entySeBio` and `entySeSyn` from `vm_emiTeDetailMkt` in `q_emiTeDetailMkt`, as they will generate negative emissions when plastics are landfilled.~  (Already accounted for elsewhere.)
2. Enforce identical shares between `entySeFos`, `entySeBio` and `entySeSyn` in `vm_demFENonEnergySector` and `vm_demFEsector_afterTax`.

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
