### PR TITLE
avoid MAGICC7 duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     [[#1429](https://github.com/remindmodel/remind/pull/1429), [#1476](https://github.com/remindmodel/remind/pull/1476)]
 - **scripts** '--test' mode for start.R and start_bundle_coupled.R does not write RData files anymore
     [[#1500](https://github.com/remindmodel/remind/pull/1500)]
-- prevent tradtional biomass spillover to other sectors than buildings
+- prevent traditional biomass spillover to other sectors than buildings
     [[#1519](https://github.com/remindmodel/remind/pull/1519)]
 - fully fix landuse and MAGICC6 variables in delayed transition runs to reference run
     [[#1565](https://github.com/remindmodel/remind/pull/1565)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     [[#1587](https://github.com/remindmodel/remind/pull/1587)]
 - **32_power** extend and reparameterize flexibility tax implementation for electrolysis for hydrogen production
 - **21_tax** add SE tax on electricity going into electrolysis for hydrogen production
-- **scripts** add compareScenarios section for MAGICC7 AR6 output
-    [[#1615](https://github.com/remindmodel/remind/pull/1615)
+- **scripts** add MAGICCv7.5.3 with AR6 settings as output script, add compareScenarios2 option
+    [[#1475](https://github.com/remindmodel/remind/pull/1475), [[#1615](https://github.com/remindmodel/remind/pull/1615)]
 
 ### fixed
 - fixed weights of energy carriers in `pm_IndstCO2Captured`
@@ -48,9 +48,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     NDC2constant, NPi2018, diffPhaseIn2Constant, diffPhaseIn2Lin, diffPhaseInLin2LinFlex, diffPriceSameCost
     [[#1480](https://github.com/remindmodel/remind/pull/1480)]
 - **36_buildings** remove outdated realizations: services_putty, services_with_capital 
-    [[#1509] (https://github.com/remindmodel/remind/pull/1509)]
+    [[#1509](https://github.com/remindmodel/remind/pull/1509)]
 - **35_transport** remove outdated realization: complex 
-    [[#1543] (https://github.com/remindmodel/remind/pull/1543)]
+    [[#1543](https://github.com/remindmodel/remind/pull/1543)]
 
 ## [3.2.1] - 2023-07-13 (incomplete)
 

--- a/main.gms
+++ b/main.gms
@@ -846,7 +846,7 @@ parameter
   cm_LimRock               = 1000;   !! def = 1000
 *'
 parameter
-  cm_expoLinear_yearStart   "time at which carbon price increases lineraly instead of exponentially"
+  cm_expoLinear_yearStart   "time at which carbon price increases linearly instead of exponentially"
 ;
   cm_expoLinear_yearStart  = 2050;   !! def = 2050
 *'
@@ -1004,7 +1004,7 @@ parameter
 *' This switch only has an effect if the flexibility tax is on by cm_flex_tax set to 1
 *' Default value is based on data from German Langfristszenarien (see ./modules/32_power/IntC/datainput.gms).
 parameter
-  cm_FlexTaxFeedback          "switch deciding whether flexibility tax feedback on buildlings and industry electricity prices is on"
+  cm_FlexTaxFeedback          "switch deciding whether flexibility tax feedback on buildings and industry electricity prices is on"
 ;
   cm_FlexTaxFeedback = 0;  !! def = 0  !! regexp = 0|1
 *' cm_FlexTaxFeedback, switches on feedback of flexibility tax on buildings and industry.
@@ -1095,12 +1095,12 @@ parameter
 *' * (any other number) limit of gas demand from 2025 on in Germany in EJ/yr
 *'
 parameter
-  c_SlackMultiplier   "Muliplicative factor to up/downscale the slack size for v_changeProdStartyearSlack"
+  c_SlackMultiplier   "Multiplicative factor to up/downscale the slack size for v_changeProdStartyearSlack"
 ;
   c_SlackMultiplier = 1;  !! def = 1
 *'
 parameter
-  c_changeProdCost   "Muliplicative factor to up/downscale the costs for vm_changeProdStartyearCost"
+  c_changeProdCost   "Multiplicative factor to up/downscale the costs for vm_changeProdStartyearCost"
 ;
   c_changeProdCost = 5;  !! def = 5
 *'
@@ -1400,7 +1400,7 @@ $setGlobal cm_EnSecScen_price  off !! def off
 $setGlobal cm_indstExogScen  off !! def off
 *** cm_exogDem_scen
 *** switch to fix FE or ES demand represented in CES function to trajectories
-*** from exgenous sources (not EDGE models) given in file p47_exogDemScen.
+*** from exogenous sources (not EDGE models) given in file p47_exogDemScen.
 *** This switch fixes demand without recalibration of REMIND CES parameters.
 *** This should be kept in mind when comparing those runs to baseline runs without fixing
 *** as the fixing shifts the CES function away from its optimal point based on the CES parameters used.

--- a/modules/21_tax/off/not_used.txt
+++ b/modules/21_tax/off/not_used.txt
@@ -51,7 +51,6 @@ pm_pvp,input,questionnaire
 pm_taxemiMkt,input,questionnaire
 pm_taxemiMkt_iteration,input,questionnaire
 vm_Mport,input,questionnaire
-vm_deltaCap, variable, ???
 sm_TWa_2_MWh,input,questionnaire
 vm_emiCO2Sector,input,questionnaire
 pm_taxCO2eqSum,input,questionnare

--- a/output.R
+++ b/output.R
@@ -93,7 +93,7 @@ choose_slurmConfig_output <- function(output) {
     return("direct")
 
   # Modify slurm options for reporting options that run in parallel (MAGICC) or need more memory
-  if ("ar6Climate" %in% output) {
+  if ("MAGICC7_AR6" %in% output) {
     slurm_options <- paste(slurm_options[1:3], "--tasks-per-node=12 --mem=32000")
   } else if ("nashAnalysis" %in% output) {
     slurm_options <- paste(slurm_options[1:3], "--mem=32000")

--- a/scripts/output/single/MAGICC7_AR6.R
+++ b/scripts/output/single/MAGICC7_AR6.R
@@ -224,8 +224,13 @@ climateAssessmentData <- read.quitte(climateAssessmentOutput) %>%
   filter(period %in% usePeriods) %>%
   interpolate_missing_periods(usePeriods, expand.values = FALSE) %>%
   mutate(variable = gsub("|MAGICCv7.5.3", "", .data$variable, fixed = TRUE)) %>%
-  mutate(variable = gsub("AR6 climate diagnostics|", "MAGICC7 AR6|", .data$variable, fixed = TRUE)) %>%
-  write.mif(remindReportingFile, append = TRUE)
+  mutate(variable = gsub("AR6 climate diagnostics|", "MAGICC7 AR6|", .data$variable, fixed = TRUE))
+
+as.quitte(remindReportingFile) %>%
+  # remove data from old MAGICC7 runs to avoid duplicated
+  filter(! grepl("AR6 climate diagnostics.*MAGICC7", .data$variable), ! grepl("^MAGICC7 AR6", .data$variable)) %>%
+  rbind(climateAssessmentData) %>%
+  write.mif(remindReportingFile)
 
 deletePlus(remindReportingFile, writemif = TRUE)
 

--- a/standalone/MOFEX/MOFEX.gms
+++ b/standalone/MOFEX/MOFEX.gms
@@ -170,7 +170,7 @@ cm_iterative_target_adj "whether or not a tax or a budget target should be itera
 cm_gdximport_target   "whether or not the starting value for iteratively adjusted budgets, tax scenarios, or forcing targets (emiscen 5,6,8,9) should be read in from the input.gdx"
 cm_gs_ew              "grain size (for enhanced weathering, CDR module) [micrometre]"
 cm_LimRock             "limit amount of rock spread each year [Gt]"
-cm_expoLinear_yearStart "time at which carbon price increases lineraly instead of exponentially"
+cm_expoLinear_yearStart "time at which carbon price increases linearly instead of exponentially"
 
 c_budgetCO2FFI        "carbon budget for CO2 emissions from FFI (in GtCO2)"
 c_abtrdy              "first year in which advanced bio-energy technology are ready (unit is year; e.g. 2050)"
@@ -200,7 +200,7 @@ cm_bioprod_histlim			"regional parameter to limit biomass (pebiolc.1) production
 cm_flex_tax                 "switch for enabling flexibility tax"
 cm_H2targets                "switches on capacity targets for electrolysis in NDC techpol following national Hydrogen Strategies"
 cm_PriceDurSlope_elh2       "slope of price duration curve of electrolysis"
-cm_FlexTaxFeedback          "switch deciding whether flexibility tax feedback on buildlings and industry electricity prices is on"
+cm_FlexTaxFeedback          "switch deciding whether flexibility tax feedback on buildings and industry electricity prices is on"
 cm_VRE_supply_assumptions        "default (0), optimistic (1), sombre (2), or bleak (3) assumptions on VRE supply"
 cm_build_H2costAddH2Inv     "additional h2 distribution costs for low diffusion levels (default value: 6.5$/ 100 /Kwh)"
 cm_build_H2costDecayStart     "simplified logistic function end of full value (ex. 5%  -> between 0 and 5% the function will have the value 1). [%]"

--- a/standalone/template.gms
+++ b/standalone/template.gms
@@ -166,7 +166,7 @@ cm_iterative_target_adj "whether or not a tax or a budget target should be itera
 cm_gdximport_target   "whether or not the starting value for iteratively adjusted budgets, tax scenarios, or forcing targets (emiscen 5,6,8,9) should be read in from the input.gdx"
 cm_gs_ew              "grain size (for enhanced weathering, CDR module) [micrometre]"
 cm_LimRock             "limit amount of rock spread each year [Gt]"
-cm_expoLinear_yearStart "time at which carbon price increases lineraly instead of exponentially"
+cm_expoLinear_yearStart "time at which carbon price increases linearly instead of exponentially"
 
 c_budgetCO2FFI        "carbon budget for CO2 emissions from FFI (in GtCO2)"
 c_abtrdy              "first year in which advanced bio-energy technology are ready (unit is year; e.g. 2050)"

--- a/standalone/trade/trade.gms
+++ b/standalone/trade/trade.gms
@@ -174,7 +174,7 @@ cm_iterative_target_adj "whether or not a tax or a budget target should be itera
 cm_gdximport_target   "whether or not the starting value for iteratively adjusted budgets, tax scenarios, or forcing targets (emiscen 5,6,8,9) should be read in from the input.gdx"
 cm_gs_ew              "grain size (for enhanced weathering, CDR module) [micrometre]"
 cm_LimRock             "limit amount of rock spread each year [Gt]"
-cm_expoLinear_yearStart "time at which carbon price increases lineraly instead of exponentially"
+cm_expoLinear_yearStart "time at which carbon price increases linearly instead of exponentially"
 
 c_budgetCO2FFI        "carbon budget for CO2 emissions from FFI (in GtCO2)"
 c_abtrdy              "first year in which advanced bio-energy technology are ready (unit is year; e.g. 2050)"
@@ -204,7 +204,7 @@ cm_bioprod_histlim			"regional parameter to limit biomass (pebiolc.1) production
 cm_flex_tax                 "switch for enabling flexibility tax"
 cm_H2targets                "switches on capacity targets for electrolysis in NDC techpol following national Hydrogen Strategies"
 cm_PriceDurSlope_elh2       "slope of price duration curve of electrolysis"
-cm_FlexTaxFeedback          "switch deciding whether flexibility tax feedback on buildlings and industry electricity prices is on"
+cm_FlexTaxFeedback          "switch deciding whether flexibility tax feedback on buildings and industry electricity prices is on"
 cm_VRE_supply_assumptions        "default (0), optimistic (1), sombre (2), or bleak (3) assumptions on VRE supply"
 cm_build_H2costAddH2Inv     "additional h2 distribution costs for low diffusion levels (default value: 6.5$/ 100 /Kwh)"
 cm_build_H2costDecayStart     "simplified logistic function end of full value (ex. 5%  -> between 0 and 5% the function will have the value 1). [%]"


### PR DESCRIPTION
## Purpose of this PR

- remove everything that looks like data from an old MAGICC7 run
- results at `/p/tmp/oliverr/remind/output/default_2024-02-29_16.45.19/REMIND_generic_default.mif` and `log_output.txt`

## Type of change

- [x] Bug fix 
## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [x] I did not run automated model tests pass, because they don't look at this file at all. But I ran MAGICC7 using the file and it worked and avoided duplicates