### PR TITLE
Limiting gas based liquids in Europe

### DIFF
--- a/modules/47_regipol/none/bounds.gms
+++ b/modules/47_regipol/none/bounds.gms
@@ -37,4 +37,9 @@ vm_deltaCap.up("2025",regi,"ngcc","1") = 0.0015;
 *** limit early retirement of coal power in Germany in 2020s to avoid extremly fast phase-out
 vm_capEarlyReti.up('2025',regi,'pc') = 0.65; 
 );
+
+*' This bound avoids hydrogen production from gas in the European region (unlikely to happen after recent gas trade changes)
+vm_deltaCap.up(t,regi,"gasftrec",rlf)$((t.val gt 2005) and (regi_group("EUR_regi",regi))) = 0;
+vm_deltaCap.up(t,regi,"gasftcrec",rlf)$((t.val gt 2005) and (regi_group("EUR_regi",regi))) = 0;
+
 *** EOF ./modules/47_regipol/none/bounds.gms

--- a/modules/47_regipol/regiCarbonPrice/bounds.gms
+++ b/modules/47_regipol/regiCarbonPrice/bounds.gms
@@ -166,6 +166,10 @@ $ifthen.exogDemScen NOT "%cm_exogDem_scen%" == "off"
 vm_cesIO.fx(t,regi,in)$(pm_exogDemScen(t,regi,"%cm_exogDem_scen%",in))=pm_exogDemScen(t,regi,"%cm_exogDem_scen%",in);
 $endif.exogDemScen
 
+*' This bound avoids hydrogen production from gas in the European region (unlikely to happen after recent gas trade changes)
+vm_deltaCap.up(t,regi,"gasftrec",rlf)$((t.val gt 2005) and (regi_group("EUR_regi",regi))) = 0;
+vm_deltaCap.up(t,regi,"gasftcrec",rlf)$((t.val gt 2005) and (regi_group("EUR_regi",regi))) = 0;
+
 *' @stop
 
 *** EOF ./modules/47_regipol/regiCarbonPrice/bounds.gms


### PR DESCRIPTION
## Purpose of this PR

- Avoid gas based liquids capacity to be build up in Europe. This is unlikely to happen, but the current European gas supply curve could cause it to be competitive enough to be considered in the model.

- This is a temporary fix until the European gas supply curve can be adjust to the current geopolitical situation.
see issue: https://github.com/remindmodel/development_issues/issues/281

## Checklist:

- [ x ] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ x ] I performed a self-review of my own code
- [ x ] I explained my changes within the PR, particularly in hard-to-understand areas
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

