### PR TITLE
lock model while updating input data in tests

### DIFF
--- a/tests/testthat/test_01-inputdata.R
+++ b/tests/testthat/test_01-inputdata.R
@@ -1,7 +1,9 @@
 test_that("Are all input data files present?", {
   missinginput <- missingInputData(path = "../..")
   if (length(missinginput) > 0) {
+    lockID <- gms::model_lock(folder = "../..")
     updateInputData(cfg = gms::readDefaultConfig("../.."), remindPath = "../..")
+    gms::model_unlock(lockID)
     missinginput <- missingInputData(path = "../..")
     if (length(missinginput) > 0) {
       warning("Missing input files: ", paste(missinginput, collapse = ", "))


### PR DESCRIPTION
## Purpose of this PR

- was a problem in the automated model tests that input files were deleted while the tests were running

## Type of change

- [x] Bug fix 

## Checklist:

- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [ ] Not all automated model tests pass, because `testOneRegi` is not failing. But the part that I changed here succeeds
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
