### PR TITLE
fix fails in case of too long descriptions for coupled runs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
     gdxdt,
     gdxrrw,
     ggplot2,
-    gms (>= 0.30.3),
+    gms (>= 0.30.5),
     goxygen,
     gridExtra,
     gtools,

--- a/modules/37_industry/subsectors/equations.gms
+++ b/modules/37_industry/subsectors/equations.gms
@@ -240,16 +240,16 @@ q37_feedstocksLimit(t,regi,entySe,entyFe,emiMkt)$(
 ;
 
 *' Feedstocks have identical fossil/biomass/synfuel shares as industry FE
-q37_feedstocksShares(t,regi,entySE,entyFE,emiMkt)$(
-                                          sum(te, se2fe(entySE,entyFE,te)) ) ..
-    vm_demFEsector_afterTax(t,regi,entySE,entyFE,"indst",emiMkt)
-  * sum(se2fe(entySE2,entyFE,te),
-      vm_demFENonEnergySector(t,regi,entySE2,entyFE,"indst",emiMkt)
+q37_feedstocksShares(t,regi,entySe,entyFe,emiMkt)$(
+                                          sum(te, se2fe(entySe,entyFe,te)) ) ..
+    vm_demFeSector_afterTax(t,regi,entySe,entyFe,"indst",emiMkt)
+  * sum(se2fe(entySe2,entyFe,te),
+      vm_demFENonEnergySector(t,regi,entySe2,entyFe,"indst",emiMkt)
     )
   =e=
-    vm_demFENonEnergySector(t,regi,entySE,entyFE,"indst",emiMkt)
-  * sum(se2fe2(entySE2,entyFE,te),
-      vm_demFEsector_afterTax(t,regi,entySE2,entyFE,"indst",emiMkt)
+    vm_demFENonEnergySector(t,regi,entySe,entyFe,"indst",emiMkt)
+  * sum(se2fe2(entySe2,entyFe,te),
+      vm_demFeSector_afterTax(t,regi,entySe2,entyFe,"indst",emiMkt)
     )
 ;
 

--- a/start_bundle_coupled.R
+++ b/start_bundle_coupled.R
@@ -417,7 +417,7 @@ for(scen in common){
 
   # Set description
   if ("description" %in% names(settings_remind) && ! is.na(settings_remind[scen, "description"])) {
-    cfg_rem$description <- gsub('"', '', settings_remind[scen, "description"])
+    cfg_rem$description <- iconv(gsub('"', '', settings_remind[scen, "description"]), from = "UTF-8", to = "ASCII//TRANSLIT")
   } else {
     cfg_rem$description <- paste0("Coupled REMIND and MAgPIE run ", scen, " started by ", path_settings_remind, " and ", path_settings_coupled, ".")
   }


### PR DESCRIPTION
## Purpose of this PR

- analog to https://github.com/remindmodel/remind/pull/1557
- if you use `°` or so in the description, it can lead to warnings and even failing runs. Avoid that.
```
 233  $setGlobal c_description  SSP2EU-PkBudg500: This climate policy scenario follows the Shared Socioeconomic Pathways 2 called Middle of the Road. The stylized climate policy scenario assumes a peak budget of 500 Gt CO2 on total CO2 emissions from 2015 to 2100. This is a 1.5<U+00B0>C scenar
****                                                                                                                                                                                                                                                                                                 $190
**** 190  Text too long, max is 255 characters
```


## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [ ] <s>All automated model tests pass</s> Useless here, as they do not touch start_bundle_coupled.R. But `./start_bundle_coupled.R --test` works without a problem

