### PR TITLE
allow to select reporting and MAGICC7_AR6 in one output.R session

### DIFF
--- a/output.R
+++ b/output.R
@@ -130,15 +130,19 @@ if (isFALSE(comp)) comp <- "single" # legacy from times only two comp modes exis
 if (isTRUE(comp)) comp <- "comparison"
 
 if (! exists("output")) {
+  # search for R scripts in scripts/output subfolders
   modules <- gsub("\\.R$", "", grep("\\.R$", list.files(paste0("./scripts/output/", if (isFALSE(comp)) "single" else comp)), value = TRUE))
+  # if more than one option exists, let user choose
   output <- if (length(modules) == 1) modules else chooseFromList(modules, type = "modules to be used for output generation", addAllPattern = FALSE)
+  # move "reporting" to first position, if it exists
+  output <- c(if ("reporting" %in% output) "reporting", output[! output %in% "reporting"])
 }
 
 # Select output directories if not defined by readArgs
 if (! exists("outputdir")) {
   modulesNeedingMif <- c("compareScenarios2", "xlsx_IIASA", "policyCosts", "Ariadne_output",
                          "plot_compare_iterations", "varListHtml", "fixOnRef", "MAGICC7_AR6")
-  needingMif <- any(modulesNeedingMif %in% output)
+  needingMif <- any(modulesNeedingMif %in% output) && ! "reporting" %in% output[[1]]
   if (exists("remind_dir")) {
     dir_folder <- c(file.path(remind_dir, "output"), remind_dir)
   } else {


### PR DESCRIPTION
## Purpose of this PR

- at the moment, for a failed run, you cannot select `reporting` and `MAGICC7_AR6` in one go in `output.R` -> `single`, because `MAGICC7_AR6` knows it needs the mif, so if you select this as `output` option, it does not allow you to select runs where the mif does not exist
- now: if `reporting` is selected as an output scripts (among others), move it to the first position to execute it first and allow to select folders where the mif does not exist (yet)
- The only reason I can imagine this might be problematic is, if there is any script in the [scripts/output/single](https://github.com/remindmodel/remind/tree/develop/scripts/output/single) where it makes sense to run it before the reporting – I doubt it.

## Type of change

- [x] improved usability

## Checklist:

- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I added [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120)
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
