### PR TITLE
add revert-dev-packages make action to revert pik-piam packages that are development versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,12 @@ update-renv-all: ## Upgrade all packages (including CRAN packages) in your renv
 		fi \
 	fi
 
+revert-dev-packages: ## All PIK-PIAM packages that are development versions, i.e.
+                     ## that have a non-zero fourth version number component, are
+                     ## reverted to the highest version lower than the
+                     ## development version.
+	@Rscript -e 'piamenv::revertDevelopmentVersions()'
+
 ensure-reqs:     ## Ensure the REMIND library requirements are fulfilled
                  ## by installing updates and new libraries as necessary. Does not
                  ## install updates unless it is required.


### PR DESCRIPTION
- [x] New feature 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)