### PR TITLE
adjust CO2 tax phase-in for diffCurvPhaseIn2Lin

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -106,10 +106,17 @@
     {
       "name": "Klein, David",
       "affiliation": "Potsdam Institute for Climate Impact Research"
+      "orcid": "0009-0001-7917-8041"
     },
     {
       "name": "Koch, Johannes",
       "affiliation": "Potsdam Institute for Climate Impact Research"
+      "orcid": "0000-0003-2920-8086"
+    },
+    {
+      "name": "Köhler-Schindler, Laurin",
+      "affiliation": "Potsdam Institute for Climate Impact Research"
+      "orcid": "0000-0003-4268-3084"
     },
     {
       "name": "Körner, Alexander"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -116,6 +116,12 @@ authors:
 
 - family-names: "Koch"
   given-names:  "Johannes"
+  orcid: https://orcid.org/0000-0003-2920-8086
+  affiliation: "Potsdam Institute for Climate Impact Research"
+
+- family-names: "Köhler-Schindler"
+  given-names:  "Laurin"
+  orcid: https://orcid.org/0000-0003-4268-3084
   affiliation: "Potsdam Institute for Climate Impact Research"
 
 - family-names: "Körner"

--- a/modules/45_carbonprice/diffCurvPhaseIn2Lin/datainput.gms
+++ b/modules/45_carbonprice/diffCurvPhaseIn2Lin/datainput.gms
@@ -6,7 +6,7 @@
 *** |  Contact: remind@pik-potsdam.de
 *** SOF ./modules/45_carbonprice/diffCurvPhaseIn2Lin/datainput.gms
 ***------------------------------------------------------------------------------------------------------------------------
-*** *BS* 20190930 linear convergence with starting points differentiated by GDP/capita, global price from 2040
+*** linear convergence with starting points differentiated by GDP/capita, global price from 2050
 ***-----------------------------------------------------------------------------------------------------------------------
 
 
@@ -31,31 +31,31 @@ if(cm_co2_tax_2020 lt 0,
   abort "please choose a valid cm_co2_tax_2020"
 elseif cm_co2_tax_2020 ge 0,
 *** convert tax value from $/t CO2eq to T$/GtC
-  p45_CO2priceTrajDeveloped("2040")= 3 * cm_co2_tax_2020 * sm_DptCO2_2_TDpGtC;  !! shifted to 2040 to make sure that even in delay scenarios the fixpoint of the linear price path is inside the "t" range, otherwise the CO2 prices from reference run may be overwritten
+  p45_CO2priceTrajDeveloped("2040") = 3 * cm_co2_tax_2020 * sm_DptCO2_2_TDpGtC;
+*** shifted to 2040 to make sure that even in delay scenarios the fixpoint of the linear price path is inside the "t" range, otherwise the CO2 prices from reference run may be overwritten
 *** The factor 3 comes from shifting the 2020 value 20 years into the future at linear increase of 10% of 2020 value per year.
 );
 
 
-
-p45_CO2priceTrajDeveloped(ttot)$((ttot.val gt 2005) AND (ttot.val ge cm_startyear)) = p45_CO2priceTrajDeveloped("2040")*( 1 + 0.1/3 * (ttot.val-2040)); !! no CO2 price in 2005 and only change CO2 prices after ; 
-*** annual increase by (10/3)% of the 2040 value is the same as a 10% increase of the 2020 value is the same as a linear increase from 0 in 2010 to the 2020/2040 value
-
+*** Until 2020, historical values are used anyway. 25$/t is the highest 2020 tax value (EUR)
+*** Use that as a starting point and linearly grow until the peak budget year
+p45_CO2priceTrajDeveloped(t)$(t.val gt 2005) = max(0, 25 * sm_DptCO2_2_TDpGtC + (p45_CO2priceTrajDeveloped("2040") - 25 * sm_DptCO2_2_TDpGtC)*( 1 + (t.val-2040) / 20));
 
 *** Then create regional phase-in:
-loop(ttot$((ttot.val ge cm_startyear) AND (ttot.val le cm_CO2priceRegConvEndYr) ),
-  p45_regCO2priceFactor(ttot,regi) = 
+loop(t$(t.val le cm_CO2priceRegConvEndYr),
+  p45_regCO2priceFactor(t,regi) =
    min(1,
-       max(0, 
-	        p45_phasein_2025ratio(regi) + (1 - p45_phasein_2025ratio(regi)) 
-			                               * Power( 
-										       ( (ttot.val - 2025) + (cm_CO2priceRegConvEndYr - 2025) * 0.1 ) 
+       max(0,
+	        p45_phasein_2025ratio(regi) + (1 - p45_phasein_2025ratio(regi))
+			                               * Power(
+										       ( (t.val - 2025) + (cm_CO2priceRegConvEndYr - 2025) * 0.1 )
                                                / ( (cm_CO2priceRegConvEndYr - 2025) * 1.1 )
 											   , 2
 											 ) !! use Power instead of ** to allow ttot be smaller than 2025, and thus the base to be negative
-       )											 
+       )
    );
 );
-p45_regCO2priceFactor(ttot,regi)$(ttot.val ge cm_CO2priceRegConvEndYr) = 1;
+p45_regCO2priceFactor(t,regi)$(t.val ge cm_CO2priceRegConvEndYr) = 1;
 
 
 *** transition to global price - starting point depends on GDP/cap

--- a/modules/45_carbonprice/diffCurvPhaseIn2Lin/not_used.txt
+++ b/modules/45_carbonprice/diffCurvPhaseIn2Lin/not_used.txt
@@ -23,3 +23,4 @@ pm_consPC,input,questionnaire
 pm_prtp,input,questionnaire
 vm_demFeSector,input,questionnaire
 pm_emifac,input,questionnaire
+cm_startyear,parameter,not needed

--- a/scripts/output/single/MAGICC7_AR6.R
+++ b/scripts/output/single/MAGICC7_AR6.R
@@ -152,7 +152,7 @@ runHarmoniseAndInfillCmd <- paste(
 
 runClimateEmulatorCmd <- paste(
   "python", file.path(scriptsFolder, "run_clim.py"),
-  normalizePath(file.path(climateAssessmentFolder, paste0(baseFileName, "_harmonized_infilled.csv"))),
+  normalizePath(file.path(climateAssessmentFolder, paste0(baseFileName, "_harmonized_infilled.csv")), mustWork = FALSE),
   climateAssessmentFolder,
   "--num-cfgs", nparsets,
   "--scenario-batch-size", 1,


### PR DESCRIPTION
## Purpose of this PR

- see https://github.com/remindmodel/development_issues/issues/295

## Type of change

- [x] Minor change (default scenarios show only small differences)

## Checklist:

- [ ] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [ ] I explained my changes within the PR, particularly in hard-to-understand areas
- [ ] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
