### PR TITLE
try to download input files once per gamscompile if missing

### DIFF
--- a/start.R
+++ b/start.R
@@ -243,6 +243,10 @@ if (any(c("--reprepare", "--restart") %in% flags)) {
     slurmConfig <- "direct"
     message("\nTrying to compile ", nrow(scenarios), " selected runs...")
     lockID <- gms::model_lock()
+    if (length(missingInputData()) > 0) {
+      # try to fix missing input data, but only once at the beginning, not for every scenario
+      updateInputData(readDefaultConfig("."), remindPath = ".", gamsCompile = FALSE)
+    }
   }
   if (! exists("slurmConfig") & (any(c("--debug", "--quick", "--testOneRegi") %in% flags)
       | ! "slurmConfig" %in% names(scenarios) || any(is.na(scenarios$slurmConfig)))) {

--- a/tests/testthat/test_04-gamscompile.R
+++ b/tests/testthat/test_04-gamscompile.R
@@ -29,7 +29,7 @@ test_that("start.R --gamscompile works on all configs and scenarios", {
     csvfiles <- Sys.glob(c(file.path("../../config/scenario_config*.csv"),
                            file.path("../../config", "*", "scenario_config*.csv")))
   }
-  csvfiles <- normalizePath(grep("^scenario_config_coupled.*", csvfiles, invert = TRUE, value = TRUE))
+  csvfiles <- normalizePath(grep("scenario_config_coupled.*", csvfiles, invert = TRUE, value = TRUE))
   expect_true(length(csvfiles) > 0)
   testthat::with_mocked_bindings(
     for (csvfile in csvfiles) {


### PR DESCRIPTION
## Purpose of this PR

- try to download input files once per gamscompile if missing to avoid that `./start.R --gamscompile` fails with some config files because another run was interrupted on the `standby` partition while distributing input files.
- fix the exclusion of coupled config files. The filenames still have the foldername in front of them, so with `^` it doesn't match anymore.

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
