### PR TITLE
avoid that run numbers change while selecting policyCosts runs

### DIFF
--- a/output.R
+++ b/output.R
@@ -160,10 +160,11 @@ if (! exists("outputdir")) {
   outputdirs <- if (length(dir_folder) == 1) file.path(dir_folder, selectedDirs) else selectedDirs
 
   if ("policyCosts" %in% output) {
-    policyrun <- chooseFromList(dirnames, type = "reference run to which policy run will be compared",
+    policyrun <- chooseFromList(c("--- only here to avoid that folder numbers change ---", dirnames),
+                                type = "reference run to which policy run will be compared",
                                 userinfo = "Select a single reference run.",
                                 returnBoolean = TRUE, multiple = FALSE)
-    outputdirs <- c(rbind(outputdirs, dirs[policyrun])) # generate 3,1,4,1,5,1 out of 3,4,5 and policyrun 1
+    outputdirs <- c(rbind(outputdirs, dirs[policyrun[-1]])) # generate 3,1,4,1,5,1 out of 3,4,5 and policyrun 1
   }
 } else {
   outputdirs <- outputdir


### PR DESCRIPTION
## Purpose of this PR

If you first select the runs for which you want to run `policyCosts`, and then the reference scenario, the numbers allocated to these runs change, because in the first case, `chooseFromList` sets the `all` option as Nr. 1, while in the second case you are only allowed to select a single run, so the `all` option does not exist. Add some pseudo run there to make sure the runs keep the same number.

## Type of change

- [x] Minor bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
