### PR TITLE
run fixOnRef and checkProjectSummations in all rem-mag iterations

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Imports:
     edgeTransport (>= 1.5.4),
     flexdashboard,
     GDPuc,
-    gdx,
+    gdx (>= 1.53.0),
     gdxdt,
     gdxrrw,
     ggplot2,

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,7 @@ test-coupled:    ## Test if the coupling with MAgPIE works. Takes significantly
 
 test-coupled-slurm: ## test-coupled, but on slurm
 	$(info Coupling tests take around 75 minutes to run. Sent to slurm, find log in test-coupled.log)
+	make ensure-reqs
 	@sbatch --qos=priority --wrap="make test-coupled" --job-name=test-coupled --mail-type=END --output=test-coupled.log --comment="test-coupled.log"
 
 test-full:       ## Run all tests, including coupling tests and a default

--- a/start_coupled.R
+++ b/start_coupled.R
@@ -73,8 +73,9 @@ start_coupled <- function(path_remind, path_magpie, cfg_rem, cfg_mag, runname, m
     cfg_rem$title          <- paste0(runname,"-rem-",i)
     
     # Switch off generation of needless output for all but the last REMIND iteration
+    output_all_iter <- c("reporting", "reportingREMIND2MAgPIE", "emulator", "rds_report", "fixOnRef", "checkProjectSummations")
     if (i < max_iterations) {
-      cfg_rem$output <- intersect(cfg_rem_original, c("reporting", "reportingREMIND2MAgPIE", "emulator", "rds_report"))
+      cfg_rem$output <- intersect(cfg_rem_original, output_all_iter)
     } else {
       cfg_rem$output <- cfg_rem_original
     }


### PR DESCRIPTION
## Purpose of this PR

- run fixOnRef and checkProjectSummations in all rem-mag iterations
- they only take a couple of seconds, but it is good to know early whether the cascade has such problems
- also make sure `make test-coupled-slurm` checks whether dependencies are satisfied instead of failing in slurm
- also increase gdx dependency here (coming from [remind2](https://github.com/pik-piam/remind2/commit/7e68884ce17ff7c69a7a45b5e3a91b477457968e)) to avoid fails

## Type of change

- [x] New feature (well, a very minor one)

## Checklist:

- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas (really hard to understand!!!)
- [x] All automated model tests pass (`FAIL 0` in the output of `make test-coupled-slurm`)
