### PR TITLE
Reduce CCS 2030 upper bound to only include 40% of announced projects as default. Changeable with switch.

### DIFF
--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -393,7 +393,7 @@ $endif
 *** -------------------------------------------------------------------------------------------------------------
 *AM* No geological storage before 2025 (omitting approx. 40 MtCCS/yr globally in 2020 for Enhanced Oil Recovery)
 *AM* Lower limit for 2025 and 2030 is capacities of all projects that are operational and under construction from project data base
-*AM* Upper limit for 2025 and 2030 additionally includes 40% (default, or changed by c_SharenonFIDCCS2030) announced/planned projects from project data base
+*AM* Upper limit for 2025 and 2030 additionally includes 40% (default, or changed by c_sharemaxCCScap2030) announced/planned projects from project data base
 *AM* In nash-mode regions cannot easily share ressources, therefore CCS potentials are redistributed in Europe: 
 *AM* Potential of EU27 regions is pooled and redistributed according to GDP (Only upper limit for 2030)
 *AM* Norway and UK announced to store CO2 for EU27 countries. So 50% of Norway and UK potential in 2030 is attributed to EU27-Pool
@@ -402,7 +402,7 @@ $endif
 
 if ( c_ccsinjecratescen gt 0,
   vm_co2CCS.lo(t,regi,"cco2","ico2","ccsinje","1")$(t.val le 2030) = pm_boundCapCCS(t,regi,"low")$(t.val le 2030) / (1000*11/3);
-  vm_co2CCS.up(t,regi,"cco2","ico2","ccsinje","1")$(t.val le 2030) = (pm_boundCapCCS(t,regi,"low")$(t.val le 2030) + (pm_boundCapCCS(t,regi,"up")$(t.val le 2030) - pm_boundCapCCS(t,regi,"low")$(t.val le 2030)) * c_SharenonFIDCCS2030) / (1000*11/3);
+  vm_co2CCS.up(t,regi,"cco2","ico2","ccsinje","1")$(t.val le 2030) = (pm_boundCapCCS(t,regi,"low")$(t.val le 2030) + (pm_boundCapCCS(t,regi,"up")$(t.val le 2030) - pm_boundCapCCS(t,regi,"low")$(t.val le 2030)) * c_sharemaxCCScap2030) / (1000*11/3);
 );
 
 loop(regi,

--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -401,8 +401,9 @@ $endif
 *** -------------------------------------------------------------------------------------------------------------
 
 if ( c_ccsinjecratescen gt 0,
-  vm_co2CCS.lo(t,regi,"cco2","ico2","ccsinje","1")$(t.val le 2030) = pm_boundCapCCS(t,regi,"low")$(t.val le 2030) / (1000*11/3);
-  vm_co2CCS.up(t,regi,"cco2","ico2","ccsinje","1")$(t.val le 2030) = (pm_boundCapCCS(t,regi,"low")$(t.val le 2030) + (pm_boundCapCCS(t,regi,"up")$(t.val le 2030) - pm_boundCapCCS(t,regi,"low")$(t.val le 2030)) * c_sharemaxCCScap2030) / (1000*11/3);
+  vm_co2CCS.fx(t,regi,"cco2","ico2","ccsinje","1")$(t.val lt 2025) = 0;
+  vm_co2CCS.lo(t,regi,"cco2","ico2","ccsinje","1")$(t.val le 2030) = pm_boundCapCCS(t,regi,"low")$(t.val le 2030) * s_MtCO2_2_GtC;
+  vm_co2CCS.up(t,regi,"cco2","ico2","ccsinje","1")$(t.val le 2030) = (pm_boundCapCCS(t,regi,"low")$(t.val le 2030) + (pm_boundCapCCS(t,regi,"up")$(t.val le 2030) - pm_boundCapCCS(t,regi,"low")$(t.val le 2030)) * c_fracRealfromAnnouncedCCScap2030) / (1000*11/3);
 );
 
 loop(regi,

--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -393,7 +393,7 @@ $endif
 *** -------------------------------------------------------------------------------------------------------------
 *AM* No geological storage before 2025 (omitting approx. 40 MtCCS/yr globally in 2020 for Enhanced Oil Recovery)
 *AM* Lower limit for 2025 and 2030 is capacities of all projects that are operational and under construction from project data base
-*AM* Upper limit for 2025 and 2030 additionally includes announced/planned projects from project data base
+*AM* Upper limit for 2025 and 2030 additionally includes 40% (default, or changed by c_SharenonFIDCCS2030) announced/planned projects from project data base
 *AM* In nash-mode regions cannot easily share ressources, therefore CCS potentials are redistributed in Europe: 
 *AM* Potential of EU27 regions is pooled and redistributed according to GDP (Only upper limit for 2030)
 *AM* Norway and UK announced to store CO2 for EU27 countries. So 50% of Norway and UK potential in 2030 is attributed to EU27-Pool
@@ -401,11 +401,8 @@ $endif
 *** -------------------------------------------------------------------------------------------------------------
 
 if ( c_ccsinjecratescen gt 0,
-  vm_co2CCS.up(ttot,regi,"cco2","ico2","ccsinje","1")$(ttot.val ge 2005 AND ttot.val lt 2025) = 0;
-	vm_co2CCS.up("2025",regi,"cco2","ico2","ccsinje","1") = pm_boundCapCCS("2025",regi,"up")/(1000*11/3);
-	vm_co2CCS.up("2030",regi,"cco2","ico2","ccsinje","1") = pm_boundCapCCS("2030",regi,"up")/(1000*11/3);
-	vm_co2CCS.lo("2025",regi,"cco2","ico2","ccsinje","1") = pm_boundCapCCS("2025",regi,"low")/(1000*11/3);
-	vm_co2CCS.lo("2030",regi,"cco2","ico2","ccsinje","1") = pm_boundCapCCS("2030",regi,"low")/(1000*11/3);
+  vm_co2CCS.lo(t,regi,"cco2","ico2","ccsinje","1")$(t.val le 2030) = pm_boundCapCCS(t,regi,"low")$(t.val le 2030) / (1000*11/3);
+  vm_co2CCS.up(t,regi,"cco2","ico2","ccsinje","1")$(t.val le 2030) = (pm_boundCapCCS(t,regi,"low")$(t.val le 2030) + (pm_boundCapCCS(t,regi,"up")$(t.val le 2030) - pm_boundCapCCS(t,regi,"low")$(t.val le 2030)) * c_SharenonFIDCCS2030) / (1000*11/3);
 );
 
 loop(regi,

--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -391,8 +391,7 @@ $endif
 
 
 *** -------------------------------------------------------------------------------------------------------------
-*AM* No geological storage before 2025 (omitting approx. 40 MtCCS/yr globally in 2020 for Enhanced Oil Recovery)
-*AM* Lower limit for 2025 and 2030 is capacities of all projects that are operational and under construction from project data base
+*AM* Lower limit for 2020-2030 is capacities of all projects that are operational (2020-2030) and under construction (2025-2030) from project data base
 *AM* Upper limit for 2025 and 2030 additionally includes 40% (default, or changed by c_fracRealfromAnnouncedCCScap2030) announced/planned projects from project data base
 *AM* In nash-mode regions cannot easily share ressources, therefore CCS potentials are redistributed in Europe: 
 *AM* Potential of EU27 regions is pooled and redistributed according to GDP (Only upper limit for 2030)
@@ -401,7 +400,6 @@ $endif
 *** -------------------------------------------------------------------------------------------------------------
 
 if ( c_ccsinjecratescen gt 0,
-  vm_co2CCS.fx(t,regi,"cco2","ico2","ccsinje","1")$(t.val lt 2025) = 0;
   vm_co2CCS.lo(t,regi,"cco2","ico2","ccsinje","1")$(t.val le 2030) = pm_boundCapCCS(t,regi,"low")$(t.val le 2030) * s_MtCO2_2_GtC;
   vm_co2CCS.up(t,regi,"cco2","ico2","ccsinje","1")$(t.val le 2030) = (pm_boundCapCCS(t,regi,"low")$(t.val le 2030) + (pm_boundCapCCS(t,regi,"up")$(t.val le 2030) - pm_boundCapCCS(t,regi,"low")$(t.val le 2030)) * c_fracRealfromAnnouncedCCScap2030) * s_MtCO2_2_GtC;
 );

--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -393,7 +393,7 @@ $endif
 *** -------------------------------------------------------------------------------------------------------------
 *AM* No geological storage before 2025 (omitting approx. 40 MtCCS/yr globally in 2020 for Enhanced Oil Recovery)
 *AM* Lower limit for 2025 and 2030 is capacities of all projects that are operational and under construction from project data base
-*AM* Upper limit for 2025 and 2030 additionally includes 40% (default, or changed by c_sharemaxCCScap2030) announced/planned projects from project data base
+*AM* Upper limit for 2025 and 2030 additionally includes 40% (default, or changed by c_fracRealfromAnnouncedCCScap2030) announced/planned projects from project data base
 *AM* In nash-mode regions cannot easily share ressources, therefore CCS potentials are redistributed in Europe: 
 *AM* Potential of EU27 regions is pooled and redistributed according to GDP (Only upper limit for 2030)
 *AM* Norway and UK announced to store CO2 for EU27 countries. So 50% of Norway and UK potential in 2030 is attributed to EU27-Pool
@@ -403,7 +403,7 @@ $endif
 if ( c_ccsinjecratescen gt 0,
   vm_co2CCS.fx(t,regi,"cco2","ico2","ccsinje","1")$(t.val lt 2025) = 0;
   vm_co2CCS.lo(t,regi,"cco2","ico2","ccsinje","1")$(t.val le 2030) = pm_boundCapCCS(t,regi,"low")$(t.val le 2030) * s_MtCO2_2_GtC;
-  vm_co2CCS.up(t,regi,"cco2","ico2","ccsinje","1")$(t.val le 2030) = (pm_boundCapCCS(t,regi,"low")$(t.val le 2030) + (pm_boundCapCCS(t,regi,"up")$(t.val le 2030) - pm_boundCapCCS(t,regi,"low")$(t.val le 2030)) * c_fracRealfromAnnouncedCCScap2030) / (1000*11/3);
+  vm_co2CCS.up(t,regi,"cco2","ico2","ccsinje","1")$(t.val le 2030) = (pm_boundCapCCS(t,regi,"low")$(t.val le 2030) + (pm_boundCapCCS(t,regi,"up")$(t.val le 2030) - pm_boundCapCCS(t,regi,"low")$(t.val le 2030)) * c_fracRealfromAnnouncedCCScap2030) * s_MtCO2_2_GtC;
 );
 
 loop(regi,

--- a/core/declarations.gms
+++ b/core/declarations.gms
@@ -587,6 +587,7 @@ sm_dmac                                               "step in MAC functions [US
 sm_macChange                                           "maximum yearly increase of relative abatement in percentage points of maximum abatement. [0..1]"      /0.05/
 sm_tgn_2_pgc                                           "conversion factor 100-yr GWP from TgN to PgCeq"
 sm_tgch4_2_pgc                                         "conversion factor 100-yr GWP from TgCH4 to PgCeq"
+s_MtCO2_2_GtC                                         "conversion factor from MtCO2 to native REMIND emission unit GtC" /2.727e-04/
 
 s_MtCH4_2_TWa                                        "Energy content of methane. MtCH4 --> TWa: 1 MtCH4 = 1.23 * 10^6 toe * 42 GJ/toe * 10^-9 EJ/GJ * 1 TWa/31.536 EJ = 0.001638 TWa (BP statistical review)"  /0.001638/
 

--- a/main.gms
+++ b/main.gms
@@ -1091,6 +1091,13 @@ parameter
 *' * (0) none
 *' * (1) no fossil carbon and capture in Germany
 *'
+
+parameter
+  c_SharenonFIDCCS2030         "switch to adjust the share of announced CCS projects from database that will be realised by 2030"
+;
+  c_SharenonFIDCCS2030 = 0.4; !! def = 0.4
+*' This switch changes the assumption about the share of realised projects from announced/planned in 2030 from the IEA CCS data base
+
 parameter
   cm_startIter_EDGET          "starting iteration of EDGE-T"
 ;

--- a/main.gms
+++ b/main.gms
@@ -1093,9 +1093,9 @@ parameter
 *'
 
 parameter
-  c_sharemaxCCScap2030         "switch to adjust the share of realised CCS capacities from total announced/planned projects from database in 2030"
+  c_fracRealfromAnnouncedCCScap2030         "switch to adjust the share of realised CCS capacities from total announced/planned projects from database in 2030"
 ;
-  c_sharemaxCCScap2030 = 0.4; !! def = 0.4
+  c_fracRealfromAnnouncedCCScap2030 = 0.4; !! def = 0.4
 *' This switch changes the assumption about the share of timely realised capacities from sum of announced/planned in 2030 from the IEA CCS data base
 *' Default assumption is that only 40% of announced or planned capacities will be realised, either due to discontinuation or delay
 

--- a/main.gms
+++ b/main.gms
@@ -1093,10 +1093,11 @@ parameter
 *'
 
 parameter
-  c_SharenonFIDCCS2030         "switch to adjust the share of announced CCS projects from database that will be realised by 2030"
+  c_sharemaxCCScap2030         "switch to adjust the share of realised CCS capacities from total announced/planned projects from database in 2030"
 ;
-  c_SharenonFIDCCS2030 = 0.4; !! def = 0.4
-*' This switch changes the assumption about the share of realised projects from announced/planned in 2030 from the IEA CCS data base
+  c_sharemaxCCScap2030 = 0.4; !! def = 0.4
+*' This switch changes the assumption about the share of timely realised capacities from sum of announced/planned in 2030 from the IEA CCS data base
+*' Default assumption is that only 40% of announced or planned capacities will be realised, either due to discontinuation or delay
 
 parameter
   cm_startIter_EDGET          "starting iteration of EDGE-T"

--- a/modules/47_regipol/regiCarbonPrice/bounds.gms
+++ b/modules/47_regipol/regiCarbonPrice/bounds.gms
@@ -49,10 +49,6 @@ vm_capEarlyReti.up('2025',regi,'pc') = 0.65;
 *' 5 GW * 8760 (hours per year) * 0.5 (capacity factor) / 0.4 (conversion efficiency) * 1e-3 * 0.35 MtCO2/TWh (emissions factor coal) ~ 20 Mt CO2/yr.
 vm_capTotal.lo("2030",regi,"pecoal","seel")$(sameas(regi,"DEU"))=5/1000;
 
-
-*' This limits CO2 underground injection up to 2030 in line with recent developments as of 2023. 
-vm_co2CCS.up(t,regi,"cco2","ico2",te,rlf)$((t.val le 2030) AND (sameas(regi,"DEU"))) = 1e-3;
-
 *' ###### Bounds for Germany-specific Policies (activated by switches)
 
 *' If c_noPeFosCCDeu = 1 chosen, fossil CCS for energy system technologies (pe2se) is forbidden.   


### PR DESCRIPTION
## Purpose of this PR
We want to realistically constrain near-term CCS deployment in line with IEA-data on projects that are operational or under construction as well as announced projects.
From all announced projects we **now** assume by default that only 40% will be realised by 2030 (previously the upper limit on CCS was 100% of all announced projects).
This assumption can be altered with the new switch ~~c_SharenonFIDCCS2030~~ `c_fracRealfromAnnouncedCCScap2030`

Furthermore, the very stringent CCS limit for DEU in 2030 was removed, as it is no longer needed. 
The reason is that CCS is now prominently discussed in German politics and the law that previously forbid it will be changed.

**Edits:** 

- [x] I renamed the switch such that it is correct (FID was not a criterion before, just realized vs. announced projects) and such that it can be understood intuitively.
- [x] As suggested in the review, I added a conversion factor `s_MtCO2_2_GtC`

## Type of change

- [x] Minor change (default scenarios show only small differences)



## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 
`/p/projects/ecemf/REMIND/2040_scenarios/_sharedRuns/v06_2024_05_14_rev1_x_CCStest_Anne/compScen-ccs_near-term-2024-05-24_10.13.14-EU27-short.pdf`
