### PR TITLE
Update ccsinje cost

### DIFF
--- a/core/input/generisdata_tech_SSP1.prn
+++ b/core/input/generisdata_tech_SSP1.prn
@@ -120,7 +120,7 @@ lifetime                30       30          45          45          45         
 
 +                 ccsinje
 tech_stat               0 
-inco0                 350
+inco0                 460
 mix0                 1.00
 eta                  1.00
 omf                  0.06

--- a/main.gms
+++ b/main.gms
@@ -1474,7 +1474,7 @@ $setglobal cm_inco0RegiFactor  off  !! def = off
 *** cm_CCS_markup "multiplicative factor for CSS cost markup"
 ***   def <- "off" = use default CCS pm_inco0_t values.
 ***   or number (ex. 0.66), multiply by 0.66 the CSS cost markup
-$setglobal cm_ccsinjeCost low !! def = low !! regexp = med|low|high
+$setglobal cm_ccsinjeCost med !! def = med !! regexp = med|low|high
 *** switch from standard to low and high CO2 transport & storage cost; approx. 12/7.5/20 USD/tCO2. Low equals cost prior to 03/2024
 $setglobal cm_CCS_markup  off  !! def = off
 *** cm_Industry_CCS_markup "multiplicative factor for Industry CSS cost markup"


### PR DESCRIPTION
## Purpose of this PR
Change the default cost for ccsinje to the medium estimate. This is the follow-up to [PR 1592](https://github.com/remindmodel/remind/pull/1592). 

## Type of change

- [x] Minor change (default scenarios show only small differences)

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):
The overview shown in the REMIND meeting on March 7 as well as compare scenarios can be found here: 
/home/tabeado/co2-transport-storage
