### PR TITLE
in checkProjectSummations, use skipUnits=TRUE

### DIFF
--- a/scripts/output/single/checkProjectSummations.R
+++ b/scripts/output/single/checkProjectSummations.R
@@ -14,15 +14,10 @@ mifdata <- as.quitte(mif)
 
 stopmessage <- NULL
 
+options(width = 160)
+
 absDiff <- 0.00001
 relDiff <- 0.01
-
-# to be skipped for regional aggregation as they are no extensive variables
-varGrep <- paste0("^Tech|CES Price|^Price|^Internal|[Pp]er[- ][Cc]apita|per-GDP|Specific|Interest Rate|",
-                  "Intensity|Productivity|Average Extraction Costs|^PVP|Other Fossil Adjusted|Projected|[Ss]hare")
-unitList <- c("%", "Percent", "percent", "% pa", "1", "share", "USD/capita", "index", "kcal/cap/day",
-             "cm/capita", "kcal/capita/day", "unitless", "kcal/kcal", "m3/ha", "tC/tC", "tC/ha", "years",
-             "share of total land", "tDM/capita/yr", "US$05 PPP/cap/yr", "t DM/ha/yr", "US$2010/kW", "US$2010/kW/yr")
 
 # emi variables where bunkers are added only to the World level
 gases <- c("BC", "CO", "CO2", "Kyoto Gases", "NOx", "OC", "Sulfur", "VOC")
@@ -30,15 +25,6 @@ vars <- c("", "|Energy", "|Energy Demand|Transportation", "|Energy and Industria
           "|Energy|Demand", "|Energy|Demand|Transportation")
 gasvars <- expand.grid(gases, vars, stringsAsFactors = FALSE)
 bunkervars <- unique(sort(paste0("Emissions|", gasvars$Var1, gasvars$Var2)))
-
-
-# failing <- mif %>%
-#   checkSummations(dataDumpFile = NULL, outputDirectory = NULL,  summationsFile = "extractVariableGroups",
-#                   absDiff = 5e-7, relDiff = 1e-8) %>%
-#   filter(abs(diff) >= 5e-7, abs(reldiff) >= 1e-8) %>%
-#   df_variation() %>%
-#   droplevels()
-# if (nrow(failing) > 0) stopmessage <- c(stopmessage, "extractVariableGroups")
 
 for (template in c("AR6", "NAVIGATE")) {
   message("\n### Check project summations for ", template)
@@ -52,8 +38,7 @@ for (template in c("AR6", "NAVIGATE")) {
     droplevels()
   
   csregi <- d %>%
-    filter(! .data$unit %in% unitList, ! grepl(varGrep, .data$variable)) %>%
-    checkSummationsRegional() %>%
+    checkSummationsRegional(skipUnits = TRUE) %>%
     rename(World = "total") %>%
     droplevels()
   checkyear <- 2050
@@ -64,7 +49,6 @@ for (template in c("AR6", "NAVIGATE")) {
   if (nrow(failregi) > 0) {
     message("For those ", template, " variables, the sum of regional values does not match the World value in 2050:")
     failregi %>% piamInterfaces::niceround() %>% print(n = 1000)
-    print(paste0(failregi$variable, collapse = ", "))
   } else {
     message("Regional summation checks are fine.")
   }


### PR DESCRIPTION
## Purpose of this PR

- use [this list](https://github.com/pik-piam/piamInterfaces/blob/aa4dcf48fe337cf9d9c1e2fe37b7f3df11c3f965/R/checkSummationsRegional.R#L27-L41) instead of a self-defined one.
- remove commented code and unnecessary prints

## Type of change

- [x] Refactoring

## Checklist:

- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I am absolutely sure that this file is not touched or checked by the automated model tests, so it is pointless to run them. But I checked that `output.R` and then selecting this script works as intended.
