### PR TITLE
magpie4 >= 2.3.10, adjust export to MAgPIE 4.8, lock while running gamscompile test

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,7 @@ Imports:
     luscale,
     lusweave,
     magclass,
-    magpie4,
+    magpie4 (>= 2.3.10),
     magpiesets,
     mip (>= 0.148.12),
     modelstats,

--- a/scripts/output/export/xlsx_IIASA.R
+++ b/scripts/output/export/xlsx_IIASA.R
@@ -37,7 +37,7 @@ projects <- list(
                     iiasatemplate = "ENGAGE_CD-LINKS_template_2019-08-22.xlsx",
                     removeFromScen = "_diff|_expoLinear|-all_regi"),
   NAVIGATE_coupled = list(mapping = c("NAVIGATE", "NAVIGATE_coupled")),
-  NGFS       = list(model = "REMIND-MAgPIE 3.3-4.7",
+  NGFS       = list(model = "REMIND-MAgPIE 3.3-4.8",
                     mapping = c("AR6", "AR6_NGFS"),
                     iiasatemplate = "../iiasa-workflow/definitions/variable/variables.yaml",
                     removeFromScen = "C_|_bIT|_bit|_bIt"),

--- a/scripts/start/run.R
+++ b/scripts/start/run.R
@@ -258,7 +258,9 @@ run <- function() {
 
   # make sure the renv used for the run is also used for generating output
   if (!is.null(renv::project())) {
-    stopifnot(`loaded renv and outputdir must be equal` = normalizePath(renv::project()) == normalizePath(outputdir))
+    if (normalizePath(renv::project()) != normalizePath(outputdir)) {
+      stop("loaded renv=", normalizePath(renv::project()), " and outputdir=", normalizePath(outputdir), " must be equal.")
+    }
     argv <- c(get0("argv"), paste0("--renv=", renv::project()))
   }
 

--- a/tests/testthat/test_01-test-gams-compile.R
+++ b/tests/testthat/test_01-test-gams-compile.R
@@ -7,8 +7,10 @@
 test_that(
   'gams -a=c works on stock configuration',
   {
+    lockID <- gms::model_lock(folder = "../..")
     expect_equal(
       attr(localSystem2('gams', 'main.gms -a=c -errmsg=1 -pw=185 -ps=0'),
-	   'status'),
+           'status'),
       0)
+    gms::model_unlock(lockID)
   })


### PR DESCRIPTION
## Purpose of this PR

- most recent MAgPIE version should be run with magpie4 2.3.10, which is backwards compatible
- https://mattermost.pik-potsdam.de/rd3/pl/3hrwa7dmh3yh3br5x61bhif5hh
- adjust model name for the NGFS export
- lock model while running `gamscompile` in test mode to avoid that it runs while some other run is deleting input files

## Type of change

- [x] Avoid using wrong R package version

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] All automated model tests pass (`[ FAIL 0 | WARN 0 | SKIP 6 | PASS 81 ]` in the output of `make test`)
