### PR TITLE
move n2ofertsom to the ESD sectors as it fits better under agriculture emissions

### DIFF
--- a/core/sets.gms
+++ b/core/sets.gms
@@ -2112,7 +2112,7 @@ macSector2emiMkt(all_enty,all_emiMkt)  "mapping mac sectors to emission markets"
         n2onitac.ETS
         n2ofertin.ES
         n2ofertcr.ES
-        n2ofertsom.other
+        n2ofertsom.ES
         n2oanwstc.ES
         n2oanwstm.ES
         n2oanwstp.ES


### PR DESCRIPTION
## Purpose of this PR

- address the points raised in this issue: https://github.com/remindmodel/development_issues/issues/255
- Moving n2ofertsom to the effort sharing sector as it fits better under agriculture emissions and avoids inconsistences between the `macSector2emiMkt` set and the emission markets definition and reporting variables. 
 
## Type of change

- [ x ] Bug fix 

## Checklist:

- [ x ] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ x ] I performed a self-review of my own code

