### PR TITLE
run MAGICC7 before output checks

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -116,7 +116,7 @@ cfg$logoption <- 2
 # List the name of output scripts from ./scripts/output/ to be used by output.R
 # You can adjust that via an 'output' column in your scenario_config.
 # To overwrite, enter 'reporting,whatever'. To add, enter 'cfg$output,additionalreporting'.
-cfg$output <- c("reporting","reportCEScalib","rds_report","fixOnRef","checkProjectSummations","MAGICC7_AR6")
+cfg$output <- c("reporting","reportCEScalib","rds_report","MAGICC7_AR6","fixOnRef","checkProjectSummations")
 
 # automatically fix remaining differences between run and path_ref
 cfg$fixOnRefAuto <- FALSE


### PR DESCRIPTION
## Purpose of this PR

- make sure checks are run while MAGICC data is already there.

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)
