### PR TITLE
Redirect log output from MAGICC7_AR6 reporting, fix code formatting

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -260,8 +260,8 @@ abstract: REMIND (REgional Model of Investment and Development) is a numerical
   technology, policy and climate constraints. It also accounts for regional trade 
   characteristics on goods, energy fuels, and emissions allowances. All greenhouse 
   gas emissions due to human activities are represented in the model.
-version: "3.3.0.dev335"
-date-released: 2024-06-07
+version: "3.3.0.dev338"
+date-released: 2024-06-12
 repository-code: https://github.com/remindmodel/remind
 keywords:
   - energy

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -71,7 +71,7 @@ cfg$validationmodel_name <- "VALIDATIONREMIND"
 
 #### model version of the overall model (used for run statistics only).
 # automatically generated for development versions, updated by hand for releases
-cfg$model_version <- "3.3.0.dev335"
+cfg$model_version <- "3.3.0.dev338"
 
 #### settings ####
 cfg$gms <- list()


### PR DESCRIPTION
## Purpose of this PR

- All stdout/stderr output from `climate_assessment` python scripts (infilling/harmonization & climate emulation) is now redirected to `log_climate.txt`
- In `climate_assessment_run.R`: Fixed code indentation to make linter more cooperative

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix 
- [ ] Refactoring
- [ ] New feature 
- [ ] Minor change (default scenarios show only small differences)
- [ ] Fundamental change
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

