### PR TITLE
avoid 46/netZero fail on negative emissions

### DIFF
--- a/modules/46_carbonpriceRegi/netZero/postsolve.gms
+++ b/modules/46_carbonpriceRegi/netZero/postsolve.gms
@@ -110,7 +110,7 @@ p46_emi_actual(nz_reg2080(all_regi))$(nz_reg_CO2(all_regi))
       );
 
 ***calculate relative change of overall price required to bring emissions to zero
-p46_factorRescaleCO2Tax(nz_reg)=(1+((p46_emi_actual(nz_reg)-p46_offset(nz_reg))/p46_emi_2020(nz_reg)))**2;
+p46_factorRescaleCO2Tax(nz_reg)=(max(0.3, (1+((p46_emi_actual(nz_reg)-p46_offset(nz_reg))/p46_emi_2020(nz_reg)))))**2;
 
 ***calculate relative change in markup, taking into account change in tax
 ***add a small amount at the end to avoid division by zero in case of mark-up being not necessary


### PR DESCRIPTION
## Purpose of this PR

- if (p46_emi_actual-p46_offset) < -p46_emi_2020, the adaptation mechanism failed because you can't use the power function with negative values. Therefore, avoid this and limit the adjustment possible in one single iteration.
- Lead to fail in `/p/tmp/oliverr/NGFS_v5/remind-2024-06-11-oldSSP/output/C_o_1p5c-rem-1-fail46netZero`, worked in `C_o_1p5c-rem-1`

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I did not run the test because this file is never checked in any test. But I think a successful run using this realization should be sufficient.
