### PR TITLE
use correct model version in xlsx_IIASA

### DIFF
--- a/scripts/output/export/xlsx_IIASA.R
+++ b/scripts/output/export/xlsx_IIASA.R
@@ -16,7 +16,7 @@ library(tidyr)
 
 options(warn = 1)
 
-model <- paste("REMIND", substr(gms::readDefaultConfig(".")$model_version, 1, 3))
+model <- paste("REMIND", paste0(strsplit(gms::readDefaultConfig(".")$model_version, "\\.")[[1]][1:2], collapse = "."))
 # model <- "REMIND 3.3"                        # modelname in final file, overwrite if necessary
 
 


### PR DESCRIPTION
## Purpose of this PR

do it right and prepare for `REMIND 3.10` which should not show up as `REMIND 3.1`