### PR TITLE
bug fix such that default and default-testOneRegi work again

### DIFF
--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -399,7 +399,7 @@ $endif
 *LP* if c_ccsinjecratescen=0 --> no CCS at all and vm_co2CCS is fixed to 0 before, therefore the upper bound is only set if there should be CCS!
 *** -------------------------------------------------------------------------------------------------------------
 
-if ( c_ccsinjecratescen gt 0,
+if ( (c_ccsinjecratescen gt 0) AND (NOT cm_emiscen eq 1),
   vm_co2CCS.lo(t,regi,"cco2","ico2","ccsinje","1")$(t.val le 2030) = pm_boundCapCCS(t,regi,"low")$(t.val le 2030) * s_MtCO2_2_GtC;
   vm_co2CCS.up(t,regi,"cco2","ico2","ccsinje","1")$(t.val le 2030) = (pm_boundCapCCS(t,regi,"low")$(t.val le 2030) + (pm_boundCapCCS(t,regi,"up")$(t.val le 2030) - pm_boundCapCCS(t,regi,"low")$(t.val le 2030)) * c_fracRealfromAnnouncedCCScap2030) * s_MtCO2_2_GtC;
 );


### PR DESCRIPTION
## Purpose of this PR
I unfortunately introduced inconsistencies in default settings with my [previous PR](https://github.com/remindmodel/remind/pull/1688). This [line](https://github.com/remindmodel/remind/blob/288a5242990d69044fe0c91edf4e0d1e0d5548bc/core/bounds.gms#L178) fixes capacities of carbon capture technologies to 0, if `cm_emiscen =1`, i.e. baseline settings, but I introduced lower bounds on geologically stored carbon in my PR according to CCS data.
This caused `make test` and `default testOneRegi` to fail. 
This PR fixes this bug by only applying the lower bound on total CCS if `cm_emiscen =/= 1`.
Thanks Oliver for pointing me to that!

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix 


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)



