### PR TITLE
Selectively revert 1620: Remove SE from dimension from industry for performance

### DIFF
--- a/modules/37_industry/subsectors/bounds.gms
+++ b/modules/37_industry/subsectors/bounds.gms
@@ -114,7 +114,7 @@ vm_cesIO.lo(t,regi_dyn29(regi),in_industry_dyn37(in))$(
                                                   0 eq vm_cesIO.lo(t,regi,in) )
   = max(sm_eps, abs(pm_cesdata(t,regi,in,"offset_quantity")));
 
-*' Limit biomass solids use in industry to 25% (or historic shares, if they are 
+*' Limit biomass solids use in industry to 25% (or historic shares, if they are
 *' higher) of baseline solids
 *' Cement CCS might otherwise become a compelling BioCCS option under very high
 *' carbon prices due to missing adjustment costs.
@@ -160,27 +160,4 @@ if (cm_CCS_steel ne 1 OR cm_IndCCSscen ne 1,
 );
 $endif.cm_subsec_model_steel
 
-*** Populate values for v37_demFeIndst to ease introduction of new variale.  Can
-*** be removed once the variable is established.
-v37_demFeIndst.l(t,regi,entySe,entyFe,out,emiMkt) = 0;
-loop ((t,regi,entySe,entyFe,out,emiMkt,secInd37,in)$(
-            sefe(entySe,entyFe)
-        AND sector2emiMkt("indst",emiMkt)
-        AND secInd37_emiMkt(secInd37,emiMkt)
-        AND secInd37_2_pf(secInd37,out)
-        AND ue_industry_2_pf(out,in)
-        AND fe2ppfEn37(entyFe,in)
-        AND sum(se2fe(entySe,entyFe,te),
-              vm_demFeSector_afterTax.l(t,regi,entySe,entyFe,"indst",emiMkt)
-            )                                                                ),
-  v37_demFeIndst.l(t,regi,entySe,entyFe,out,emiMkt)
-  = sum((fe2ppfEn37_2(entyFe,in),ue_industry_2_pf(out,in)),
-      vm_cesIO.l(t,regi,in)
-    + pm_cesdata(t,regi,in,"offset_quantity")
-    )
-  * vm_demFeSector_afterTax.l(t,regi,entySe,entyFe,"indst",emiMkt)
-  / sum(se2fe(entySe2,entyFe,te),
-      vm_demFeSector_afterTax.l(t,regi,entySe2,entyFe,"indst",emiMkt)
-    );
-);
 *** EOF ./modules/37_industry/subsectors/bounds.gms

--- a/modules/37_industry/subsectors/declarations.gms
+++ b/modules/37_industry/subsectors/declarations.gms
@@ -44,6 +44,8 @@ Parameters
 
 *** output parameters only for reporting
   o37_cementProcessEmissions(ttot,all_regi,all_enty)                     "cement process emissions [GtC/a]"
+  o37_demFeIndTotEn(ttot,all_regi,all_enty,all_emiMkt)                   "total FE per energy carrier and emissions market in industry (sum over subsectors)"
+  o37_shIndFE(ttot,all_regi,all_enty,secInd37,all_emiMkt)                "share of subsector in FE industry energy carriers and emissions markets"
   o37_demFeIndSub(ttot,all_regi,all_enty,all_enty,secInd37,all_emiMkt)   "FE demand per industry subsector"
   !! process-based implementation
   o37_demFePrc(ttot,all_regi,all_enty,all_te,opmoPrc)                    "Process-based FE demand per FE type and process"
@@ -65,9 +67,9 @@ $ifthen.sec_steel_scen NOT "%cm_steel_secondary_max_share_scenario%" == "off"   
   / %cm_steel_secondary_max_share_scenario% /
 $endif.sec_steel_scen
 
-  p37_regionalWasteIncinerationCCSshare(ttot,all_regi)    "regional proportion of waste incineration that is captured [%]"   
+  p37_regionalWasteIncinerationCCSshare(ttot,all_regi)    "regional proportion of waste incineration that is captured [%]"
 $ifthen.cm_wasteIncinerationCCSshare not "%cm_wasteIncinerationCCSshare%" == "off"
-  p37_wasteIncinerationCCSshare(ttot,ext_regi)            "switch values for proportion of waste incineration that is captured [%]"   
+  p37_wasteIncinerationCCSshare(ttot,ext_regi)            "switch values for proportion of waste incineration that is captured [%]"
   / %cm_wasteIncinerationCCSshare% /
 $endIf.cm_wasteIncinerationCCSshare
 ;
@@ -80,7 +82,7 @@ Positive Variables
   v37_FeedstocksCarbon(ttot,all_regi,all_enty,all_enty,all_emiMkt)          "Carbon flow: carbon contained in chemical feedstocks [GtC]"
   v37_plasticsCarbon(ttot,all_regi,all_enty,all_enty,all_emiMkt)            "Carbon flow: carbon contained in plastics [GtC]"
   v37_plasticWaste(ttot,all_regi,all_enty,all_enty,all_emiMkt)              "Carbon flow: carbon contained in plastic waste [GtC]"
-  v37_demFeIndst(ttot,all_regi,all_enty,all_enty,all_in,all_emiMkt)         "FE demand of industry sector by SE origin, industry subsector, and emission market. [TWa]"
+
   !! process-based implementation
   vm_outflowPrc(tall,all_regi,all_te,opmoPrc)                               "Production volume of processes in process-based model [Gt/a]"
   v37_matFlow(tall,all_regi,all_enty)                                       "Production of materials [Gt/a]"
@@ -99,11 +101,10 @@ $endif.no_calibration
   q37_limit_IndCCS_growth(ttot,all_regi,emiInd37)                                   "limit industry CCS scale-up"
   q37_cementCCS(ttot,all_regi)                                                      "link cement fuel and process abatement"
   q37_IndCCSCost                                                                    "Calculate industry CCS costs"
-  q37_demFeIndst(ttot,all_regi,all_enty,all_enty,all_emiMkt)                        "industry final energy demand (per emission market)"
-  q37_demFeIndst_intermediate(ttot,all_regi,all_enty,all_in,secInd37,all_emiMkt)    "industry final energy demand (per emission market)"
+  q37_demFeIndst(ttot,all_regi,all_enty,all_emiMkt)                                 "industry final energy demand (per emission market)"
   q37_costCESmarkup(ttot,all_regi,all_in)                                           "calculation of additional CES markup cost to represent demand-side technology cost of end-use transformation, for example, cost of heat pumps etc."
   q37_chemicals_feedstocks_limit(ttot,all_regi)                                     "lower bound on feso/feli/fega in chemicals FE input for feedstocks"
-  q37_demFeFeedstockChemIndst(ttot,all_regi,all_enty,all_enty,all_emiMkt)           "defines energy flow of non-energy feedstocks for the chemicals industry. It is used for emissions accounting"
+  q37_demFeFeedstockChemIndst(ttot,all_regi,all_enty,all_emiMkt)                    "defines energy flow of non-energy feedstocks for the chemicals industry. It is used for emissions accounting"
   q37_FossilFeedstock_Base(ttot,all_regi,all_enty,all_emiMkt)                       "in baseline runs feedstocks only come from fossil energy carriers"
   q37_FeedstocksCarbon(ttot,all_regi,all_enty,all_enty,all_emiMkt)                  "calculate carbon contained in feedstocks [GtC]"
   q37_plasticsCarbon(ttot,all_regi,all_enty,all_enty,all_emiMkt)                    "calculate carbon contained in plastics [GtC]"
@@ -111,7 +112,8 @@ $endif.no_calibration
   q37_incinerationEmi(ttot,all_regi,all_enty,all_enty,all_emiMkt)                   "calculate carbon contained in plastics that are incinerated [GtC]"
   q37_nonIncineratedPlastics(ttot,all_regi,all_enty,all_enty,all_emiMkt)            "calculate carbon contained in plastics that are not incinerated [GtC]"
   q37_feedstockEmiUnknownFate(ttot,all_regi,all_enty,all_enty,all_emiMkt)           "calculate carbon contained in chemical feedstock with unknown fate [GtC]"
-  q37_feedstocksLimit(ttot,all_regi,all_enty,all_enty,all_in,all_emiMkt)            "restrict feedstocks flow to total energy flows into industry"
+  q37_feedstocksLimit(ttot,all_regi,all_enty,all_enty,all_emiMkt)                   "restrict feedstocks flow to total energy flows into industry"
+  q37_feedstocksShares(ttot,all_regi,all_enty,all_enty,all_emiMkt)                  "identical fossil/biomass/synfuel shares for FE and feedstocks"
 
   !! process-based implementation
   q37_demMatPrc(tall,all_regi,mat)                                                  "Material demand of processes"

--- a/modules/37_industry/subsectors/equations.gms
+++ b/modules/37_industry/subsectors/equations.gms
@@ -13,38 +13,26 @@
 ***------------------------------------------------------
 *' Industry final energy balance
 ***------------------------------------------------------
-*' Industry final energy demand is calculated by (entySe,entyFe,out,secIind37)
-*' tuple, where out is the root of the CES subtree (e.g. ue_cement).  The
-*' (entyFe,out) tuple is equivalent to ppfen, and necessary to deal with
-*' process-based steel, which is not part of the CES tree below
-*' ue_steel_primary/ue_steel_secondary.
-q37_demFeIndst_intermediate(t,regi,entyFe,out,secInd37,emiMkt)$(
-                                      entyFe_out_emiMkt(entyFe,out,emiMkt)
-                                  AND secInd37_emiMkt(secInd37,emiMkt)
-                                  AND secInd37_2_pf(secInd37,out)          ) ..
-  sum(sefe(entySe,entyFe),
-    v37_demFeIndst(t,regi,entySe,entyFe,out,emiMkt)
+q37_demFeIndst(t,regi,entyFe,emiMkt)$( entyFe2Sector(entyFe,"indst") ) ..
+  sum(se2fe(entySe,entyFe,te),
+    vm_demFeSector_afterTax(t,regi,entySe,entyFe,"indst",emiMkt)
   )
   =e=
-    sum((ue_industry_2_pf(out,in),
-         fe2ppfEn(entyFe,in)),
-      vm_cesIO(t,regi,in)
-    + pm_cesdata(t,regi,in,"offset_quantity")
+  sum(fe2ppfEn(entyFe,ppfen_industry_dyn37(in)),
+    sum((secInd37_emiMkt(secInd37,emiMkt),secInd37_2_pf(secInd37,in)),
+      (
+          vm_cesIO(t,regi,in)
+        + pm_cesdata(t,regi,in,"offset_quantity")
+      )$(NOT secInd37Prc(secInd37))
     )
-  + sum(tePrc2ue(tePrc,opmoPrc,out),
-      pm_specFeDem(t,regi,entyFe,tePrc,opmoPrc)
-    * vm_outflowPrc(t,regi,tePrc,opmoPrc)
-    )
-;
-
-q37_demFeIndst(t,regi,entySe,entyFe,emiMkt)$(
-                                             sefe(entySe,entyFe)
-                                         AND entyFe2Sector(entyFe,"indst")
-                                         AND sector2emiMkt("indst",emiMkt) ) ..
-  vm_demFeSector_afterTax(t,regi,entySe,entyFe,"indst",emiMkt)
-  =e=
-  sum(entyFe_out_emiMkt(entyFe,out,emiMkt),
-    v37_demFeIndst(t,regi,entySe,entyFe,out,emiMkt)
+  )
+  +
+  sum((secInd37_emiMkt(secInd37Prc,emiMkt),
+       secInd37_tePrc(secInd37Prc,tePrc),
+       tePrc2opmoPrc(tePrc,opmoPrc)),
+    pm_specFeDem(t,regi,entyFe,tePrc,opmoPrc)
+    *
+    vm_outflowPrc(t,regi,tePrc,opmoPrc)
   )
 ;
 
@@ -224,32 +212,50 @@ q37_chemicals_feedstocks_limit(t,regi) ..
   * p37_chemicals_feedstock_share(t,regi)
 ;
 
-*' Define the flow of non-energy feedstocks. It is used for emissions accounting
-*' and calculating plastics production
-q37_demFeFeedstockChemIndst(t,regi,entySe,entyFe,emiMkt)$(
-                         sefe(entySe,entyFe)
-                     AND entyFE2sector2emiMkt_NonEn(entyFe,"indst",emiMkt) ) ..
-  vm_demFENonEnergySector(t,regi,entySe,entyFe,"indst",emiMkt)
+*' Define the flow of non-energy feedstocks. It is used for emissions accounting and calculating plastics production
+q37_demFeFeedstockChemIndst(t,regi,entyFe,emiMkt)$(
+                         entyFE2sector2emiMkt_NonEn(entyFe,"indst",emiMkt) ) ..
+  sum(se2fe(entySe,entyFe,te),
+    vm_demFENonEnergySector(t,regi,entySe,entyFe,"indst",emiMkt)
+  )
   =e=
-    sum(entyFe_out_emiMkt(entyFe,out,emiMkt)$( sameas(out,"ue_chemicals") ),
-      v37_demFeIndst(t,regi,entySe,entyFe,out,emiMkt)
+  sum((fe2ppfEn(entyFe,ppfen_industry_dyn37(in)),
+       secInd37_emiMkt(secInd37,emiMkt),
+       secInd37_2_pf(secInd37,in_chemicals_feedstock_37(in))),
+    ( vm_cesIO(t,regi,in)
+    + pm_cesdata(t,regi,in,"offset_quantity")
     )
   * p37_chemicals_feedstock_share(t,regi)
+  )
 ;
 
 *' Feedstocks flow has to be lower than total energy flow into the industry
-q37_feedstocksLimit(t,regi,entySe,entyFe,out,emiMkt)$(
-                                       sefe(entySe,entyFe)
-                                   AND entyFe_out_emiMkt(entyFe,out,emiMkt)
-                                   AND sameas(out,"ue_chemicals")
-                                   AND entyFeCC37(entyFe)                   ) ..
-  sum((ue_industry_2_pf(out,in),
-       fe2ppfEn(entyFe,in)),
-    vm_demFENonEnergySector(t,regi,entySe,entyFe,"indst",emiMkt)
-  )
-  =l=
-  v37_demFeIndst(t,regi,entySe,entyFe,out,emiMkt)
+q37_feedstocksLimit(t,regi,entySe,entyFe,emiMkt)$(
+                                             sefe(entySe,entyFe)
+                                         AND sector2emiMkt("indst",emiMkt)
+                                         AND entyFe2Sector(entyFe,"indst")
+                                         AND entyFeCC37(entyFe)            ) ..
+  vm_demFeSector_afterTax(t,regi,entySe,entyFe,"indst",emiMkt)
+  =g=
+  vm_demFENonEnergySector(t,regi,entySe,entyFe,"indst",emiMkt)
 ;
+
+*' Feedstocks have identical fossil/biomass/synfuel shares as industry FE
+q37_feedstocksShares(t,regi,entySe,entyFe,emiMkt)$(
+                         sum(te, se2fe(entySe,entyFe,te))
+                     AND entyFE2sector2emiMkt_NonEn(entyFe,"indst",emiMkt)
+                     AND cm_emiscen ne 1                                   ) ..
+    vm_demFeSector_afterTax(t,regi,entySe,entyFe,"indst",emiMkt)
+  * sum(se2fe(entySe2,entyFe,te),
+      vm_demFENonEnergySector(t,regi,entySe2,entyFe,"indst",emiMkt)
+    )
+  =e=
+    vm_demFENonEnergySector(t,regi,entySe,entyFe,"indst",emiMkt)
+  * sum(se2fe2(entySe2,entyFe,te),
+      vm_demFeSector_afterTax(t,regi,entySe2,entyFe,"indst",emiMkt)
+    )
+;
+
 
 *' Calculate mass of carbon contained in chemical feedstocks
 q37_FeedstocksCarbon(t,regi,sefe(entySe,entyFe),emiMkt)$(

--- a/modules/37_industry/subsectors/postsolve.gms
+++ b/modules/37_industry/subsectors/postsolve.gms
@@ -8,35 +8,58 @@
 
 *** calculation of FE Industry Prices (useful for internal use and reporting
 *** purposes)
-pm_FEPrice(ttot,regi,entyFe,"indst",emiMkt)$(
-          abs(qm_budget.m(ttot,regi)) gt sm_eps
-      AND sum(sefe(entySe,entyFe),
-            vm_demFeSector_afterTax.l(ttot,regi,entySe,entyFe,"indst",emiMkt)
-          )                                                                   )
-  = sum(sefe(entySe,entyFe),
-      q37_demFeIndst.m(ttot,regi,entySe,entyFe,emiMkt)
-    / qm_budget.m(ttot,regi)
-    * vm_demFeSector_afterTax.l(ttot,regi,entySe,entyFe,"indst",emiMkt)
-    )
-  / sum(sefe(entySe,entyFe),
-      vm_demFeSector_afterTax.l(ttot,regi,entySe,entyFe,"indst",emiMkt)
-    );
+pm_FEPrice(ttot,regi,entyFe,"indst",emiMkt)$( abs(qm_budget.m(ttot,regi)) gt sm_eps )
+  = q37_demFeIndst.m(ttot,regi,entyFe,emiMkt)
+  / qm_budget.m(ttot,regi);
 
 *** calculate reporting parameters for FE per subsector and SE origin to make R
 *** reporting easier
 
 o37_demFePrc(ttot,regi,entyFe,tePrc,opmoPrc)$(pm_specFeDem(ttot,regi,entyFe,tePrc,opmoPrc))
   = vm_outflowPrc.l(ttot,regi,tePrc,opmoPrc)
-  * pm_specFeDem(ttot,regi,entyFe,tePrc,opmoPrc);
+    * pm_specFeDem(ttot,regi,entyFe,tePrc,opmoPrc)
+;
+
+*** total FE per energy carrier and emissions market in industry (sum over
+*** subsectors)
+o37_demFeIndTotEn(ttot,regi,entyFe,emiMkt)
+  = sum((fe2ppfEn37(entyFe,in),secInd37_2_pf(secInd37,in),
+                         secInd37_emiMkt(secInd37,emiMkt))$(NOT secInd37Prc(secInd37)),
+      (vm_cesIO.l(ttot,regi,in)
+      +pm_cesdata(ttot,regi,in,"offset_quantity"))
+    )
+  + sum((secInd37_emiMkt(secInd37Prc,emiMkt),secInd37_tePrc(secInd37Prc,tePrc),tePrc2opmoPrc(tePrc,opmoPrc)),
+      o37_demFePrc(ttot,regi,entyFe,tePrc,opmoPrc)
+    )
+;
+
+*** share of subsector in FE industry energy carriers and emissions markets
+o37_shIndFE(ttot,regi,entyFe,secInd37,emiMkt)$(
+                                    o37_demFeIndTotEn(ttot,regi,entyFe,emiMkt) )
+  =
+  (
+    sum(( fe2ppfEn37(entyFe,in),
+          secInd37_2_pf(secInd37,in),
+          secInd37_emiMkt(secInd37,emiMkt))$(NOT secInd37Prc(secInd37)),
+      (vm_cesIO.l(ttot,regi,in)
+      + pm_cesdata(ttot,regi,in,"offset_quantity"))
+      )
+  + sum((secInd37_emiMkt(secInd37Prc,emiMkt),
+           secInd37_tePrc(secInd37Prc,tePrc),
+           tePrc2opmoPrc(tePrc,opmoPrc)),
+      o37_demFePrc(ttot,regi,entyFe,tePrc,opmoPrc)
+      )$(secInd37Prc(secInd37))
+  )
+  / o37_demFeIndTotEn(ttot,regi,entyFe,emiMkt)
+;
+
 
 *** FE per subsector and energy carriers
-o37_demFeIndSub(ttot,regi,entySe,entyFe,secInd37,emiMkt)$(
-                                             sefe(entySe,entyFe)
-                                         AND secInd37_emiMkt(secInd37,emiMkt) )
-  = sum((secInd37_2_pf(secInd37,out),
-         ue_industry_dyn37(out)),
-      v37_demFeIndst.l(ttot,regi,entySe,entyFe,out,emiMkt)
-    );
+o37_demFeIndSub(ttot,regi,entySe,entyFe,secInd37,emiMkt)
+  = sum(secInd37_emiMkt(secInd37,emiMkt),
+      o37_shIndFE(ttot,regi,entyFe,secInd37,emiMkt)
+    * vm_demFeSector_afterTax.l(ttot,regi,entySe,entyFe,"indst",emiMkt)
+  );
 
 *** industry captured fuel CO2
 pm_IndstCO2Captured(ttot,regi,entySe,entyFe(entyFeCC37),secInd37,emiMkt)$(

--- a/modules/37_industry/subsectors/sets.gms
+++ b/modules/37_industry/subsectors/sets.gms
@@ -352,15 +352,6 @@ ppfen_MkupCost37(all_in)   "primary production factors in industry on which CES 
   /
   /
 
-  entyFe_out_emiMkt(all_enty,all_in,all_emiMkt) "link FE demand to subsector production to emission markets"
-  /
-    (fesos, fehos, fegas, feh2s,        feels) . ue_cement          . ETS
-    (fesos, fehos, fegas, feh2s,        feels) . ue_chemicals       . ETS
-    (fesos, fehos, fegas, feh2s,        feels) . ue_steel_primary   . ETS
-                                        feels  . ue_steel_secondary . ETS
-    (fesos, fehos, fegas, feh2s, fehes, feels) . ue_otherInd        . ES
-  /
-
 
 *** ---------------------------------------------------------------------------
 ***        2. Process-Based


### PR DESCRIPTION
## Purpose of this PR

Pull request #1620 (with the follow-up #1641 and #1648) introduces a secondary energy dimension in subsector-specific industry FE demand.
It was designed to fix performance issues, but in fact convergence is better without it (see images below). 
This is due to a flat optimum in the new dimension, as it does not make a difference which SE ends up in which subsector. 

This PR reverts the main changes in these PRs while keeping some others, like a price change limit between calibration iterations.  

Credit for all the performance tests go to @0UmfHxcvx5J7JoaOhFSs5mncnisTJJ6q; Thanks for that! 

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [ ] Bug fix 
- [ ] Refactoring
- [ ] New feature 
- [x] Minor change (default scenarios show only small differences)
- [ ] Fundamental change
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Test runs are here: `/p/tmp/pehl/Remind_selectively_revert_1620/output/`
* Comparison of results (what changes by this PR?): 

**H12:** 
![image](https://github.com/remindmodel/remind/assets/44020564/120b9473-3596-4082-8a15-4abff0e45e89)
**EU21:**
![image](https://github.com/remindmodel/remind/assets/44020564/1c2d0ca0-b880-4814-9d16-6c679c3d39b3)
 



