### PR TITLE
adjust NPi carbon price settings

### DIFF
--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -1308,8 +1308,21 @@ if(c_macscen eq 1,
 *pm_macCostSwitch(enty)=pm_macSwitch(enty);
 
 *** for NDC and NPi switch off landuse MACs
+$if %carbonprice% == "off"      pm_macSwitch(emiMacMagpie) = 0;
 $if %carbonprice% == "NDC"      pm_macSwitch(emiMacMagpie) = 0;
 $if %carbonprice% == "NPi"      pm_macSwitch(emiMacMagpie) = 0;
+
+*** Load historical carbon prices defined in $/t CO2, need to be rescaled to right unit
+pm_taxCO2eq(t,regi)$(t.val le 2020) = 0;
+parameter f_taxCO2eqHist(ttot,all_regi)       "historic CO2 prices ($/tCO2)"
+/
+$ondelim
+$include "./core/input/pm_taxCO2eqHist.cs4r"
+$offdelim
+/
+;
+pm_taxCO2eq(t,regi)$(t.val le 2020) = f_taxCO2eqHist(t,regi) * sm_DptCO2_2_TDpGtC;
+
 
 *DK* LU emissions are abated in MAgPIE in coupling mode
 *** An alternative to the approach below could be to introduce a new value for c_macswitch that only deactivates the LU MACs

--- a/core/input/files
+++ b/core/input/files
@@ -45,3 +45,4 @@ p_regi_2_MAGICC_regions.cs3r
 p_share_ind_fehos.cs4r
 p_share_ind_fesos_bio.cs4r
 p_share_ind_fesos.cs4r
+pm_taxCO2eqHist.cs4r

--- a/modules/21_tax/off/not_used.txt
+++ b/modules/21_tax/off/not_used.txt
@@ -51,7 +51,6 @@ pm_pvp,input,questionnaire
 pm_taxemiMkt,input,questionnaire
 pm_taxemiMkt_iteration,input,questionnaire
 vm_Mport,input,questionnaire
-vm_deltaCap, variable, ???
 sm_TWa_2_MWh,input,questionnaire
 vm_emiCO2Sector,input,questionnaire
 pm_taxCO2eqSum,input,questionnare

--- a/modules/45_carbonprice/NDC/datainput.gms
+++ b/modules/45_carbonprice/NDC/datainput.gms
@@ -11,16 +11,6 @@ Execute_Loadpoint "input_ref" p45_taxCO2eq_bau = pm_taxCO2eq;
 
 pm_taxCO2eq(t,regi) = p45_taxCO2eq_bau(t,regi)
 
-*** Carbon prices defined in $/t CO2, has to be rescaled to right unit
-parameter f45_taxCO2eqHist(ttot,all_regi)       "historic CO2 prices ($/tCO2)"
-/
-$ondelim
-$include "./modules/45_carbonprice/NDC/input/pm_taxCO2eqHist.cs4r"
-$offdelim
-/
-;
-pm_taxCO2eq(t,regi)$(t.val < 2025) = f45_taxCO2eqHist(t,regi) * sm_DptCO2_2_TDpGtC;
-
 *** parameters for exponential increase after NDC targets
 Scalar p45_taxCO2eqGlobal2030 "startprice in 2030 (unit TDpGtC) of global CO2eq taxes towards which countries converge";
 p45_taxCO2eqGlobal2030 = 30 * sm_DptCO2_2_TDpGtC;

--- a/modules/45_carbonprice/NDC/input/files
+++ b/modules/45_carbonprice/NDC/input/files
@@ -1,4 +1,3 @@
 fm_2005shareTarget.cs3r
 fm_factorTargetyear.cs3r
 fm_histShare.cs3r
-pm_taxCO2eqHist.cs4r

--- a/modules/45_carbonprice/NPi/datainput.gms
+++ b/modules/45_carbonprice/NPi/datainput.gms
@@ -6,34 +6,19 @@
 *** |  Contact: remind@pik-potsdam.de
 *** SOF ./modules/45_carbonprice/NPi/datainput.gms
 
-pm_taxCO2eq(ttot,regi)$(ttot.val lt 2020) = 0;
+*** Historic data including year 2020 is read in core/datainput.gms
 
-*** Carbon prices defined in $/t CO2, will be rescaled to right unit at the end of this file
-
-parameter f45_taxCO2eqHist(ttot,all_regi)       "historic CO2 prices ($/tCO2)"
-/
-$ondelim
-$include "./modules/45_carbonprice/NPi/input/pm_taxCO2eqHist.cs4r"
-$offdelim
-/
-;
-
-pm_taxCO2eq(t,regi)$(t.val < 2025) = f45_taxCO2eqHist(t,regi);
-
-*** convergence scheme post 2020: parabolic convergence up to 40$/tCO2 in the convergence year (here chosen as 2070) and then linear increase of 2$/year afterwards
-pm_taxCO2eq(ttot,regi)$( (ttot.val ge 2025) AND (ttot.val le 2070)) =
+*** convergence scheme post 2020: parabolic convergence up to 25$/tCO2 in the convergence year (here chosen as 2100) and then constant
+pm_taxCO2eq(ttot,regi)$( (ttot.val ge 2025) AND (ttot.val le 2100)) =
   pm_taxCO2eq("2020",regi) 
   + ( 
-      ( 40 - pm_taxCO2eq("2020",regi) ) 
+      ( 25 * sm_DptCO2_2_TDpGtC - pm_taxCO2eq("2020",regi) )
       * ( 
-          (ttot.val - 2020) / (2070 - 2020) 
+          (ttot.val - 2020) / (2100 - 2020)
         ) ** 2 
     )
 ;
-pm_taxCO2eq(ttot,regi)$(ttot.val gt 2070) = pm_taxCO2eq("2070",regi) + (ttot.val - 2070) * 0.5;
-
-*** rescale everything to $/t CO2
-pm_taxCO2eq(ttot,regi) = pm_taxCO2eq(ttot,regi) * sm_DptCO2_2_TDpGtC;
+pm_taxCO2eq(ttot,regi)$(ttot.val gt 2100) = pm_taxCO2eq("2100",regi);
 
 display pm_taxCO2eq;
 

--- a/modules/45_carbonprice/NPi/input/files
+++ b/modules/45_carbonprice/NPi/input/files
@@ -1,1 +1,0 @@
-pm_taxCO2eqHist.cs4r

--- a/tutorials/02_RunningREMIND.md
+++ b/tutorials/02_RunningREMIND.md
@@ -92,12 +92,12 @@ sq
 ```
 in the terminal.
 
-To see how far your run is or whether it was stopped due to some problems, go to the `output` folder and type
-
+To see how far your run is or whether it was stopped due to some problems, you can check based on the output folder (shown as `WORK_DIR` in `sq`) by typing
 ``` bash
-rs2
+remindstatus output/default_2024-02-29_16.45.19
 ```
-in the console. For more commands to manage your runs, type **piaminfo**.
+in the console. If you are in the folder, `remindstatus` is sufficient.
+For a short version, use `rs2` (see help at `rs2 -h`). For more commands to manage your runs, type `piaminfo`.
 
 NOTE: A few words on the scripts that we currently use to start runs. The scripts containing the string 'start' have a double functionality:
 - they submit the run to the cluster or to your GAMS system if you work locally


### PR DESCRIPTION
## Purpose of this PR

- Old setting lead to very high prices in developing prices in 2100, around 60$/t. Now, go back to 25$/t global convergence. I'm sure that underestimates a bit what might be going on in industrialized countries, but I don't want to give up on global convergence at the moment.
- I also moved the historical data to the core to avoid that any setting has no historical CO2 prices, as it may happen if you fix on a Base run until 2020, that you miss the 2010 and 2015 prices, see below.
- test runs for NPi and NDC with one single iteration are running in `/p/tmp/oliverr/remind/output`. With `dumpgdx fulldata.gdx pm_taxCO2eq 20[0123][05],` one can have a look whether that is more or less correct. Running a full scenario would not fit into today's schedule, I guess.

![image](https://github.com/remindmodel/remind/assets/90761609/8e02a48f-9d23-4120-97e9-5b9e75274204)


## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
