### PR TITLE
New ccs near-term bounds based on project announcements

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -27,7 +27,7 @@ cfg$regionmapping <- "config/regionmappingH12.csv"
 ### Additional (optional) region mapping, so that those validation data can be loaded that contain the corresponding additional regions.
 cfg$extramappings_historic <- ""
 #### Current input data revision (<mainrevision>.<subrevision>) ####
-cfg$inputRevision <- "6.70"
+cfg$inputRevision <- "6.74"
 
 #### Current CES parameter and GDX revision (commit hash) ####
 cfg$CESandGDXversion <- "cdddb54b54a8586b4fef00eb60a3be6cfa23ca55"

--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -391,20 +391,28 @@ $endif
 
 
 *** -------------------------------------------------------------------------------------------------------------
-*RP* Upper limit on CCS deployment in 2020-2030
+*AM* No geological storage before 2025 (omitting approx. 40 MtCCS/yr globally in 2020 for Enhanced Oil Recovery)
+*AM* Lower limit for 2025 and 2030 is capacities of all projects that are operational and under construction from project data base
+*AM* Upper limit for 2025 and 2030 additionally includes announced/planned projects from project data base
+*AM* In nash-mode regions cannot easily share ressources, therefore CCS potentials are redistributed in Europe: 
+*AM* Potential of EU27 regions is pooled and redistributed according to GDP (Only upper limit for 2030)
+*AM* Norway and UK announced to store CO2 for EU27 countries. So 50% of Norway and UK potential in 2030 is attributed to EU27-Pool
 *LP* if c_ccsinjecratescen=0 --> no CCS at all and vm_co2CCS is fixed to 0 before, therefore the upper bound is only set if there should be CCS!
 *** -------------------------------------------------------------------------------------------------------------
 
 if ( c_ccsinjecratescen gt 0,
-        vm_co2CCS.up(ttot,regi,"cco2","ico2","ccsinje","1")$(ttot.val ge 2005 AND ttot.val lt 2020) = 0;
-	vm_co2CCS.up("2020",regi,"cco2","ico2","ccsinje","1") = pm_boundCapCCS(regi);
-	vm_co2CCS.up("2025",regi,"cco2","ico2","ccsinje","1") = pm_boundCapCCS(regi);
+  vm_co2CCS.up(ttot,regi,"cco2","ico2","ccsinje","1")$(ttot.val ge 2005 AND ttot.val lt 2025) = 0;
+	vm_co2CCS.up("2025",regi,"cco2","ico2","ccsinje","1") = pm_boundCapCCS("2025",regi,"up")/(1000*11/3);
+	vm_co2CCS.up("2030",regi,"cco2","ico2","ccsinje","1") = pm_boundCapCCS("2030",regi,"up")/(1000*11/3);
+	vm_co2CCS.lo("2025",regi,"cco2","ico2","ccsinje","1") = pm_boundCapCCS("2025",regi,"low")/(1000*11/3);
+	vm_co2CCS.lo("2030",regi,"cco2","ico2","ccsinje","1") = pm_boundCapCCS("2030",regi,"low")/(1000*11/3);
 );
 
 loop(regi,
-  if( (pm_boundCapCCS(regi) eq 0),
-    vm_cap.fx("2020",regi,teCCS,rlf) = 0;
-	vm_cap.fx("2025",regi,teCCS,rlf) = 0;
+  loop(t$(t.val le 2030),
+    if( ( pm_boundCapCCS(t,regi,"up") eq 0),
+      vm_cap.fx(t,regi,teCCS,rlf) = 0;
+    );
   );
 );
 

--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -823,8 +823,8 @@ if(pm_NuclearConstraint("2020",regi,"tnrs")<0,
 );
 );
 
-*** read in data on CCS capacities used as bound on vm_co2CCS.up("2020",regi,"cco2","ico2","ccsinje","1")
-parameter pm_boundCapCCS(all_regi)        "installed and planed capacity of CCS"
+*** read in data on CCS capacities and announced projects used as upper and lower bound on vm_co2CCS in 2025 and 2030
+parameter pm_boundCapCCS(ttot,all_regi,bounds)        "installed and planned capacity of CCS"
 /
 $ondelim
 $include "./core/input/pm_boundCapCCS.cs4r"

--- a/core/sets.gms
+++ b/core/sets.gms
@@ -1035,6 +1035,7 @@ RCP_regions_world(RCP_regions_world_bunkers) "five RCP regions plus total (world
 Sets
   counter   "helper set to facilitate looping in defined order"   / 1 * 20 /
   NDC_version "NDC data version for NDC realizations of 40_techpol and 45_carbonprice"  /2018_cond, 2018_uncond, 2021_cond, 2021_uncond, 2022_cond, 2022_uncond, 2023_cond, 2023_uncond/
+  bounds "helper set to define upper and lower bounds read in from input data" /low, up/
 ;
 
 ***-----------------------------------------------------------------------------

--- a/modules/32_power/RLDC/bounds.gms
+++ b/modules/32_power/RLDC/bounds.gms
@@ -55,10 +55,12 @@ loop(regi,
 
 *Avoiding infeasibilities from upper limit on CCS deployment in 2020
 loop(regi,
-	if( (pm_boundCapCCS(regi) eq 0),
-		vm_capFac.fx("2020",regi,teCCS)      = 0;
-        v32_capLoB.fx("2020",regi,teCCS,LoB)    = 0;
-        v32_capER.fx("2020",regi,teCCS)         = 0;
+  loop(t$(t.val le 2030),
+    if( ( pm_boundCapCCS(t,regi,"up") eq 0),
+      vm_capFac.fx(t,regi,teCCS)      = 0;
+          v32_capLoB.fx(t,regi,teCCS,LoB)    = 0;
+          v32_capER.fx(t,regi,teCCS)         = 0;
+      );
     );
 );
 


### PR DESCRIPTION
## Purpose of this PR
I updated the near-term projections of geologic CO2 storage according to the IEA CCUS project database. 
Therefore, I newly introduce a regional lower bound for 2025 and 2030 based on storage projects that are either operational or under construction. I update the upper bound for both years including also announced projects (often times the final investment decision is still pending). This assumption follows the reasoning that geologic storage requires extensive geologic exploration and lead times for CCS projects are at least 5 years, but likely even longer (expert judgement, personal communication, CDRterra). 

## Type of change
Update near-term CCS bounds

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [ ] Bug fix 
- [ ] Refactoring
- [ ] New feature 
- [ ] Minor change (default scenarios show only small differences)
- [ ] Fundamental change


## Checklist:

- [ ] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [ ] I explained my changes within the PR, particularly in hard-to-understand areas
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

