### PR TITLE
adjust checkFixCfg error message

### DIFF
--- a/scripts/start/checkFixCfg.R
+++ b/scripts/start/checkFixCfg.R
@@ -58,7 +58,7 @@ checkFixCfg <- function(cfg, remindPath = ".", testmode = FALSE) {
       useregexp <- gsub("is.share", grepisshare, useregexp, fixed = TRUE)
       # check whether parameter value fits regular expression
       if (! grepl(useregexp, cfg$gms[[n]])) {
-        errormsg <- paste0("Parameter cfg$gms$", n, "=", cfg$gms[[n]], " does not fit this regular expression: ", regexp)
+        errormsg <- paste0("Parameter cfg$gms$", n, "=", cfg$gms[[n]], " does not fit this regular expression in main.gms: ", regexp)
       }
     } else if (length(filtered) > 1) {
       # fail if more than one regexp found for parameter
@@ -74,7 +74,7 @@ checkFixCfg <- function(cfg, remindPath = ".", testmode = FALSE) {
 
   if (errorsfound > 0) {
     if (testmode) warning(errorsfound, " errors found.")
-      else stop(errorsfound, " errors found, see above. Either adapt the parameter choice or the regexp in main.gms")
+      else stop(errorsfound, " errors found, see above.")
   }
 
   # Check for compatibility with subsidizeLearning


### PR DESCRIPTION
## Purpose of this PR

- remove confusing text, see #1634 
- I think the following error message that will be printed in case of regexp mismatches anyway is sufficient:
```
Parameter cfg$gms$whatever = off does not fit this regular expression: yes|no
```

## Type of change

- [x] just some error message change