### PR TITLE
add 'make test-fix': check-fix and then test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **21_tax** add SE tax on electricity going into electrolysis for hydrogen production
 - **scripts** add MAGICCv7.5.3 with AR6 settings as output script, add compareScenarios2 option
     [[#1475](https://github.com/remindmodel/remind/pull/1475), [[#1615](https://github.com/remindmodel/remind/pull/1615)]
+- **scripts** add 'make test-fix' which runs codeCheck in interactive mode, adjusting not_used.txt files
+    [[#1625](https://github.com/remindmodel/remind/pull/1625)
 
 ### fixed
 - fixed weights of energy carriers in `pm_IndstCO2Captured`

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
     gdxdt,
     gdxrrw,
     ggplot2,
-    gms (>= 0.30.5),
+    gms (>= 0.30.7),
     goxygen,
     gridExtra,
     gtools,

--- a/Makefile
+++ b/Makefile
@@ -64,12 +64,12 @@ restore-renv:    ## Restore renv to the state described in interactively
 
 check:           ## Check if the GAMS code follows the coding etiquette
                  ## using gms::codeCheck
-	Rscript -e 'invisible(gms::codeCheck(strict = TRUE))'
+	Rscript -e 'options(warn = 1); invisible(gms::codeCheck(strict = TRUE));'
 
 check-fix:       ## Check if the GAMS code follows the coding etiquette
                  ## and offer fixing any problems directly if possible
                  ## using gms::codeCheck
-	Rscript -e 'invisible(gms::codeCheck(strict = TRUE, interactive = TRUE))'
+	Rscript -e 'options(warn = 1); invisible(gms::codeCheck(strict = TRUE, interactive = TRUE));'
 
 test:            ## Test if the model compiles and runs without running a full
                  ## scenario. Tests take about 15 minutes to run.
@@ -79,7 +79,9 @@ test:            ## Test if the model compiles and runs without running a full
 test-fix:        ## First run codeCheck interactively, then test if the model compiles and runs without
                  ## running a full scenario. Tests take about 15 minutes to run.
 	$(info Tests take about 18 minutes to run, please be patient)
-	@Rscript -e 'invisible(gms::codeCheck(strict = TRUE, interactive = TRUE)); testthat::test_dir("tests/testthat"); message("Do not forget to commit changes done by codeCheck to not_used.txt files");'
+	@Rscript -e 'rlang::with_options(warn = 1, invisible(gms::codeCheck(strict = TRUE, interactive = TRUE))); testthat::test_dir("tests/testthat");'
+	@echo "Do not forget to commit possible changes done by codeCheck to not_used.txt files"
+	@git add -p modules/*/*/not_used.txt
 
 test-coupled:    ## Test if the coupling with MAgPIE works. Takes significantly
                  ## longer than 60 minutes to run and needs slurm and magpie

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,11 @@ test:            ## Test if the model compiles and runs without running a full
 	$(info Tests take about 15 minutes to run, please be patient)
 	@Rscript -e 'testthat::test_dir("tests/testthat")'
 
+test-fix:        ## First run codeCheck interactively, then test if the model compiles and runs without
+                 ## running a full scenario. Tests take about 15 minutes to run.
+	$(info Tests take about 18 minutes to run, please be patient)
+	@Rscript -e 'invisible(gms::codeCheck(strict = TRUE, interactive = TRUE)); testthat::test_dir("tests/testthat"); message("Do not forget to commit changes done by codeCheck to not_used.txt files");'
+
 test-coupled:    ## Test if the coupling with MAgPIE works. Takes significantly
                  ## longer than 60 minutes to run and needs slurm and magpie
                  ## available

--- a/modules/30_biomass/magpie_40/declarations.gms
+++ b/modules/30_biomass/magpie_40/declarations.gms
@@ -32,7 +32,7 @@ p30_pebiolc_costs_emu_preloop(ttot,all_regi)    "Bioenergy costs calculated with
 p30_pebiolc_price_emu_preloop(ttot,all_regi)    "Bioenergy price calculated with emulator using MAgPIE demand. For shift factor calculation [T$US/TWa]"
 p30_pebiolc_price_emu_preloop_shifted(ttot,all_regi) "Bioenergy price calculated with emulator using MAgPIE demand after shift factor calculation [T$US/TWa]"
 p30_pebiolc_pricshift(ttot,all_regi)            "Regional translation factor that shifts emulator prices to better fit actual MAgPIE prices [-]"
-p30_pebiolc_pricmult(ttot,all_regi)             "Regional multiplication factor that sclaes emulator prices to better fit actual MAgPIE prices [-]"
+p30_pebiolc_pricmult(ttot,all_regi)             "Regional multiplication factor that scales emulator prices to better fit actual MAgPIE prices [-]"
 
 *** Parameters for regression of MAgPIE prices and costs ("MAgPIE emulator")
 
@@ -53,7 +53,7 @@ v30_shift_r2                       "Least square to minimize during shift calcul
 
 Positive variable
 v30_priceshift(ttot,all_regi)      "Regional translation factor that shifts emulator prices to better fit actual MAgPIE prices [-]"
-v30_pricemult(ttot,all_regi)       "Regional multiplication factor that sclaes emulator prices to better fit actual MAgPIE prices [-]"
+v30_pricemult(ttot,all_regi)       "Regional multiplication factor that scales emulator prices to better fit actual MAgPIE prices [-]"
 v30_multcost(ttot,all_regi)        "Cost markup factor for deviations from demand of last coupling iteration [-]"
 v30_BioPEProdTotal(ttot,all_regi)  "total domestic PE biomass production [unit: TWyr]"
 ***v30_pedem_BAU(tall,all_regi,all_enty,all_enty,all_te)    "Primary energy demand imported from refernce gdx [TWa]"

--- a/tests/testthat/test_01-codeCheck.R
+++ b/tests/testthat/test_01-codeCheck.R
@@ -7,7 +7,7 @@
 test_that("GAMS code follows the coding etiquette", {
   # have to run this via localSystem2 so that it uses the renv, where gms
   # is actually installed.
-  codecheckcode <- "'invisible(gms::codeCheck(strict = TRUE)); if (! is.null(warnings())) stop(warnings())'"
+  codecheckcode <- "'options(warn = 1); invisible(gms::codeCheck(strict = TRUE));'"
   output <- localSystem2("Rscript", c("-e", codecheckcode))
   printIfFailed(output)
   expectSuccessStatus(output)

--- a/tests/testthat/test_01-codeCheck.R
+++ b/tests/testthat/test_01-codeCheck.R
@@ -7,7 +7,7 @@
 test_that("GAMS code follows the coding etiquette", {
   # have to run this via localSystem2 so that it uses the renv, where gms
   # is actually installed.
-  codecheckcode <- "'invisible(gms::codeCheck(strict=TRUE)); if (! is.null(warnings())) stop(warnings())'"
+  codecheckcode <- "'invisible(gms::codeCheck(strict = TRUE)); if (! is.null(warnings())) stop(warnings())'"
   output <- localSystem2("Rscript", c("-e", codecheckcode))
   printIfFailed(output)
   expectSuccessStatus(output)


### PR DESCRIPTION
## Purpose of this PR

- since https://github.com/pik-piam/gms/pull/92, codeCheck within `make test` does not adjust `not_used.txt` files anymore.
- add option `make test-fix` that runs `codeCheck` in interactive mode
- correct some typos
- close #1623

## Type of change

- [x] New feature 

## Checklist:

- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test-fix`)
