### PR TITLE
Subtract emissions from natural gas for DAC from emiTeMkt

### DIFF
--- a/core/declarations.gms
+++ b/core/declarations.gms
@@ -401,7 +401,7 @@ vm_co2CCS(ttot,all_regi,all_enty,all_enty,all_te,rlf)       "all different ccs. 
 
 vm_co2capture(ttot,all_regi,all_enty,all_enty,all_te,rlf)   "all captured CO2. [GtC/a]"
 v_co2capturevalve(ttot,all_regi)                            "CO2 emitted right after capture [GtC/a] (in q_balCCUvsCCS to account for different lifetimes of capture and CCU/CCS te and capacities)"
-vm_share_CCS_CCO2(ttot, all_regi)                           "Share of captured CO2 that is stored"
+v_share_CCS_CCO2(ttot, all_regi)                            "Share of captured CO2 that is stored"
 
 v_prodUe (ttot,all_regi,all_enty,all_enty,all_te)    "Useful energy production [TWa]"
 

--- a/core/declarations.gms
+++ b/core/declarations.gms
@@ -401,6 +401,7 @@ vm_co2CCS(ttot,all_regi,all_enty,all_enty,all_te,rlf)       "all different ccs. 
 
 vm_co2capture(ttot,all_regi,all_enty,all_enty,all_te,rlf)   "all captured CO2. [GtC/a]"
 v_co2capturevalve(ttot,all_regi)                            "CO2 emitted right after capture [GtC/a] (in q_balCCUvsCCS to account for different lifetimes of capture and CCU/CCS te and capacities)"
+vm_share_CCS_CCO2(ttot, all_regi)                           "Share of captured CO2 that is stored"
 
 v_prodUe (ttot,all_regi,all_enty,all_enty,all_te)    "Useful energy production [TWa]"
 
@@ -501,6 +502,7 @@ q_emiAllMkt(ttot,all_regi,all_enty,all_emiMkt)       "total regional emissions f
 q_transCCS(ttot,all_regi,all_enty,all_enty,all_te,all_enty,all_enty,all_te,rlf)        "transformation equation for ccs"
 q_limitCapCCS(ttot,all_regi,all_enty,all_enty,all_te,rlf)                              "capacity constraint for ccs"
 q_limitCCS(all_regi,all_enty,all_enty,all_te,rlf)                                      "ccs constraint for sequestration alternatives"
+q_share_CCS_CCO2(ttot, all_regi)                                                       "share of captured CO2 that is stored"
 
 q_emiCdrAll(ttot,all_regi)                           "summing over all CDR emissions"
 

--- a/core/equations.gms
+++ b/core/equations.gms
@@ -611,7 +611,7 @@ q_emiTeMkt(t,regi,emiTe(enty),emiMkt) ..
     !! CCU from captured non-atmospheric CO2 from CDR activities (e.g., natural gas for DAC heat)
   - ((
       sum(teCCS2rlf(te,rlf), vm_ccs_cdr(t, regi, "cco2", "ico2", "ccsinje", rlf)) + vm_emiCdrTeDetail(t, regi, "dac")
-    ) * (1 - vm_share_CCS_CCO2(t,regi)))
+    ) * (1 - v_share_CCS_CCO2(t,regi)))
     $(sameas(enty, "co2") AND sameas(emiMkt, "ETS"))
 ;
 
@@ -728,7 +728,7 @@ q_emiMac(t,regi,emiMac) ..
 *' Share of captured CO2 that is stored
 ***--------------------------------------------------
 q_share_CCS_CCO2(t, regi)..
-  vm_share_CCS_CCO2(t, regi)
+  v_share_CCS_CCO2(t, regi)
   =e=
   sum(teCCS2rlf(te, rlf), vm_co2CCS(t, regi, "cco2", "ico2", te, rlf))
   / (
@@ -745,7 +745,7 @@ q_emiCdrAll(t,regi)..
   !! BECC + DACC (scaled by the fraction that gets stored geologically)
   (sum(emiBECCS2te(enty,enty2,te,enty3), vm_emiTeDetail(t,regi,enty,enty2,te,enty3))
     - vm_emiCdrTeDetail(t, regi, "dac")
-  ) * vm_share_CCS_CCO2(t, regi)
+  ) * v_share_CCS_CCO2(t, regi)
   !! net negative emissions from co2luc
   -  p_macBaseMagpieNegCo2(t,regi)
   !! negative emissions from the CDR module that are not stored geologically

--- a/core/equations.gms
+++ b/core/equations.gms
@@ -728,12 +728,10 @@ q_emiMac(t,regi,emiMac) ..
 *' Share of captured CO2 that is stored
 ***--------------------------------------------------
 q_share_CCS_CCO2(t, regi)..
-  v_share_CCS_CCO2(t, regi)
+  v_share_CCS_CCO2(t, regi) * sum(teCCS2rlf(te, rlf), vm_co2capture(t, regi, "cco2", "ico2", "ccsinje", rlf))
   =e=
   sum(teCCS2rlf(te, rlf), vm_co2CCS(t, regi, "cco2", "ico2", te, rlf))
-  / (
-    sum(teCCS2rlf(te, rlf), vm_co2capture(t, regi, "cco2", "ico2", "ccsinje", rlf)) + sm_eps
-  );
+  ;
 
 
 ***--------------------------------------------------

--- a/core/equations.gms
+++ b/core/equations.gms
@@ -609,9 +609,7 @@ q_emiTeMkt(t,regi,emiTe(enty),emiMkt) ..
       vm_co2CCUshort(t,regi,"cco2","ccuco2short",te2,rlf)$( sameas(enty,"co2") )
     )$(sameas(emiMkt,"ETS"))
     !! CCU from captured non-atmospheric CO2 from CDR activities (e.g., natural gas for DAC heat)
-  - ((
-      sum(teCCS2rlf(te,rlf), vm_ccs_cdr(t, regi, "cco2", "ico2", "ccsinje", rlf)) + vm_emiCdrTeDetail(t, regi, "dac")
-    ) * (1 - v_share_CCS_CCO2(t,regi)))
+  - vm_co2capture_cdr_energy(t, regi)
     $(sameas(enty, "co2") AND sameas(emiMkt, "ETS"))
 ;
 
@@ -834,7 +832,7 @@ q_balcapture(t,regi,ccs2te(ccsCo2(enty),enty2,te)) ..
     )
 *** Carbon captured from CDR technologies in CDR module
   + sum(teCCS2rlf(te,rlf),
-      vm_ccs_cdr(t,regi,enty,enty2,te,rlf)
+      vm_co2capture_cdr(t,regi,enty,enty2,te,rlf)
     )
 *** Carbon captured from industry
   + sum(emiInd37,

--- a/core/postsolve.gms
+++ b/core/postsolve.gms
@@ -798,7 +798,7 @@ o_capture_energy_other(ttot,regi,"co2")$(ttot.val ge 2005) =
 ***Carbon Management|Carbon Capture|Process|Direct Air Capture (Mt CO2/yr)
 o_capture_cdr(ttot,regi,"co2")$(ttot.val ge 2005) =
     sum(teCCS2rlf("ccsinje",rlf),
-      vm_ccs_cdr.l(ttot,regi,"cco2","ico2","ccsinje",rlf)
+      vm_co2capture_cdr.l(ttot,regi,"cco2","ico2","ccsinje",rlf)
     )*o_emi_conv("co2");
 
 ***Carbon Management|Carbon Capture|Process|Industrial Processes (Mt CO2/yr)

--- a/modules/33_CDR/portfolio/bounds.gms
+++ b/modules/33_CDR/portfolio/bounds.gms
@@ -14,9 +14,9 @@ if(card(te_used33) eq 0,
     vm_emiCdr.fx(t,regi,"co2") = 0;
 );
 
-*** Fix CCS from CDR if there're no technologies that require CCS
+*** Fix carbon capture from CDR if there're no technologies that require carbon capture
 if(card(te_ccs33) eq 0,
-    vm_ccs_cdr.fx(t,regi,enty,enty2,te,rlf)$ccs2te(enty,enty2,te) = 0;
+    vm_co2capture_cdr.fx(t,regi,enty,enty2,te,rlf)$ccs2te(enty,enty2,te) = 0;
 );
 
 *** Fix negative emissions and FE demand to zero for all the technologies that are not used
@@ -31,7 +31,7 @@ vm_emiCdr.fx(t,regi,"co2")$(t.val lt 2025) = 0;
 vm_omcosts_cdr.fx(t,regi)$((t.val lt 2025)) = 0;
 vm_cap.fx(t,regi,"weathering",rlf)$(t.val lt 2025) = 0;
 *** vm_cap for dac is fixed for t<2025 in core/bounds.gms (tech_stat eq 4)
-vm_ccs_cdr.fx(t,regi,enty,enty2,te,rlf)$(ccs2te(enty,enty2,te) AND t.val lt 2025) = 0;
+vm_co2capture_cdr.fx(t,regi,enty,enty2,te,rlf)$(ccs2te(enty,enty2,te) AND t.val lt 2025) = 0;
 
 
 *** Set minimum DAC capacities (if available) to help the solver find the technology 

--- a/modules/33_CDR/portfolio/declarations.gms
+++ b/modules/33_CDR/portfolio/declarations.gms
@@ -23,7 +23,8 @@ positive variables
 v33_EW_onfield(ttot,all_regi,rlf,rlf)  "amount of ground rock spread on fields in each timestep [Gt]"
 v33_EW_onfield_tot(ttot,all_regi,rlf,rlf)  "total amount of ground rock on fields, for each climate zone and transportation distance [Gt]"
 v33_FEdemand(ttot,all_regi,all_enty,all_enty,all_te)  "FE demand of each technology [TWa]"
-vm_ccs_cdr(ttot,all_regi,all_enty,all_enty,all_te,rlf)  "total emissions captured through technologies in the CDR module that enter the CCUS chain + captured emissions from associated FE demand [GtC / a]"
+vm_co2capture_cdr_energy(ttot,all_regi)  "carbon captured from FE demand [GtC / a]"
+vm_co2capture_cdr(ttot,all_regi,all_enty,all_enty,all_te,rlf)  "total emissions captured through technologies in the CDR module that enter the CCUS chain + captured emissions from associated FE demand [GtC / a]"
 ;
 
 negative variables
@@ -34,6 +35,7 @@ equations
 q33_demFeCDR(ttot,all_regi,all_enty)  "CDR demand balance for final energy"
 q33_emiCDR(ttot,all_regi)  "aggregates the (negative) emissions captured by the CDR technologies"
 q33_H2bio_lim(ttot,all_regi)  "limits H2 from bioenergy to FE - H2 demand from CDR, i.e. no H2 from bioenergy for DAC"
+q33_captured_energy_emi(ttot,all_regi) "calculates the captured carbon from FE emissions"
 q33_DAC_emi(ttot,all_regi)  "calculates amount of carbon captured by DAC"
 q33_DAC_FEdemand(ttot,all_regi,all_enty)  "calculates final energy demand from DAC"
 q33_DAC_ccsbal(ttot,all_regi,all_enty,all_enty,all_te)  "calculates CCS emissions from CDR technologies"

--- a/modules/33_CDR/portfolio/equations.gms
+++ b/modules/33_CDR/portfolio/equations.gms
@@ -44,6 +44,16 @@ q33_H2bio_lim(t,regi)..
     ;
 
 ***---------------------------------------------------------------------------
+*'  The amount of energy-related carbon from CDR activities,
+*'  the gas for DAC is assumed to be captured.
+***---------------------------------------------------------------------------
+q33_captured_energy_emi(t, regi)..
+    vm_co2capture_CDR_energy(t, regi)
+    =e=
+    (1 / pm_eta_conv(t,regi,"gash2c")) * fm_dataemiglob("pegas","seh2","gash2c","cco2") * sum(fe2cdr("fegas",entyFe2,te_used33), v33_FEdemand(t,regi,"fegas", entyFe2,te_used33))
+    ;
+
+***---------------------------------------------------------------------------
 *' #### DAC equations
 
 ***---------------------------------------------------------------------------
@@ -64,10 +74,10 @@ q33_DAC_emi(t,regi)..
 *'  assuming 90% capture rate.
 ***---------------------------------------------------------------------------
 q33_DAC_ccsbal(t,regi,ccs2te(ccsCo2(enty),enty2,te))..
-    sum(teCCS2rlf(te,rlf), vm_ccs_cdr(t,regi,enty,enty2,te,rlf))
+    sum(teCCS2rlf(te,rlf), vm_co2capture_cdr(t,regi,enty,enty2,te,rlf))
     =e=
     - vm_emiCdrTeDetail(t,regi,"dac")
-    + (1 / pm_eta_conv(t,regi,"gash2c")) * fm_dataemiglob("pegas","seh2","gash2c","cco2") * sum(fe2cdr("fegas",entyFe2,te_used33), v33_FEdemand(t,regi,"fegas", entyFe2,te_used33))
+    + vm_co2capture_cdr_energy(t, regi)
     ;
 
 ***---------------------------------------------------------------------------


### PR DESCRIPTION
## Purpose of this PR

Discounting the emissions that are captured in the CDR module from using natural gas for DAC’s heat and used (e.g., for synfuels) within REMIND.

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix  
- [x] Minor change (default scenarios show only small differences)

## Checklist:

- [ ] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [ ] I explained my changes within the PR, particularly in hard-to-understand areas
- [ ] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

