### PR TITLE
add capacity factor for biogasc

### DIFF
--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -714,6 +714,9 @@ pm_cf(ttot,regi,"h2turbVRE")$(ttot.val ge 2025) = pm_cf(ttot,regi,"ngt");
 pm_cf(ttot,regi,"tdh2b") = pm_cf(ttot,regi,"tdh2s");
 pm_cf(ttot,regi,"tdh2i") = pm_cf(ttot,regi,"tdh2s");
 
+*** set CF for biogasc to the same value as for biogas
+pm_cf(t,regi,"biogasc") = 0.91;
+
 
 *SB* Region- and tech-specific early retirement rates
 *Regional*

--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -715,7 +715,7 @@ pm_cf(ttot,regi,"tdh2b") = pm_cf(ttot,regi,"tdh2s");
 pm_cf(ttot,regi,"tdh2i") = pm_cf(ttot,regi,"tdh2s");
 
 *** set CF for biogasc to the same value as for biogas
-pm_cf(t,regi,"biogasc") = 0.91;
+pm_cf(ttot,regi,"biogasc") = 0.91;
 
 
 *SB* Region- and tech-specific early retirement rates


### PR DESCRIPTION
## Purpose of this PR

According to the [PR](https://github.com/remindmodel/remind/pull/859) that introduces the technology biogasc, the technology is supposed to have the same capacity factor as the biogas tech without capture (pm_cf = 0.91).
However, this factor does not show up in the fulldata.gdx and the deployment is 0 (see e.g. the recent AMT /p/projects/remind/modeltests/remind/output/SSP2EU-PkBudg650-AMT_2024-05-11_03.20.31/fulldata.gdx).

When the CF is added as in this PR, deployment is small but non-zero: /p/tmp/tabeado/sebiochar_AprRelease/remind/output/PB650-biogascCF_2024-05-08_12.09.32


## Type of change
- [x] Bug fix 
- [x] Minor change (default scenarios show only small differences)

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)


