### PR TITLE
fix R complaining about if in output.R

### DIFF
--- a/modules/70_water/heat/declarations.gms
+++ b/modules/70_water/heat/declarations.gms
@@ -19,7 +19,7 @@ p70_cap_vintages(ttot, all_regi, all_te, ttot2)                 "capacity build 
 p70_cap_vintages_share(ttot, all_regi, all_te, ttot2)           "fraction of capacity build in ttot2 still standing in ttot out of total capacity in ttot. Unit: 0-1"
 p70_heat(ttot,all_regi,all_enty,all_enty,all_te)                "excess heat. Unit: TWa"
 p70_water_con(all_regi, all_te, coolte70)                       "water consumption coefficients per excess heat. Unit: m3/MWh"
-p70_water_wtd(all_regi, all_te, coolte70)                       "water withdrawal coefficients per excess heat. Unit: m3/MWh)"
+p70_water_wtd(all_regi, all_te, coolte70)                       "water withdrawal coefficients per excess heat. Unit: m3/MWh"
 
 p70_water_output(ttot,all_regi,descr_water_ext)                          "output"
 

--- a/output.R
+++ b/output.R
@@ -279,7 +279,7 @@ if (comp %in% c("comparison", "export")) {
 
     # output creation for --testOneRegi was switched off in start.R in this commit:
     # https://github.com/remindmodel/remind/commit/5905d9dd814b4e4a62738d282bf1815e6029c965
-    if (all(is.na(output)) || output == "NA") {
+    if (all(output %in% c(NA, "NA"))) {
       message("\nNo output generation, as output was set to NA, as for example for --testOneRegi or --quick.")
     } else {
       message("\nStarting output generation for ", outputdir, "\n")


### PR DESCRIPTION
## Purpose of this PR

`/p/tmp/rahelma/ElevateWP2_3/SSPupdated/remind3.3.1/remind/output/ELV_LTS_T44_2024-06-20_10.17.29/log.txt` on new cluster:
```
Error in all(is.na(output)) || output == "NA" : 
  'length = 5' in coercion to 'logical(1)'
Calls: prepareAndRun -> run -> sys.source -> eval -> eval
```
Probably newer R version on the new cluster treats that differently

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] adjusting the reporting in [`remind2`](https://github.com/pik-piam/remind2) was not needed
- [x] I did not adjust `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) as this PR did not lead to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`): testOneRegi fails with `  Modelstat after 1 iterations: 5 (Locally Infeasible)`
- [x] No need to adjust the changelog `CHANGELOG.md`.
