### PR TITLE
fix nashAnalysis, add cs2 tutorial link

### DIFF
--- a/scripts/output/comparison/compareScenarios2.R
+++ b/scripts/output/comparison/compareScenarios2.R
@@ -94,7 +94,8 @@ if (! exists("profileNames") || ! all(profileNames %in% names(profiles))) {
   profileNames <- names(profiles)[gms::chooseFromList(
     ifelse(names(profiles) %in% profileNamesDefault, crayon::cyan(names(profiles)), names(profiles)),
     type = "profiles for cs2",
-    userinfo = paste0("Leave empty for ", crayon::cyan("cyan"), " default profiles."),
+    userinfo = paste0("Leave empty for ", crayon::cyan("cyan"), " default profiles.\n",
+                      "For a tutorial, see https://pik-piam.r-universe.dev/articles/remind2/compareScenariosRemind2.html"),
     returnBoolean = TRUE
   )]
 }

--- a/scripts/output/single/nashAnalysis.R
+++ b/scripts/output/single/nashAnalysis.R
@@ -9,7 +9,7 @@ library(remind2)
 
 if (!exists("outputdir")) {
   # Define arguments that can be read from command line
-  readArgs("outputdir")
+  lucode2::readArgs("outputdir")
 }
 
 gdx_name <- "fulldata.gdx"

--- a/tutorials/05_AnalysingModelOutputs.md
+++ b/tutorials/05_AnalysingModelOutputs.md
@@ -182,7 +182,7 @@ In both cases, you can choose from the list of available model scenarios, for wh
 
 Now, the selected scripts are executed. After completion, the results are written in the respective folder of the run (combination of **model title** name and the **current date** inside the **output** folder of the model).
 
-One recommended script for comparison of different scenarios is `compareScenarios2`. After you selected folder names, specified a `filename_prefix`, the priority on the cluster, and a *profile* (describes some output parameters) it produces a large PDF (or HTML if a respective profile is chosen) in the `./remind/` folder.
+One recommended script for comparison of different scenarios is `compareScenarios2`, see [the specific tutorial](https://pik-piam.r-universe.dev/articles/remind2/compareScenariosRemind2.html). After you selected folder names, specified a `filename_prefix`, the priority on the cluster, and a *profile* (describes some output parameters) it produces a large PDF (or HTML if a respective profile is chosen) in the `./remind/` folder.
 
 You can also specify the parameters in the command line, for example starting a `compareScenario2` run without any prefix as:
 


### PR DESCRIPTION
## Purpose of this PR

- nashAnalysis was broken, did not find `readArgs`, after you removed the call to lucode2 [here](https://github.com/remindmodel/remind/commit/d2e26b5ca8bf641d645f5c8cfa578af1b506e08a)
- add some links to cs2 tutorial

## Type of change

- [x] Bug fix 

## Checklist:

- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] automated model tests are not affected at all by this change
