### PR TITLE
BugFix - pm_taxCO2eqSum was not correctly define before its used for MAC curves

### DIFF
--- a/core/presolve.gms
+++ b/core/presolve.gms
@@ -5,8 +5,11 @@
 *** |  REMIND License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: remind@pik-potsdam.de
 *** SOF ./core/presolve.gms
-*JeS* calculate share of transport fuels in liquids
 
+* defining the CO2 price parameter that sums up the 3 CO2eq tax components
+pm_taxCO2eqSum(ttot,regi) = pm_taxCO2eq(ttot,regi) + pm_taxCO2eqRegi(ttot,regi) + pm_taxCO2eqSCC(ttot,regi);
+
+*JeS* calculate share of transport fuels in liquids
 pm_share_trans(ttot,regi)$(ttot.val ge 2005) = sum(se2fe(entySe,entyFe,te)$(seAgg2se("all_seliq",entySe) AND ( sameas(entyFe,"fepet") OR sameas(entyFe,"fedie"))), vm_prodFe.l(ttot,regi,entySe,entyFe,te)) / (sum(se2fe(entySe,entyFe,te)$seAgg2se("all_seliq",entySe), vm_prodFe.l(ttot,regi,entySe,entyFe,te)) + 0.0000001);
 
 *AJS* we need those in nash

--- a/modules/21_tax/on/postsolve.gms
+++ b/modules/21_tax/on/postsolve.gms
@@ -15,9 +15,6 @@ OPTION decimals =5;
 display p21_deltarev;
 OPTION decimals =3;
 
-*** sum all 3 CO2eq tax components
-pm_taxCO2eqSum(ttot,regi) = pm_taxCO2eq(ttot,regi) + pm_taxCO2eqRegi(ttot,regi) + pm_taxCO2eqSCC(ttot,regi);
-
 *GL* save reference level value of taxes for revenue recycling
 *JH* !!Warning!! The same allocation block exists in presolve.gms.
 ***                Do not forget to update the other file.

--- a/modules/21_tax/on/presolve.gms
+++ b/modules/21_tax/on/presolve.gms
@@ -12,9 +12,6 @@ p21_tau_so2_tax("2005",regi)=0;
 p21_tau_so2_tax("2100",regi)=s21_so2_tax_2010*pm_gdp_gdx("2100",regi)/pm_pop("2100",regi);
 p21_tau_so2_tax(ttot,regi)$(ttot.val>2100)=p21_tau_so2_tax("2100",regi);
 
-*** sum all 4 CO2eq tax components
-pm_taxCO2eqSum(ttot,regi) = pm_taxCO2eq(ttot,regi) + pm_taxCO2eqRegi(ttot,regi) + pm_taxCO2eqSCC(ttot,regi);
-
 *GL* save reference level value of taxed variables for revenue recycling
 *JH* !!Warning!! The same allocation block exists in postsolve.gms. 
 ***                Do not forget to update the other file.

--- a/modules/47_regipol/regiCarbonPrice/postsolve.gms
+++ b/modules/47_regipol/regiCarbonPrice/postsolve.gms
@@ -853,6 +853,7 @@ loop((ttot,ext_regi)$p47_exoCo2tax(ext_regi,ttot),
 
 *** setting exogenous CO2 prices
   pm_taxCO2eq(ttot,regi)$(regi_group(ext_regi,regi) and (ttot.val ge cm_startyear)) = p47_exoCo2tax(ext_regi,ttot)*sm_DptCO2_2_TDpGtC;
+  pm_taxCO2eqSum(ttot,regi)$(regi_group(ext_regi,regi) and (ttot.val ge cm_startyear)) = pm_taxCO2eq(ttot,regi);
 );
 display 'update of CO2 prices due to exogenously given CO2 prices in p47_exoCo2tax', pm_taxCO2eq;
 $endIf.regiExoPrice


### PR DESCRIPTION

## Purpose of this PR
- moving definition of pm_taxCO2eqSum to the core presolve so it is upated before mac abatament curves need it.

## Type of change

- [ x ] Bug fix 
- [ x ] Fundamental change

## Checklist:

- [ x ] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ x ] I performed a self-review of my own code
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

