### PR TITLE
fail on self-referential coupled scenarios

### DIFF
--- a/modules/40_techpol/module.gms
+++ b/modules/40_techpol/module.gms
@@ -10,7 +10,7 @@
 *'
 *' @description  The 40_techpol module formulates technological policies. They can be part of a baseline or climate policy scenario.
 *'
-*' @authors Christoph Bertram, Falko Ueckertd
+*' @authors Christoph Bertram, Falko Ueckerdt
 
 *###################### R SECTION START (MODULETYPES) ##########################
 $Ifi "%techpol%" == "CombLowCandCoalPO" $include "./modules/40_techpol/CombLowCandCoalPO/realization.gms"

--- a/start_bundle_coupled.R
+++ b/start_bundle_coupled.R
@@ -466,6 +466,7 @@ for(scen in common){
     # Create list of gdx's that this run needs as input from other runs
     gdxlist <- unlist(settings_remind[scen, names(path_gdx_list)])
     names(gdxlist) <- path_gdx_list
+    if (scen %in% gdxlist) stop(scen, " is self-referencial for ", paste(names(path_gdx_list)[which(gdxlist == scen)], collapse = ", "))
     # look for gdx's not only among runs to be started but among all coupled scenarios, as runs that have already finished may also be required
     gdxlist[gdxlist %in% rownames(settings_coupled)] <- paste0(prefix_runname, gdxlist[gdxlist %in% rownames(settings_coupled)], "-rem-", i)
     possibleFulldata <- file.path(path_remind, "output", gdxlist, "fulldata.gdx")


### PR DESCRIPTION
## Purpose of this PR

- close https://github.com/remindmodel/development_issues/issues/269
- fail on a coupled run that tries to reference itself

## Type of change

- [x] Bug fix 

## Checklist:

- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test-coupled-slurm`: `[ FAIL 0 | WARN 0 | SKIP 0 | PASS 94 ] Done!`)
