### PR TITLE
do not define steel CCS MAC curve for pbs steel and cm_optimisticMAC

### DIFF
--- a/modules/37_industry/fixed_shares/input/pm_abatparam_Ind.gms
+++ b/modules/37_industry/fixed_shares/input/pm_abatparam_Ind.gms
@@ -34,7 +34,12 @@ $endif.cm_subsec_model_steel
     if (cm_optimisticMAC eq 1,
 
       !! logarithmic curve through 0.75 @ $50 and 0.9 @ $150, limited to 0.95
-      pm_abatparam_Ind(ttot,regi,emiInd37,steps)
+      pm_abatparam_Ind(ttot,regi,emiInd37,steps)$( 
+                                              YES
+        $$ifthen.cm_subsec_model_steel "%cm_subsec_model_steel%" == "ces"
+                                          AND NOT sameas(emiInd37,"co2steel")
+        $$endif.cm_subsec_model_steel
+                                                                              )
       = max(0, min(0.95, 0.2159 + 0.1365 * log(sm_tmp)));
 
     else


### PR DESCRIPTION
## Purpose of this PR


## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [ ] Bug fix 
- [ ] Refactoring
- [ ] New feature 
- [ ] Minor change (default scenarios show only small differences)
- [ ] Fundamental change
- [ ] This change requires a documentation update


## Checklist:

- [ ] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [ ] I explained my changes within the PR, particularly in hard-to-understand areas
- [ ] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

