### PR TITLE
net-zero biofuels trade scenario

### DIFF
--- a/modules/24_trade/se_trade/datainput.gms
+++ b/modules/24_trade/se_trade/datainput.gms
@@ -182,14 +182,14 @@ $endif.import_h2_EU
 
 *** parameters used in cm_import_EU scenarios nzero, nzero_bio and high_bio
 
-*** calculating the share of FE demand per carrier for each region in each region group
+*** calculate regional share of each region in the total of region group ext_regi, with respect to FE demand, for each aggregated carrier (liquids, gases,solids)
 p24_seAggReference(ttot,regi,seAgg) = sum(enty$seAgg2se(seAgg,enty), sum(se2fe(enty,enty2,te), pm_prodFEReference(ttot,regi,enty,enty2,te)));
-p24_FEShareInRegion(ttot,ext_regi,regi,seAgg)$(regi_group(ext_regi,regi) and p24_seAggReference(ttot,regi,seAgg)) = p24_seAggReference(ttot,regi,seAgg) / sum(regi2$regi_group(ext_regi,regi2), p24_seAggReference(ttot,regi2,seAgg));
+p24_FEregiShareInRegiGroup(ttot,ext_regi,regi,seAgg)$(regi_group(ext_regi,regi) and p24_seAggReference(ttot,regi,seAgg)) = p24_seAggReference(ttot,regi,seAgg) / sum(regi2$regi_group(ext_regi,regi2), p24_seAggReference(ttot,regi2,seAgg));
 
 execute_load "input_ref.gdx", p24_demFeForEsReference = vm_demFeForEs.l;
 execute_load "input_ref.gdx", p24_demFeIndSubReference = o37_demFeIndSub;
 
-*** calculating share of FE aviation and chemicals demand at each region group
+*** calculate regional share of each region in the total of region group ext_regi with respect to FE demand, for chemicals + aviation liquids
 p24_aviationAndChemicalsFE(ttot,regi) = p24_demFeForEsReference(ttot,regi,"fedie","esdie_pass_lo","te_esdie_pass_lo") + !! aviation FE demand
   sum((entySe,entyFe,emiMkt)$(sefe(entySe,entyFe) AND entyFe2Sector(entyFe,"indst") AND sector2emiMkt("indst",emiMkt) AND (sameas("fehos",entyFe))), p24_demFeIndSubReference(ttot,regi,entySe,entyFe,"chemicals",emiMkt)); !! chemicals FE demand
 p24_aviationAndChemicalsFEShareInRegion(ttot,ext_regi,regi)$(regi_group(ext_regi,regi) and p24_aviationAndChemicalsFE(ttot,regi)) = 
@@ -217,9 +217,9 @@ $ifthen.import_nzero_EU "%cm_import_EU%" == "nzero"
 
 *** defining EWN H2 trade import flows
 *** 2050 and onward
-  p24_seTradeCapacity(t,regi,"EWN","seh2")$((t.val ge 2050) and (sameas(regi,"UKI") or sameas(regi,"NEN") or sameas(regi,"ESW"))) = (100 / sm_TWa_2_TWh) * (p24_FEShareInRegion("2050","EUR_regi","EWN","all_sega")/p24_FEShareInRegion("2050","EUR_regi","DEU","all_sega")) * 1/3;
+  p24_seTradeCapacity(t,regi,"EWN","seh2")$((t.val ge 2050) and (sameas(regi,"UKI") or sameas(regi,"NEN") or sameas(regi,"ESW"))) = (100 / sm_TWa_2_TWh) * (p24_FEregiShareInRegiGroup("2050","EUR_regi","EWN","all_sega")/p24_FEregiShareInRegiGroup("2050","EUR_regi","DEU","all_sega")) * 1/3;
 *** 2030
-  p24_seTradeCapacity("2030",regi,"EWN","seh2")$((sameas(regi,"UKI") or sameas(regi,"NEN") or sameas(regi,"ESW"))) = (12 / sm_TWa_2_TWh) * (p24_FEShareInRegion("2050","EUR_regi","EWN","all_sega")/p24_FEShareInRegion("2050","EUR_regi","DEU","all_sega")) * 1/3;
+  p24_seTradeCapacity("2030",regi,"EWN","seh2")$((sameas(regi,"UKI") or sameas(regi,"NEN") or sameas(regi,"ESW"))) = (12 / sm_TWa_2_TWh) * (p24_FEregiShareInRegiGroup("2050","EUR_regi","EWN","all_sega")/p24_FEregiShareInRegiGroup("2050","EUR_regi","DEU","all_sega")) * 1/3;
 
 *** exponential curve for years in between
   p24_seTradeCapacity(t,regi,regi2,"seh2")$(p24_seTradeCapacity("2050",regi,regi2,"seh2") and (t.val gt 2030 and t.val lt 2050)) = 
@@ -272,9 +272,9 @@ $ifthen.import_nzero_bio_EU "%cm_import_EU%" == "nzero_bio"
 
 *** defining EWN H2 trade import flows
 *** 2050 and onward
-  p24_seTradeCapacity(t,regi,"EWN","seh2")$((t.val ge 2050) and (sameas(regi,"UKI") or sameas(regi,"NEN") or sameas(regi,"ESW"))) = (100 / sm_TWa_2_TWh) * (p24_FEShareInRegion("2050","EUR_regi","EWN","all_sega")/p24_FEShareInRegion("2050","EUR_regi","DEU","all_sega")) * 1/3;
+  p24_seTradeCapacity(t,regi,"EWN","seh2")$((t.val ge 2050) and (sameas(regi,"UKI") or sameas(regi,"NEN") or sameas(regi,"ESW"))) = (100 / sm_TWa_2_TWh) * (p24_FEregiShareInRegiGroup("2050","EUR_regi","EWN","all_sega")/p24_FEregiShareInRegiGroup("2050","EUR_regi","DEU","all_sega")) * 1/3;
 *** 2030
-  p24_seTradeCapacity("2030",regi,"EWN","seh2")$((sameas(regi,"UKI") or sameas(regi,"NEN") or sameas(regi,"ESW"))) = (12 / sm_TWa_2_TWh) * (p24_FEShareInRegion("2050","EUR_regi","EWN","all_sega")/p24_FEShareInRegion("2050","EUR_regi","DEU","all_sega")) * 1/3;
+  p24_seTradeCapacity("2030",regi,"EWN","seh2")$((sameas(regi,"UKI") or sameas(regi,"NEN") or sameas(regi,"ESW"))) = (12 / sm_TWa_2_TWh) * (p24_FEregiShareInRegiGroup("2050","EUR_regi","EWN","all_sega")/p24_FEregiShareInRegiGroup("2050","EUR_regi","DEU","all_sega")) * 1/3;
 
 *** exponential curve for years in between
   p24_seTradeCapacity(t,regi,regi2,"seh2")$(p24_seTradeCapacity("2050",regi,regi2,"seh2") and (t.val gt 2030 and t.val lt 2050)) = 

--- a/modules/24_trade/se_trade/datainput.gms
+++ b/modules/24_trade/se_trade/datainput.gms
@@ -182,7 +182,7 @@ $endif.import_h2_EU
 
 $ifthen.import_nzero_EU "%cm_import_EU%" == "nzero"
 
-*** NZero scenario with with 2050 levels for: 
+*** NZero scenario with 2050 levels for: 
 *** - h2 imports -> DEU: 100 TWh/yr, EWN: ~75 TWh/yr; total EU: ~0.63 EJ
 *** - seliqsyn imports -> DEU: 100 TWh/yr, other EU regions proportional to aviation and chemicals FE demand; Total EU: ~ 2 EJ by 2050
 
@@ -251,7 +251,7 @@ $endif.import_nzero_EU
 
 $ifthen.import_nzero_bio_EU "%cm_import_EU%" == "nzero_bio"
 
-*** NZero scenario for high biomass available sensitivy with 2050 levels for: 
+*** EU net-zero trade scenario for high biomass availability sensitivity with 2050 levels for: 
 *** - h2 imports -> DEU: 100 TWh/yr, EWN: ~75 TWh/yr; total EU: ~0.63 EJ
 *** - seliqsyn imports (reduced pull due to bioliquids availability) -> DEU: 50 TWh/yr, other EU regions proportional to aviation and chemicals FE demand; Total EU: ~ 1 EJ by 2050
 *** - seliqbio imports -> EU: 7.44 EJ (~ 8 EJ of biomass primary energy, assuming pebioil.seliqbio.biodiesel eta)

--- a/modules/24_trade/se_trade/datainput.gms
+++ b/modules/24_trade/se_trade/datainput.gms
@@ -306,7 +306,7 @@ $ifthen.import_nzero_bio_EU "%cm_import_EU%" == "nzero_bio"
 
 *** bio-liquids trade:
 ***   All regions (EU-27 and UKI) import proportionally to their 2050 FE|Transport|Pass|Aviation + FE|Industry|Chemicals|Liquids in the reference NPi run.
-***   Exporting regions: SSA and LAM (half each)
+***   Exporting regions: SSA and LAM (half each). LAM and SSA as exporting regions were chosen based on this paper: https://doi.org/10.1111/gcbb.12614
 ***   Import quantities: exponential increase from 0.3 EJ by 2030 to 7.44 EJ by 2050 for EU-27
 
 *** defining EU-27 & UK seliqbio trade import flows
@@ -338,7 +338,7 @@ $ifthen.high_bio "%cm_import_EU%" == "high_bio"
 
 *** bio-liquids trade:
 ***   All regions (EU-27 and UKI) import proportionally to their 2050 FE|Transport|Pass|Aviation + FE|Industry|Chemicals|Liquids in the reference NPi run.
-***   Exporting regions: SSA and LAM (half each)
+***   Exporting regions: SSA and LAM (half each). LAM and SSA as exporting regions were chosen based on this paper: https://doi.org/10.1111/gcbb.12614
 ***   Import quantities: exponential increase from 0.3 EJ by 2030 to 7.44 EJ by 2050 for EU-27
 
 *** defining EU-27 & UK seliqbio trade import flows

--- a/modules/24_trade/se_trade/datainput.gms
+++ b/modules/24_trade/se_trade/datainput.gms
@@ -180,6 +180,23 @@ $ifthen.import_h2_EU "%cm_Ger_Pol%" == "ensec"
   p24_seTradeCapacity(t,regi,regi2,entySe)$(t.val eq 2030) = p24_seTrade_Quantity(regi,regi2,entySe)*0.2;
 $endif.import_h2_EU
 
+*** parameters used in cm_import_EU scenarios nzero, nzero_bio and high_bio
+
+*** calculating the share of FE demand per carrier for each region in each region group
+p24_seAggReference(ttot,regi,seAgg) = sum(enty$seAgg2se(seAgg,enty), sum(se2fe(enty,enty2,te), pm_prodFEReference(ttot,regi,enty,enty2,te)));
+p24_FEShareInRegion(ttot,ext_regi,regi,seAgg)$(regi_group(ext_regi,regi) and p24_seAggReference(ttot,regi,seAgg)) = p24_seAggReference(ttot,regi,seAgg) / sum(regi2$regi_group(ext_regi,regi2), p24_seAggReference(ttot,regi2,seAgg));
+
+execute_load "input_ref.gdx", p24_demFeForEsReference = vm_demFeForEs.l;
+execute_load "input_ref.gdx", p24_demFeIndSubReference = o37_demFeIndSub;
+
+*** calculating share of FE aviation and chemicals demand at each region group
+p24_aviationAndChemicalsFE(ttot,regi) = p24_demFeForEsReference(ttot,regi,"fedie","esdie_pass_lo","te_esdie_pass_lo") + !! aviation FE demand
+  sum((entySe,entyFe,emiMkt)$(sefe(entySe,entyFe) AND entyFe2Sector(entyFe,"indst") AND sector2emiMkt("indst",emiMkt) AND (sameas("fehos",entyFe))), p24_demFeIndSubReference(ttot,regi,entySe,entyFe,"chemicals",emiMkt)); !! chemicals FE demand
+p24_aviationAndChemicalsFEShareInRegion(ttot,ext_regi,regi)$(regi_group(ext_regi,regi) and p24_aviationAndChemicalsFE(ttot,regi)) = 
+  p24_aviationAndChemicalsFE(ttot,regi) / sum(regi2$regi_group(ext_regi,regi2), p24_aviationAndChemicalsFE(ttot,regi2));
+
+* display p24_aviationAndChemicalsFEShareInRegion;
+
 $ifthen.import_nzero_EU "%cm_import_EU%" == "nzero"
 
 *** NZero scenario with 2050 levels for: 
@@ -191,9 +208,6 @@ $ifthen.import_nzero_EU "%cm_import_EU%" == "nzero"
 ***   Exporting regions: UK, Norway and Spain (one-third each)
 ***   exponential curve starting at 12 TWh by 2030 for Germany
 
-*** calculating the share of FE demand per carrier for each region in each region group
-  p24_seAggReference(ttot,regi,seAgg) = sum(enty$seAgg2se(seAgg,enty), sum(se2fe(enty,enty2,te), pm_prodFEReference(ttot,regi,enty,enty2,te)));
-  p24_FEShareInRegion(ttot,ext_regi,regi,seAgg)$(regi_group(ext_regi,regi) and p24_seAggReference(ttot,regi,seAgg)) = p24_seAggReference(ttot,regi,seAgg) / sum(regi2$regi_group(ext_regi,regi2), p24_seAggReference(ttot,regi2,seAgg));
 
 *** defining Germany H2 trade import flows
 *** 2050 and onward
@@ -215,17 +229,6 @@ $ifthen.import_nzero_EU "%cm_import_EU%" == "nzero"
 ***   All regions (EU-27 and UKI) import proportionally to their 2050 FE|Transport|Pass|Aviation + FE|Industry|Chemicals|Liquids in the reference NPi run.
 ***   Exporting regions: SSA, LAM and MEA (one-third each)
 ***   Import quantities: exponential increase from 1.2 TWh/yr by 2030 to 100 TWh/yr by 2050 for Germany
-
-execute_load "input_ref.gdx", p24_demFeForEsReference = vm_demFeForEs.l;
-execute_load "input_ref.gdx", p24_demFeIndSubReference = o37_demFeIndSub;
-
-*** calculating share of FE aviation and chemicals demand at each region group
-  p24_aviationAndChemicalsFE(ttot,regi) = p24_demFeForEsReference(ttot,regi,"fedie","esdie_pass_lo","te_esdie_pass_lo") + !! aviation FE demand
-    sum((entySe,entyFe,emiMkt)$(sefe(entySe,entyFe) AND entyFe2Sector(entyFe,"indst") AND sector2emiMkt("indst",emiMkt) AND (sameas("fehos",entyFe))), p24_demFeIndSubReference(ttot,regi,entySe,entyFe,"chemicals",emiMkt)); !! chemicals FE demand
-  p24_aviationAndChemicalsFEShareInRegion(ttot,ext_regi,regi)$(regi_group(ext_regi,regi) and p24_aviationAndChemicalsFE(ttot,regi)) = 
-    p24_aviationAndChemicalsFE(ttot,regi) / sum(regi2$regi_group(ext_regi,regi2), p24_aviationAndChemicalsFE(ttot,regi2));
-
-* display p24_aviationAndChemicalsFEShareInRegion;
 
 *** defining Germany seliqsyn trade import flows
   loop(regi$(sameas(regi,"SSA") or sameas(regi,"LAM") or sameas(regi,"MEA")), 
@@ -261,10 +264,6 @@ $ifthen.import_nzero_bio_EU "%cm_import_EU%" == "nzero_bio"
 ***   Exporting regions: UK, Norway and Spain (one-third each)
 ***   exponential curve starting at 12 TWh by 2030 for Germany
 
-*** calculating the share of FE demand per carrier for each region in each region group
-  p24_seAggReference(ttot,regi,seAgg) = sum(enty$seAgg2se(seAgg,enty), sum(se2fe(enty,enty2,te), pm_prodFEReference(ttot,regi,enty,enty2,te)));
-  p24_FEShareInRegion(ttot,ext_regi,regi,seAgg)$(regi_group(ext_regi,regi) and p24_seAggReference(ttot,regi,seAgg)) = p24_seAggReference(ttot,regi,seAgg) / sum(regi2$regi_group(ext_regi,regi2), p24_seAggReference(ttot,regi2,seAgg));
-
 *** defining Germany H2 trade import flows
 *** 2050 and onward
   p24_seTradeCapacity(t,regi,"DEU","seh2")$((t.val ge 2050) and (sameas(regi,"UKI") or sameas(regi,"NEN") or sameas(regi,"ESW"))) = (100 / sm_TWa_2_TWh) * 1/3; !! each supplier region provides one-third of the imports
@@ -285,17 +284,6 @@ $ifthen.import_nzero_bio_EU "%cm_import_EU%" == "nzero_bio"
 ***   All regions (EU-27 and UKI) import proportionally to their 2050 FE|Transport|Pass|Aviation + FE|Industry|Chemicals|Liquids in the reference NPi run.
 ***   Exporting regions: SSA, LAM and MEA (one-third each)
 ***   Import quantities: exponential increase from 0.6 TWh/yr by 2030 to 50 TWh/yr by 2050 for Germany
-
-execute_load "input_ref.gdx", p24_demFeForEsReference = vm_demFeForEs.l;
-execute_load "input_ref.gdx", p24_demFeIndSubReference = o37_demFeIndSub;
-
-*** calculating share of FE aviation and chemicals demand at each region group
-  p24_aviationAndChemicalsFE(ttot,regi) = p24_demFeForEsReference(ttot,regi,"fedie","esdie_pass_lo","te_esdie_pass_lo") + !! aviation FE demand
-    sum((entySe,entyFe,emiMkt)$(sefe(entySe,entyFe) AND entyFe2Sector(entyFe,"indst") AND sector2emiMkt("indst",emiMkt) AND (sameas("fehos",entyFe))), p24_demFeIndSubReference(ttot,regi,entySe,entyFe,"chemicals",emiMkt)); !! chemicals FE demand
-  p24_aviationAndChemicalsFEShareInRegion(ttot,ext_regi,regi)$(regi_group(ext_regi,regi) and p24_aviationAndChemicalsFE(ttot,regi)) = 
-    p24_aviationAndChemicalsFE(ttot,regi) / sum(regi2$regi_group(ext_regi,regi2), p24_aviationAndChemicalsFE(ttot,regi2));
-
-* display p24_aviationAndChemicalsFEShareInRegion;
 
 *** defining Germany seliqsyn trade import flows
   loop(regi$(sameas(regi,"SSA") or sameas(regi,"LAM") or sameas(regi,"MEA")),
@@ -352,17 +340,6 @@ $ifthen.high_bio "%cm_import_EU%" == "high_bio"
 ***   All regions (EU-27 and UKI) import proportionally to their 2050 FE|Transport|Pass|Aviation + FE|Industry|Chemicals|Liquids in the reference NPi run.
 ***   Exporting regions: SSA and LAM (half each)
 ***   Import quantities: exponential increase from 0.3 EJ by 2030 to 7.44 EJ by 2050 for EU-27
-
-execute_load "input_ref.gdx", p24_demFeForEsReference = vm_demFeForEs.l;
-execute_load "input_ref.gdx", p24_demFeIndSubReference = o37_demFeIndSub;
-
-*** calculating share of FE aviation and chemicals demand at each region group
-  p24_aviationAndChemicalsFE(ttot,regi) = p24_demFeForEsReference(ttot,regi,"fedie","esdie_pass_lo","te_esdie_pass_lo") + !! aviation FE demand
-    sum((entySe,entyFe,emiMkt)$(sefe(entySe,entyFe) AND entyFe2Sector(entyFe,"indst") AND sector2emiMkt("indst",emiMkt) AND (sameas("fehos",entyFe))), p24_demFeIndSubReference(ttot,regi,entySe,entyFe,"chemicals",emiMkt)); !! chemicals FE demand
-  p24_aviationAndChemicalsFEShareInRegion(ttot,ext_regi,regi)$(regi_group(ext_regi,regi) and p24_aviationAndChemicalsFE(ttot,regi)) = 
-    p24_aviationAndChemicalsFE(ttot,regi) / sum(regi2$regi_group(ext_regi,regi2), p24_aviationAndChemicalsFE(ttot,regi2));
-
-* display p24_aviationAndChemicalsFEShareInRegion;
 
 *** defining EU-27 & UK seliqbio trade import flows
   loop(regi$(sameas(regi,"SSA") or sameas(regi,"LAM")),

--- a/modules/24_trade/se_trade/datainput.gms
+++ b/modules/24_trade/se_trade/datainput.gms
@@ -182,6 +182,10 @@ $endif.import_h2_EU
 
 $ifthen.import_nzero_EU "%cm_import_EU%" == "nzero"
 
+*** NZero scenario with with 2050 levels for: 
+*** - h2 imports -> DEU: 100 TWh/yr, EWN: ~75 TWh/yr; total EU: ~0.63 EJ
+*** - seliqsyn imports -> DEU: 100 TWh/yr, other EU regions proportional to aviation and chemicals FE demand; Total EU: ~ 2 EJ by 2050
+
 *** H2 trade:
 ***   Importing regions: Germany, 100 TWh/yr, and EWN, proportional to German values and FE|Gases demand by 2050 in the reference NPi run.
 ***   Exporting regions: UK, Norway and Spain (one-third each)
@@ -224,13 +228,17 @@ execute_load "input_ref.gdx", p24_demFeIndSubReference = o37_demFeIndSub;
 * display p24_aviationAndChemicalsFEShareInRegion;
 
 *** defining Germany seliqsyn trade import flows
-  loop(regi$(sameas(regi,"SSA") or sameas(regi,"LAM") or sameas(regi,"MEA")), !! each supplier region provide one-third of total imports
+  loop(regi$(sameas(regi,"SSA") or sameas(regi,"LAM") or sameas(regi,"MEA")), 
 *** 2050 and onward
     p24_seTradeCapacity(t,regi,regi2,"seliqsyn")$(t.val ge 2050) = 
       ( (100 / sm_TWa_2_TWh)  / p24_aviationAndChemicalsFEShareInRegion("2050","EUR_regi","DEU") ) !! total EUR imports based on Germany values
-      * p24_aviationAndChemicalsFEShareInRegion("2050","EUR_regi",regi2) * 1/3;
+      * p24_aviationAndChemicalsFEShareInRegion("2050","EUR_regi",regi2) 
+      * 1/3; !! each supplier region provide one-third of total imports
 *** 2030 
-    p24_seTradeCapacity("2030",regi,regi2,"seliqsyn") = (((1.2 / sm_TWa_2_TWh) / p24_aviationAndChemicalsFEShareInRegion("2050","EUR_regi","DEU") ) * p24_aviationAndChemicalsFEShareInRegion("2050","EUR_regi",regi2)) * 1/3;
+    p24_seTradeCapacity("2030",regi,regi2,"seliqsyn") = 
+      ((1.2 / sm_TWa_2_TWh) / p24_aviationAndChemicalsFEShareInRegion("2050","EUR_regi","DEU") ) 
+      * p24_aviationAndChemicalsFEShareInRegion("2050","EUR_regi",regi2) 
+      * 1/3;
   );
 
 *** exponential curve for years in between
@@ -240,5 +248,99 @@ execute_load "input_ref.gdx", p24_demFeIndSubReference = o37_demFeIndSub;
 display p24_seTradeCapacity;
 
 $endif.import_nzero_EU
+
+$ifthen.import_nzero_bio_EU "%cm_import_EU%" == "nzero_bio"
+
+*** NZero scenario for high biomass available sensitivy with 2050 levels for: 
+*** - h2 imports -> DEU: 100 TWh/yr, EWN: ~75 TWh/yr; total EU: ~0.63 EJ
+*** - seliqsyn imports (reduced pull due to bioliquids availability) -> DEU: 50 TWh/yr, other EU regions proportional to aviation and chemicals FE demand; Total EU: ~ 1 EJ by 2050
+*** - seliqbio imports -> EU: 7.44 EJ (~ 8 EJ of biomass primary energy, assuming pebioil.seliqbio.biodiesel eta)
+
+*** H2 trade:
+***   Importing regions: Germany, 100 TWh/yr, and EWN, proportional to German values and FE|Gases demand by 2050 in the reference NPi run.
+***   Exporting regions: UK, Norway and Spain (one-third each)
+***   exponential curve starting at 12 TWh by 2030 for Germany
+
+*** calculating the share of FE demand per carrier for each region in each region group
+  p24_seAggReference(ttot,regi,seAgg) = sum(enty$seAgg2se(seAgg,enty), sum(se2fe(enty,enty2,te), pm_prodFEReference(ttot,regi,enty,enty2,te)));
+  p24_FEShareInRegion(ttot,ext_regi,regi,seAgg)$(regi_group(ext_regi,regi) and p24_seAggReference(ttot,regi,seAgg)) = p24_seAggReference(ttot,regi,seAgg) / sum(regi2$regi_group(ext_regi,regi2), p24_seAggReference(ttot,regi2,seAgg));
+
+*** defining Germany H2 trade import flows
+*** 2050 and onward
+  p24_seTradeCapacity(t,regi,"DEU","seh2")$((t.val ge 2050) and (sameas(regi,"UKI") or sameas(regi,"NEN") or sameas(regi,"ESW"))) = (100 / sm_TWa_2_TWh) * 1/3; !! each supplier region provides one-third of the imports
+*** 2030
+  p24_seTradeCapacity("2030",regi,"DEU","seh2")$((sameas(regi,"UKI") or sameas(regi,"NEN") or sameas(regi,"ESW"))) = (12 / sm_TWa_2_TWh) * 1/3; !! each supplier region provides one-third of the imports
+
+*** defining EWN H2 trade import flows
+*** 2050 and onward
+  p24_seTradeCapacity(t,regi,"EWN","seh2")$((t.val ge 2050) and (sameas(regi,"UKI") or sameas(regi,"NEN") or sameas(regi,"ESW"))) = (100 / sm_TWa_2_TWh) * (p24_FEShareInRegion("2050","EUR_regi","EWN","all_sega")/p24_FEShareInRegion("2050","EUR_regi","DEU","all_sega")) * 1/3;
+*** 2030
+  p24_seTradeCapacity("2030",regi,"EWN","seh2")$((sameas(regi,"UKI") or sameas(regi,"NEN") or sameas(regi,"ESW"))) = (12 / sm_TWa_2_TWh) * (p24_FEShareInRegion("2050","EUR_regi","EWN","all_sega")/p24_FEShareInRegion("2050","EUR_regi","DEU","all_sega")) * 1/3;
+
+*** exponential curve for years in between
+  p24_seTradeCapacity(t,regi,regi2,"seh2")$(p24_seTradeCapacity("2050",regi,regi2,"seh2") and (t.val gt 2030 and t.val lt 2050)) = 
+    p24_seTradeCapacity("2030",regi,regi2,"seh2") * ((sqrt(sqrt(p24_seTradeCapacity("2050",regi,regi2,"seh2") / p24_seTradeCapacity("2030",regi,regi2,"seh2")))) ** ((t.val - 2030)/5)) ;
+
+*** E-fuels (e-liquids) trade:
+***   All regions (EU-27 and UKI) import proportionally to their 2050 FE|Transport|Pass|Aviation + FE|Industry|Chemicals|Liquids in the reference NPi run.
+***   Exporting regions: SSA, LAM and MEA (one-third each)
+***   Import quantities: exponential increase from 0.6 TWh/yr by 2030 to 50 TWh/yr by 2050 for Germany
+
+execute_load "input_ref.gdx", p24_demFeForEsReference = vm_demFeForEs.l;
+execute_load "input_ref.gdx", p24_demFeIndSubReference = o37_demFeIndSub;
+
+*** calculating share of FE aviation and chemicals demand at each region group
+  p24_aviationAndChemicalsFE(ttot,regi) = p24_demFeForEsReference(ttot,regi,"fedie","esdie_pass_lo","te_esdie_pass_lo") + !! aviation FE demand
+    sum((entySe,entyFe,emiMkt)$(sefe(entySe,entyFe) AND entyFe2Sector(entyFe,"indst") AND sector2emiMkt("indst",emiMkt) AND (sameas("fehos",entyFe))), p24_demFeIndSubReference(ttot,regi,entySe,entyFe,"chemicals",emiMkt)); !! chemicals FE demand
+  p24_aviationAndChemicalsFEShareInRegion(ttot,ext_regi,regi)$(regi_group(ext_regi,regi) and p24_aviationAndChemicalsFE(ttot,regi)) = 
+    p24_aviationAndChemicalsFE(ttot,regi) / sum(regi2$regi_group(ext_regi,regi2), p24_aviationAndChemicalsFE(ttot,regi2));
+
+* display p24_aviationAndChemicalsFEShareInRegion;
+
+*** defining Germany seliqsyn trade import flows
+  loop(regi$(sameas(regi,"SSA") or sameas(regi,"LAM") or sameas(regi,"MEA")),
+*** 2050 and onward
+    p24_seTradeCapacity(t,regi,regi2,"seliqsyn")$(t.val ge 2050) = 
+      ( (50 / sm_TWa_2_TWh)  / p24_aviationAndChemicalsFEShareInRegion("2050","EUR_regi","DEU") ) !! total EUR imports based on Germany values
+      * p24_aviationAndChemicalsFEShareInRegion("2050","EUR_regi",regi2) 
+      * 1/3; !! each supplier region provide one-third of total imports
+*** 2030 
+    p24_seTradeCapacity("2030",regi,regi2,"seliqsyn") = 
+      ( (0.6 / sm_TWa_2_TWh) / p24_aviationAndChemicalsFEShareInRegion("2050","EUR_regi","DEU") )
+      * p24_aviationAndChemicalsFEShareInRegion("2050","EUR_regi",regi2) 
+      * 1/3; 
+  );
+
+*** exponential curve for years in between
+  p24_seTradeCapacity(t,regi,regi2,"seliqsyn")$(p24_seTradeCapacity("2050",regi,regi2,"seliqsyn") and (t.val gt 2030 and t.val lt 2050)) = 
+    p24_seTradeCapacity("2030",regi,regi2,"seliqsyn") * ((sqrt(sqrt(p24_seTradeCapacity("2050",regi,regi2,"seliqsyn") / p24_seTradeCapacity("2030",regi,regi2,"seliqsyn")))) ** ((t.val - 2030)/5)) ;
+
+
+*** bio-liquids trade:
+***   All regions (EU-27 and UKI) import proportionally to their 2050 FE|Transport|Pass|Aviation + FE|Industry|Chemicals|Liquids in the reference NPi run.
+***   Exporting regions: SSA and LAM (half each)
+***   Import quantities: exponential increase from 0.3 EJ by 2030 to 7.44 EJ by 2050 for EU-27
+
+*** defining EU-27 & UK seliqbio trade import flows
+  loop(regi$(sameas(regi,"SSA") or sameas(regi,"LAM")),
+*** 2050 and onward
+    p24_seTradeCapacity(t,regi,regi2,"seliqbio")$(t.val ge 2050) = 
+      ( (7.44 * sm_EJ_2_TWa) / sum(regi3$regi_group("EU27_regi",regi3),p24_aviationAndChemicalsFEShareInRegion("2050","EUR_regi",regi3)) ) !! total EUR imports based on EU-27 values
+      * p24_aviationAndChemicalsFEShareInRegion("2050","EUR_regi",regi2) 
+      * 1/2; !! each supplier region provide half of total imports
+*** 2030 
+    p24_seTradeCapacity("2030",regi,regi2,"seliqbio") = 
+      ( (0.3 * sm_EJ_2_TWa) / sum(regi3$regi_group("EU27_regi",regi3),p24_aviationAndChemicalsFEShareInRegion("2050","EUR_regi",regi3)) ) !! total EUR imports based on EU-27 values
+      * p24_aviationAndChemicalsFEShareInRegion("2050","EUR_regi",regi2) 
+      * 1/2;
+  );
+
+*** exponential curve for years in between
+  p24_seTradeCapacity(t,regi,regi2,"seliqbio")$(p24_seTradeCapacity("2050",regi,regi2,"seliqbio") and (t.val gt 2030 and t.val lt 2050)) = 
+    p24_seTradeCapacity("2030",regi,regi2,"seliqbio") * ((sqrt(sqrt(p24_seTradeCapacity("2050",regi,regi2,"seliqbio") / p24_seTradeCapacity("2030",regi,regi2,"seliqbio")))) ** ((t.val - 2030)/5)) ;
+
+display p24_seTradeCapacity;
+
+$endif.import_nzero_bio_EU
 
 *** EOF ./modules/24_trade/se_trade/datainput.gms

--- a/modules/24_trade/se_trade/declarations.gms
+++ b/modules/24_trade/se_trade/declarations.gms
@@ -28,7 +28,7 @@ pm_XPortsPrice(tall,all_regi,all_enty)              "Secondary energy export pri
 
 *** parameters used in cm_import_EU scenarios nzero, nzero_bio and high_bio
 p24_seAggReference(ttot,all_regi,seAgg)                                        "Secondary energy per carrier (seAgg) in the reference run [TWa]"
-p24_FEShareInRegion(ttot,ext_regi,all_regi,seAgg)                              "Region share of total final energy demand per carrier (seAgg) within the region group (ext_regi) [%]"
+p24_FEregiShareInRegiGroup(ttot,ext_regi,all_regi,seAgg)                       "Region share of total final energy demand per carrier (seAgg) within the region group (ext_regi) [%]"
 p24_demFeForEsReference(ttot,all_regi,all_enty,all_esty,all_teEs)              "Final energy which will be used in the ES layer in the reference run [TWa]"
 p24_demFeIndSubReference(ttot,all_regi,all_enty,all_enty,secInd37,all_emiMkt)  "Final energy demand per industry subsector, FE carrier, SE carrier, emissions market in the reference run [TWa]"
 p24_aviationAndChemicalsFE(ttot,all_regi)                                      "Final energy of aviation and chemicals liquids demand [TWa]"

--- a/modules/24_trade/se_trade/declarations.gms
+++ b/modules/24_trade/se_trade/declarations.gms
@@ -17,15 +17,6 @@ p24_Mport2005correct(all_regi,all_enty)     "Correction factor to match fossil s
 p24_seTradeCapacity(tall,all_regi,all_regi,all_enty) "Secondary energy international yearly trade capacity potential from regi to regi2 [TWa]"
 p24_seTrade_Quantity(all_regi,all_regi,all_enty)      "Maximum import quantity in import scenarios with fixed quantities [TWa]"
 
-$ifthen.import_nzero_EU "%cm_import_EU%" == "nzero"
-  p24_seAggReference(ttot,all_regi,seAgg)                                        "Secondary energy per carrier (seAgg) in the reference run [TWa]"
-  p24_FEShareInRegion(ttot,ext_regi,all_regi,seAgg)                              "Region share of total final energy demand per carrier (seAgg) within the region group (ext_regi) [%]"
-  p24_demFeForEsReference(ttot,all_regi,all_enty,all_esty,all_teEs)              "Final energy which will be used in the ES layer in the reference run [TWa]"
-  p24_demFeIndSubReference(ttot,all_regi,all_enty,all_enty,secInd37,all_emiMkt)  "Final energy demand per industry subsector, FE carrier, SE carrier, emissions market in the reference run [TWa]"
-  p24_aviationAndChemicalsFE(ttot,all_regi)                                      "Final energy of aviation and chemicals liquids demand [TWa]"
-  p24_aviationAndChemicalsFEShareInRegion(ttot,ext_regi,all_regi)                "Region share of total final energy aviation and chemicals liquids demand within the region group (ext_regi) [%]"
-$endif.import_nzero_EU
-
 $IFTHEN.trade_SE_exog not "%cm_trade_SE_exog%" == "off"
   p24_trade_exog(ttot,ttot,ext_regi,ext_regi,all_enty)   "parameter to define exogenous SE trade trajectories [EJ/yr]" / %cm_trade_SE_exog% /
 $ENDIF.trade_SE_exog
@@ -34,6 +25,14 @@ p24_MportsRegi(tall,all_regi,all_regi,all_enty)      "Mports to regi from regi2,
 p24_XportsRegi(tall,all_regi,all_regi,all_enty)      "Exports from regi to regi2. Defined in the postsolve as a result of p24_MportsRegi calculation [TWa]"
 pm_MPortsPrice(tall,all_regi,all_enty)              "Secondary energy import price for region. Calculated in the postsolve and assuming that trade is distributed uniformetly according existent capacities defined at p24_seTradeCapacity [T$/TWa]"
 pm_XPortsPrice(tall,all_regi,all_enty)              "Secondary energy export price for region. Calculated in the postsolve and corresponding to the region secondary energy price [T$/TWa]"
+
+*** parameters used in cm_import_EU scenarios nzero, nzero_bio and high_bio
+p24_seAggReference(ttot,all_regi,seAgg)                                        "Secondary energy per carrier (seAgg) in the reference run [TWa]"
+p24_FEShareInRegion(ttot,ext_regi,all_regi,seAgg)                              "Region share of total final energy demand per carrier (seAgg) within the region group (ext_regi) [%]"
+p24_demFeForEsReference(ttot,all_regi,all_enty,all_esty,all_teEs)              "Final energy which will be used in the ES layer in the reference run [TWa]"
+p24_demFeIndSubReference(ttot,all_regi,all_enty,all_enty,secInd37,all_emiMkt)  "Final energy demand per industry subsector, FE carrier, SE carrier, emissions market in the reference run [TWa]"
+p24_aviationAndChemicalsFE(ttot,all_regi)                                      "Final energy of aviation and chemicals liquids demand [TWa]"
+p24_aviationAndChemicalsFEShareInRegion(ttot,ext_regi,all_regi)                "Region share of total final energy aviation and chemicals liquids demand within the region group (ext_regi) [%]"
 ;
 
 ***-------------------------------------------------------------------------------

--- a/modules/24_trade/se_trade/presolve.gms
+++ b/modules/24_trade/se_trade/presolve.gms
@@ -20,10 +20,17 @@ vm_Mport.l(t,regi,entySe)$(sum(regi2,p24_seTradeCapacity(t,regi2,regi,entySe)) g
 *** Xport price
 pm_XPortsPrice(t,regi,tradeSe) = pm_SEPrice(t,regi,tradeSe);
 
+display pm_XPortsPrice;
+
 *** Setting Xport price bound to avoid unrealists trading prices.
-*** Lower bound: avoiding epsilon values (caused by using equation marginals for setting prices) or unrealistic small value for H2 exporting prices -> minimun price = 1$/kg (1$/kg = 0.030769231 $/Kwh = 0.030769231 / (10^12/10^9*8760) T$/TWa = 0.26953846356 T$/TWa) 
-pm_XPortsPrice(t,regi,"seh2") = min(0.26953846356,pm_XPortsPrice(t,regi,"seh2"));
-pm_XPortsPrice(t,regi,"seliqsyn") = min(0.26953846356,pm_XPortsPrice(t,regi,"seliqsyn"));
+*** Lower bound: avoiding epsilon values (caused by using equation marginals for setting prices) or unrealistic small values for secondary energy prices
+*** - H2 and seliqsyn exporting prices -> minimun price = 1$/kg (1$/kg = 0.030769231 $/Kwh = 0.030769231 / (10^12/10^9*8760) T$/TWa = 0.26953846356 T$/TWa)
+*** - seliqbio exporting prices -> minimun price = 5 US$2005/GJ (5/31.71 = 0.157678966 T$/TWa)
+pm_XPortsPrice(t,regi,"seh2") = max(0.26953846356,pm_XPortsPrice(t,regi,"seh2"));
+pm_XPortsPrice(t,regi,"seliqsyn") = max(0.26953846356,pm_XPortsPrice(t,regi,"seliqsyn"));
+pm_XPortsPrice(t,regi,"seliqbio") = max(0.157678966,pm_XPortsPrice(t,regi,"seliqbio"));
+
+display pm_XPortsPrice;
 
 $ontext
 *** Mports from where? Mports from regi to regi2, assuming that trade is distributed uniformetly according existent trade capacities
@@ -68,6 +75,6 @@ pm_MPortsPrice(t,regi,tradeSe)$(sum(regi2,p24_seTradeCapacity(t,regi2,regi,trade
   )
 ;
 
-display  p24_seTradeCapacity, pm_MPortsPrice, pm_XPortsPrice, pm_SEPrice; 
+display  p24_seTradeCapacity, pm_MPortsPrice, pm_SEPrice; 
 
 *** EOF ./modules/24_trade/se_trade/presolve.gms

--- a/modules/24_trade/se_trade/presolve.gms
+++ b/modules/24_trade/se_trade/presolve.gms
@@ -24,11 +24,11 @@ display pm_XPortsPrice;
 
 *** Setting Xport price bound to avoid unrealists trading prices.
 *** Lower bound: avoiding epsilon values (caused by using equation marginals for setting prices) or unrealistic small values for secondary energy prices
-*** - H2 and seliqsyn exporting prices -> minimun price = 1$/kg (1$/kg = 0.030769231 $/Kwh = 0.030769231 / (10^12/10^9*8760) T$/TWa = 0.26953846356 T$/TWa)
-*** - seliqbio exporting prices -> minimun price = 5 US$2005/GJ (5/31.71 = 0.157678966 T$/TWa)
-pm_XPortsPrice(t,regi,"seh2") = max(0.26953846356,pm_XPortsPrice(t,regi,"seh2"));
-pm_XPortsPrice(t,regi,"seliqsyn") = max(0.26953846356,pm_XPortsPrice(t,regi,"seliqsyn"));
-pm_XPortsPrice(t,regi,"seliqbio") = max(0.157678966,pm_XPortsPrice(t,regi,"seliqbio"));
+*** - H2 and seliqsyn exporting prices -> minimun price = 1$/kg (1$/kg = 0.0301 $/Kwh = 0.0301 / (10^12/10^9*8760) T$/TWa = 0.264 T$/TWa)
+*** - seliqbio exporting prices -> minimun price = 5 US$2005/GJ (5/31.71 = 0.158 T$/TWa)
+pm_XPortsPrice(t,regi,"seh2") = max(0.264, pm_XPortsPrice(t,regi,"seh2"));
+pm_XPortsPrice(t,regi,"seliqsyn") = max(0.264, pm_XPortsPrice(t,regi,"seliqsyn"));
+pm_XPortsPrice(t,regi,"seliqbio") = max(0.158, pm_XPortsPrice(t,regi,"seliqbio"));
 
 display pm_XPortsPrice;
 

--- a/modules/24_trade/se_trade/sets.gms
+++ b/modules/24_trade/se_trade/sets.gms
@@ -54,4 +54,10 @@ tradeSe("seliqsyn") = YES;
 tradeSe("seliqbio") = YES;
 $endif.import_nzero_bio_EU
 
+$ifthen.high_bio "%cm_import_EU%" == "high_bio"
+*** Defining secondary energy commoditites that are tradeable in this scenario 
+tradeSe(all_enty) = NO;
+tradeSe("seliqbio") = YES;
+$endif.import_nzero_bio_EU
+
 *** EOF ./modules/24_trade/se_trade/sets.gms

--- a/modules/24_trade/se_trade/sets.gms
+++ b/modules/24_trade/se_trade/sets.gms
@@ -46,4 +46,12 @@ tradeSe("seh2") = YES;
 tradeSe("seliqsyn") = YES;
 $endif.import_nzero_EU
 
+$ifthen.import_nzero_bio_EU "%cm_import_EU%" == "nzero_bio"
+*** Defining secondary energy commoditites that are tradeable in this scenario 
+tradeSe(all_enty) = NO;
+tradeSe("seh2") = YES;
+tradeSe("seliqsyn") = YES;
+tradeSe("seliqbio") = YES;
+$endif.import_nzero_bio_EU
+
 *** EOF ./modules/24_trade/se_trade/sets.gms

--- a/modules/24_trade/se_trade/sets.gms
+++ b/modules/24_trade/se_trade/sets.gms
@@ -58,6 +58,6 @@ $ifthen.high_bio "%cm_import_EU%" == "high_bio"
 *** Defining secondary energy commoditites that are tradeable in this scenario 
 tradeSe(all_enty) = NO;
 tradeSe("seliqbio") = YES;
-$endif.import_nzero_bio_EU
+$endif.high_bio
 
 *** EOF ./modules/24_trade/se_trade/sets.gms


### PR DESCRIPTION
## Purpose of this PR

- Add EU net-zero trade scenario for high biomass availability sensitivity.
  - set the switch `cm_import_EU` either to `nzero_bio` to enable the scenario with biofuels, synfuels and H2 trade to the EU, or 
  - set the switch `cm_import_EU` either to `high_bio` to enable the scenario with biofuels trade to the EU.
 
- Bio-liquids trade assumptions: 
```
***   All EU-27 and UKI regions import quantities proportional to their 2050 `FE|Transport|Pass|Aviation + FE|Industry|Chemicals|Liquids` in the reference NPi run.
***   Exporting regions: SSA and LAM (half each)
***   Import quantities: exponential increase from 0.3 EJ by 2030 (EU-27) to 7.44 EJ by 2050 for Germany. Fixed from 2050 onward.
PS: 7.44 EJ =~ 8 EJ of biomass primary energy, assuming pebioil.seliqbio.biodiesel eta
```

- H2 trade assumptions:
```
***   Importing regions: Germany, from 12 TWh by 2030 to 100 TWh/yr by 2050; and EWN, proportional to German values and `FE|Gases` demand by 2050 in the reference NPi run.
***   Exporting regions: UK, Norway and Spain (one-third each)
***   Trajectory: exponential curve in between 2030 and 2050 and fixed from 2050 onward.
```

- E-fuels (e-liquids) trade assumptions:
```
***   All EU-27 and UKI regions import quantities proportional to their 2050 `FE|Transport|Pass|Aviation + FE|Industry|Chemicals|Liquids` in the reference NPi run.
***   Exporting regions: SSA, LAM and MEA (one-third each)
***   Import quantities: exponential increase from 0.6 TWh/yr by 2030 to 50 TWh/yr by 2050 for Germany. Fixed from 2050 onward.
```

## Type of change

- [x] New feature 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Test runs are here: 
WIP: `/p/projects/ecemf/REMIND/2040_scenarios/v06_2024_05_14_rev1_SWG/output`