### PR TITLE
adjust python calls to new cluster

### DIFF
--- a/scripts/input/climate_assessment_run.R
+++ b/scripts/input/climate_assessment_run.R
@@ -204,7 +204,7 @@ if (any(!alreadySet)) do.call(Sys.setenv, as.list(environmentVariables[!alreadyS
 # BUILD climate-assessment RUN COMMANDS
 #
 runHarmoniseAndInfillCmd <- paste(
-  "python", file.path(scriptsDir, "run_harm_inf.py"),
+  "python3.9", file.path(scriptsDir, "run_harm_inf.py"),
   climateAssessmentEmi,
   climateTempDir,
   "--no-inputcheck",
@@ -212,7 +212,7 @@ runHarmoniseAndInfillCmd <- paste(
 )
 
 runClimateEmulatorCmd <- paste(
-  "python", file.path(scriptsDir, "run_clim.py"),
+  "python3.9", file.path(scriptsDir, "run_clim.py"),
   normalizePath(file.path(climateTempDir, paste0(baseFn, "_harmonized_infilled.csv"))),
   climateTempDir,
   "--num-cfgs", nparsets,

--- a/scripts/input/climate_assessment_temperatureImpulseResponse.R
+++ b/scripts/input/climate_assessment_temperatureImpulseResponse.R
@@ -178,7 +178,7 @@ fileAllPulsesClimate <- paste0(normalizePath(climateTempDir), "/allpulses_IAMC_c
 
 # BUILD climate-assessment RUN COMMAND
 runClimateEmulatorCmd <- paste(
-  "python", file.path(scriptsDir, "run_clim.py"),
+  "python3.9", file.path(scriptsDir, "run_clim.py"),
   fileAllPulsesScen,
   climateTempDir,
   # Note: Option --year-filter-last requires https://github.com/gabriel-abrahao/climate-assessment/tree/yearfilter

--- a/scripts/output/single/MAGICC7_AR6.R
+++ b/scripts/output/single/MAGICC7_AR6.R
@@ -143,7 +143,7 @@ Sys.setenv(MAGICC_WORKER_NUMBER = 1) # TODO: Get this from slurm or nproc
 #deactivate_venv_cmd <- "deactivate"
 
 runHarmoniseAndInfillCmd <- paste(
-  "python", file.path(scriptsFolder, "run_harm_inf.py"),
+  "python3.9", file.path(scriptsFolder, "run_harm_inf.py"),
   climateAssessmentEmi,
   climateAssessmentFolder,
   "--no-inputcheck",
@@ -151,8 +151,8 @@ runHarmoniseAndInfillCmd <- paste(
 )
 
 runClimateEmulatorCmd <- paste(
-  "python", file.path(scriptsFolder, "run_clim.py"),
-  normalizePath(file.path(climateAssessmentFolder, paste0(baseFileName, "_harmonized_infilled.csv"))),
+  "python3.9", file.path(scriptsFolder, "run_clim.py"),
+  normalizePath(file.path(climateAssessmentFolder, paste0(baseFileName, "_harmonized_infilled.csv")), mustWork = FALSE),
   climateAssessmentFolder,
   "--num-cfgs", nparsets,
   "--scenario-batch-size", 1,
@@ -172,7 +172,7 @@ logmsg <- paste0(
   "  MAGICC_WORKER_ROOT_DIR = ", Sys.getenv("MAGICC_WORKER_ROOT_DIR") ,"\n",
   "  MAGICC_WORKER_NUMBER   = ", Sys.getenv("MAGICC_WORKER_NUMBER") ,"\n",
   date(), " =================== RUN climate-assessment infilling & harmonization ===================\n",
-  runHarmoniseAndInfillCmd, "'\n"
+  runHarmoniseAndInfillCmd, "\n"
 )
 cat(logmsg)
 capture.output(cat(logmsg), file = logFile, append = TRUE)

--- a/scripts/utils/checkSetup.R
+++ b/scripts/utils/checkSetup.R
@@ -23,7 +23,7 @@ if (length(missingDeps) > 0) {
   message("all required R packages are installed")
 }
 
-if (Sys.which("python3") != ""
+if (Sys.which("python3.9") != ""
     || (Sys.which("python.exe") != ""
         && suppressWarnings(isTRUE(startsWith(system2("python.exe", "--version", stdout = TRUE), "Python 3"))))) {
   message("checking for Python 3 - ok")

--- a/scripts/utils/climate_assessment/submit_climate_assessment.sh
+++ b/scripts/utils/climate_assessment/submit_climate_assessment.sh
@@ -8,4 +8,4 @@
 #SBATCH --output=PYTHONLOG-%x.%j.out
 # Replace this with the resulting xls of output.R -> export -> xlsx_IIASA -> AR6
 filename="../../../output/export/REMIND_gabrielAR6SHAPE_2023-05-17_05.12.52.xlsx"
-python source_climate_assessment.py $filename
+python3.9 source_climate_assessment.py $filename


### PR DESCRIPTION
## Purpose of this PR

- `python` will not be available on the new cluster, see `man python`:

> unversioned-python
> The  "unversioned"  `python` command (/usr/bin/python) is missing by default.  We recommend using `python3` or `python2` instead.  If using the explicit versioned command is inconvenient, you can use `alternatives` to configure `python` to launch either Python 3 or Python 2.

- still, this is just a draft because `python3.9` is currently missing on the compute nodes, see `sbatch --qos=priority --job-name=pythontest --wrap="python3.9 --version"` currently returning `/var/spool/slurm/d/job406373/slurm_script: line 4: python3.9: command not found`

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
