### PR TITLE
avoid NA (sticky value) for p80_repy_iteration

### DIFF
--- a/modules/80_optimization/nash/solve.gms
+++ b/modules/80_optimization/nash/solve.gms
@@ -129,14 +129,19 @@ if (o_modelstat ne 2,
 );
 $endif.solprint
 
-p80_repy_iteration(regi,solveinfo80,iteration)$( p80_repy_thisSolitr(regi,solveinfo80) ) !! add information if this region was solved in this iteration
+!! add information if this region was solved in this iteration
+p80_repy_iteration(regi,solveinfo80,iteration)$(
+                                         p80_repy_thisSolitr(regi,solveinfo80) )
     !! store sum of resusd for all sol_itrs
   = ( p80_repy_iteration(regi,solveinfo80,iteration)
-    + p80_repy_thisSolitr(regi,solveinfo80)
+    + p80_repy_thisSolitr(regi,solveinfo80)$( 
+                                   p80_repy_thisSolitr(regi,solveinfo80) ne NA )
     )$( sameas(solveinfo80,"resusd") )
   + p80_repy_thisSolitr(regi,solveinfo80)$( NOT sameas(solveinfo80,"resusd") );
 
-p80_repy_nashitr_solitr(regi,solveinfo80,iteration,sol_itr)$( p80_repy_thisSolitr(regi,solveinfo80) ) !! add information if this region was solved in this iteration
+!! add information if this region was solved in this iteration
+p80_repy_nashitr_solitr(regi,solveinfo80,iteration,sol_itr)$(
+                                         p80_repy_thisSolitr(regi,solveinfo80) )
   = p80_repy_thisSolitr(regi,solveinfo80);
 
 put_utility "msg" / "Solve overview: The following are the results for iteration " iteration.tl:3:0  " , sol_itr " sol_itr.tl:3:0 ;

--- a/modules/80_optimization/nash/solve.gms
+++ b/modules/80_optimization/nash/solve.gms
@@ -129,15 +129,15 @@ if (o_modelstat ne 2,
 );
 $endif.solprint
 
-p80_repy_iteration(all_regi,solveinfo80,iteration)$( p80_repy_thisSolitr(all_regi,solveinfo80) ) !! add information if this region was solved in this iteration
+p80_repy_iteration(regi,solveinfo80,iteration)$( p80_repy_thisSolitr(regi,solveinfo80) ) !! add information if this region was solved in this iteration
     !! store sum of resusd for all sol_itrs
-  = ( p80_repy_iteration(all_regi,solveinfo80,iteration)
-    + p80_repy_thisSolitr(all_regi,solveinfo80)
+  = ( p80_repy_iteration(regi,solveinfo80,iteration)
+    + p80_repy_thisSolitr(regi,solveinfo80)
     )$( sameas(solveinfo80,"resusd") )
-  + p80_repy_thisSolitr(all_regi,solveinfo80)$( NOT sameas(solveinfo80,"resusd") );
+  + p80_repy_thisSolitr(regi,solveinfo80)$( NOT sameas(solveinfo80,"resusd") );
 
-p80_repy_nashitr_solitr(all_regi,solveinfo80,iteration,sol_itr)$( p80_repy_thisSolitr(all_regi,solveinfo80) ) !! add information if this region was solved in this iteration
-  = p80_repy_thisSolitr(all_regi,solveinfo80);
+p80_repy_nashitr_solitr(regi,solveinfo80,iteration,sol_itr)$( p80_repy_thisSolitr(regi,solveinfo80) ) !! add information if this region was solved in this iteration
+  = p80_repy_thisSolitr(regi,solveinfo80);
 
 put_utility "msg" / "Solve overview: The following are the results for iteration " iteration.tl:3:0  " , sol_itr " sol_itr.tl:3:0 ;
 display o_modelstat;


### PR DESCRIPTION
- if a solitr resulted in some error, resusd (and objval) would be NA
- adding next solitr's resusd would still be NA

E.g.
```
$ nashstat -a ./output/SSP2EU_PBS-NPi-calibrate_fast_2024-03-21_16.01.30/fulldata_01.gdx | sed -n '/^ 58/,/^$/ p'
 58 	solvestat            	modelstat               	resusd   	objval           
CAZ 	   normal completion 	        locally optimal 	 178.863 	 7.13680651610885 	
CHA 	terminated by solver 	      feasible solution 	1064.384 	 63.6267564043344 	
EUR 	   normal completion 	        locally optimal 	 550.479 	 40.8219747705235 	
IND 	   normal completion 	        locally optimal 	 429.799 	 32.8488696846889 	
JPN 	   normal completion 	        locally optimal 	 353.987 	 8.09839448471788 	
LAM 	   normal completion 	        locally optimal 	 270.285 	 45.3837159515231 	
MEA 	terminated by solver 	      feasible solution 	 289.894 	 45.3708387332332 	
NEU 	   normal completion 	        locally optimal 	 189.139 	 9.18595503758698 	
OAS 	   normal completion 	        locally optimal 	 342.464 	 75.8974121937532 	
REF 	   normal completion 	        locally optimal 	      NA 	 17.4658963610186 	
SSA 	   normal completion 	        locally optimal 	 365.984 	 94.1888131959033 	
USA 	   normal completion 	        locally optimal 	  358.75 	 32.9330008820871 	
```