### PR TITLE
rename industry feedstock variables according to naming convention

### DIFF
--- a/core/declarations.gms
+++ b/core/declarations.gms
@@ -417,9 +417,6 @@ v_shGasLiq_fe(ttot,all_regi,emi_sectors)             "share of gases and liquids
 
 vm_emiCdrAll(ttot,all_regi)                          "all CDR emissions"
 
-vm_FeedstocksCarbon(ttot,all_regi,all_enty,all_enty,all_emiMkt)             "Carbon flow: carbon contained in chemical feedstocks [GtC]"
-vm_plasticsCarbon(ttot,all_regi,all_enty,all_enty,all_emiMkt)               "Carbon flow: carbon contained in plastics [GtC]"
-vm_plasticWaste(ttot,all_regi,all_enty,all_enty,all_emiMkt)                 "Carbon flow: carbon contained in plastic waste [GtC]"
 vm_feedstockEmiUnknownFate(ttot,all_regi,all_enty,all_enty,all_emiMkt)      "Carbon flow: carbon contained in feedstocks with unknown fate (not plastics)(assumed to go back into the atmosphere) [GtC]"
 vm_incinerationEmi(ttot,all_regi,all_enty,all_enty,all_emiMkt)              "Emissions from incineration of plastic waste [GtC]"
 vm_nonIncineratedPlastics(ttot,all_regi,all_enty,all_enty,all_emiMkt)       "Carbon flow: carbon contained in plastics that are not incinerated [GtC]"

--- a/modules/37_industry/fixed_shares/not_used.txt
+++ b/modules/37_industry/fixed_shares/not_used.txt
@@ -4,33 +4,33 @@
 # |  AGPL-3.0, you are granted additional permissions described in the
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
-name,type,reason
-pm_delta_kap,               input,      questionnaire
-pm_calibrate_eff_scale,     parameter,  not needed
-pm_fedemand,                parameter,  not needed
-sm_TWa_2_MWh,               input,      questionnaire
-sm_giga_2_non,              input,      not needed
-sm_EJ_2_TWa,                input,      not needed
-sm_tmp2,                    parameter,  not needed
-vm_cap,                     variable,   not needed
-vm_capFac,                  variable,   not needed
-pm_tau_ces_tax,             input,      questionnaire
-pm_secBioShare,             parameter,  not needed
-pm_exogDemScen,             input,      added by codeCheck
-pm_ts,                      parameter,  not needed
-pm_outflowPrcIni,           parameter,  not needed
-pm_specFeDem,               parameter,  not needed
-sm_macChange,               parameter,  not needed
-vm_demFENonEnergySector,    variable,   not needed
-vm_FeedstocksCarbon,        variable,   not needed
-vm_plasticsCarbon,          variable,   not needed
-vm_plasticWaste,            variable,   not needed
-vm_feedstockEmiUnknownFate, variable,   not needed
-vm_incinerationEmi,         variable,   not needed
-vm_nonIncineratedPlastics,  variable,   not needed
-vm_outflowPrc,              variable,   not needed
-vm_costMatPrc,              variable,   not needed
-pm_emifacNonEnergy,         parameter,  not needed
-pm_incinerationRate,        parameter,  not needed
-cm_emiscen,                 parameter,  not needed
-vm_demFeSector,             variable,   not needed
+name,                        type,       reason
+pm_delta_kap,                input,      questionnaire
+pm_calibrate_eff_scale,      parameter,  not needed
+pm_fedemand,                 parameter,  not needed
+sm_TWa_2_MWh,                input,      questionnaire
+sm_giga_2_non,               input,      not needed
+sm_EJ_2_TWa,                 input,      not needed
+sm_tmp2,                     parameter,  not needed
+vm_cap,                      variable,   not needed
+vm_capFac,                   variable,   not needed
+pm_tau_ces_tax,              input,      questionnaire
+pm_secBioShare,              parameter,  not needed
+pm_exogDemScen,              input,      added by codeCheck
+pm_ts,                       parameter,  not needed
+pm_outflowPrcIni,            parameter,  not needed
+pm_specFeDem,                parameter,  not needed
+sm_macChange,                parameter,  not needed
+vm_demFENonEnergySector,     variable,   not needed
+v37_FeedstocksCarbon,        variable,   not needed
+v37_plasticsCarbon,          variable,   not needed
+v37_plasticWaste,            variable,   not needed
+vm_feedstockEmiUnknownFate,  variable,   not needed
+vm_incinerationEmi,          variable,   not needed
+vm_nonIncineratedPlastics,   variable,   not needed
+vm_outflowPrc,               variable,   not needed
+vm_costMatPrc,               variable,   not needed
+pm_emifacNonEnergy,          parameter,  not needed
+pm_incinerationRate,         parameter,  not needed
+cm_emiscen,                  parameter,  not needed
+vm_demFeSector,              variable,   not needed

--- a/modules/37_industry/subsectors/declarations.gms
+++ b/modules/37_industry/subsectors/declarations.gms
@@ -73,6 +73,9 @@ Positive Variables
   vm_emiIndCCS(ttot,all_regi,all_enty)                                      "industry CCS emissions [GtC/a]"
   vm_IndCCSCost(ttot,all_regi,all_enty)                                     "industry CCS cost"
   v37_emiIndCCSmax(ttot,all_regi,emiInd37)                                  "maximum abatable industry emissions"
+  v37_FeedstocksCarbon(ttot,all_regi,all_enty,all_enty,all_emiMkt)          "Carbon flow: carbon contained in chemical feedstocks [GtC]"
+  v37_plasticsCarbon(ttot,all_regi,all_enty,all_enty,all_emiMkt)            "Carbon flow: carbon contained in plastics [GtC]"
+  v37_plasticWaste(ttot,all_regi,all_enty,all_enty,all_emiMkt)              "Carbon flow: carbon contained in plastic waste [GtC]"
 
   !! process-based implementation
   vm_outflowPrc(tall,all_regi,all_te,opmoPrc)                               "Production volume of processes in process-based model [Gt/a]"

--- a/modules/37_industry/subsectors/equations.gms
+++ b/modules/37_industry/subsectors/equations.gms
@@ -242,7 +242,7 @@ q37_feedstocksLimit(t,regi,entySe,entyFe,emiMkt)$(
 *' Calculate mass of carbon contained in chemical feedstocks
 q37_FeedstocksCarbon(t,regi,sefe(entySe,entyFe),emiMkt)$(
                          entyFE2sector2emiMkt_NonEn(entyFe,"indst",emiMkt) ) ..
-  vm_FeedstocksCarbon(t,regi,entySe,entyFe,emiMkt)
+  v37_FeedstocksCarbon(t,regi,entySe,entyFe,emiMkt)
   =e=
     vm_demFENonEnergySector(t,regi,entySe,entyFe,"indst",emiMkt)
   * p37_FeedstockCarbonContent(t,regi,entyFe)
@@ -251,9 +251,9 @@ q37_FeedstocksCarbon(t,regi,sefe(entySe,entyFe),emiMkt)$(
 *' Calculate carbon contained in plastics as a share of carbon in feedstock [GtC]
 q37_plasticsCarbon(t,regi,sefe(entySe,entyFe),emiMkt)$(
                          entyFE2sector2emiMkt_NonEn(entyFe,"indst",emiMkt) ) ..
-  vm_plasticsCarbon(t,regi,entySe,entyFe,emiMkt)
+  v37_plasticsCarbon(t,regi,entySe,entyFe,emiMkt)
   =e=
-    vm_FeedstocksCarbon(t,regi,entySe,entyFe,emiMkt)
+    v37_FeedstocksCarbon(t,regi,entySe,entyFe,emiMkt)
   * s37_plasticsShare
 ;
 
@@ -263,15 +263,15 @@ q37_plasticsCarbon(t,regi,sefe(entySe,entyFe),emiMkt)$(
 q37_plasticWaste(ttot,regi,sefe(entySe,entyFe),emiMkt)$(
                          entyFE2sector2emiMkt_NonEn(entyFe,"indst",emiMkt)
                      AND ttot.val ge max(2015, cm_startyear)               ) ..
-  vm_plasticWaste(ttot,regi,entySe,entyFe,emiMkt)
+  v37_plasticWaste(ttot,regi,entySe,entyFe,emiMkt)
   =e=
-    vm_plasticsCarbon(ttot-2,regi,entySe,entyFe,emiMkt)$( ttot.val lt 2070 )
-  + ( ( vm_plasticsCarbon(ttot-2,regi,entySe,entyFe,emiMkt)
-      + vm_plasticsCarbon(ttot-1,regi,entySe,entyFe,emiMkt)
+    v37_plasticsCarbon(ttot-2,regi,entySe,entyFe,emiMkt)$( ttot.val lt 2070 )
+  + ( ( v37_plasticsCarbon(ttot-2,regi,entySe,entyFe,emiMkt)
+      + v37_plasticsCarbon(ttot-1,regi,entySe,entyFe,emiMkt)
       )
     / 2
     )$( ttot.val eq 2070 )
-  + vm_plasticsCarbon(ttot-1,regi,entySe,entyFe,emiMkt)$( ttot.val gt 2070 )
+  + v37_plasticsCarbon(ttot-1,regi,entySe,entyFe,emiMkt)$( ttot.val gt 2070 )
   ;
 
 *' emissions from plastics incineration as a share of total plastic waste
@@ -279,7 +279,7 @@ q37_incinerationEmi(t,regi,sefe(entySe,entyFe),emiMkt)$(
                          entyFE2sector2emiMkt_NonEn(entyFe,"indst",emiMkt)) ..
   vm_incinerationEmi(t,regi,entySe,entyFe,emiMkt)
   =e=
-    vm_plasticWaste(t,regi,entySe,entyFe,emiMkt)
+    v37_plasticWaste(t,regi,entySe,entyFe,emiMkt)
   * pm_incinerationRate(t,regi)
 ;
 
@@ -290,9 +290,9 @@ q37_nonIncineratedPlastics(t,regi,sefe(entySe,entyFe),emiMkt)$(
                          entyFE2sector2emiMkt_NonEn(entyFe,"indst",emiMkt) ) ..
   vm_nonIncineratedPlastics(t,regi,entySe,entyFe,emiMkt)
   =e=
-    vm_plasticWaste(t,regi,entySe,entyFe,emiMkt)
+    v37_plasticWaste(t,regi,entySe,entyFe,emiMkt)
   * (1 - pm_incinerationRate(t,regi))
-;
+  ;
 
 *' calculate flow of carbon contained in chemical feedstock with unknown fate
 *' it is assumed that this carbon is re-emitted in the same timestep
@@ -300,7 +300,7 @@ q37_feedstockEmiUnknownFate(t,regi,sefe(entySe,entyFe),emiMkt)$(
                          entyFE2sector2emiMkt_NonEn(entyFe,"indst",emiMkt) ) ..
   vm_feedstockEmiUnknownFate(t,regi,entySe,entyFe,emiMkt)
   =e=
-    vm_FeedstocksCarbon(t,regi,entySe,entyFe,emiMkt)
+    v37_FeedstocksCarbon(t,regi,entySe,entyFe,emiMkt)
   * (1 - s37_plasticsShare)
 ;
 


### PR DESCRIPTION
- [x] Refactoring

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)