### PR TITLE
adjust description of failing tax convergence to actual calculation

### DIFF
--- a/modules/80_optimization/nash/declarations.gms
+++ b/modules/80_optimization/nash/declarations.gms
@@ -97,7 +97,7 @@ p80_SolNonOpt(all_regi)                    "solve status"
 
 pm_fuExtrForeign(ttot,all_regi,all_enty,rlf) "foreign fuel extraction"
 
-p80_convNashTaxrev_iter(iteration,ttot,all_regi) "deviation of tax revenue in percent GDP per iteration"
+p80_convNashTaxrev_iter(iteration,ttot,all_regi) "deviation of tax revenue relative to GDP per iteration, thus 0.01 means 1 percent"
 p80_convNashObjVal_iter(iteration,all_regi)          "deviation of objective value to objective value from last iteration per iteration"
 p80_fadeoutPriceAnticip_iter(iteration)           "Helper parameter, describes fadeout of price anticipation during iterations per iteration"
 $ifthen.cm_implicitQttyTarget not "%cm_implicitQttyTarget%" == "off"

--- a/modules/80_optimization/nash/postsolve.gms
+++ b/modules/80_optimization/nash/postsolve.gms
@@ -428,7 +428,7 @@ display "Reasons for non-convergence in this iteration (if not yet converged)";
 		      display "#### Just trying a different gdx may help.";
 	      );	 
 	      if(sameas(convMessage80, "taxconv"),
-		      display "#### 4.) Taxes did not converge in all regions and time steps. Absolute level of tax revenue must be smaller than 0.01 percent of GDP. Check p80_convNashTaxrev_iter below.";
+		      display "#### 4.) Taxes did not converge in all regions and time steps. Absolute level of tax revenue must be smaller than 0.1 percent of GDP. Check p80_convNashTaxrev_iter below.";
 	      );
         if(sameas(convMessage80, "DevPriceAnticip"),
 		      display "#### 5.) The total monetary value of the price anticipation term times the traded amount are larger than the goods imbalance threshold * 0.1";
@@ -547,7 +547,7 @@ if( (s80_bool eq 0) and (iteration.val eq cm_iteration_max),     !! reached max 
 	     );	 
 	     if(sameas(convMessage80, "taxconv"),
 		 display "####";
-		 display "#### 4.) Taxes did not converge in all regions and time steps. Absolut level of tax revenue must be smaller than 0.01 percent of GDP. Check p80_convNashTaxrev_iter.";
+		 display "#### 4.) Taxes did not converge in all regions and time steps. Absolut level of tax revenue must be smaller than 0.1 percent of GDP. Check p80_convNashTaxrev_iter.";
 	     );	
       if(sameas(convMessage80, "anticip"),
 		      display "#### 5.) The fadeout price anticipation terms are not sufficiently small.";


### PR DESCRIPTION
## Purpose of this PR

- the [calculation](https://github.com/remindmodel/remind/blob/0acd4a79833278926362d32db49954d376ae7490/modules/80_optimization/nash/postsolve.gms#L321-L323) is `abs(tax / GDP) > 0.001`. Adjust the definitions and messages to it.

## Type of change

- [x] Documentation

## Checklist:

- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] Most automated model tests pass (`FAIL 1` in the output of `make test`) `testOneRegi` fails with `Error in `run()`: ! loaded renv=/p/tmp/oliverr/remind and outputdir=/p/tmp/oliverr/remind/output/testOneRegi must be equal.` but I'm very confident this is not caused by my PR.