### PR TITLE
EU27 exogenously defined H2 and e-liquids trade flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **scripts** do not check anymore that MAgPIE uses renv
   [[1646](https://github.com/remindmodel/remind/pull/1646)]
 
+### added
+- **24_trade** add optinal trade scenario for EUR hydrogen and e-liquids imports [[#1666](https://github.com/remindmodel/remind/pull/1666)] 
+
 ## [3.3.0] - 2024-03-28
 
 ### changed

--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -1585,7 +1585,7 @@ sm_globalBudget_dev = 1;
 *' load production values from reference gdx to allow penalizing changes vs reference run in the first time step via q_changeProdStartyearCost/q21_taxrevChProdStartYear
 if (cm_startyear gt 2005,
 execute_load "input_ref.gdx", p_prodSeReference = vm_prodSe.l;
-execute_load "input_ref.gdx", p_prodFEReference = vm_prodFe.l;
+execute_load "input_ref.gdx", pm_prodFEReference = vm_prodFe.l;
 execute_load "input_ref.gdx", p_prodUeReference = v_prodUe.l;
 execute_load "input_ref.gdx", p_co2CCSReference = vm_co2CCS.l;
 );
@@ -1593,7 +1593,7 @@ execute_load "input_ref.gdx", p_co2CCSReference = vm_co2CCS.l;
 p_prodAllReference(t,regi,te) =
     sum(pe2se(enty,enty2,te),  p_prodSeReference(t,regi,enty,enty2,te) )
   + sum(se2se(enty,enty2,te),  p_prodSeReference(t,regi,enty,enty2,te) )
-  + sum(se2fe(enty,enty2,te),  p_prodFEReference(t,regi,enty,enty2,te) )
+  + sum(se2fe(enty,enty2,te),  pm_prodFEReference(t,regi,enty,enty2,te) )
   + sum(fe2ue(enty,enty2,te),  p_prodUeReference(t,regi,enty,enty2,te) )
   + sum(ccs2te(enty,enty2,te), sum(teCCS2rlf(te,rlf), p_co2CCSReference(t,regi,enty,enty2,te,rlf) ) )
 ;

--- a/core/declarations.gms
+++ b/core/declarations.gms
@@ -572,6 +572,7 @@ sm_trillion_2_non                                     "trillion to non"         
 s_zj_2_twa                                            "zeta joule to tw year"                              /31.7098/,
 sm_EJ_2_TWa                                           "multiplicative factor to convert from EJ to TWa"    /31.71e-03/,
 sm_GJ_2_TWa                                           "multiplicative factor to convert from GJ to TWa"    /31.71e-12/,
+sm_TWa_2_TWh                                          "tera Watt year to Tera Watt hour"                    /8.76e+3/,
 sm_TWa_2_MWh                                          "tera Watt year to Mega Watt hour"                    /8.76e+9/,
 sm_TWa_2_kWh                                          "tera Watt year to kilo Watt hour"                    /8.76e+12/,
 *RP* all these new conversion factors with the form "s_xxx_2_yyy" are multplicative factors. Thus, if you have a number in Unit xxx, you have to

--- a/core/declarations.gms
+++ b/core/declarations.gms
@@ -227,7 +227,7 @@ pm_share_CCS_CCO2(ttot,all_regi)                      "share of stored CO2 from 
 pm_delta_histCap(tall,all_regi,all_te)                "parameter to store data of historic capacity additions [TW/yr]"
 
 p_prodSeReference(ttot,all_regi,all_enty,all_enty,all_te)         "Secondary Energy output of a te in the reference run [TWa]"
-p_prodFEReference(ttot,all_regi,all_enty,all_enty,all_te)         "Final Energy output of a te in the reference run [TWa]"
+pm_prodFEReference(ttot,all_regi,all_enty,all_enty,all_te)         "Final Energy output of a te in the reference run [TWa]"
 p_prodUeReference(ttot,all_regi,all_enty,all_enty,all_te)         "Useful Energy output of a te in the reference run [TWa]"
 p_co2CCSReference(ttot,all_regi,all_enty,all_enty,all_te,rlf)     "Captured CO2 put through the CCS chain in ccs2te (pipelines/injection) in the reference run [GtC]"
 p_prodAllReference(ttot,all_regi,all_te)                          "Sum of the above in the reference run. As each te has only one type of output, the differing units should not be a problem"

--- a/core/equations.gms
+++ b/core/equations.gms
@@ -893,7 +893,7 @@ q_changeProdStartyear(t,regi,te)$( (t.val gt 2005) AND (t.val eq cm_startyear ) 
   =e=
   sum(pe2se(enty,enty2,te),   vm_prodSe(t,regi,enty,enty2,te)  - p_prodSeReference(t,regi,enty,enty2,te) )
   + sum(se2se(enty,enty2,te), vm_prodSe(t,regi,enty,enty2,te)  - p_prodSeReference(t,regi,enty,enty2,te) )
-  + sum(se2fe(enty,enty2,te), vm_prodFe(t,regi,enty,enty2,te)  - p_prodFEReference(t,regi,enty,enty2,te) )
+  + sum(se2fe(enty,enty2,te), vm_prodFe(t,regi,enty,enty2,te)  - pm_prodFEReference(t,regi,enty,enty2,te) )
   + sum(fe2ue(enty,enty2,te), v_prodUe (t,regi,enty,enty2,te)  - p_prodUeReference(t,regi,enty,enty2,te) )
   + sum(ccs2te(enty,enty2,te), sum(teCCS2rlf(te,rlf), vm_co2CCS(t,regi,enty,enty2,te,rlf) - p_co2CCSReference(t,regi,enty,enty2,te,rlf) ) )
 ;

--- a/main.gms
+++ b/main.gms
@@ -1388,7 +1388,7 @@ $setGlobal cm_import_tax off !! def = off  !! regexp = .*(worldPricemarkup|CO2ta
 *** cm_import_EU                "EU switch for different scenarios of EU SE import assumptions"
 *** EU-specific SE import assumptions (used for ariadne)
 *** different exogenous hydrogen import scenarios for EU regions (developed in ARIADNE project)
-*** "bal", "low_elec", "high_elec", "low_h2", "high_h2", "low_synf", "high_synf"
+*** "bal", "low_elec", "high_elec", "low_h2", "high_h2", "low_synf", "high_synf", "nzero"
 *** see 24_trade/se_trade/datainput for H2 import assumptions, this switch only works if the trade realization "se_trade" is selected
 $setGlobal cm_import_EU  off !! def off
 *** cm_import_ariadne        "Germany-specific H2 imports assumptions for Ariadne project (needs cm_import_EU to be on)"

--- a/modules/24_trade/capacity/not_used.txt
+++ b/modules/24_trade/capacity/not_used.txt
@@ -7,3 +7,4 @@
 name,type,reason
 pm_gdp,input,questionnaire
 pm_SEPrice, parameter, not yet used in capacity realization
+pm_prodFEReference, parameter, not needed

--- a/modules/24_trade/capacity/not_used.txt
+++ b/modules/24_trade/capacity/not_used.txt
@@ -8,3 +8,4 @@ name,type,reason
 pm_gdp,input,questionnaire
 pm_SEPrice, parameter, not yet used in capacity realization
 pm_prodFEReference, parameter, not needed
+sm_TWa_2_TWh, parameter, not needed

--- a/modules/24_trade/se_trade/datainput.gms
+++ b/modules/24_trade/se_trade/datainput.gms
@@ -183,78 +183,64 @@ $endif.import_h2_EU
 $ifthen.import_nzero_EU "%cm_import_EU%" == "nzero"
 
 *** H2 trade:
-***   Importing regions: Germany, 100 TWh/yr, and EWN, proportional to German values and FE|Gases demand by 2050 in reference run (NZero run without trade, or NPi?).
+***   Importing regions: Germany, 100 TWh/yr, and EWN, proportional to German values and FE|Gases demand by 2050 in the reference NPi run.
 ***   Exporting regions: UK, Norway and Spain (one-third each)
-***   exponential curve starting by 2020 at 4 TWh for Germany
+***   exponential curve starting at 12 TWh by 2030 for Germany
+*** 100 TWh = 100 * 0.0036 EJ/yr =  100 * 0.0036 * sm_EJ_2_TWa TWa = 100 * 0.0036 * 0.03171 TWa = 0.0114156 TWa
 
-*** calculating share of FE demand per carrier at each region group
-  loop(regi_group(ext_regi,regi),
-    loop(seAgg,
-      p24_FEShareInRegion(ttot,ext_regi,regi,seAgg) = 
-        sum(enty$seAgg2se(seAgg,enty), sum(se2fe(enty,enty2,te), p_prodFEReference(ttot,regi,enty,enty2,te))) !! 2050 fe gas 
-        /
-        sum(regi2$regi_group(ext_regi,regi2), sum(enty$seAgg2se(seAgg,enty), sum(se2fe(enty,enty2,te), p_prodFEReference(ttot,regi2,enty,enty2,te))));
-    );
-  );
+*** calculating the share of FE demand per carrier for each region in each region group
+  p24_seAggReference(ttot,regi,seAgg) = sum(enty$seAgg2se(seAgg,enty), sum(se2fe(enty,enty2,te), p_prodFEReference(ttot,regi,enty,enty2,te)));
+  p24_FEShareInRegion(ttot,ext_regi,regi,seAgg)$(regi_group(ext_regi,regi) and p24_seAggReference(ttot,regi,seAgg)) = p24_seAggReference(ttot,regi,seAgg) / sum(regi2$regi_group(ext_regi,regi2), p24_seAggReference(ttot,regi2,seAgg));
 
 *** defining Germany H2 trade import flows
 *** 2050 and onward
-  p24_seTradeCapacity(t,"UKI","DEU","seh2")$(t.val ge 2050) = 100 * 1/3;
-  p24_seTradeCapacity(t,"NEN","DEU","seh2")$(t.val ge 2050) = 100 * 2/3;
+  p24_seTradeCapacity(t,"UKI","DEU","seh2")$(t.val ge 2050) = 100 * 0.0036 * sm_EJ_2_TWa * 1/3;
+  p24_seTradeCapacity(t,"NEN","DEU","seh2")$(t.val ge 2050) = 100 * 0.0036 * sm_EJ_2_TWa * 2/3;
 *** 2030
-  p24_seTradeCapacity("2030","UKI","DEU","seh2") = 12 * 1/3;
-  p24_seTradeCapacity("2030","NEN","DEU","seh2") = 12 * 2/3;
+  p24_seTradeCapacity("2030","UKI","DEU","seh2") = 12 * 0.0036 * sm_EJ_2_TWa * 1/3;
+  p24_seTradeCapacity("2030","NEN","DEU","seh2") = 12 * 0.0036 * sm_EJ_2_TWa * 2/3;
 
 *** defining EWN H2 trade import flows
 *** 2050 and onward
-  p24_seTradeCapacity(t,"UK","EWN","seh2")$(t.val ge 2050) = 
-    (100 / (p24_FEShareInRegion("2050","EUR_regi","DEU","all_sega") / (p24_FEShareInRegion("2050","EUR_regi","DEU","all_sega") + p24_FEShareInRegion("2050","EUR_regi","EWN","all_sega")))) !! total EU imports given DEU = 100 TWh/yr
-    * p24_FEShareInRegion("2050","EUR_regi","EWN","all_sega") * 1/3;
-  p24_seTradeCapacity(t,"ESW","EWN","seh2")$(t.val ge 2050) = 
-    (100 / (p24_FEShareInRegion("2050","EUR_regi","DEU","all_sega") / (p24_FEShareInRegion("2050","EUR_regi","DEU","all_sega") + p24_FEShareInRegion("2050","EUR_regi","EWN","all_sega")))) !! total EU imports given DEU = 100 TWh/yr
-    * p24_FEShareInRegion("2050","EUR_regi","EWN","all_sega") * 2/3;
+  p24_seTradeCapacity(t,"UKI","EWN","seh2")$(t.val ge 2050) = 100 * 0.0036 * sm_EJ_2_TWa * (p24_FEShareInRegion("2050","EUR_regi","EWN","all_sega")/p24_FEShareInRegion("2050","EUR_regi","DEU","all_sega")) * 1/3;
+  p24_seTradeCapacity(t,"ESW","EWN","seh2")$(t.val ge 2050) = 100 * 0.0036 * sm_EJ_2_TWa * (p24_FEShareInRegion("2050","EUR_regi","EWN","all_sega")/p24_FEShareInRegion("2050","EUR_regi","DEU","all_sega")) * 2/3;
 *** 2030
-  p24_seTradeCapacity("2030","UKI","EWN","seh2") = 8 * 1/3;
-  p24_seTradeCapacity("2030","ESW","EWN","seh2") = 8 * 2/3;
+  p24_seTradeCapacity("2030","UKI","EWN","seh2") = 12 * 0.0036 * sm_EJ_2_TWa * (p24_FEShareInRegion("2050","EUR_regi","EWN","all_sega")/p24_FEShareInRegion("2050","EUR_regi","DEU","all_sega")) * 1/3;
+  p24_seTradeCapacity("2030","ESW","EWN","seh2") = 12 * 0.0036 * sm_EJ_2_TWa * (p24_FEShareInRegion("2050","EUR_regi","EWN","all_sega")/p24_FEShareInRegion("2050","EUR_regi","DEU","all_sega")) * 2/3;
 
 *** exponential curve for years in between
-  p24_seTradeCapacity(t,enty,enty2,"seh2")$(p24_seTradeCapacity("2050",enty,enty2,"seh2") and (t.val gt 2030 and t.val lt 2050)) = 
-    ((power(p24_seTradeCapacity("2050",enty,enty2,"seh2"),1/4)) / p24_seTradeCapacity("2030",enty,enty2,"seh2")) - 1;
+  p24_seTradeCapacity(t,regi,regi2,"seh2")$(p24_seTradeCapacity("2050",regi,regi2,"seh2") and (t.val gt 2030 and t.val lt 2050)) = 
+    p24_seTradeCapacity("2030",regi,regi2,"seh2") * ((sqrt(sqrt(p24_seTradeCapacity("2050",regi,regi2,"seh2") / p24_seTradeCapacity("2030",regi,regi2,"seh2")))) ** ((t.val - 2030)/5)) ;
 
-*** E-fuels trade:
-***   All regions import proportionally to their 2050 FE|Transport|Pass|Aviation + FE|Industry|Chemicals in a reference run (NZero run without trade, or NPi?)
+*** E-fuels (e-liquids) trade:
+***   All regions (EU-27 and UKI) import proportionally to their 2050 FE|Transport|Pass|Aviation + FE|Industry|Chemicals|Liquids in the reference NPi run.
 ***   Exporting regions: SSA, LAM and MEA (one-third each)
-***   Import quantities: exponential increase with 6 TWh/yr by 2030 for the EU27, and 500 TWh/yr by 2050 (Germany: 100 TWh/yr by 2050)
-***   Imports are considered as pure e-liquids (no e-gases for now)
+***   Import quantities: exponential increase from 1.2 TWh/yr by 2030 to 100 TWh/yr by 2050 for Germany
 
 execute_load "input_ref.gdx", p24_demFeForEsReference = vm_demFeForEs.l;
 execute_load "input_ref.gdx", p24_demFeIndSubReference = o37_demFeIndSub;
 
 *** calculating share of FE aviation and chemicals demand at each region group
-p24_aviationAndChemicalsFEShareInRegion(ttot,ext_regi,regi) = 
-  ( 
-    p24_demFeForEsReference(ttot,regi,"fedie","esdie_pass_lo","te_esdie_pass_lo") + !! aviation FE demand
-    sum((entySe,entyFe,emiMkt)$(sefe(entySe,entyFe) AND entyFe2Sector(entyFe,"indst") AND sector2emiMkt("indst",emiMkt)), o37_demFeIndSub(ttot,regi,entySe,entyFe,"chemicals",emiMkt)) !! chemicals FE demand
-  ) /
-  sum(regi2$regi_group(ext_regi,regi2), 
-    p24_demFeForEsReference(ttot,regi2,"fedie","esdie_pass_lo","te_esdie_pass_lo") + !! aviation FE demand
-    sum((entySe,entyFe,emiMkt)$(sefe(entySe,entyFe) AND entyFe2Sector(entyFe,"indst") AND sector2emiMkt("indst",emiMkt)), o37_demFeIndSub(ttot,regi2,entySe,entyFe,"chemicals",emiMkt)) !! chemicals FE demand
-  )
-  ;
+  p24_aviationAndChemicalsFE(ttot,regi) = p24_demFeForEsReference(ttot,regi,"fedie","esdie_pass_lo","te_esdie_pass_lo") + !! aviation FE demand
+    sum((entySe,entyFe,emiMkt)$(sefe(entySe,entyFe) AND entyFe2Sector(entyFe,"indst") AND sector2emiMkt("indst",emiMkt) AND (sameas("fehos",entyFe))), p24_demFeIndSubReference(ttot,regi,entySe,entyFe,"chemicals",emiMkt)); !! chemicals FE demand
+  p24_aviationAndChemicalsFEShareInRegion(ttot,ext_regi,regi)$(regi_group(ext_regi,regi) and p24_aviationAndChemicalsFE(ttot,regi)) = 
+    p24_aviationAndChemicalsFE(ttot,regi) / sum(regi2$regi_group(ext_regi,regi2), p24_aviationAndChemicalsFE(ttot,regi2));
+
+display p24_aviationAndChemicalsFEShareInRegion;
 
 *** defining Germany seliqsyn trade import flows
-  loop(regi$(sameas(regi,"SSA") or sameas(regi,"LAM") or sameas(regi,"MEA")), !! supplier regions provide each one-third of total imports
+  loop(regi$(sameas(regi,"SSA") or sameas(regi,"LAM") or sameas(regi,"MEA")), !! each supplier region provide one-third of total imports
 *** 2050 and onward
     p24_seTradeCapacity(t,regi,regi2,"seliqsyn")$(t.val ge 2050) = 
-      ( 100 / p24_aviationAndChemicalsFEShareInRegion("2050","EUR_regi","DEU") ) !! total EUR imports based on Germany values
+      ( 100 * 0.0036 * sm_EJ_2_TWa  / p24_aviationAndChemicalsFEShareInRegion("2050","EUR_regi","DEU") ) !! total EUR imports based on Germany values
       * p24_aviationAndChemicalsFEShareInRegion("2050","EUR_regi",regi2) * 1/3;
 *** 2030 
-    p24_seTradeCapacity("2030",regi,regi2,"seliqsyn") = (6 * p24_aviationAndChemicalsFEShareInRegion("2050","EUR_regi",regi2)) * 1/3;
+    p24_seTradeCapacity("2030",regi,regi2,"seliqsyn") = ((1.2 * 0.0036 * sm_EJ_2_TWa / p24_aviationAndChemicalsFEShareInRegion("2050","EUR_regi","DEU") ) * p24_aviationAndChemicalsFEShareInRegion("2050","EUR_regi",regi2)) * 1/3;
   );
 
 *** exponential curve for years in between
-  p24_seTradeCapacity(t,enty,enty2,"seliqsyn")$(p24_seTradeCapacity("2050",enty,enty2,"seliqsyn") and (t.val gt 2030 and t.val lt 2050)) = 
-    ((power(p24_seTradeCapacity("2050",enty,enty2,"seliqsyn"),1/4)) / p24_seTradeCapacity("2030",enty,enty2,"seliqsyn")) - 1;
+  p24_seTradeCapacity(t,regi,regi2,"seliqsyn")$(p24_seTradeCapacity("2050",regi,regi2,"seliqsyn") and (t.val gt 2030 and t.val lt 2050)) = 
+    p24_seTradeCapacity("2030",regi,regi2,"seliqsyn") * ((sqrt(sqrt(p24_seTradeCapacity("2050",regi,regi2,"seliqsyn") / p24_seTradeCapacity("2030",regi,regi2,"seliqsyn")))) ** ((t.val - 2030)/5)) ;
 
 display p24_seTradeCapacity;
 

--- a/modules/24_trade/se_trade/datainput.gms
+++ b/modules/24_trade/se_trade/datainput.gms
@@ -193,19 +193,15 @@ $ifthen.import_nzero_EU "%cm_import_EU%" == "nzero"
 
 *** defining Germany H2 trade import flows
 *** 2050 and onward
-  p24_seTradeCapacity(t,"UKI","DEU","seh2")$(t.val ge 2050) = (100 / sm_TWa_2_TWh) * 1/3;
-  p24_seTradeCapacity(t,"NEN","DEU","seh2")$(t.val ge 2050) = (100 / sm_TWa_2_TWh) * 2/3;
+  p24_seTradeCapacity(t,regi,"DEU","seh2")$((t.val ge 2050) and (sameas(regi,"UKI") or sameas(regi,"NEN") or sameas(regi,"ESW"))) = (100 / sm_TWa_2_TWh) * 1/3; !! each supplier region provides one-third of the imports
 *** 2030
-  p24_seTradeCapacity("2030","UKI","DEU","seh2") = (12 / sm_TWa_2_TWh) * 1/3;
-  p24_seTradeCapacity("2030","NEN","DEU","seh2") = (12 / sm_TWa_2_TWh) * 2/3;
+  p24_seTradeCapacity("2030",regi,"DEU","seh2")$((sameas(regi,"UKI") or sameas(regi,"NEN") or sameas(regi,"ESW"))) = (12 / sm_TWa_2_TWh) * 1/3; !! each supplier region provides one-third of the imports
 
 *** defining EWN H2 trade import flows
 *** 2050 and onward
-  p24_seTradeCapacity(t,"UKI","EWN","seh2")$(t.val ge 2050) = (100 / sm_TWa_2_TWh) * (p24_FEShareInRegion("2050","EUR_regi","EWN","all_sega")/p24_FEShareInRegion("2050","EUR_regi","DEU","all_sega")) * 1/3;
-  p24_seTradeCapacity(t,"ESW","EWN","seh2")$(t.val ge 2050) = (100 / sm_TWa_2_TWh) * (p24_FEShareInRegion("2050","EUR_regi","EWN","all_sega")/p24_FEShareInRegion("2050","EUR_regi","DEU","all_sega")) * 2/3;
+  p24_seTradeCapacity(t,regi,"EWN","seh2")$((t.val ge 2050) and (sameas(regi,"UKI") or sameas(regi,"NEN") or sameas(regi,"ESW"))) = (100 / sm_TWa_2_TWh) * (p24_FEShareInRegion("2050","EUR_regi","EWN","all_sega")/p24_FEShareInRegion("2050","EUR_regi","DEU","all_sega")) * 1/3;
 *** 2030
-  p24_seTradeCapacity("2030","UKI","EWN","seh2") = (12 / sm_TWa_2_TWh) * (p24_FEShareInRegion("2050","EUR_regi","EWN","all_sega")/p24_FEShareInRegion("2050","EUR_regi","DEU","all_sega")) * 1/3;
-  p24_seTradeCapacity("2030","ESW","EWN","seh2") = (12 / sm_TWa_2_TWh) * (p24_FEShareInRegion("2050","EUR_regi","EWN","all_sega")/p24_FEShareInRegion("2050","EUR_regi","DEU","all_sega")) * 2/3;
+  p24_seTradeCapacity("2030",regi,"EWN","seh2")$((sameas(regi,"UKI") or sameas(regi,"NEN") or sameas(regi,"ESW"))) = (12 / sm_TWa_2_TWh) * (p24_FEShareInRegion("2050","EUR_regi","EWN","all_sega")/p24_FEShareInRegion("2050","EUR_regi","DEU","all_sega")) * 1/3;
 
 *** exponential curve for years in between
   p24_seTradeCapacity(t,regi,regi2,"seh2")$(p24_seTradeCapacity("2050",regi,regi2,"seh2") and (t.val gt 2030 and t.val lt 2050)) = 
@@ -225,7 +221,7 @@ execute_load "input_ref.gdx", p24_demFeIndSubReference = o37_demFeIndSub;
   p24_aviationAndChemicalsFEShareInRegion(ttot,ext_regi,regi)$(regi_group(ext_regi,regi) and p24_aviationAndChemicalsFE(ttot,regi)) = 
     p24_aviationAndChemicalsFE(ttot,regi) / sum(regi2$regi_group(ext_regi,regi2), p24_aviationAndChemicalsFE(ttot,regi2));
 
-display p24_aviationAndChemicalsFEShareInRegion;
+* display p24_aviationAndChemicalsFEShareInRegion;
 
 *** defining Germany seliqsyn trade import flows
   loop(regi$(sameas(regi,"SSA") or sameas(regi,"LAM") or sameas(regi,"MEA")), !! each supplier region provide one-third of total imports

--- a/modules/24_trade/se_trade/datainput.gms
+++ b/modules/24_trade/se_trade/datainput.gms
@@ -186,7 +186,6 @@ $ifthen.import_nzero_EU "%cm_import_EU%" == "nzero"
 ***   Importing regions: Germany, 100 TWh/yr, and EWN, proportional to German values and FE|Gases demand by 2050 in the reference NPi run.
 ***   Exporting regions: UK, Norway and Spain (one-third each)
 ***   exponential curve starting at 12 TWh by 2030 for Germany
-*** 100 TWh = 100 * 0.0036 EJ/yr =  100 * 0.0036 * sm_EJ_2_TWa TWa = 100 * 0.0036 * 0.03171 TWa = 0.0114156 TWa
 
 *** calculating the share of FE demand per carrier for each region in each region group
   p24_seAggReference(ttot,regi,seAgg) = sum(enty$seAgg2se(seAgg,enty), sum(se2fe(enty,enty2,te), pm_prodFEReference(ttot,regi,enty,enty2,te)));
@@ -194,19 +193,19 @@ $ifthen.import_nzero_EU "%cm_import_EU%" == "nzero"
 
 *** defining Germany H2 trade import flows
 *** 2050 and onward
-  p24_seTradeCapacity(t,"UKI","DEU","seh2")$(t.val ge 2050) = 100 * 0.0036 * sm_EJ_2_TWa * 1/3;
-  p24_seTradeCapacity(t,"NEN","DEU","seh2")$(t.val ge 2050) = 100 * 0.0036 * sm_EJ_2_TWa * 2/3;
+  p24_seTradeCapacity(t,"UKI","DEU","seh2")$(t.val ge 2050) = (100 / sm_TWa_2_TWh) * 1/3;
+  p24_seTradeCapacity(t,"NEN","DEU","seh2")$(t.val ge 2050) = (100 / sm_TWa_2_TWh) * 2/3;
 *** 2030
-  p24_seTradeCapacity("2030","UKI","DEU","seh2") = 12 * 0.0036 * sm_EJ_2_TWa * 1/3;
-  p24_seTradeCapacity("2030","NEN","DEU","seh2") = 12 * 0.0036 * sm_EJ_2_TWa * 2/3;
+  p24_seTradeCapacity("2030","UKI","DEU","seh2") = (12 / sm_TWa_2_TWh) * 1/3;
+  p24_seTradeCapacity("2030","NEN","DEU","seh2") = (12 / sm_TWa_2_TWh) * 2/3;
 
 *** defining EWN H2 trade import flows
 *** 2050 and onward
-  p24_seTradeCapacity(t,"UKI","EWN","seh2")$(t.val ge 2050) = 100 * 0.0036 * sm_EJ_2_TWa * (p24_FEShareInRegion("2050","EUR_regi","EWN","all_sega")/p24_FEShareInRegion("2050","EUR_regi","DEU","all_sega")) * 1/3;
-  p24_seTradeCapacity(t,"ESW","EWN","seh2")$(t.val ge 2050) = 100 * 0.0036 * sm_EJ_2_TWa * (p24_FEShareInRegion("2050","EUR_regi","EWN","all_sega")/p24_FEShareInRegion("2050","EUR_regi","DEU","all_sega")) * 2/3;
+  p24_seTradeCapacity(t,"UKI","EWN","seh2")$(t.val ge 2050) = (100 / sm_TWa_2_TWh) * (p24_FEShareInRegion("2050","EUR_regi","EWN","all_sega")/p24_FEShareInRegion("2050","EUR_regi","DEU","all_sega")) * 1/3;
+  p24_seTradeCapacity(t,"ESW","EWN","seh2")$(t.val ge 2050) = (100 / sm_TWa_2_TWh) * (p24_FEShareInRegion("2050","EUR_regi","EWN","all_sega")/p24_FEShareInRegion("2050","EUR_regi","DEU","all_sega")) * 2/3;
 *** 2030
-  p24_seTradeCapacity("2030","UKI","EWN","seh2") = 12 * 0.0036 * sm_EJ_2_TWa * (p24_FEShareInRegion("2050","EUR_regi","EWN","all_sega")/p24_FEShareInRegion("2050","EUR_regi","DEU","all_sega")) * 1/3;
-  p24_seTradeCapacity("2030","ESW","EWN","seh2") = 12 * 0.0036 * sm_EJ_2_TWa * (p24_FEShareInRegion("2050","EUR_regi","EWN","all_sega")/p24_FEShareInRegion("2050","EUR_regi","DEU","all_sega")) * 2/3;
+  p24_seTradeCapacity("2030","UKI","EWN","seh2") = (12 / sm_TWa_2_TWh) * (p24_FEShareInRegion("2050","EUR_regi","EWN","all_sega")/p24_FEShareInRegion("2050","EUR_regi","DEU","all_sega")) * 1/3;
+  p24_seTradeCapacity("2030","ESW","EWN","seh2") = (12 / sm_TWa_2_TWh) * (p24_FEShareInRegion("2050","EUR_regi","EWN","all_sega")/p24_FEShareInRegion("2050","EUR_regi","DEU","all_sega")) * 2/3;
 
 *** exponential curve for years in between
   p24_seTradeCapacity(t,regi,regi2,"seh2")$(p24_seTradeCapacity("2050",regi,regi2,"seh2") and (t.val gt 2030 and t.val lt 2050)) = 
@@ -232,10 +231,10 @@ display p24_aviationAndChemicalsFEShareInRegion;
   loop(regi$(sameas(regi,"SSA") or sameas(regi,"LAM") or sameas(regi,"MEA")), !! each supplier region provide one-third of total imports
 *** 2050 and onward
     p24_seTradeCapacity(t,regi,regi2,"seliqsyn")$(t.val ge 2050) = 
-      ( 100 * 0.0036 * sm_EJ_2_TWa  / p24_aviationAndChemicalsFEShareInRegion("2050","EUR_regi","DEU") ) !! total EUR imports based on Germany values
+      ( (100 / sm_TWa_2_TWh)  / p24_aviationAndChemicalsFEShareInRegion("2050","EUR_regi","DEU") ) !! total EUR imports based on Germany values
       * p24_aviationAndChemicalsFEShareInRegion("2050","EUR_regi",regi2) * 1/3;
 *** 2030 
-    p24_seTradeCapacity("2030",regi,regi2,"seliqsyn") = ((1.2 * 0.0036 * sm_EJ_2_TWa / p24_aviationAndChemicalsFEShareInRegion("2050","EUR_regi","DEU") ) * p24_aviationAndChemicalsFEShareInRegion("2050","EUR_regi",regi2)) * 1/3;
+    p24_seTradeCapacity("2030",regi,regi2,"seliqsyn") = (((1.2 / sm_TWa_2_TWh) / p24_aviationAndChemicalsFEShareInRegion("2050","EUR_regi","DEU") ) * p24_aviationAndChemicalsFEShareInRegion("2050","EUR_regi",regi2)) * 1/3;
   );
 
 *** exponential curve for years in between

--- a/modules/24_trade/se_trade/datainput.gms
+++ b/modules/24_trade/se_trade/datainput.gms
@@ -189,7 +189,7 @@ $ifthen.import_nzero_EU "%cm_import_EU%" == "nzero"
 *** 100 TWh = 100 * 0.0036 EJ/yr =  100 * 0.0036 * sm_EJ_2_TWa TWa = 100 * 0.0036 * 0.03171 TWa = 0.0114156 TWa
 
 *** calculating the share of FE demand per carrier for each region in each region group
-  p24_seAggReference(ttot,regi,seAgg) = sum(enty$seAgg2se(seAgg,enty), sum(se2fe(enty,enty2,te), p_prodFEReference(ttot,regi,enty,enty2,te)));
+  p24_seAggReference(ttot,regi,seAgg) = sum(enty$seAgg2se(seAgg,enty), sum(se2fe(enty,enty2,te), pm_prodFEReference(ttot,regi,enty,enty2,te)));
   p24_FEShareInRegion(ttot,ext_regi,regi,seAgg)$(regi_group(ext_regi,regi) and p24_seAggReference(ttot,regi,seAgg)) = p24_seAggReference(ttot,regi,seAgg) / sum(regi2$regi_group(ext_regi,regi2), p24_seAggReference(ttot,regi2,seAgg));
 
 *** defining Germany H2 trade import flows

--- a/modules/24_trade/se_trade/declarations.gms
+++ b/modules/24_trade/se_trade/declarations.gms
@@ -30,10 +30,10 @@ $IFTHEN.trade_SE_exog not "%cm_trade_SE_exog%" == "off"
   p24_trade_exog(ttot,ttot,ext_regi,ext_regi,all_enty)   "parameter to define exogenous SE trade trajectories [EJ/yr]" / %cm_trade_SE_exog% /
 $ENDIF.trade_SE_exog
 
-p24_MportsRegi(tall,all_regi,all_regi,tradeSe)      "Mports to regi from regi2, assuming that trade is distributed uniformetly according existent capacities defined at p24_seTradeCapacity [TWa]"
-p24_XportsRegi(tall,all_regi,all_regi,tradeSe)      "Exports from regi to regi2. Defined in the postsolve as a result of p24_MportsRegi calculation [TWa]"
-pm_MPortsPrice(tall,all_regi,tradeSe)              "Secondary energy import price for region. Calculated in the postsolve and assuming that trade is distributed uniformetly according existent capacities defined at p24_seTradeCapacity [T$/TWa]"
-pm_XPortsPrice(tall,all_regi,tradeSe)              "Secondary energy export price for region. Calculated in the postsolve and corresponding to the region secondary energy price [T$/TWa]"
+p24_MportsRegi(tall,all_regi,all_regi,all_enty)      "Mports to regi from regi2, assuming that trade is distributed uniformetly according existent capacities defined at p24_seTradeCapacity [TWa]"
+p24_XportsRegi(tall,all_regi,all_regi,all_enty)      "Exports from regi to regi2. Defined in the postsolve as a result of p24_MportsRegi calculation [TWa]"
+pm_MPortsPrice(tall,all_regi,all_enty)              "Secondary energy import price for region. Calculated in the postsolve and assuming that trade is distributed uniformetly according existent capacities defined at p24_seTradeCapacity [T$/TWa]"
+pm_XPortsPrice(tall,all_regi,all_enty)              "Secondary energy export price for region. Calculated in the postsolve and corresponding to the region secondary energy price [T$/TWa]"
 ;
 
 ***-------------------------------------------------------------------------------

--- a/modules/24_trade/se_trade/declarations.gms
+++ b/modules/24_trade/se_trade/declarations.gms
@@ -17,6 +17,12 @@ p24_Mport2005correct(all_regi,all_enty)     "Correction factor to match fossil s
 p24_seTradeCapacity(tall,all_regi,all_regi,all_enty) "Secondary energy international yearly trade capacity potential from regi to regi2 [TWa]"
 p24_seTrade_Quantity(all_regi,all_regi,all_enty)      "Maximum import quantity in import scenarios with fixed quantities [TWa]"
 
+$ifthen.import_nzero_EU "%cm_import_EU%" == "nzero"
+p24_FEShareInRegion(ttot,ext_regi,all_regi,seAgg) "region share (regi) of total final energy demand per carrier (seAgg) in region group (ext_regi)"
+p24_demFeForEsReference(ttot,all_regi,all_enty,all_esty,all_teEs) "Final Energy which will be used in the ES layer in the reference run [TWa]"
+p24_demFeIndSubReference(ttot,all_regi,all_enty,all_enty,secInd37,all_emiMkt)  "FE demand per industry subsector, FE carrier, SE carrier, emissions market in the reference run "
+p24_aviationAndChemicalsFEShareInRegion(ttot,ext_regi,all_regi) "region share (regi) of total final energy aviation and chemicals demand in region group (ext_regi)"
+$endif.import_nzero_EU
 
 $IFTHEN.trade_SE_exog not "%cm_trade_SE_exog%" == "off"
 p24_trade_exog(ttot,ttot,ext_regi,ext_regi,all_enty)   "parameter to define exogenous SE trade trajectories [EJ/yr]" / %cm_trade_SE_exog% /

--- a/modules/24_trade/se_trade/declarations.gms
+++ b/modules/24_trade/se_trade/declarations.gms
@@ -18,14 +18,16 @@ p24_seTradeCapacity(tall,all_regi,all_regi,all_enty) "Secondary energy internati
 p24_seTrade_Quantity(all_regi,all_regi,all_enty)      "Maximum import quantity in import scenarios with fixed quantities [TWa]"
 
 $ifthen.import_nzero_EU "%cm_import_EU%" == "nzero"
-p24_FEShareInRegion(ttot,ext_regi,all_regi,seAgg) "region share (regi) of total final energy demand per carrier (seAgg) in region group (ext_regi)"
-p24_demFeForEsReference(ttot,all_regi,all_enty,all_esty,all_teEs) "Final Energy which will be used in the ES layer in the reference run [TWa]"
-p24_demFeIndSubReference(ttot,all_regi,all_enty,all_enty,secInd37,all_emiMkt)  "FE demand per industry subsector, FE carrier, SE carrier, emissions market in the reference run "
-p24_aviationAndChemicalsFEShareInRegion(ttot,ext_regi,all_regi) "region share (regi) of total final energy aviation and chemicals demand in region group (ext_regi)"
+  p24_seAggReference(ttot,all_regi,seAgg)                                        "Secondary energy per carrier (seAgg) in the reference run [TWa]"
+  p24_FEShareInRegion(ttot,ext_regi,all_regi,seAgg)                              "Region share of total final energy demand per carrier (seAgg) within the region group (ext_regi) [%]"
+  p24_demFeForEsReference(ttot,all_regi,all_enty,all_esty,all_teEs)              "Final energy which will be used in the ES layer in the reference run [TWa]"
+  p24_demFeIndSubReference(ttot,all_regi,all_enty,all_enty,secInd37,all_emiMkt)  "Final energy demand per industry subsector, FE carrier, SE carrier, emissions market in the reference run [TWa]"
+  p24_aviationAndChemicalsFE(ttot,all_regi)                                      "Final energy of aviation and chemicals liquids demand [TWa]"
+  p24_aviationAndChemicalsFEShareInRegion(ttot,ext_regi,all_regi)                "Region share of total final energy aviation and chemicals liquids demand within the region group (ext_regi) [%]"
 $endif.import_nzero_EU
 
 $IFTHEN.trade_SE_exog not "%cm_trade_SE_exog%" == "off"
-p24_trade_exog(ttot,ttot,ext_regi,ext_regi,all_enty)   "parameter to define exogenous SE trade trajectories [EJ/yr]" / %cm_trade_SE_exog% /
+  p24_trade_exog(ttot,ttot,ext_regi,ext_regi,all_enty)   "parameter to define exogenous SE trade trajectories [EJ/yr]" / %cm_trade_SE_exog% /
 $ENDIF.trade_SE_exog
 
 p24_MportsRegi(tall,all_regi,all_regi,tradeSe)      "Mports to regi from regi2, assuming that trade is distributed uniformetly according existent capacities defined at p24_seTradeCapacity [TWa]"

--- a/modules/24_trade/se_trade/presolve.gms
+++ b/modules/24_trade/se_trade/presolve.gms
@@ -23,7 +23,9 @@ pm_XPortsPrice(t,regi,tradeSe) = pm_SEPrice(t,regi,tradeSe);
 *** Setting Xport price bound to avoid unrealists trading prices.
 *** Lower bound: avoiding epsilon values (caused by using equation marginals for setting prices) or unrealistic small value for H2 exporting prices -> minimun price = 1$/kg (1$/kg = 0.030769231 $/Kwh = 0.030769231 / (10^12/10^9*8760) T$/TWa = 0.26953846356 T$/TWa) 
 pm_XPortsPrice(t,regi,"seh2") = min(0.26953846356,pm_XPortsPrice(t,regi,"seh2"));
+pm_XPortsPrice(t,regi,"seliqsyn") = min(0.26953846356,pm_XPortsPrice(t,regi,"seliqsyn"));
 
+$ontext
 *** Mports from where? Mports from regi to regi2, assuming that trade is distributed uniformetly according existent trade capacities
 p24_MportsRegi(t,regi,regi2,tradeSe)$(p24_seTradeCapacity(t,regi2,regi,tradeSe)) =
   vm_Mport.l(t,regi,tradeSe)*
@@ -32,6 +34,9 @@ p24_MportsRegi(t,regi,regi2,tradeSe)$(p24_seTradeCapacity(t,regi2,regi,tradeSe))
 
 *** Xports quantitites as a result of Mports
 p24_XportsRegi(t,regi,regi2,tradeSe) = p24_MportsRegi(t,regi2,regi,tradeSe);
+
+*** Fixing exports for current iteration based on previous iteration trade results
+vm_Xport.fx(t,regi,tradeSe) = sum(regi2, p24_XportsRegi(t,regi,regi2,tradeSe));
 
 *** Mport price. Calculates the secondary energy price seen by the importing country as a weighted average of prices observed in countries with capacity to export (regi2) to the country (regi) and their existent capacity connections with the importing country
 pm_MPortsPrice(t,regi,tradeSe)$(sum(regi2,p24_XportsRegi(t,regi2,regi,tradeSe)) gt 0) =
@@ -44,10 +49,25 @@ pm_MPortsPrice(t,regi,tradeSe)$(sum(regi2,p24_XportsRegi(t,regi2,regi,tradeSe)) 
     )
   )
 ;
+display p24_MportsRegi, p24_XportsRegi, 
+$offtext
 
-*** Fixing exports for current iteration based on previous iteration trade results
-vm_Xport.fx(t,regi,tradeSe) = sum(regi2, p24_XportsRegi(t,regi,regi2,tradeSe));
+*** Temporarily forcing Xports (until all bugs are fixed with automatic trading)
+vm_Xport.fx(t,regi,tradeSe)$(sum(regi2,p24_seTradeCapacity(t,regi,regi2,tradeSe)) gt 0)  = sum(regi2,p24_seTradeCapacity(t,regi,regi2,tradeSe));
+vm_Xport.l(t,regi,tradeSe)$(sum(regi2,p24_seTradeCapacity(t,regi,regi2,tradeSe)) gt 0) = sum(regi2,p24_seTradeCapacity(t,regi,regi2,tradeSe));
 
-display  p24_seTradeCapacity, p24_MportsRegi, p24_XportsRegi, pm_MPortsPrice, pm_XPortsPrice, pm_SEPrice;
+*** Mport price. Calculates the secondary energy price seen by the importing country as a weighted average of prices observed in countries with capacity to export (regi2) to the country (regi) and their existent capacity connections with the importing country
+pm_MPortsPrice(t,regi,tradeSe)$(sum(regi2,p24_seTradeCapacity(t,regi2,regi,tradeSe)) gt 0) =
+  sum(regi2$p24_seTradeCapacity(t,regi2,regi,tradeSe),
+    pm_XPortsPrice(t,regi2,tradeSe)
+    *(
+      p24_seTradeCapacity(t,regi,regi2,tradeSe)
+      /
+      sum(regi3$p24_seTradeCapacity(t,regi3,regi,tradeSe), p24_seTradeCapacity(t,regi3,regi,tradeSe))
+    )
+  )
+;
+
+display  p24_seTradeCapacity, pm_MPortsPrice, pm_XPortsPrice, pm_SEPrice; 
 
 *** EOF ./modules/24_trade/se_trade/presolve.gms

--- a/modules/24_trade/se_trade/sets.gms
+++ b/modules/24_trade/se_trade/sets.gms
@@ -28,8 +28,7 @@ tradePe(all_enty)           "Traded primary energy commodities"
 
 tradeSe(all_enty)           "Traded secondary energy commodities"
 /
-***    seel,
-    seh2
+    null
 /
 
 tradeCap(all_enty)          "Commodities traded via capacity mode."
@@ -37,5 +36,14 @@ tradeCap(all_enty)          "Commodities traded via capacity mode."
     null
 /
 ;
+
+tradeSe("seh2") = YES;
+
+$ifthen.import_nzero_EU "%cm_import_EU%" == "nzero"
+*** Defining secondary energy commoditites that are tradeable in this scenario 
+tradeSe(all_enty) = NO;
+tradeSe("seh2") = YES;
+tradeSe("seliqsyn") = YES;
+$endif.import_nzero_EU
 
 *** EOF ./modules/24_trade/se_trade/sets.gms

--- a/modules/24_trade/standard/declarations.gms
+++ b/modules/24_trade/standard/declarations.gms
@@ -14,8 +14,8 @@ pm_Xport0(tall,all_regi,all_enty)           "Reference level value of export."
 pm_IO_trade(tall,all_regi,all_enty,char)    "Energy trade bounds based on IEA data."
 p24_Mport2005correct(all_regi,all_enty)     "Correction factor to match fossil supply and internal region energy demand in the initial year"
 
-pm_MPortsPrice(tall,all_regi,tradeSe)              "Secondary energy import price for region. Calculated in the postsolve and assuming that trade is distributed uniformetly according existent capacities defined at p24_seTradeCapacity [T$/TWa]"
-pm_XPortsPrice(tall,all_regi,tradeSe)              "Secondary energy export price for region. Calculated in the postsolve and corresponding to the region secondary energy price [T$/TWa]"
+pm_MPortsPrice(tall,all_regi,all_enty)              "Secondary energy import price for region. Calculated in the postsolve and assuming that trade is distributed uniformetly according existent capacities defined at p24_seTradeCapacity [T$/TWa]"
+pm_XPortsPrice(tall,all_regi,all_enty)              "Secondary energy export price for region. Calculated in the postsolve and corresponding to the region secondary energy price [T$/TWa]"
 ;
 ***-------------------------------------------------------------------------------
 ***                                   VARIABLES

--- a/modules/24_trade/standard/not_used.txt
+++ b/modules/24_trade/standard/not_used.txt
@@ -14,3 +14,4 @@ pm_tsu2opTimeYr,parameter,only used in capacity realization
 pm_ttot_val,parameter,only used in capacity realization
 pm_ts,parameter,only used in capacity realization
 pm_prodFEReference, parameter, not needed
+sm_TWa_2_TWh, parameter, not needed

--- a/modules/24_trade/standard/not_used.txt
+++ b/modules/24_trade/standard/not_used.txt
@@ -13,3 +13,4 @@ pm_data,parameter,only used in capacity realization
 pm_tsu2opTimeYr,parameter,only used in capacity realization
 pm_ttot_val,parameter,only used in capacity realization
 pm_ts,parameter,only used in capacity realization
+pm_prodFEReference, parameter, not needed

--- a/modules/39_CCU/on/bounds.gms
+++ b/modules/39_CCU/on/bounds.gms
@@ -17,9 +17,10 @@ vm_co2capture.up(t,regi,"cco2","ico2","ccsinje","1") = 50;
 vm_cap.lo(t,regi,te_ccu39,"1")=0;
 vm_cap.lo(t,regi,te_ccu39,"1")$(t.val gt 2031)=1e-7;
 
-*** CCU technologies will not be used at scale before 2035
-vm_cap.up(t,regi,te_ccu39,"1")$(t.val le 2030)=1e-6;
-
+*** CCU technologies will not be used at scale before 2030
+vm_cap.up(t,regi,te_ccu39,"1")$(t.val le 2025)=1e-6;
+*** CCU technologies will not be used at scale in 2030 (for non potential exporting regions)
+vm_cap.up(t,regi,te_ccu39,"1")$((t.val eq 2030) and (not(sameas(regi,"SSA") or sameas(regi,"LAM") or sameas(regi,"MEA"))))=1e-6;
 
 *** FS: switch off CCU in baseline runs (as CO2 capture technologies teCCS are also switched off)
 if(cm_emiscen = 1,


### PR DESCRIPTION
## Purpose of this PR

- Include an additional option named `nzero` to the switch `cm_import_EU` to reflect assumptions regarding exogenously defined h2 trade and e-liquids trade.

- H2 trade assumptions:
```
***   Importing regions: Germany, from 12 TWh by 2030 to 100 TWh/yr by 2050; and EWN, proportional to German values and `FE|Gases` demand by 2050 in the reference NPi run.
***   Exporting regions: UK, Norway and Spain (one-third each)
***   Trajectory: exponential curve in between 2030 and 2050 and fixed from 2050 onward.
```

- E-fuels (e-liquids) trade assumptions:
```
***   All EU-27 and UKI regions import quantities proportional to their 2050 `FE|Transport|Pass|Aviation + FE|Industry|Chemicals|Liquids` in the reference NPi run.
***   Exporting regions: SSA, LAM and MEA (one-third each)
***   Import quantities: exponential increase from 1.2 TWh/yr by 2030 to 100 TWh/yr by 2050 for Germany. Fixed from 2050 onward.
```

## Type of change

- [ x ] New feature 

## Checklist:

- [ x ] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ x ] I performed a self-review of my own code
- [ x ] I explained my changes within the PR, particularly in hard-to-understand areas
- [ x ] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ x ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Test runs are here: 
`/p/projects/ecemf/REMIND/2040_scenarios/v05_2024_04_09_rev1/output/05_Nzero_57_bio7p5_seTrade_EU27_2024-04-26_18.18.38`

* Comparison of results (what changes by this PR?): 
`/p/projects/ecemf/REMIND/2040_scenarios/v05_2024_04_09_rev1/compScen-NZero_trade-2024-04-29_10.54.09-EU27-short.pdf`
