### PR TITLE
fix plastic waste to zero in historic years where it is not defined due to time delay

### DIFF
--- a/modules/37_industry/subsectors/bounds.gms
+++ b/modules/37_industry/subsectors/bounds.gms
@@ -133,6 +133,10 @@ $ifthen.policy_scenario "%cm_indstExogScen_set%" == "YES"
 $endif.policy_scenario
 $drop cm_indstExogScen_set
 
+!! fix plastic waste to zero in historic years
+v37_plasticWaste.fx(ttot,regi,sefe(entySe,entyFe),emiMkt)$(
+                         entyFE2sector2emiMkt_NonEn(entyFe,"indst",emiMkt)
+                     AND ttot.val lt max(2015, cm_startyear)               ) = 0.;
 
 $ifthen.cm_subsec_model_steel "%cm_subsec_model_steel%" == "processes"
 !! fix processes procudction in historic years


### PR DESCRIPTION
Tests still to be run.

## Purpose of this PR


## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix 
- [ ] Refactoring
- [ ] New feature 
- [ ] Minor change (default scenarios show only small differences)
- [ ] Fundamental change
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

