### PR TITLE
Collect calibration: auto copy new hash into default.cfg (if user agrees)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,4 +109,4 @@ test-validation: ## Run validation tests, requires a full set of runs in the out
 
 set-local-calibration:		## set up local calibration results directory
 	@./scripts/utils/set-local-calibration.sh
-	$(info use `collect_calibration` script in calibration_results/ directory )
+	$(info Local calibration has been set. Now use `collect_calibration` script in calibration_results/ directory )

--- a/scripts/utils/set-local-calibration/collect_calibration
+++ b/scripts/utils/set-local-calibration/collect_calibration
@@ -74,8 +74,7 @@ do
 	fi
 done
 
-# if there where errors during copying, show the user the files that where
-# staged
+# if there where errors during copying, show staged files to the user
 if [ 0 -ne $(( all_errors )) ]
 then
 	echo " "

--- a/scripts/utils/set-local-calibration/collect_calibration
+++ b/scripts/utils/set-local-calibration/collect_calibration
@@ -21,7 +21,8 @@ new CES parameters and GDX files
 
 # add descriptions for parameter sources as needed
 # comments starting with '#' are ignored
-# quit the editor without saving to abort the commit (use \`:cq\` in vim)
+# to confirm the commit, save the file (use \`:wq\` in vim)
+# to abort the commit, quit the editor without saving (use \`:cq\` in vim)
 
 parameters based on calibrations:" > commit-message.txt
 

--- a/scripts/utils/set-local-calibration/post-commit
+++ b/scripts/utils/set-local-calibration/post-commit
@@ -85,6 +85,22 @@ else
     git branch -vv | grep -q "^\* .* [0-9a-f]\+ \[.*\]" && git push 
     
     # report hash
-    echo -e "\n'CESandGDXversion' to include in REMIND configuration:" \
-	    "$commit_hash\n"
+    echo -e "\n'CESandGDXversion' to include in REMIND configuration: $commit_hash"
+
+    configFile=../config/default.cfg
+    configRegex='^cfg.CESandGDXversion .*'
+    if [ -f $configFile ] && oldLine=$(grep -E "$configRegex" $configFile) && [[ $oldLine ]]
+    then
+        newLine='cfg$CESandGDXversion <- "'"${commit_hash}"'"'
+
+        echo -e "File $configFile currently contains:\n\t$oldLine"
+        read -p "Do you want to update it automatically with the new hash (Y/n)? " confirm
+        if echo $confirm | grep '^[Yy]\?$'
+        then
+            sed --in-place "s/$configRegex/$newLine/" $configFile
+            echo -e "File $configFile now contains:\n\t$(grep -E "$configRegex" $configFile)"
+        else 
+            echo "Please manually set 'CESandGDXversion' to: $commit_hash"
+        fi
+    fi
 fi

--- a/scripts/utils/set-local-calibration/post-commit
+++ b/scripts/utils/set-local-calibration/post-commit
@@ -87,17 +87,20 @@ else
     # report hash
     echo -e "\n'CESandGDXversion' to include in REMIND configuration: $commit_hash"
 
+    # if default.cfg is easy to find, paste hash there automatically
     configFile=../config/default.cfg
     configRegex='^cfg.CESandGDXversion .*'
     if [ -f $configFile ] && oldLine=$(grep -E "$configRegex" $configFile) && [[ $oldLine ]]
     then
-        newLine='cfg$CESandGDXversion <- "'"${commit_hash}"'"'
-
         echo -e "File $configFile currently contains:\n\t$oldLine"
-        printf "%s" "Do you want to update it automatically with the new hash (Y/n)? "
-        read confirm
-        if echo $confirm | grep '^[Yy]\?$'
+
+        # ask confirmation to user (https://stackoverflow.com/a/54866905/8072168)
+        read -p "Do you want to update it automatically with the new hash (Y/n)? " -n 1 -r < /dev/tty
+        echo
+        if echo $REPLY | grep '^[Yy]\?$' > /dev/null
         then
+            newLine='cfg$CESandGDXversion <- "'"${commit_hash}"'"'
+            # replace old hash by new hash
             sed --in-place "s/$configRegex/$newLine/" $configFile
             echo -e "File $configFile now contains:\n\t$(grep -E "$configRegex" $configFile)"
         else 

--- a/scripts/utils/set-local-calibration/post-commit
+++ b/scripts/utils/set-local-calibration/post-commit
@@ -94,7 +94,8 @@ else
         newLine='cfg$CESandGDXversion <- "'"${commit_hash}"'"'
 
         echo -e "File $configFile currently contains:\n\t$oldLine"
-        read -p "Do you want to update it automatically with the new hash (Y/n)? " confirm
+        printf "%s" "Do you want to update it automatically with the new hash (Y/n)? "
+        read confirm
         if echo $confirm | grep '^[Yy]\?$'
         then
             sed --in-place "s/$configRegex/$newLine/" $configFile


### PR DESCRIPTION
## Purpose of this PR
While setting my first own calibration, i was confused by the several steps involved; this PR makes one of them automatic.
Namely, after using ` ./collect_calibration`, one has to copy paste the commit hash into a config file. This is now done automatically, upon user confirmation.

Do you think user confirmation is necessary? Does it happen that we don't want to copy the hash, or to copy it to a different file?

Here is the new terminal output:
![image](https://github.com/remindmodel/remind/assets/1883023/54397de6-5f80-4cf7-afad-175538808a67)

## Type of change

- [x] Minor change (default scenarios show only small differences)

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [ ] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):




