### PR TITLE
add warning if model version in rdata file and now differ when building model

### DIFF
--- a/scripts/start/checkFixCfg.R
+++ b/scripts/start/checkFixCfg.R
@@ -20,6 +20,10 @@ checkFixCfg <- function(cfg, remindPath = ".", testmode = FALSE) {
                      settings_config = file.path(remindPath, "config", "settings_config.csv"),
                      extras = remindextras),
                      error = function(x) { paste0(red, "Error", NC, ": ", gsub("^Error: ", "", x)) } )
+  if (! identical(refcfg$model_version, cfg$model_version)) {
+    message("The model version when the cfg was generated (", cfg$model_version, ") and the current version (",
+            refcfg$model_version, ") differ. This might cause fails. If so, try to start the run from scratch.")
+  }
   if (is.character(fail) && length(fail) == 1 && grepl("Error", fail)) {
     message(fail, appendLF = FALSE)
     if (testmode) warning(fail)


### PR DESCRIPTION
## Purpose of this PR

- this might happen if you pull at a bad time between model is submitted and executed. Would have made debugging #1634 easier

## Type of change

- [x] improved logging

## Checklist:

- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
