### PR TITLE
new input data 6.75 and new CES parameters and gdx files SSP2EU and SSP2EU-EU21

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -27,10 +27,10 @@ cfg$regionmapping <- "config/regionmappingH12.csv"
 ### Additional (optional) region mapping, so that those validation data can be loaded that contain the corresponding additional regions.
 cfg$extramappings_historic <- ""
 #### Current input data revision (<mainrevision>.<subrevision>) ####
-cfg$inputRevision <- "6.74"
+cfg$inputRevision <- "6.75"
 
 #### Current CES parameter and GDX revision (commit hash) ####
-cfg$CESandGDXversion <- "251cdf881a2bbe351cd57a59ce601e59ab96f14f"
+cfg$CESandGDXversion <- "efd26de15b7f8021ba79309676d208ed63b1668c"
 
 #### Force the model to download new input data ####
 cfg$force_download <- FALSE


### PR DESCRIPTION
## Purpose of this PR
new input data revision 6.75 and new CES parameters and gdx files for SSP2EU and SSP2EU-EU21,

calibration runs:
/p/tmp/pehl/Remind/output/SSP2EU-NPi-calibrate_fast_2024-03-22_16.01.45 and
/p/tmp/pehl/Remind/output/SSP2EU-EU21-NPi-calibrate_2024-03-18_16.23.52


## Type of change

- [x] Minor change (default scenarios show only small differences)

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

