### PR TITLE
delete p21_tech_tax, p21_tech_sub, only used in complex

### DIFF
--- a/modules/21_tax/on/datainput.gms
+++ b/modules/21_tax/on/datainput.gms
@@ -14,72 +14,51 @@ Parameter f21_tau_fe_tax(tall,all_regi,emi_sectors,all_enty) "2005 final energy 
 $ondelim
 $include "./modules/21_tax/on/input/f21_tau_fe_tax.cs4r"
 $offdelim
-  /             ;
+  /
+;
 Parameter f21_tau_fe_sub(tall,all_regi,emi_sectors,all_enty) "2005 final energy subsidy"
   /
 $ondelim
 $include "./modules/21_tax/on/input/f21_tau_fe_sub.cs4r"
 $offdelim
-  /             ;
-  
+  /
+;
 Parameter f21_tau_fuEx_sub(tall,all_regi,all_enty) "2005 subsidy for fuel extraction"
   /
 $ondelim
 $include "./modules/21_tax/on/input/f21_tau_pe_sub.cs4r"
 $offdelim
-  /             ;
-
+  /
+;
 Parameter f21_tax_convergence(tall,all_regi,all_enty) "Tax convergence level for specific regions, year and final energy type"
   /
 $ondelim
 $include "./modules/21_tax/on/input/f21_tax_convergence.cs4r"
 $offdelim
-  /             ;
- 
+  /
+;
 Parameter f21_max_fe_sub(tall,all_regi,all_enty) "maximum final energy subsidy levels (in $/Gj) from REMIND version prior to rev. 5429"
   /
 $ondelim
 $include "./modules/21_tax/on/input/f21_max_fe_sub.cs4r"
 $offdelim
-  /             ;
-
+  /
+;
 Parameter f21_max_pe_sub(tall,all_regi,all_enty) "maximum primary energy subsidy levels (in $/Gj) to provide plausible upper bound: 40$/barrel ~ 8 $/GJ" 
   /
 $ondelim
 $include "./modules/21_tax/on/input/f21_max_pe_sub.cs4r"
 $offdelim
-  /             ;
-
+  /
+;
 Parameter f21_prop_fe_sub(tall,all_regi,all_enty) "subsidy proportional cap to avoid liquids increasing dramatically"
   /
 $ondelim
 $include "./modules/21_tax/on/input/f21_prop_fe_sub.cs4r"
 $offdelim
-  /             ;  
-  
-
-
-*** -------------------------Technology specific subsidies and taxes for new capacity--------------------------
-*** initialize subsidies and taxes to zero
-p21_tech_tax(t,regi,te,rlf) = 0;
-p21_tech_sub(t,regi,te,rlf) = 0;
-
-$ifthen.vehiclesSubsidies not "%cm_vehiclesSubsidies%" == "off"
-
-Parameter f21_tech_sub(tall,all_regi,all_te) "subsidy path for transport specific new capacity (BEV and FCEV)"
   /
-$ondelim
-$include "./modules/21_tax/on/input/f21_vehiclesSubsidies.cs4r"
-$offdelim
-  /; 
+;
 
-  p21_tech_sub(t,regi,te,"1")$(f21_tech_sub(t,regi,te)) = - f21_tech_sub("2020",regi,te);
-
-  display p21_tech_sub;
-
-$endIf.vehiclesSubsidies
-
-  
 *** transfer data to parameters and rescaling of FE parameters from $/GJ to trillion $ / TWa (subsidies also get adjusted in preloop.gms to avoid neg. prices)
 
   p21_tau_fe_tax(ttot,all_regi,emi_sectors,entyFe)$f21_tau_fe_tax(ttot,all_regi,emi_sectors,entyFe) = f21_tau_fe_tax(ttot,all_regi,emi_sectors,entyFe)*0.001/sm_EJ_2_TWa;
@@ -151,7 +130,6 @@ s21_so2_tax_2010=0.0006;   !! This tax level leads to 6000$/t S  @10,000$/cap
 elseif(cm_so2tax_scen eq 4),
 s21_so2_tax_2010=0.000144;
 );
-
 
 *** Implicit discount rates mark-ups over the normal discount rate
 if ((cm_DiscRateScen eq 0),

--- a/modules/21_tax/on/declarations.gms
+++ b/modules/21_tax/on/declarations.gms
@@ -6,20 +6,17 @@
 *** |  Contact: remind@pik-potsdam.de
 *** SOF ./modules/21_tax/on/declarations.gms
 Parameters
-p21_tau_so2_tax(tall,all_regi)               "so2 tax path"
-p21_tau_pe2se_tax(tall,all_regi,all_te)      "tax path for primary energy technologies"
-p21_tau_pe2se_inconv(tall,all_regi,all_te)   "inconvenience cost path for primary energy technologies"
-p21_tech_tax(tall,all_regi,all_te,rlf)       "tax path for technology specific new capacity"
-p21_tech_sub(tall,all_regi,all_te,rlf)       "subsidy path for technology specific new capacity"
-
+p21_tau_so2_tax(tall,all_regi)                     "so2 tax path"
+p21_tau_pe2se_tax(tall,all_regi,all_te)        "tax path for primary energy technologies"
+p21_tau_pe2se_inconv(tall,all_regi,all_te)     "inconvenience cost path for primary energy technologies"
 p21_tau_pe2se_sub(tall,all_regi,all_te)        "subsidy path for primary energy technologies"
 p21_max_fe_sub(tall,all_regi,all_enty)         "maximum final energy subsidy levels from REMIND version prior to rev. 5429 [$/TWa]"
 p21_prop_fe_sub(tall,all_regi,all_enty)        "subsidy proportional cap to avoid liquids increasing dramatically"
 p21_tau_fuEx_sub(tall,all_regi,all_enty)       "subsidy path for fuel extraction [$/TWa]"
 p21_bio_EF(ttot,all_regi)                      "bioenergy emission factor, which is used to calculate the emission-factor-based tax level [GtC/TWa]"
 p21_tau_Import(ttot,all_regi,all_enty,tax_import_type_21)         "tax on energy imports, only works on energy carriers traded on nash markets, tax defined as share of world market price pm_pvp [Unit: share]"
-pm_tau_pe_tax(ttot,all_regi,all_enty)          "pe tax path"
-pm_tau_ces_tax(ttot,all_regi,all_in)           "ces production tax to implement CES mark-up cost in a budget-neutral way"
+pm_tau_pe_tax(ttot,all_regi,all_enty)                 "pe tax path"
+pm_tau_ces_tax(ttot,all_regi,all_in)                  "ces production tax to implement CES mark-up cost in a budget-neutral way"
 p21_tau_fe_tax(ttot,all_regi,emi_sectors,all_enty)    "tax path for final energy"
 p21_tau_fe_sub(ttot,all_regi,emi_sectors,all_enty)    "subsidy path for final energy"
 

--- a/modules/21_tax/on/equations.gms
+++ b/modules/21_tax/on/equations.gms
@@ -175,10 +175,9 @@ v21_taxrevPE2SE(t,regi)
 ***---------------------------------------------------------------------------
 q21_taxrevTech(t,regi)$(t.val ge max(2010,cm_startyear))..
 v21_taxrevTech(t,regi) 
-=e= sum(te2rlf(te,rlf),
-          (p21_tech_tax(t,regi,te,rlf) + p21_tech_sub(t,regi,te,rlf)) * vm_deltaCap(t,regi,te,rlf)
+=e= sum(te2rlf(te,rlf), vm_deltaCap(t,regi,te,rlf)
        )
-	- p21_taxrevTech0(t,regi);
+    - p21_taxrevTech0(t,regi);
 
 ***---------------------------------------------------------------------------
 *'  Calculation of export taxes: tax rate times export volume

--- a/modules/21_tax/on/input/files
+++ b/modules/21_tax/on/input/files
@@ -6,4 +6,3 @@ f21_tau_pe_sub.cs4r
 f21_max_pe_sub.cs4r
 f21_tax_convergence.cs4r
 p21_tau_xpres_tax.cs4r
-f21_vehiclesSubsidies.cs4r

--- a/modules/21_tax/on/postsolve.gms
+++ b/modules/21_tax/on/postsolve.gms
@@ -38,11 +38,11 @@ p21_taxrevFE0(ttot,regi) = sum((entyFe,sector)$entyFe2Sector(entyFe,sector),
 p21_taxrevResEx0(ttot,regi) = sum(pe2rlf(peEx(enty),rlf), p21_tau_fuEx_sub(ttot,regi,enty) * vm_fuExtr.l(ttot,regi,enty,rlf));
 p21_taxrevPE0(ttot,regi,entyPe) = pm_tau_pe_tax(ttot,regi,entyPe) * vm_prodPe.l(ttot,regi,entyPe);
 p21_taxrevCES0(ttot,regi,in) = pm_tau_ces_tax(ttot,regi,in) * vm_cesIO.l(ttot,regi,in);
-p21_taxrevPE2SE0(ttot,regi) = SUM(pe2se(enty,enty2,te),
+p21_taxrevPE2SE0(ttot,regi) = sum(pe2se(enty,enty2,te),
                                     (p21_tau_pe2se_tax(ttot,regi,te) + p21_tau_pe2se_sub(ttot,regi,te) + p21_tau_pe2se_inconv(ttot,regi,te)) * vm_prodSe.l(ttot,regi,enty,enty2,te)
                                   ); 
-p21_taxrevTech0(ttot,regi) = sum(te2rlf(te,rlf), (p21_tech_tax(ttot,regi,te,rlf) + p21_tech_sub(ttot,regi,te,rlf)) * vm_deltaCap.l(ttot,regi,te,rlf));
-p21_taxrevXport0(ttot,regi) = SUM(tradePe(enty), p21_tau_xpres_tax(ttot,regi,enty) * vm_Xport.l(ttot,regi,enty));
+p21_taxrevTech0(ttot,regi) = sum(te2rlf(te,rlf), vm_deltaCap.l(ttot,regi,te,rlf));
+p21_taxrevXport0(ttot,regi) = sum(tradePe(enty), p21_tau_xpres_tax(ttot,regi,enty) * vm_Xport.l(ttot,regi,enty));
 p21_taxrevSO20(ttot,regi) = p21_tau_so2_tax(ttot,regi) * vm_emiTe.l(ttot,regi,"so2");
 p21_taxrevBio0(ttot,regi) = v21_tau_bio.l(ttot) * vm_pebiolc_price.l(ttot,regi) * vm_fuExtr.l(ttot,regi,"pebiolc","1")
                             + p21_bio_EF(ttot,regi) * pm_taxCO2eq(ttot,regi) * (vm_fuExtr.l(ttot,regi,"pebiolc","1") - (vm_Xport.l(ttot,regi,"pebiolc")-vm_Mport.l(ttot,regi,"pebiolc")));

--- a/modules/21_tax/on/presolve.gms
+++ b/modules/21_tax/on/presolve.gms
@@ -37,11 +37,11 @@ p21_taxrevFE0(ttot,regi) = sum((entyFe,sector)$entyFe2Sector(entyFe,sector),
 p21_taxrevResEx0(ttot,regi) = sum(pe2rlf(peEx(enty),rlf), p21_tau_fuEx_sub(ttot,regi,enty) * vm_fuExtr.l(ttot,regi,enty,rlf));
 p21_taxrevPE0(ttot,regi,entyPe) = pm_tau_pe_tax(ttot,regi,entyPe) * vm_prodPe.l(ttot,regi,entyPe);
 p21_taxrevCES0(ttot,regi,in) = pm_tau_ces_tax(ttot,regi,in) * vm_cesIO.l(ttot,regi,in);
-p21_taxrevPE2SE0(ttot,regi) = SUM(pe2se(enty,enty2,te),
+p21_taxrevPE2SE0(ttot,regi) = sum(pe2se(enty,enty2,te),
                                     (p21_tau_pe2se_tax(ttot,regi,te) + p21_tau_pe2se_sub(ttot,regi,te) + p21_tau_pe2se_inconv(ttot,regi,te)) * vm_prodSe.l(ttot,regi,enty,enty2,te)
                                   ); 
-p21_taxrevTech0(ttot,regi) = sum(te2rlf(te,rlf), (p21_tech_tax(ttot,regi,te,rlf) + p21_tech_sub(ttot,regi,te,rlf)) * vm_deltaCap.l(ttot,regi,te,rlf));
-p21_taxrevXport0(ttot,regi) = SUM(tradePe(enty), p21_tau_xpres_tax(ttot,regi,enty) * vm_Xport.l(ttot,regi,enty));
+p21_taxrevTech0(ttot,regi) = sum(te2rlf(te,rlf), vm_deltaCap.l(ttot,regi,te,rlf));
+p21_taxrevXport0(ttot,regi) = sum(tradePe(enty), p21_tau_xpres_tax(ttot,regi,enty) * vm_Xport.l(ttot,regi,enty));
 p21_taxrevSO20(ttot,regi) = p21_tau_so2_tax(ttot,regi) * vm_emiTe.l(ttot,regi,"so2");
 p21_taxrevBio0(ttot,regi) = v21_tau_bio.l(ttot) * vm_pebiolc_price.l(ttot,regi) * vm_fuExtr.l(ttot,regi,"pebiolc","1")
                             + p21_bio_EF(ttot,regi) * pm_taxCO2eq(ttot,regi) * (vm_fuExtr.l(ttot,regi,"pebiolc","1") - (vm_Xport.l(ttot,regi,"pebiolc")-vm_Mport.l(ttot,regi,"pebiolc")));


### PR DESCRIPTION
## Purpose of this PR
delete p21_tech_tax and p21_tech_sub, which were only used in deleted realization complex of module transport

## Type of change

- [x] Minor change (default scenarios show only small differences)

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code


## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

