### PR TITLE
automatically check project summations (AR6, NAVIGATE), bugfixes ar6climate, fixOnRef, policyCosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **37_industry** add process-based steel model as alternative to CES-tree branch
 - **47_regipol** add support for delaying quantity targets and improving regional emission tax convergence
 - **core** change of preference parameters and associated computation of interest rates/mark ups 	
+- **scripts** add script to automatically check project summations from piamInterfaces
+    [[#1587](https://github.com/remindmodel/remind/pull/1587)]
 
 ### fixed
 - fixed weights of energy carriers in `pm_IndstCO2Captured`

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,7 +51,7 @@ Imports:
     nleqslv,
     optparse,
     piamenv (>= 0.4.0),
-    piamInterfaces (>= 0.12.18),
+    piamInterfaces (>= 0.13.12),
     plotly,
     purrr,
     quitte (>= 0.3128.4),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,7 +51,7 @@ Imports:
     nleqslv,
     optparse,
     piamenv (>= 0.4.0),
-    piamInterfaces (>= 0.13.12),
+    piamInterfaces (>= 0.13.14),
     plotly,
     purrr,
     quitte (>= 0.3128.4),

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -114,10 +114,13 @@ cfg$pythonEnabled <- "off"  # def <- off
 # Should REMIND output be shown in console? (0:no, 2:logfile, 3:yes)
 cfg$logoption <- 2
 
-# Just list the name of the output scripts that should be used by output.R
-# At the moment there are several R-scripts located in scripts/output/
+# List the name of output scripts from ./scripts/output/ to be used by output.R
+# You can adjust that via an 'output' column in your scenario_config.
+# To overwrite, enter 'reporting,whatever'. To add, enter 'cfg$output,additionalreporting'.
 cfg$output <- c("reporting","reportCEScalib","rds_report","fixOnRef","checkProjectSummations")
-# "ar6Climate","validation","emulator","reportCEScalib","validationSummary","dashboard"
+
+# automatically fix remaining differences between run and path_ref
+cfg$fixOnRefAuto <- FALSE
 
 # Set the format for the results folder, type string :date: in order to use the current time stamp in the folder name (e.g. "results:date:") use :title: to use the current title in the folder name
 cfg$results_folder <- "output/:title::date:"

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -116,7 +116,8 @@ cfg$logoption <- 2
 
 # Just list the name of the output scripts that should be used by output.R
 # At the moment there are several R-scripts located in scripts/output/
-cfg$output <- c("reporting","reportCEScalib","rds_report","fixOnRef") #"ar6Climate","emulator"
+cfg$output <- c("reporting","reportCEScalib","rds_report","fixOnRef","checkProjectSummations")
+# "ar6Climate","validation","emulator","reportCEScalib","validationSummary","dashboard"
 
 # Set the format for the results folder, type string :date: in order to use the current time stamp in the folder name (e.g. "results:date:") use :title: to use the current title in the folder name
 cfg$results_folder <- "output/:title::date:"

--- a/modules/21_tax/on/input/files
+++ b/modules/21_tax/on/input/files
@@ -6,4 +6,3 @@ f21_tau_pe_sub.cs4r
 f21_max_pe_sub.cs4r
 f21_tax_convergence.cs4r
 p21_tau_xpres_tax.cs4r
-f21_vehiclesSubsidies.cs4r

--- a/scripts/output/comparison/policyCosts.R
+++ b/scripts/output/comparison/policyCosts.R
@@ -297,7 +297,7 @@ if (!"3" %in% special_requests) {
 
   tmp_policy_costs <- tmp_policy_costs_magpie %>%
     lapply(quitte::as.quitte) %>%
-    lapply(select, region, period, data, value)
+    lapply(select, "region", "period", "variable", "value")
 
   # Combine results in single tibble, with names like "Pol_w.r.t_Ref"
   policy_costs <- rename(tmp_policy_costs[[1]], !!sym(paste0(pol_names[1], "_w.r.t_",ref_names[1])):=value)
@@ -305,13 +305,13 @@ if (!"3" %in% special_requests) {
     for (i in 2:length(tmp_policy_costs)) {
       policy_costs <- tmp_policy_costs[[i]] %>%
         rename(!!sym(paste0(pol_names[i], "_w.r.t_", ref_names[i])) := value) %>%
-        left_join(policy_costs, tmp_policy_costs[[i]], by = c("region", "period", "data"))
+        left_join(policy_costs, tmp_policy_costs[[i]], by = c("region", "period", "variable"))
     }
   }
   # and do some pivotting
   policy_costs <- policy_costs %>%
     pivot_longer(cols = matches(".*w\\.r\\.t.*"), names_to = "Model Output") %>%
-    pivot_wider(names_from = data)
+    pivot_wider(names_from = "variable")
 
   # By default, plots are only created until 2100
   if (!"4" %in% special_requests) {

--- a/scripts/output/single/ar6Climate.R
+++ b/scripts/output/single/ar6Climate.R
@@ -224,6 +224,8 @@ climateAssessmentData <- read.quitte(climateAssessmentOutput) %>%
   interpolate_missing_periods(usePeriods, expand.values = FALSE) %>%
   write.mif(remindReportingFile, append = TRUE)
 
+deletePlus(remind_reporting_file, writemif = TRUE)
+
 logmsg <- paste0(
   date(), " postprocessing done! Results appended to REMIND mif '", remindReportingFile, "'\n",
   "ar6Climate.R finished\n"

--- a/scripts/output/single/checkProjectSummations.R
+++ b/scripts/output/single/checkProjectSummations.R
@@ -16,8 +16,16 @@ stopmessage <- NULL
 absDiff <- 0.00001
 relDiff <- 0.01
 
-for (template in c("AR6", "NAVIGATE")) {
+# failing <- mif %>%
+#   checkSummations(dataDumpFile = NULL, outputDirectory = NULL,  summationsFile = "extractVariableGroups",
+#                   absDiff = 5e-7, relDiff = 1e-8) %>%
+#   filter(abs(diff) >= 5e-7, abs(reldiff) >= 1e-8) %>%
+#   df_variation() %>%
+#   droplevels()
+# if (nrow(failing) > 0) stopmessage <- c(stopmessage, "extractVariableGroups")
 
+for (template in c("AR6", "NAVIGATE")) {
+  message("\n### Check project summations for ", template)
   d <- generateIIASASubmission(mif, outputDirectory = NULL, logFile = NULL, mapping = template, checkSummation = FALSE)
   failing <- d %>%
     checkSummations(template = template, summationsFile = template, logFile = NULL, dataDumpFile = NULL,
@@ -26,12 +34,9 @@ for (template in c("AR6", "NAVIGATE")) {
     df_variation() %>%
     droplevels()
   
-  if (nrow(failing) > 0) {
-    stopmessage <- c(stopmessage,
-                     paste0("\nThe following variables do not satisfy the ", template, " summation checks:"),
-                     paste("\n-", unique(failing$variable), collapse = ""))
-  }
+  if (nrow(failing) > 0) stopmessage <- c(stopmessage, template)
 }
+
 if (length(stopmessage) > 0) {
-  stop("Failing summation checks, see above.", stopmessage)
+  stop("Failing summation checks for ", paste(stopmessage, collapse = ", "), ", see above.")
 }

--- a/scripts/output/single/checkProjectSummations.R
+++ b/scripts/output/single/checkProjectSummations.R
@@ -1,0 +1,37 @@
+library(piamInterfaces)
+library(quitte)
+suppressPackageStartupMessages(library(tidyverse))
+
+if(! exists("source_include")) {
+  # Define arguments that can be read from command line
+  outputdir <- "."
+  lucode2::readArgs("outputdir")
+}
+
+scen <- lucode2::getScenNames(outputdir)
+mif  <- file.path(outputdir, paste0("REMIND_generic_", scen, ".mif"))
+
+stopmessage <- NULL
+
+absDiff <- 0.00001
+relDiff <- 0.01
+
+for (template in c("AR6", "NAVIGATE")) {
+
+  d <- generateIIASASubmission(mif, outputDirectory = NULL, logFile = NULL, mapping = template, checkSummation = FALSE)
+  failing <- d %>%
+    checkSummations(template = template, summationsFile = template, logFile = NULL, dataDumpFile = NULL,
+                    absDiff = absDiff, relDiff = relDiff) %>%
+    filter(abs(diff) >= absDiff, abs(reldiff) >= relDiff) %>%
+    df_variation() %>%
+    droplevels()
+  
+  if (nrow(failing) > 0) {
+    stopmessage <- c(stopmessage,
+                     paste0("\nThe following variables do not satisfy the ", template, " summation checks:"),
+                     paste("\n-", unique(failing$variable), collapse = ""))
+  }
+}
+if (length(stopmessage) > 0) {
+  stop("Failing summation checks, see above.", stopmessage)
+}

--- a/scripts/output/single/fixOnRef.R
+++ b/scripts/output/single/fixOnRef.R
@@ -37,7 +37,7 @@ findRefMif <- function(outputdir, envi) {
   return(refmif)
 }
 
-fixMAGICC <- function(d, dref, startyear) {
+fixMAGICC <- function(d, dref, startyear, scenario) {
   magiccgrep <- "^Forcing|^Temperature|^Concentration"
   message("Fixing MAGICC6 data before ", startyear)
   dnew <-
@@ -46,7 +46,9 @@ fixMAGICC <- function(d, dref, startyear) {
              .data$period < startyear),
       filter(d, ! grepl(magiccgrep, .data$variable) |
              .data$period >= startyear)
-    )
+    ) %>%
+    mutate(scenario = factor(scenario)) %>%
+    droplevels()
   return(dnew)
 }
 
@@ -77,21 +79,28 @@ fixOnMif <- function(outputdir) {
   refname <- basename(dirname(refmif))
   d <- quitte::as.quitte(mifs)
   dref <- quitte::as.quitte(refmif)
-  d <- fixMAGICC(d, dref, startyear)
+  d <- fixMAGICC(d, dref, startyear, title)
   failfile <- file.path(outputdir, "log_fixOnRef.csv")
-  fixeddata <- piamInterfaces::fixOnRef(d, dref, ret = "fixed", startyear = startyear, failfile = failfile)
+  fixeddata <- piamInterfaces::fixOnRef(d, dref, ret = "TRUE_or_fixed", startyear = startyear, failfile = failfile)
 
-  if (exists("flags") && isTRUE("--interactive" %in% flags)) {
-    message("\nDo you want to fix that by overwriting ", title, " mif with reference run ", refname, " for t < ", startyear, "?\nType: y/N")
+  update <- paste0("MAGICC data. ", if (! isTRUE(fixeddata)) "Run output.R -> single -> fixOnRef to fix the rest.")
+  if (! isTRUE(fixeddata) && isTRUE(envi$cfg$fixOnRefAuto)) {
+    d <- fixeddata
+    update <- "data from reference run because cfg$fixOnRefAuto=TRUE."
+  } else if (! isTRUE(fixeddata) && exists("flags") && isTRUE("--interactive" %in% flags)) {
+    message("\nDo you want to fix that by overwriting ", title, " mif with reference run ",
+            refname, " for t < ", startyear, "?\nType: y/N")
     if (tolower(gms::getLine()) %in% c("y", "yes")) {
-      message("Updating ", mifs[[1]])
-      tmpfile <- paste0(mifs[[1]], "fixOnMif")
-      quitte::write.mif(fixeddata, tmpfile)
-      file.rename(tmpfile, mifs[[1]])
-      remind2::deletePlus(mifs[[1]], writemif = TRUE)
-      message("Keep in mind to update the runs that use this as `path_gdx_ref` as well.")
+      d <- fixeddata
+      update <- "data from reference run."
     }
   }
+  message("Updating ", mifs[[1]], " with ", update)
+  tmpfile <- paste0(mifs[[1]], "fixOnMif")
+  quitte::write.mif(d, tmpfile)
+  file.rename(tmpfile, mifs[[1]])
+  remind2::deletePlus(mifs[[1]], writemif = TRUE)
+  message("Keep in mind to update the runs that use this as `path_gdx_ref` as well.")
   return(NULL)
 }
 


### PR DESCRIPTION
## Purpose of this PR

- automatically run script that converts remind2 data into AR6 and NAVIGATE data and runs a variable summation check and a regional summation check. Prints results to log. The scripts fails in case of problems, but that fail basically does nothing, except output.R telling the user it failed. The regional summation check has to skip several `Emissions|*` variables because they have bunkers included on the `World` level, but not in the regions as this was the default for AR6.
- for `fixOnRef`, add option `cfg$fixOnRefAuto` to the config that allows to autocorrect wrong fixing. Not sure whether we want to activate that as usual. I would rather prefer to [fix it the EDGE-T issues](https://github.com/remindmodel/development_issues/issues/222) at the core, but as long as [magpie does not know reference fixing](https://github.com/magpiemodel/magpie/issues/494), this switch is useful for coupled runs.
- for `fixOnRef`, use `TRUE_or_fixed` to avoid asking if the user wants to update if everything is fine
- for `fixOnRef`, set scenario name correctly for MAGICC6 data. Be more clear what was changed and why.
- add higher memory requirements for `nashAnalysis`
- if an `output/single` script does not exist, skip this script, not the whole `outputdir`
- update `_withoutPlus` file after writing `MAGICC7.5.3` data
- fix bug in policyCosts plotting after I named the data dimension correctly as `variable` in [this remind2 PR](https://github.com/pik-piam/remind2/pull/465) but did not adjust this script.

## Type of change

- [x] New feature 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] Some automated model tests pass: testOneRegi [fails because of this error](https://github.com/remindmodel/remind/issues/1597). Everything before is fine, also codeCheck succeeds, and `test_06-output.R` also works (after I put some fulldata.gdx into the testOneRegi folder).
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
