### PR TITLE
change of preference parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **core** add process emissions from chemicals subsector and from plastics incineration
 - **37_industry** add process-based steel model as alternative to CES-tree branch
 - **47_regipol** add support for delaying quantity targets and improving regional emission tax convergence
+- **core** change of preference parameters and associated computation of interest rates/mark ups 	
 
 ### fixed
 - fixed weights of energy carriers in `pm_IndstCO2Captured`

--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -55,6 +55,7 @@ pm_ttot_2_tall(ttot,tall)$((ttot.val = tall.val) ) = Yes;
 *** define pm_prtp according to cm_prtpScen:
 if(cm_prtpScen eq 1, pm_prtp(regi) = 0.01);
 if(cm_prtpScen eq 3, pm_prtp(regi) = 0.03);
+pm_ies(regi) = 0.5;
 
 *------------------------------------------------------------------------------------
 *------------------------------------------------------------------------------------
@@ -272,16 +273,16 @@ $offdelim
 loop(te$(fm_dataglob("constrTme",te) > 0),
   p_tkpremused(regi,te) = 1/fm_dataglob("constrTme",te)
     * sum(integ$(integ.val <= fm_dataglob("constrTme",te)),
-$if %cm_techcosts% == "REG"  (1.03 + pm_prtp(regi) + p_risk_premium_constr(regi) )  ** (integ.val - 0.5) - 1
-$if %cm_techcosts% == "GLO"  (1.03 + pm_prtp(regi) )                                 ** (integ.val - 0.5) - 1
+$if %cm_techcosts% == "REG"  (1 + 0.02/pm_ies(regi) + pm_prtp(regi) + p_risk_premium_constr(regi) )  ** (integ.val - 0.5) - 1
+$if %cm_techcosts% == "GLO"  (1 + 0.02/pm_ies(regi) +  pm_prtp(regi) )                               ** (integ.val - 0.5) - 1
       )
 );
 *** nuclear sees 3% higher interest rates during construction time due to higher construction time risk, see "The economic future of nuclear power - A study conducted at The University of Chicago" (2004)
 loop(te$sameas(te,"tnrs"),
   p_tkpremused(regi,te) = 1/fm_dataglob("constrTme",te)
     * sum(integ$(integ.val <= fm_dataglob("constrTme",te)),
-$if %cm_techcosts% == "REG"  (1.03 + 0.03 + pm_prtp(regi) + p_risk_premium_constr(regi) )  ** (integ.val - 0.5) - 1
-$if %cm_techcosts% == "GLO"  (1.03 + 0.03 + pm_prtp(regi) )                                 ** (integ.val - 0.5) - 1
+$if %cm_techcosts% == "REG"  (1 + 0.02/pm_ies(regi) + 0.03 + pm_prtp(regi) + p_risk_premium_constr(regi) )  ** (integ.val - 0.5) - 1
+$if %cm_techcosts% == "GLO"  (1 + 0.02/pm_ies(regi) + 0.03 + pm_prtp(regi) )                                ** (integ.val - 0.5) - 1
       )
 );
 

--- a/core/equations.gms
+++ b/core/equations.gms
@@ -57,7 +57,7 @@ q_costInvTeDir(t,regi,te)..
   =e=
   vm_costTeCapital(t,regi,te)
   * sum(te2rlf(te,rlf), vm_deltaCap(t,regi,te,rlf))
-  * (1.02 + pm_prtp(regi) ) ** (pm_ts(t) / 2) !! This increases the investments as if the money was actually borrowed
+  * (1 + 0.02/pm_ies(regi) + pm_prtp(regi) ) ** (pm_ts(t) / 2) !! This increases the investments as if the money was actually borrowed
   !! half a time step earlier, using an interest rate of pm_prtp + 2%, which is close to the model-endogenous interest rate.
   !! We do this to reduce the difference to the previous version where the effect of deltacap on capacity was split
   !! half to the current and half to the next time.
@@ -74,7 +74,7 @@ q_costInvTeAdj(t,regi,teAdj)..
   vm_costTeCapital(t,regi,teAdj) * (
     (p_adj_coeff(t,regi,teAdj) * v_adjFactor(t,regi,teAdj)) + (p_adj_coeff_glob(teAdj) * v_adjFactorGlob(t,regi,teAdj))
   )
-  * (1.02 + pm_prtp(regi) ) ** (pm_ts(t) / 2) !! This increases the investments as if the money was actually borrowed
+  * (1 + 0.02/pm_ies(regi) + pm_prtp(regi) ) ** (pm_ts(t) / 2) !! This increases the investments as if the money was actually borrowed
   !! half a time step earlier, using an interest rate of pm_prtp + 2%, which is close to the model-endogenous interest rate.
   !! We do this to reduce the difference to the previous version where the effect of deltacap on capacity was split
   !! half to the current and half to the next time.

--- a/core/postsolve.gms
+++ b/core/postsolve.gms
@@ -603,7 +603,7 @@ o_margAdjCostInv(ttot,regi,te)$(ttot.val ge max(2010, cm_startyear) AND teAdj(te
       + p_adj_deltacapoffset("2010",regi,te)$(ttot.val eq 2010) + p_adj_deltacapoffset("2015",regi,te)$(ttot.val eq 2015)
       + p_adj_deltacapoffset("2020",regi,te)$(ttot.val eq 2020) + p_adj_deltacapoffset("2025",regi,te)$(ttot.val eq 2025)
     )
-    * (1.02 + pm_prtp(regi)) ** (pm_ts(ttot) / 2)
+    * (1 + 0.02/pm_ies(regi) + pm_prtp(regi)) ** (pm_ts(ttot) / 2)
 ;
 
 *** CG: calculate average adjustment cost for capacity investment: vm_costInvTeAdj / vm_deltaCap
@@ -850,7 +850,7 @@ o_carbon_reemitted(ttot,regi,"co2")$(ttot.val ge 2005) =
 
 *CG**ML*: capital interest rate
 p_r(ttot,regi)$(ttot.val gt 2005 and ttot.val le 2130)
-    = (( (vm_cons.l(ttot+1,regi)/pm_pop(ttot+1,regi)) /
+    = 1 / pm_ies(regi) * (( (vm_cons.l(ttot+1,regi)/pm_pop(ttot+1,regi)) /
       (vm_cons.l(ttot-1,regi)/pm_pop(ttot-1,regi)) )
       ** (1 / ( pm_ttot_val(ttot+1)- pm_ttot_val(ttot-1))) - 1) + pm_prtp(regi)
 ;

--- a/main.gms
+++ b/main.gms
@@ -658,7 +658,7 @@ parameter
 parameter
   cm_prtpScen               "pure rate of time preference standard values"
 ;
-  cm_prtpScen         = 1;         !! def = 3  !! regexp = 1|3
+  cm_prtpScen         = 1;         !! def = 1  !! regexp = 1|3
 *' *  (1): 1 %
 *' *  (3): 3 %
 *'

--- a/main.gms
+++ b/main.gms
@@ -658,7 +658,7 @@ parameter
 parameter
   cm_prtpScen               "pure rate of time preference standard values"
 ;
-  cm_prtpScen         = 3;         !! def = 3  !! regexp = 1|3
+  cm_prtpScen         = 1;         !! def = 3  !! regexp = 1|3
 *' *  (1): 1 %
 *' *  (3): 3 %
 *'

--- a/modules/23_capitalMarket/debt_limit/datainput.gms
+++ b/modules/23_capitalMarket/debt_limit/datainput.gms
@@ -6,7 +6,6 @@
 *** |  Contact: remind@pik-potsdam.de
 *** SOF ./modules/23_capitalMarket/debt_limit/datainput.gms
 
-pm_ies(regi) = 1;
 pm_risk_premium(regi) = 0.0;
 p23_debt_growthCoeff(regi) = 0.2 ;
 


### PR DESCRIPTION
## Purpose of this PR
Change of preference parameters - time preference rate and intertemporal elasticity of substitution - adjust to more commonly used values. This requires an update of the mark ups/interest rates used in energy investment equations to keep them in line with market interest rates.

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Minor change (default scenarios show only small differences)
- [x] Fundamental change
- [ ] This change requires a documentation update


## Checklist:

- [ ] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [ ] I explained my changes within the PR, particularly in hard-to-understand areas
- [ ] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

