### PR TITLE
fix non-fossil feedstock emi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **37_industry** remove subsector-specific shares of SE
   origins in FE carriers for performance reasons [[#1659]](https://github.com/remindmodel/remind/pull/1659)
 - **37_industry** make process-based steel production model the default over the ces-based model [[#1663]](https://github.com/remindmodel/remind/pull/1663)
+- **37_industry** fixed incineration of plastic and non-plastic waste causing
+  non-zero emissions for biomass and synfuels
+  [[#1682]](https://github.com/remindmodel/remind/pull/1682)
 - **core** another change of preference parameters and associated computation of interest rates/mark ups [[#1663]](https://github.com/remindmodel/remind/pull/1663)	
 - **scripts** adjust function calls after moving functionality from `remind2` [[#578]]](https://github.com/pik-piam/remind2/pull/578) to `piamPlotComparison` and `piamutils` [[#1661](https://github.com/remindmodel/remind/pull/1661)
 - **scripts** enhance output script `reportCEScalib` to include additional plot formats [[#1671](https://github.com/remindmodel/remind/pull/1671)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -60,7 +60,7 @@ Imports:
     raster,
     readr,
     readxl,
-    remind2 (>= 1.139.3),
+    remind2 (>= 1.142),
     renv,
     reshape2,
     reticulate,

--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -1470,16 +1470,9 @@ $offdelim
 /
 ;
 
-pm_emifacNonEnergy(ttot,regi,"segafos","fegas","indst","co2") = f_nechem_emissionFactors(ttot,regi,"gases") / s_zj_2_twa;
+pm_emifacNonEnergy(ttot,regi,"sesofos", "fesos","indst","co2") = f_nechem_emissionFactors(ttot,regi,"solids")  / s_zj_2_twa;
 pm_emifacNonEnergy(ttot,regi,"seliqfos","fehos","indst","co2") = f_nechem_emissionFactors(ttot,regi,"liquids") / s_zj_2_twa;
-pm_emifacNonEnergy(ttot,regi,"sesofos","fesos","indst","co2") = f_nechem_emissionFactors(ttot,regi,"solids") / s_zj_2_twa;
-
-pm_emifacNonEnergy(ttot,regi,"segabio","fegas","indst","co2") = f_nechem_emissionFactors(ttot,regi,"gases") / s_zj_2_twa;
-pm_emifacNonEnergy(ttot,regi,"seliqbio","fehos","indst","co2") = f_nechem_emissionFactors(ttot,regi,"liquids") / s_zj_2_twa;
-pm_emifacNonEnergy(ttot,regi,"sesobio","fesos","indst","co2") = f_nechem_emissionFactors(ttot,regi,"solids") / s_zj_2_twa;
-
-pm_emifacNonEnergy(ttot,regi,"segasyn","fegas","indst","co2") = f_nechem_emissionFactors(ttot,regi,"gases") / s_zj_2_twa;
-pm_emifacNonEnergy(ttot,regi,"seliqsyn","fehos","indst","co2") = f_nechem_emissionFactors(ttot,regi,"liquids") / s_zj_2_twa;
+pm_emifacNonEnergy(ttot,regi,"segafos", "fegas","indst","co2") = f_nechem_emissionFactors(ttot,regi,"gases")   / s_zj_2_twa;
 
 ***------ Read in projections for incineration rates of plastic waste---
 *** "incineration rates [fraction]"

--- a/core/equations.gms
+++ b/core/equations.gms
@@ -581,20 +581,20 @@ q_emiTeMkt(t,regi,emiTe(enty),emiMkt) ..
   - sum(emiInd37_fuel,
       vm_emiIndCCS(t,regi,emiInd37_fuel)
     )$( sameas(enty,"co2") AND sameas(emiMkt,"ETS") )
-    !! substract carbon from biogenic or synthetic origin contained in
-    !! plastics that don't get incinerated ("plastic removals")
+    !! substract carbon from non-fossil origin contained in plastics that don't
+    !! get incinerated ("plastic removals")
   - sum((entyFE2sector2emiMkt_NonEn(entyFe,"indst",emiMkt),
          se2fe(entySe,entyFe,te))$( entySeBio(entySe) OR entySeSyn(entySe) ),
       vm_nonIncineratedPlastics(t,regi,entySe,entyFe,emiMkt)
     )$( sameas(enty,"co2") )
-    !! add emissions from plastics incineration. CHECK FOR DOUBLE-COUNTING RISK
+    !! add fossil emissions from plastics incineration. 
   + sum((entyFE2sector2emiMkt_NonEn(entyFe,"indst",emiMkt),
-         se2fe(entySe,entyFe,te)),
+         se2fe(entySe,entyFe,te))$( entySeFos(entySe) ),
       vm_incinerationEmi(t,regi,entySe,entyFe,emiMkt)
     )$( sameas(enty,"co2") )
-    !! add emissions from chemical feedstock with unknown fate
+    !! add fossil emissions from chemical feedstock with unknown fate
   + sum((entyFE2sector2emiMkt_NonEn(entyFe,"indst",emiMkt),
-         se2fe(entySe,entyFe,te)),
+         se2fe(entySe,entyFe,te))$( entySeFos(entySe) ),
       vm_feedstockEmiUnknownFate(t,regi,entySe,entyFe,emiMkt)
     )$( sameas(enty,"co2") )
     !! Valve from cco2 capture step, to mangage if capture capacity and CCU/CCS
@@ -631,9 +631,6 @@ q_emiAllMkt(t,regi,emi,emiMkt) ..
       vm_demFENonEnergySector(t,regi,entySe,entyFe,sector,emiMkt)
     * pm_emifacNonEnergy(t,regi,entySe,entyFe,sector,emi)
     )
-    !!emissions from plastics incineration
-
-    !!emissions from chemical feedstock with unknown fate (assumed to go into the atmosphere)
 ;
 
 

--- a/core/equations.gms
+++ b/core/equations.gms
@@ -519,10 +519,10 @@ q_emiTeDetailMkt(t,regi,enty,enty2,te,enty3,emiMkt)$(
                         OR (pe2se(enty,enty2,te) AND sameas(enty3,"cco2")) ) ..
   vm_emiTeDetailMkt(t,regi,enty,enty2,te,enty3,emiMkt)
   =e=
-    sum(emi2te(enty,enty2,te,enty3),
-      ( sum(pe2se(enty,enty2,te),
-          pm_emifac(t,regi,enty,enty2,te,enty3)
-        * vm_demPe(t,regi,enty,enty2,te)
+  sum(emi2te(enty,enty2,te,enty3),
+    ( sum(pe2se(enty,enty2,te),
+        pm_emifac(t,regi,enty,enty2,te,enty3)
+      * vm_demPe(t,regi,enty,enty2,te)
       )
     + sum((ccs2Leak(enty,enty2,te,enty3),teCCS2rlf(te,rlf)),
         pm_emifac(t,regi,enty,enty2,te,enty3)
@@ -538,9 +538,9 @@ q_emiTeDetailMkt(t,regi,enty,enty2,te,enty3,emiMkt)$(
         !! not create energy-related emissions
       - sum(entyFE2sector2emiMkt_NonEn(enty2,sector,emiMkt),
           vm_demFENonEnergySector(t,regi,enty,enty2,sector,emiMkt))
-        )
       )
     )
+  )
 ;
 
 ***--------------------------------------------------
@@ -576,29 +576,26 @@ q_emiTeMkt(t,regi,emiTe(enty),emiMkt) ..
       vm_emiTeDetailMkt(t,regi,enty2,enty3,te,enty,emiMkt)
     )
     !! energy emissions fuel extraction
-  + v_emiEnFuelEx(t,regi,enty)$(sameas(emiMkt,"ETS"))
+  + v_emiEnFuelEx(t,regi,enty)$( sameas(emiMkt,"ETS") )
     !! Industry CCS emissions
-	- sum(emiInd37_fuel,
-		  vm_emiIndCCS(t,regi,emiInd37_fuel)
-		)$( sameas(enty,"co2") AND sameas(emiMkt,"ETS"))
+  - sum(emiInd37_fuel,
+      vm_emiIndCCS(t,regi,emiInd37_fuel)
+    )$( sameas(enty,"co2") AND sameas(emiMkt,"ETS") )
     !! substract carbon from biogenic or synthetic origin contained in
     !! plastics that don't get incinerated ("plastic removals")
-  - sum(entyFE2sector2emiMkt_NonEn(entyFe,"indst",emiMkt),
-      sum(se2fe(entySe,entyFe,te)$( entySeBio(entySe) OR entySeSyn(entySe) ),
-        vm_nonIncineratedPlastics(t,regi,entySe,entyFe,emiMkt)
-      )
+  - sum((entyFE2sector2emiMkt_NonEn(entyFe,"indst",emiMkt),
+         se2fe(entySe,entyFe,te))$( entySeBio(entySe) OR entySeSyn(entySe) ),
+      vm_nonIncineratedPlastics(t,regi,entySe,entyFe,emiMkt)
     )$( sameas(enty,"co2") )
     !! add emissions from plastics incineration. CHECK FOR DOUBLE-COUNTING RISK
-  + sum(entyFE2sector2emiMkt_NonEn(entyFe,"indst",emiMkt),
-      sum(se2fe(entySe,entyFe,te),
-        vm_incinerationEmi(t,regi,entySe,entyFe,emiMkt)
-      )
+  + sum((entyFE2sector2emiMkt_NonEn(entyFe,"indst",emiMkt),
+         se2fe(entySe,entyFe,te)),
+      vm_incinerationEmi(t,regi,entySe,entyFe,emiMkt)
     )$( sameas(enty,"co2") )
     !! add emissions from chemical feedstock with unknown fate
-  + sum(entyFE2sector2emiMkt_NonEn(entyFe,"indst",emiMkt),
-      sum(se2fe(entySe,entyFe,te),
-        vm_feedstockEmiUnknownFate(t,regi,entySe,entyFe,emiMkt)
-      )
+  + sum((entyFE2sector2emiMkt_NonEn(entyFe,"indst",emiMkt),
+         se2fe(entySe,entyFe,te)),
+      vm_feedstockEmiUnknownFate(t,regi,entySe,entyFe,emiMkt)
     )$( sameas(enty,"co2") )
     !! Valve from cco2 capture step, to mangage if capture capacity and CCU/CCS
     !! capacity don't have the same lifetime
@@ -606,8 +603,8 @@ q_emiTeMkt(t,regi,emiTe(enty),emiMkt) ..
     !! CO2 from short-term CCU (short term CCU co2 is emitted again in a time
     !! period shorter than 5 years)
   + sum(teCCU2rlf(te2,rlf),
-      vm_co2CCUshort(t,regi,"cco2","ccuco2short",te2,rlf)$( sameas(enty,"co2") )
-    )$(sameas(emiMkt,"ETS"))
+      vm_co2CCUshort(t,regi,"cco2","ccuco2short",te2,rlf)
+    )$( sameas(enty,"co2") AND sameas(emiMkt,"ETS") )
 ;
 
 ***--------------------------------------------------

--- a/core/sets.gms
+++ b/core/sets.gms
@@ -1738,39 +1738,39 @@ peReComp(all_enty) "Renewable PE used by several technologies, thus the competit
         pesol        "PE solar"
 /
 
-entySe(all_enty)       "secondary energy types"
+entySe(all_enty)   "secondary energy types"
 /
-        seliqbio     "secondary energy liquids from biomass"
-        seliqfos     "secondary energy liquids from fossil primary energy"
-        seliqsyn     "secondary energy synthetic liquids from H2"
-        sesobio      "secondary energy solids from biomass"
-        sesofos      "secondary energy solids from fossil primary energy"
-        seel         "SE electricity"
-        seh2         "SE hydrogen"
-        segabio      "secondary energy gas from biomass"
-        segafos      "secondary energy gas from fossil primary energy"
-        segasyn      "secondary energy synthetic gas from H2"
-        sehe         "SE district heating nd heat pumps"
+  sesofos    "secondary energy solids from fossil primary energy"
+  sesobio    "secondary energy solids from biomass"
+  seliqfos   "secondary energy liquids from fossil primary energy"
+  seliqbio   "secondary energy liquids from biomass"
+  seliqsyn   "secondary energy synthetic liquids from H2"
+  segafos    "secondary energy gas from fossil primary energy"
+  segabio    "secondary energy gas from biomass"
+  segasyn    "secondary energy synthetic gas from H2"
+  seh2       "SE hydrogen"
+  sehe       "SE district heating nd heat pumps"
+  seel       "SE electricity"
 /
 
-entySeBio(all_enty)       "biomass secondary energy types"
+entySeFos(all_enty)   "secondary energy types from fossil primary energy"
 /
-        seliqbio     "secondary energy liquids from biomass"
-        sesobio      "secondary energy solids from biomass"
-        segabio      "secondary energy gas from biomass"
+  sesofos    "secondary energy solids from fossil primary energy"
+  seliqfos   "secondary energy liquids from fossil primary energy"
+  segafos    "secondary energy gas from fossil primary energy"
+/
+
+entySeBio(all_enty)   "biomass secondary energy types"
+/
+  sesobio    "secondary energy solids from biomass"
+  seliqbio   "secondary energy liquids from biomass"
+  segabio    "secondary energy gas from biomass"
 /
 
 entySeSyn(all_enty)   "synfuel secondary energy types"
 /
   seliqsyn   "secondary energy liquids from H2"
   segasyn    "secondary energy gas from H2"
-/
-
-entySeFos(all_enty) "secondary energy types from fossil primary energy"
-/
-        seliqfos     "secondary energy liquids from fossil primary energy"
-        sesofos      "secondary energy solids from fossil primary energy"
-        segafos      "secondary energy gas from fossil primary energy"
 /
 
 entyFe(all_enty)      "final energy types."


### PR DESCRIPTION
Fixes non-fossil (biomass and synfuels) emissions from plastic waste incineration and non-plastics feedstock use having non-zero emissions in `q_emiTeMkt`, when they should be carbon-neutral.

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

Test runs
```
29738652  0:15  /p/tmp/pehl/Remind/output/foo2_2024-05-22_11.58.24
29738651  0:31  /p/tmp/pehl/Remind/output/foo1_2024-05-22_11.58.07
29738650  0:48  /p/tmp/pehl/Remind/output/SSP2EU-PkBudg500_2024-05-22_11.57.46
```