### PR TITLE
reset CES input in 29_CES_parameters/datainput

### DIFF
--- a/modules/29_CES_parameters/load/datainput.gms
+++ b/modules/29_CES_parameters/load/datainput.gms
@@ -6,9 +6,9 @@
 *** |  Contact: remind@pik-potsdam.de
 *** SOF ./modules/29_CES_parameters/load/datainput.gms
 *** Load CES parameters based on current model configuration
-*** ATTENTION the file name is replaced by the function start_run()
+*** ATTENTION the file name is replaced by the function updateInputData()
 *##################### R SECTION START (CES INPUT) ##########################
-$include "./modules/29_CES_parameters/load/input/indu_subsectors-buil_simple-tran_edge_esm-POP_pop_SSP2EU-GDP_gdp_SSP2EU-En_gdp_SSP2EU-Kap_debt_limit-Reg_62eff8f7.inc"
+$include "./modules/29_CES_parameters/load/input/CES_configuration.inc"
 *###################### R SECTION END (CES INPUT) ###########################
 
 option pm_cesdata:8:3:1;

--- a/scripts/start/prepare.R
+++ b/scripts/start/prepare.R
@@ -266,6 +266,7 @@ prepare <- function() {
 
   ################## M O D E L   U N L O C K ###################################
   # After full.gms was produced remind folders have to be unlocked to allow setting up the next run
+  resetCESfile()
   model_unlock(lock_id)
   # Reset on.exit: Prevent model_unlock from being executed again at the end
   # and remove "setwd(cfg$results_folder)" from on.exit, becaue we change to it in the next line

--- a/scripts/start/resetCESfile.R
+++ b/scripts/start/resetCESfile.R
@@ -1,0 +1,8 @@
+#' reset modules/29_CES_parameters/load/datainput.gms
+#' @param remindPath path to main remind folder
+
+resetCESfile <- function(remindPath = ".") {
+  replace_in_file(file    = file.path(remindPath, "modules/29_CES_parameters/load/datainput.gms"),
+                  content = '$include "./modules/29_CES_parameters/load/input/CES_configuration.inc"',
+                  subject = "CES INPUT")
+}

--- a/scripts/start/runGamsCompile.R
+++ b/scripts/start/runGamsCompile.R
@@ -42,12 +42,14 @@ runGamsCompile <- function(modelFile, cfg, interactive = TRUE, testmode = FALSE)
         return(runGamsCompile(modelFile, cfg, interactive))
       }
     }
+    if (! testmode) resetCESfile()
     return(FALSE)
   } else {
     message(green, " OK  ", NC, gsub("gms$", "lst", tmpModelFile))
     if (isTRUE(grepl("TESTTHAT_scenario_config", cfg$title))) { # for test_04-gamscompile
       unlink(c(tmpModelFile, tmpModelLst))
     }
+    if (! testmode) resetCESfile()
     return(TRUE)
   }
 }

--- a/tests/testthat/test_01-inputdata.R
+++ b/tests/testthat/test_01-inputdata.R
@@ -3,6 +3,7 @@ test_that("Are all input data files present?", {
   if (length(missinginput) > 0) {
     lockID <- gms::model_lock(folder = "../..")
     updateInputData(cfg = gms::readDefaultConfig("../.."), remindPath = "../..")
+    resetCESfile(remindPath = "../..")
     gms::model_unlock(lockID)
     missinginput <- missingInputData(path = "../..")
     if (length(missinginput) > 0) {


### PR DESCRIPTION
## Purpose of this PR

- after `main.gms` is not changed automatically anymore, also reset the last file that is adjusted while model is running before unlocking the model again.
- I just used a generic name, as this is replaced anyway in the `prepare()` process.

## Type of change

- [x] Refactoring

## Checklist:

- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
