### PR TITLE
remove renvVersion check for MAgPIE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### changed
+- **scripts** do not check anymore that MAgPIE uses renv
+  [[1646](https://github.com/remindmodel/remind/pull/1646)]
+
 ## [3.3.0] - 2024-03-28
 
 ### changed
 - **37_industry** changed industry to have subsector-specific shares of SE
-  origins in FE carriers[[#1620]](https://github.com/remindmodel/remind/pull/1620)
+  origins in FE carriers [[#1620]](https://github.com/remindmodel/remind/pull/1620)
 
 ### added
 - **config** regex tests for many parameters [[#1356](https://github.com/remindmodel/remind/pull/1356)]

--- a/start_bundle_coupled.R
+++ b/start_bundle_coupled.R
@@ -104,9 +104,6 @@ if (!is.null(renv::project())) {
     message("Installing missing MAgPIE dependencies ", paste(missingDeps, collapse = ", "))
     renv::install(missingDeps)
   }
-  if (! any(grepl("renvVersion", readLines(file.path(path_magpie, ".Rprofile"), warn = FALSE)))) {
-    stop("REMIND uses renv, but no renvVersion defined in MAgPIE .Rprofile. Checkout a recent .Rprofile in ", path_magpie)
-  }
 }
 
 ########################################################################################################


### PR DESCRIPTION
## Purpose of this PR

- not needed anymore, because all recent MAgPIE versions use renv.

## Type of change

- [x] Bug fix 

## Checklist:

- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test-coupled`): `[ FAIL 0 | WARN 0 | SKIP 0 | PASS 94 ] Done!`
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
