### PR TITLE
use newest gms in github action; fail on codeCheck warning; test that no line starts with ****

### DIFF
--- a/.github/workflows/test-code.yaml
+++ b/.github/workflows/test-code.yaml
@@ -25,17 +25,22 @@ jobs:
 
       - uses: r-lib/actions/setup-r@v2
         with:
+          use-public-rspm: true
           extra-repositories: https://rse.pik-potsdam.de/r/packages/
 
       - name: Install R dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          packages: gms
-        
+          extra-packages: |
+            any::gms
+          # piam packages also available on CRAN (madrat, magclass, citation,
+          # gms, goxygen, GDPuc) will usually have an outdated binary version
+          # available; by using extra-packages we get the newest version
+
       - name: codeCheck
         run: null <- gms::codeCheck(strict=TRUE)
         shell: Rscript {0}
-        
+
       - name: fileSizeCheck
         run: source(".github/workflows/size-check")
         shell: Rscript {0}

--- a/core/declarations.gms
+++ b/core/declarations.gms
@@ -17,7 +17,6 @@ parameters
 ***--------------------------------------------------MACRO module--------------------------
 ***
 ***prices
-failnamingconvention(ttot,all_enty)       "whatever"
 pm_pvp(ttot,all_enty)                                "Price on commodity markets",
 p_pvpRef(ttot,all_enty)                              "Price on commodity markets - imported from REF gdx",
 

--- a/core/declarations.gms
+++ b/core/declarations.gms
@@ -17,6 +17,7 @@ parameters
 ***--------------------------------------------------MACRO module--------------------------
 ***
 ***prices
+failnamingconvention(ttot,all_enty)       "whatever"
 pm_pvp(ttot,all_enty)                                "Price on commodity markets",
 p_pvpRef(ttot,all_enty)                              "Price on commodity markets - imported from REF gdx",
 

--- a/tests/testthat/test_99-codeCheck.R
+++ b/tests/testthat/test_99-codeCheck.R
@@ -8,7 +8,24 @@ test_that("GAMS code follows the coding etiquette", {
   # have to run this via localSystem2 so that it uses the renv, where gms
   # is actually installed.
   skipIfPreviousFailed()
-  output <- localSystem2("Rscript", c("-e", "'invisible(gms::codeCheck(strict=TRUE))'"))
+  codecheckcode <- "'invisible(gms::codeCheck(strict=TRUE)); if (! is.null(warnings())) stop(warnings())'"
+  output <- localSystem2("Rscript", c("-e", codecheckcode))
   printIfFailed(output)
   expectSuccessStatus(output)
+})
+
+test_that("No four asterisks in code", {
+  notavailable <- Sys.which("grep") == ""
+  if (notavailable) {
+    skip("'grep' not available, please check yourself whether code starts with four asterisks.")
+  } else {
+    files <- paste0("../../", c("*.gms", "core/*.gms", "modules/*.gms", "modules/*/*.gms", "modules/*/*/*.gms"))
+    grepcode <- paste("grep", "'^\\*\\*\\*\\*'", paste(files, collapse = " "))
+    starlines <- suppressWarnings(system(grepcode, intern = TRUE))
+    if (length(starlines) > 0) {
+      warning("The following lines start with four asterisks, reserved for GAMS error messages.\n",
+              paste(starlines, collapse = "\n"))
+    }
+    expect_true(length(starlines) == 0)
+  }
 })


### PR DESCRIPTION
## Purpose of this PR

- avoid that old gms version is used as [here](https://github.com/remindmodel/remind/actions/runs/8051033598/job/21988009538) where it is obvious through `convetions` being printed that the version is older than [Jun 2022](https://github.com/pik-piam/gms/commit/c1c7c47729efbc4598e09d2134cf2422179b0b44#diff-2320721be543d29628bf52cda7b0e14e0e7543b4c892c38e96c3172b115de27bR111)
- in tests, fail on codeCheck warnings
- add test that no lines starting with `****` are in the code to avoid #1571

Failure:
```
-- Testing test_99-codeCheck.R ---------------------------------------------------
[ FAIL 1 | WARN 1 | SKIP 0 | PASS 1 ]

-- Warning (test_99-codeCheck.R:25:7): No four asterisks in code ---------------
The following lines start with four asterisks, reserved for GAMS error messages.
../../core/datainput.gms:**** |  (C) 2006-2023 Potsdam Institute for Climate Impact Research (PIK)

-- Failure (test_99-codeCheck.R:28:5): No four asterisks in code ---------------
length(starlines) == 0 is not TRUE

`actual`:   FALSE
`expected`: TRUE
[ FAIL 1 | WARN 1 | SKIP 0 | PASS 1 ]
```

grep not available:
```
-- Testing test_99-codeCheck.R ----------------------------------------------------------------------
[ FAIL 0 | WARN 0 | SKIP 1 | PASS 1 ]

-- Skipped tests (1) ------------------------------------------------
• 'grep' not available, please check yourself whether code starts with four asterisks. (1): test_99-codeCheck.R:19:5
```

Everything fine:
```
-- Testing test_99-codeCheck.R ----------------------------------------------------------------------
[ FAIL 0 | WARN 0 | SKIP 0 | PASS 2 ] Done!
```

## Type of change

- [x] Bug fix 

## Checklist:

- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`) `[ FAIL 0 | WARN 0 | SKIP 6 | PASS 82 ]`
