### PR TITLE
Exposing SE electricity tax rate tech specific ramp up logistic function parameters as a switch

### DIFF
--- a/main.gms
+++ b/main.gms
@@ -1408,7 +1408,8 @@ $setGlobal cm_import_ariadne  off !! def off
 *** For example: "2030.2050.MEA.EU27_regi.seh2 0.5, 2030.2050.MEA.DEU.seh2 0.3".
 $setGlobal cm_trade_SE_exog off !! def off
 *** cm_SEtaxRampUpParam "set the logistic function parameters to describe relationship between SE electricity tax rate and share of technology in total electricity demand"
-$setGlobal cm_SEtaxRampUpParam  GLO.te.a 0.4, GLO.te.b 10    !! def = GLO.te.a 0.4, GLO.te.b 10
+*** cm_SEtaxRampUpParam = "off" disables v21_tau_SE_tax 
+$setGlobal cm_SEtaxRampUpParam  GLO.elh2.a 0.4, GLO.elh2.b 10    !! def = GLO.te.a 0.4, GLO.te.b 10
 *** cm_EnSecScen             "switch for running an ARIADNE energy security scenario, introducing a tax on PE fossil energy in Germany"
 *** switch on energy security scenario for Germany (used in ARIADNE project), sets tax on fossil PE
 *** switch to activate energy security scenario assumptions for Germany including additional tax on gas/oil

--- a/main.gms
+++ b/main.gms
@@ -1413,7 +1413,7 @@ $setGlobal cm_trade_SE_exog off !! def off
 *** The parameter a defines how fast the tax increases with increasing share, with 4/a being the percentage point range over which the tax value increases from 12% to 88%
 *** The parameter b defines at which share the tax is halfway between the value at 0 share and the maximum value (defined by a region's electricity tax and the electricity grid cost) that it converges to for high shares.
 *** Example use: 
-*** cm_SEtaxRampUpParam = "GLO.elh2.a 0.4, GLO.elh2.b 20" sets the logistic function parameter values a=0.4 and b=10 for electrolysis (elh2) to all model regions (GLO). 
+*** cm_SEtaxRampUpParam = "GLO.elh2.a 0.4, GLO.elh2.b 30" sets the logistic function parameter values a=0.4 and b=30 for electrolysis (elh2) to all model regions (GLO). 
 *** cm_SEtaxRampUpParam = "off" disables v21_tau_SE_tax 
 *** For details, please see ./modules/21_tax/on/equations.gms.
 $setGlobal cm_SEtaxRampUpParam  GLO.elh2.a 0.4, GLO.elh2.b 30    !! def = GLO.elh2.a 0.4, GLO.elh2.b 30

--- a/main.gms
+++ b/main.gms
@@ -1410,13 +1410,13 @@ $setGlobal cm_trade_SE_exog off !! def off
 *** This allows to manually adjust the ramp-up curve of the SE tax on electricity. It is mainly used for taxing electricity going into electrolysis for green hydrogen production.
 *** The ramp-up curve is a logistic function that determines how fast taxes increase with increasing share of technology in total power demand.
 *** This essentially makes an assumption about to what extend the power demand of electrolysis will be taxed and how much tax exemptions there will be at low shares of green hydrogen production.
-*** The parameter a defines how fast the tax increases with increasing share, while the parameter b defines at which share
-*** the tax is halfway between the value at 0 share and the maximum value (defined by a region's electricity tax and the electricity grid cost) that it converges to for high shares.
+*** The parameter a defines how fast the tax increases with increasing share, with 4/a being the percentage point range over which the tax value increases from 12% to 88%
+*** The parameter b defines at which share the tax is halfway between the value at 0 share and the maximum value (defined by a region's electricity tax and the electricity grid cost) that it converges to for high shares.
 *** Example use: 
 *** cm_SEtaxRampUpParam = "GLO.elh2.a 0.4, GLO.elh2.b 20" sets the logistic function parameter values a=0.4 and b=10 for electrolysis (elh2) to all model regions (GLO). 
 *** cm_SEtaxRampUpParam = "off" disables v21_tau_SE_tax 
 *** For details, please see ./modules/21_tax/on/equations.gms.
-$setGlobal cm_SEtaxRampUpParam  GLO.elh2.a 0.4, GLO.elh2.b 10    !! def = GLO.elh2.a 0.4, GLO.elh2.b 10
+$setGlobal cm_SEtaxRampUpParam  GLO.elh2.a 0.4, GLO.elh2.b 30    !! def = GLO.elh2.a 0.4, GLO.elh2.b 30
 *** cm_EnSecScen             "switch for running an ARIADNE energy security scenario, introducing a tax on PE fossil energy in Germany"
 *** switch on energy security scenario for Germany (used in ARIADNE project), sets tax on fossil PE
 *** switch to activate energy security scenario assumptions for Germany including additional tax on gas/oil

--- a/main.gms
+++ b/main.gms
@@ -1409,7 +1409,7 @@ $setGlobal cm_import_ariadne  off !! def off
 $setGlobal cm_trade_SE_exog off !! def off
 *** cm_SEtaxRampUpParam "set the logistic function parameters to describe relationship between SE electricity tax rate and share of technology in total electricity demand"
 *** cm_SEtaxRampUpParam = "off" disables v21_tau_SE_tax 
-$setGlobal cm_SEtaxRampUpParam  GLO.elh2.a 0.4, GLO.elh2.b 10    !! def = GLO.te.a 0.4, GLO.te.b 10
+$setGlobal cm_SEtaxRampUpParam  GLO.elh2.a 0.4, GLO.elh2.b 10    !! def = GLO.elh2.a 0.4, GLO.elh2.b 10
 *** cm_EnSecScen             "switch for running an ARIADNE energy security scenario, introducing a tax on PE fossil energy in Germany"
 *** switch on energy security scenario for Germany (used in ARIADNE project), sets tax on fossil PE
 *** switch to activate energy security scenario assumptions for Germany including additional tax on gas/oil

--- a/main.gms
+++ b/main.gms
@@ -1407,8 +1407,15 @@ $setGlobal cm_import_ariadne  off !! def off
 *** then the values from the region group disaggregation will be overwritten by this region-specific value.
 *** For example: "2030.2050.MEA.EU27_regi.seh2 0.5, 2030.2050.MEA.DEU.seh2 0.3".
 $setGlobal cm_trade_SE_exog off !! def off
-*** cm_SEtaxRampUpParam "set the logistic function parameters to describe relationship between SE electricity tax rate and share of technology in total electricity demand"
+*** This allows to manually adjust the ramp-up curve of the SE tax on electricity. It is mainly used for taxing electricity going into electrolysis for green hydrogen production.
+*** The ramp-up curve is a logistic function that determines how fast taxes increase with increasing share of technology in total power demand.
+*** This essentially makes an assumption about to what extend the power demand of electrolysis will be taxed and how much tax exemptions there will be at low shares of green hydrogen production.
+*** The parameter a defines how fast the tax increases with increasing share, while the parameter b defines at which share
+*** the tax is halfway between the value at 0 share and the maximum value (defined by a region's electricity tax and the electricity grid cost) that it converges to for high shares.
+*** Example use: 
+*** cm_SEtaxRampUpParam = "GLO.elh2.a 0.4, GLO.elh2.b 20" sets the logistic function parameter values a=0.4 and b=10 for electrolysis (elh2) to all model regions (GLO). 
 *** cm_SEtaxRampUpParam = "off" disables v21_tau_SE_tax 
+*** For details, please see ./modules/21_tax/on/equations.gms.
 $setGlobal cm_SEtaxRampUpParam  GLO.elh2.a 0.4, GLO.elh2.b 10    !! def = GLO.elh2.a 0.4, GLO.elh2.b 10
 *** cm_EnSecScen             "switch for running an ARIADNE energy security scenario, introducing a tax on PE fossil energy in Germany"
 *** switch on energy security scenario for Germany (used in ARIADNE project), sets tax on fossil PE

--- a/main.gms
+++ b/main.gms
@@ -1407,6 +1407,8 @@ $setGlobal cm_import_ariadne  off !! def off
 *** then the values from the region group disaggregation will be overwritten by this region-specific value.
 *** For example: "2030.2050.MEA.EU27_regi.seh2 0.5, 2030.2050.MEA.DEU.seh2 0.3".
 $setGlobal cm_trade_SE_exog off !! def off
+*** cm_SEtaxRampUpParam "set the logistic function parameters to describe relationship between SE electricity tax rate and share of technology in total electricity demand"
+$setGlobal cm_SEtaxRampUpParam  GLO.te.a 0.4, GLO.te.b 10    !! def = GLO.te.a 0.4, GLO.te.b 10
 *** cm_EnSecScen             "switch for running an ARIADNE energy security scenario, introducing a tax on PE fossil energy in Germany"
 *** switch on energy security scenario for Germany (used in ARIADNE project), sets tax on fossil PE
 *** switch to activate energy security scenario assumptions for Germany including additional tax on gas/oil

--- a/modules/21_tax/on/datainput.gms
+++ b/modules/21_tax/on/datainput.gms
@@ -105,6 +105,13 @@ p21_tau_pe2se_tax(ttot,regi,te)$(ttot.val ge 2005)    = p21_tau_pe2se_tax(ttot,r
 p21_tau_pe2se_sub(ttot,regi,te)$(ttot.val ge 2005)    = p21_tau_pe2se_sub(ttot,regi,te)    * 0.001 / sm_EJ_2_TWa;
 p21_tau_pe2se_inconv(ttot,regi,te)$(ttot.val ge 2005) = p21_tau_pe2se_inconv(ttot,regi,te) * 0.001 / sm_EJ_2_TWa;
 
+*** SE electricity tax rate tech specific ramp up logistic function parameters
+loop((ext_regi,te,teSeTax_coeff)$p21_SEtaxRampUpParameters(ext_regi,te,teSeTax_coeff),
+  loop(regi$regi_groupExt(ext_regi,regi),
+    p21_tau_SE_tax_rampup(t,regi,te,teSeTax_coeff) = p21_SEtaxRampUpParameters(ext_regi,te,teSeTax_coeff);
+  );
+);
+
 ***cb 20110923 load paths for ressource export taxes
 ***cb* file for resource export taxes, not used in default settings
 Parameter p21_tau_xpres_tax(tall,all_regi,all_enty) "tax path for ressource export"

--- a/modules/21_tax/on/datainput.gms
+++ b/modules/21_tax/on/datainput.gms
@@ -106,11 +106,14 @@ p21_tau_pe2se_sub(ttot,regi,te)$(ttot.val ge 2005)    = p21_tau_pe2se_sub(ttot,r
 p21_tau_pe2se_inconv(ttot,regi,te)$(ttot.val ge 2005) = p21_tau_pe2se_inconv(ttot,regi,te) * 0.001 / sm_EJ_2_TWa;
 
 *** SE electricity tax rate tech specific ramp up logistic function parameters
-loop((ext_regi,te,teSeTax_coeff)$p21_SEtaxRampUpParameters(ext_regi,te,teSeTax_coeff),
-  loop(regi$regi_groupExt(ext_regi,regi),
-    p21_tau_SE_tax_rampup(t,regi,te,teSeTax_coeff) = p21_SEtaxRampUpParameters(ext_regi,te,teSeTax_coeff);
+p21_tau_SE_tax_rampup(t,regi,te,teSeTax_coeff) = 0;
+$ifThen.SEtaxRampUpParam not "%cm_SEtaxRampUpParam%" == "off" 
+  loop((ext_regi,te,teSeTax_coeff)$p21_SEtaxRampUpParameters(ext_regi,te,teSeTax_coeff),
+    loop(regi$regi_groupExt(ext_regi,regi),
+      p21_tau_SE_tax_rampup(t,regi,te,teSeTax_coeff) = p21_SEtaxRampUpParameters(ext_regi,te,teSeTax_coeff);
+    );
   );
-);
+$endif.SEtaxRampUpParam
 
 ***cb 20110923 load paths for ressource export taxes
 ***cb* file for resource export taxes, not used in default settings

--- a/modules/21_tax/on/declarations.gms
+++ b/modules/21_tax/on/declarations.gms
@@ -69,7 +69,9 @@ p21_tau_CO2_tax_gdx_bau(ttot,all_regi)       "tax path from gdx, may overwrite d
 p21_implicitDiscRateMarg(ttot,all_regi,all_in)  "Difference between the normal discount rate and the implicit discount rate"
 
 p21_tau_SE_tax_rampup(ttot,all_regi,all_te,teSeTax_coeff)  "Parameters of logistic function to describe relationship between SE electricity tax rate and share of technology in total electricity demand"
-p21_SEtaxRampUpParameters(ext_regi,all_te,teSeTax_coeff)   "config values for SE electricity tax rate tech specific ramp up logistic function parameters" / %cm_SEtaxRampUpParam% /
+$ifThen.SEtaxRampUpParam not "%cm_SEtaxRampUpParam%" == "off" 
+  p21_SEtaxRampUpParameters(ext_regi,all_te,teSeTax_coeff)   "config values for SE electricity tax rate tech specific ramp up logistic function parameters" / %cm_SEtaxRampUpParam% /
+$endif.SEtaxRampUpParam
 ;
 
 $ifThen.import not "%cm_import_tax%" == "off" 

--- a/modules/21_tax/on/declarations.gms
+++ b/modules/21_tax/on/declarations.gms
@@ -68,9 +68,9 @@ p21_tau_CO2_tax_gdx_bau(ttot,all_regi)       "tax path from gdx, may overwrite d
 
 p21_implicitDiscRateMarg(ttot,all_regi,all_in)  "Difference between the normal discount rate and the implicit discount rate"
 
-p21_tau_SE_tax_rampup(ttot,all_regi,all_te,teSeTax_coeff)  "Paramters of logistic function to describe relationship between SE electricity tax rate and share of technology in total electricity demand"
+p21_tau_SE_tax_rampup(ttot,all_regi,all_te,teSeTax_coeff)  "Parameters of logistic function to describe relationship between SE electricity tax rate and share of technology in total electricity demand"
+p21_SEtaxRampUpParameters(ext_regi,all_te,teSeTax_coeff)   "config values for SE electricity tax rate tech specific ramp up logistic function parameters" / %cm_SEtaxRampUpParam% /
 ;
-
 
 $ifThen.import not "%cm_import_tax%" == "off" 
 Parameter

--- a/modules/21_tax/on/preloop.gms
+++ b/modules/21_tax/on/preloop.gms
@@ -147,7 +147,10 @@ display p21_tau_pe2se_sub, p21_tau_fuEx_sub;
 *** as the technology has system benefits in this domain. At higher shares this rapidly increases and converges towards the maximum tax rate.
 *** See the equations file of the tax module for more information on the SE tax.
 *** Parameter datainput needs to happen here because pm_tau_fe_tax, the final energy tax rate, is set in this file and not in the datainput file.
-p21_tau_SE_tax(t,regi,"elh2") = p21_tau_fe_tax(t,regi,"indst","feels")
+p21_tau_SE_tax(t,regi,te) = 0;
+$ifThen.SEtaxRampUpParam not "%cm_SEtaxRampUpParam%" == "off" 
+  p21_tau_SE_tax(t,regi,"elh2") = p21_tau_fe_tax(t,regi,"indst","feels")
+$endif.SEtaxRampUpParam
 *** calculate grid fees as levelized cost of CAPEX from tdels, the electricity transmission and distribution grid
 *** by annualising the CAPEX and dividing by the capacity factor
                                   + pm_inco0_t(t,regi,"tdels") 

--- a/modules/21_tax/on/preloop.gms
+++ b/modules/21_tax/on/preloop.gms
@@ -154,9 +154,6 @@ p21_tau_SE_tax(t,regi,"elh2") = p21_tau_fe_tax(t,regi,"indst","feels")
                                   * pm_teAnnuity("tdels")
                                   / pm_cf(t,regi,"tdels");
 
-p21_tau_SE_tax_rampup(t,regi,te,"a") = 0.4;
-p21_tau_SE_tax_rampup(t,regi,te,"b") = 10;
-
 *LB* initialization of vm_emiMac
 vm_emiMac.l(ttot,regi,enty) = 0;
 *LB* initialization of v21_emiALLco2neg

--- a/modules/21_tax/on/preloop.gms
+++ b/modules/21_tax/on/preloop.gms
@@ -140,6 +140,8 @@ display p21_tau_fe_tax;
 display p21_tau_pe2se_sub, p21_tau_fuEx_sub;
 
 *** SE Tax
+p21_tau_SE_tax(t,regi,te) = 0;
+$ifThen.SEtaxRampUpParam not "%cm_SEtaxRampUpParam%" == "off" 
 *** SE tax is currently used to tax electricity going into electrolysis. There is a maximum tax rate that is assumed
 *** to be the sum of the industry electricity FE tax and the investment cost per unit electricity of the grid (grid fee). 
 *** There is a ramp up of the SE electricity tax for electrolysis depending on the share of electrolysis in total electricity demand
@@ -147,15 +149,13 @@ display p21_tau_pe2se_sub, p21_tau_fuEx_sub;
 *** as the technology has system benefits in this domain. At higher shares this rapidly increases and converges towards the maximum tax rate.
 *** See the equations file of the tax module for more information on the SE tax.
 *** Parameter datainput needs to happen here because pm_tau_fe_tax, the final energy tax rate, is set in this file and not in the datainput file.
-p21_tau_SE_tax(t,regi,te) = 0;
-$ifThen.SEtaxRampUpParam not "%cm_SEtaxRampUpParam%" == "off" 
   p21_tau_SE_tax(t,regi,"elh2") = p21_tau_fe_tax(t,regi,"indst","feels")
-$endif.SEtaxRampUpParam
 *** calculate grid fees as levelized cost of CAPEX from tdels, the electricity transmission and distribution grid
 *** by annualising the CAPEX and dividing by the capacity factor
                                   + pm_inco0_t(t,regi,"tdels") 
                                   * pm_teAnnuity("tdels")
                                   / pm_cf(t,regi,"tdels");
+$endif.SEtaxRampUpParam
 
 *LB* initialization of vm_emiMac
 vm_emiMac.l(ttot,regi,enty) = 0;


### PR DESCRIPTION
## Purpose of this PR

- Expose the exponential curve parameter a and b to be changed directly in the scenario config.

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)

## Further information (optional):

* Test runs are here: 

- p21_tau_SE_tax disabled
`/p/projects/ecemf/REMIND/2040_scenarios/v05_2024_04_09_rev1/output/05_Nzero_57_bio7p5_seTrade_EU27_off_2024-04-30_18.47.42`
- a = 0.1, b = 10 (current default)
`/p/projects/ecemf/REMIND/2040_scenarios/v05_2024_04_09_rev1/output/05_Nzero_57_bio7p5_seTrade_EU27_def_2024-04-30_18.47.23`
- a = 0.1, b = 20
`/p/projects/ecemf/REMIND/2040_scenarios/v05_2024_04_09_rev1/output/05_Nzero_57_bio7p5_seTrade_EU27_b20_2024-04-30_18.48.01`
- a = 0.1, b = 30
`/p/projects/ecemf/REMIND/2040_scenarios/v05_2024_04_09_rev1/output/05_Nzero_57_bio7p5_seTrade_EU27_b30_2024-04-30_18.48.20`
- a = 0.1, b = 150 (it should be very close to off)
`/p/projects/ecemf/REMIND/2040_scenarios/v05_2024_04_09_rev1/output/05_Nzero_57_bio7p5_seTrade_EU27_b150_2024-04-30_18.48.39`

* Comparison of results (what changes by this PR?): 

`/p/projects/ecemf/REMIND/2040_scenarios/v05_2024_04_09_rev1/compScen-h2Tax-2024-05-10_10.40.15-EU27.pdf`