### PR TITLE
new CES parameters and gdx files

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -30,7 +30,7 @@ cfg$extramappings_historic <- ""
 cfg$inputRevision <- "6.70"
 
 #### Current CES parameter and GDX revision (commit hash) ####
-cfg$CESandGDXversion <- "cdddb54b54a8586b4fef00eb60a3be6cfa23ca55"
+cfg$CESandGDXversion <- "251cdf881a2bbe351cd57a59ce601e59ab96f14f"
 
 #### Force the model to download new input data ####
 cfg$force_download <- FALSE


### PR DESCRIPTION

## Purpose of this PR
A new calibration was necessary because of changed time preference rate: new CES parameters and gdx files for SSP2EU, SSP2EU-PBS, SSP1, SSP5, SDP_MC, SDP_RC, SSP2EU_lowEn, SSP2EU-EU21 (not well converged), SDP_MC still missing, runs: /p/tmp/rempie/REMIND/REMIND_calibration_2024_02_29/remind

## Type of change

- [x] Minor change (default scenarios show only small differences)


## Checklist:

- [x]My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code


## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

