### PR TITLE
New realizations diffExp2Lin and diffLin2Lin in 45_carbonprice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### changed
 
 ### added
+- added realizations diffExp2Lin and diffLin2Lin to 45_carbonprice [#1723](https://github.com/remindmodel/remind/pull/1723)
 
 ### fixed
 - included CCS from plastic waste incineration in CCS mass flows so it is

--- a/main.gms
+++ b/main.gms
@@ -372,12 +372,14 @@ $setglobal emicapregi  none           !! def = none
 *' This module defines the carbon price pm_taxCO2eq, with behaviour across regions governed by similar principles (e.g. global targets, or all following NDC or NPi policies).
 *'
 *' * (none): no tax policy (combined with all emiscens except emiscen = 9)
-*' * (exponential): 5% exponential increase over time of the tax level in 2020 set via cm_co2_tax_2020 (combined with emiscen = 9 and cm_co2_tax_2020>0)
-*' * (expoLinear): 5% exponential increase until c_expoLinear_yearStart, linear increase thereafter
+*' * (exponential): 4.5% exponential increase over time of the tax level in 2020 set via cm_co2_tax_2020 (combined with emiscen = 9 and cm_co2_tax_2020>0)
+*' * (expoLinear): 4.5% exponential increase until c_expoLinear_yearStart, linear increase thereafter
 *' * (exogenous): carbon price is specified using an external input file or using the switch cm_regiExoPrice. Requires cm_emiscen = 9 and cm_iterative_target_adj = 0
 *' * (linear): linear increase over time of the tax level in 2020 set via cm_co2_tax_2020 (combined with emiscen = 9 and cm_co2_tax_2020>0)
 *' * (temperatureNotToExceed): [test and verify before using it!] Find the optimal carbon carbon tax (set cm_emiscen = 1, iterative_target_adj = 9] curved convergence of CO2 prices between regions until cm_CO2priceRegConvEndYr; developed countries have linear path from 0 in 2010 through cm_co2_tax_2020 in 2020;
 *' * (diffCurvPhaseIn2Lin): [REMIND 2.1 default for validation peakBudget runs, in combination with iterative_target_adj = 9] curved convergence of CO2 prices between regions until cm_CO2priceRegConvEndYr; developed countries have linear path from 0 in 2010 through cm_co2_tax_2020 in 2020;
+*' * (diffExp2Lin): quadratic convergence of CO2 prices between regions until cm_CO2priceRegConvEndYr; starting level of differentiation in cm_startyear is given by cm_co2_tax_spread; developed countries have exponential path until peak year (with iterative_target_adj = 9) or until 2100 (with iterative_target_adj = 5);
+*' * (diffLin2Lin): [Variant of diffCurvPhaseIn2Lin, will be further developed before becoming the new default] quadratic convergence of CO2 prices between regions until cm_CO2priceRegConvEndYr; starting level of differentiation in cm_startyear is given by cm_co2_tax_spread; developed countries have linear path until peak year (with iterative_target_adj = 9) or until 2100 (with iterative_target_adj = 5);
 *' * (NDC): implements a carbon price trajectory consistent with the NDC targets (up to 2030) and a trajectory of comparable ambition post 2030 (1.25%/yr price increase and regional convergence of carbon price). Choose version using cm_NDC_version "2023_cond", "2023_uncond", or replace 2023 by 2022, 2021 or 2018 to get all NDC published until end of these years.
 *' * (NPi): National Policies Implemented, extrapolation of historical (until 2020) carbon prices
 $setglobal carbonprice  none           !! def = none
@@ -508,8 +510,8 @@ parameter
 parameter
   cm_co2_tax_growth         "growth rate of carbon tax"
 ;
-  cm_co2_tax_growth = 1.05;            !! def = 1.05  !! regexp = is.numeric
-*'  (any number >= 0): rate of exponential increase over time
+  cm_co2_tax_growth = 1.045;            !! def = 1.045  !! regexp = is.numeric
+*'  (any number >= 0): rate of exponential increase over time, default value chosen to be consistent with interest rate
 parameter
   c_macscen                 "scenario switch on whether or not to use MAC (Marginal Abatement Cost) for certain sectors not related to direct combustion of fossil fuel, e.g. fugitive emissions from old mines, forestry, agriculture and cement"
 ;
@@ -977,10 +979,19 @@ parameter
   c_taxCO2inc_after_peakBudgYr = 0; !! def = 0 . For weak targets (higher than 1100 Peak Budget), this value might need to increased to prevent continually increasing temperatures
 *'
 parameter
-  cm_CO2priceRegConvEndYr      "Year at which regional CO2 taxes converge in module 45 realization diffCurvPhaseIn2Lin"
+  cm_CO2priceRegConvEndYr      "Year at which regional CO2 taxes converge in module 45 for realizations with differentiated carbon prices"
 ;
-  cm_CO2priceRegConvEndYr  = 2050;   !! def = 2050
+  cm_CO2priceRegConvEndYr  = 2050;   !! def = 2050    
 *'
+parameter
+  cm_co2_tax_spread            "spread of carbon prices in 2025 given as a factor"
+;
+  cm_co2_tax_spread        = 10;     !! def = 10  !! regexp = 1|10|20
+*'  Initial spread of carbon prices (in 2025) between the regions with highest respectively lowest GDP per capita (PPP)
+*' * (1) Uniform carbon pricing, i.e. no differentiation
+*' * (10) Spread of carbon prices in 2025 is equal to 10
+*' * (20) Spread of carbon prices in 2025 is equal to 20
+
 parameter
   c_teNoLearngConvEndYr      "Year at which regional costs of non-learning technologies converge"
 ;

--- a/modules/45_carbonprice/NDC/not_used.txt
+++ b/modules/45_carbonprice/NDC/not_used.txt
@@ -21,3 +21,4 @@ pm_shPPPMER,input,questionnaire
 pm_pop,input,questionnaire
 pm_gdp,input,questionnaire
 cm_CO2priceRegConvEndYr,input,questionnaire
+cm_co2_tax_spread,switch,no carbon price differentiation in this realization

--- a/modules/45_carbonprice/NPi/not_used.txt
+++ b/modules/45_carbonprice/NPi/not_used.txt
@@ -29,3 +29,4 @@ cm_NDC_divergentScenario,input,questionnaire
 vm_demFeSector,input,questionnaire
 pm_emifac,input,questionnaire
 cm_startyear,input,added by codeCheck
+cm_co2_tax_spread,input,no carbon price differentiation in this realization

--- a/modules/45_carbonprice/diffCurvPhaseIn2Lin/not_used.txt
+++ b/modules/45_carbonprice/diffCurvPhaseIn2Lin/not_used.txt
@@ -23,3 +23,4 @@ pm_consPC,input,questionnaire
 pm_prtp,input,questionnaire
 vm_demFeSector,input,questionnaire
 pm_emifac,input,questionnaire
+cm_co2_tax_spread,input,added by codeCheck

--- a/modules/45_carbonprice/diffExp2Lin/datainput.gms
+++ b/modules/45_carbonprice/diffExp2Lin/datainput.gms
@@ -1,0 +1,81 @@
+*** |  (C) 2006-2023 Potsdam Institute for Climate Impact Research (PIK)
+*** |  authors, and contributors see CITATION.cff file. This file is part
+*** |  of REMIND and licensed under AGPL-3.0-or-later. Under Section 7 of
+*** |  AGPL-3.0, you are granted additional permissions described in the
+*** |  REMIND License Exception, version 1.0 (see LICENSE file).
+*** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/45_carbonprice/diffExp2Lin/datainput.gms
+***---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+*** regional prices are initially differentiated by GDP/capita and converge using quadratic phase-in, 
+*** global price from cm_CO2priceRegConvEndYr (default = 2050)
+*** carbon price of developed regions increases exponentially with rate given by cm_co2_tax_growth until peak year (with iterative_target_adj = 9) or until 2100 (with iterative_target_adj = 5)
+*** linear carbon price curve of developed regions starts at 0 in 2020 
+***---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+
+*** convergence to global CO2 price depends on GDP per capita (in 1e3 $ PPP 2005).
+*** benchmark year kept at 2015 since 2020 not suitable. 
+p45_gdppcap2015_PPP(regi) = pm_gdp("2015",regi)/pm_shPPPMER(regi) / pm_pop("2015",regi);
+display p45_gdppcap2015_PPP;
+
+*** Selection of differentiation scheme via cm_co2_tax_spread
+if(cm_co2_tax_spread eq 1,
+p45_phasein_2025ratio(regi) = 1; !! all regions
+);
+
+if(cm_co2_tax_spread eq 10,
+p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) le 3.5) = 0.1; !! SSA
+p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 3.5 and p45_gdppcap2015_PPP(regi) le 5)  = 0.2; !! IND
+p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 5   and p45_gdppcap2015_PPP(regi) le 10) = 0.3; !! OAS
+p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 10  and p45_gdppcap2015_PPP(regi) le 15) = 0.5; !! CHA, REF, LAM
+p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 15  and p45_gdppcap2015_PPP(regi) le 20) = 0.7; !! MEA, NEU
+p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 20) = 1; !! EUR, JPN, USA, CAZ
+);
+
+if(cm_co2_tax_spread eq 20,
+p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) le 3.5) = 0.05; !! SSA
+p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 3.5 and p45_gdppcap2015_PPP(regi) le 5)  = 0.1; !! IND
+p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 5   and p45_gdppcap2015_PPP(regi) le 10) = 0.2; !! OAS
+p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 10  and p45_gdppcap2015_PPP(regi) le 15) = 0.4; !! CHA, REF, LAM
+p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 15  and p45_gdppcap2015_PPP(regi) le 20) = 0.6; !! MEA, NEU
+p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 20) = 1; !! EUR, JPN, USA, CAZ
+);
+display p45_phasein_2025ratio;
+
+
+*GL: tax path in 10^12$/GtC = 1000 $/tC
+*** according to Asian Modeling Excercise tax case setup, 30$/t CO2eq in 2020 = 0.110 k$/tC
+
+*** for the current implementation, use the following trajectory for rich countries:
+*** price increases exponentially from cm_co2_tax_2020 in 2020
+if(cm_co2_tax_2020 lt 0,
+abort "please choose a valid cm_co2_tax_2020"
+elseif cm_co2_tax_2020 ge 0,
+*** convert tax value from $/t CO2eq to T$/GtC
+p45_CO2priceTrajDeveloped("2020") = cm_co2_tax_2020 * sm_DptCO2_2_TDpGtC;
+);
+
+p45_CO2priceTrajDeveloped(t)$(t.val gt 2005) = p45_CO2priceTrajDeveloped("2020") * cm_co2_tax_growth**(t.val-2020);
+p45_CO2priceTrajDeveloped(t)$(t.val gt 2110) = p45_CO2priceTrajDeveloped("2110"); !! to prevent huge taxes after 2110 and the resulting convergence problems, set taxes after 2110 equal to 2110 value
+
+*** Then create regional phase-in:
+*** Set regional CO2 price factor equal to p45_phasein_2025ratio until 2025:
+p45_regCO2priceFactor(t,regi)$(t.val le 2025) = p45_phasein_2025ratio(regi);
+*** Then define quadratic phase-in until cm_CO2priceRegConvEndYr:
+loop(t$((t.val gt 2025) and (t.val le cm_CO2priceRegConvEndYr)),
+  p45_regCO2priceFactor(t,regi) = 
+   min(1,
+       max(0, 
+	        p45_phasein_2025ratio(regi) + (1 - p45_phasein_2025ratio(regi)) * Power( (t.val - 2025) / (cm_CO2priceRegConvEndYr - 2025), 2) 
+       )				 
+   );
+);
+p45_regCO2priceFactor(t,regi)$(t.val ge cm_CO2priceRegConvEndYr) = 1;
+
+
+*** transition to global price - starting point depends on GDP/cap
+pm_taxCO2eq(t,regi) = p45_regCO2priceFactor(t,regi) * p45_CO2priceTrajDeveloped(t);
+
+
+display p45_regCO2priceFactor, p45_CO2priceTrajDeveloped, pm_taxCO2eq;
+*** EOF ./modules/45_carbonprice/diffExp2Lin/datainput.gms

--- a/modules/45_carbonprice/diffExp2Lin/declarations.gms
+++ b/modules/45_carbonprice/diffExp2Lin/declarations.gms
@@ -1,0 +1,23 @@
+*** |  (C) 2006-2023 Potsdam Institute for Climate Impact Research (PIK)
+*** |  authors, and contributors see CITATION.cff file. This file is part
+*** |  of REMIND and licensed under AGPL-3.0-or-later. Under Section 7 of
+*** |  AGPL-3.0, you are granted additional permissions described in the
+*** |  REMIND License Exception, version 1.0 (see LICENSE file).
+*** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/45_carbonprice/diffExp2Lin/datainput.gms
+***---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+*** regional prices are initially differentiated by GDP/capita and converge using quadratic phase-in, 
+*** global price from cm_CO2priceRegConvEndYr (default = 2050)
+*** carbon price of developed regions increases exponentially with rate given by cm_co2_tax_growth until peak year (with iterative_target_adj = 9) or until 2100 (with iterative_target_adj = 5)
+*** linear carbon price curve of developed regions starts at 0 in 2020 
+***---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+parameters
+p45_gdppcap2015_PPP(all_regi)               "2015 GDP per capita (k $ PPP 2005)"
+p45_phasein_2025ratio(all_regi)             "ratio of CO2 price to that of developed region in 2025"
+
+p45_regCO2priceFactor(ttot,all_regi)                    "regional multiplicative factor to the CO2 price of the developed countries"
+p45_CO2priceTrajDeveloped(ttot)                         "CO2 price trajectory for developed/rich countries"
+;
+
+
+*** EOF ./modules/45_carbonprice/diffExp2Lin/declarations.gms

--- a/modules/45_carbonprice/diffExp2Lin/not_used.txt
+++ b/modules/45_carbonprice/diffExp2Lin/not_used.txt
@@ -6,15 +6,12 @@
 # |  Contact: remind@pik-potsdam.de
 name,type,reason
 cm_emiscen, switch, ???
-cm_co2_tax_2020, switch, ???
 sm_c_2_co2,switch, ???
 pm_ttot_val,parameter,???
-cm_co2_tax_growth,switch,???
 cm_startyear,switch,???
 cm_iterative_target_adj,switch,???
 cm_expoLinear_yearStart,switch,???
 vm_co2eq,variable,???
-sm_DptCO2_2_TDpGtC,scalar,???
 vm_emiFgas,input,questionnaire
 pm_globalMeanTemperature,input,questionnaire
 pm_temperatureImpulseResponseCO2,input,questionnaire
@@ -23,11 +20,6 @@ pm_GDPGross,input,questionnaire
 pm_prtp,input,questionnaire
 cm_carbonprice_temperatureLimit,input,questionnaire
 pm_ttot_2_tall,input,questionnaire
-pm_shPPPMER,input,questionnaire
-pm_pop,input,questionnaire
-pm_gdp,input,questionnaire
-cm_CO2priceRegConvEndYr,input,questionnaire
 cm_NDC_divergentScenario,input,questionnaire
 vm_demFeSector,input,questionnaire
 pm_emifac,input,questionnaire
-cm_co2_tax_spread,input,no carbon price differentiation in this realization

--- a/modules/45_carbonprice/diffExp2Lin/postsolve.gms
+++ b/modules/45_carbonprice/diffExp2Lin/postsolve.gms
@@ -1,0 +1,25 @@
+*** |  (C) 2006-2023 Potsdam Institute for Climate Impact Research (PIK)
+*** |  authors, and contributors see CITATION.cff file. This file is part
+*** |  of REMIND and licensed under AGPL-3.0-or-later. Under Section 7 of
+*** |  AGPL-3.0, you are granted additional permissions described in the
+*** |  REMIND License Exception, version 1.0 (see LICENSE file).
+*** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/45_carbonprice/diffExp2Lin/postsolve.gms
+***---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+*** regional prices are initially differentiated by GDP/capita and converge using quadratic phase-in, 
+*** global price from cm_CO2priceRegConvEndYr (default = 2050)
+*** carbon price of developed regions increases exponentially with rate given by cm_co2_tax_growth until peak year (with iterative_target_adj = 9) or until 2100 (with iterative_target_adj = 5)
+*** linear carbon price curve of developed regions starts at 0 in 2020 
+***---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+*** re-create the regional differentation, use path from developed countries as the basis.
+*** This doesn't need to be a loop, but it will be correct for any cycle of the loop, so also for the last cycle.
+loop(regi$(p45_gdppcap2015_PPP(regi) gt 20),
+  p45_CO2priceTrajDeveloped(t) = pm_taxCO2eq(t,regi);
+);
+
+*** quadratic transition to global price - starting point depends on GDP/cap
+pm_taxCO2eq(t,regi) = p45_regCO2priceFactor(t,regi) * p45_CO2priceTrajDeveloped(t);
+
+display pm_taxCO2eq;
+*** EOF ./modules/45_carbonprice/diffExp2Lin/postsolve.gms

--- a/modules/45_carbonprice/diffExp2Lin/realization.gms
+++ b/modules/45_carbonprice/diffExp2Lin/realization.gms
@@ -1,0 +1,16 @@
+*** |  (C) 2006-2023 Potsdam Institute for Climate Impact Research (PIK)
+*** |  authors, and contributors see CITATION.cff file. This file is part
+*** |  of REMIND and licensed under AGPL-3.0-or-later. Under Section 7 of
+*** |  AGPL-3.0, you are granted additional permissions described in the
+*** |  REMIND License Exception, version 1.0 (see LICENSE file).
+*** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/45_carbonprice/diffExp2Lin/realization.gms
+
+*#' @description: This realization implements an exponential increase in carbon price from the predefined 2020 level. Optional carbon price differentiation and quadratic phase-in can be activated via switch cm_co2_tax_spread.
+
+*####################### R SECTION START (PHASES) ##############################
+$Ifi "%phase%" == "declarations" $include "./modules/45_carbonprice/diffExp2Lin/declarations.gms"
+$Ifi "%phase%" == "datainput" $include "./modules/45_carbonprice/diffExp2Lin/datainput.gms"
+$Ifi "%phase%" == "postsolve" $include "./modules/45_carbonprice/diffExp2Lin/postsolve.gms"
+*######################## R SECTION END (PHASES) ###############################
+*** EOF ./modules/45_carbonprice/diffExp2Lin/realization.gms

--- a/modules/45_carbonprice/diffExp2Lin/realization.gms
+++ b/modules/45_carbonprice/diffExp2Lin/realization.gms
@@ -6,7 +6,7 @@
 *** |  Contact: remind@pik-potsdam.de
 *** SOF ./modules/45_carbonprice/diffExp2Lin/realization.gms
 
-*#' @description: This realization implements an exponential increase in carbon price from the predefined 2020 level. Optional carbon price differentiation and quadratic phase-in can be activated via switch cm_co2_tax_spread.
+*#' @description: This realization implements exponentially increasing carbon price - either until 2100 or until peak year (constant or linear thereafter). Optional carbon price differentiation and quadratic phase-in can be activated via switch cm_co2_tax_spread.
 
 *####################### R SECTION START (PHASES) ##############################
 $Ifi "%phase%" == "declarations" $include "./modules/45_carbonprice/diffExp2Lin/declarations.gms"

--- a/modules/45_carbonprice/diffLin2Lin/datainput.gms
+++ b/modules/45_carbonprice/diffLin2Lin/datainput.gms
@@ -1,0 +1,82 @@
+*** |  (C) 2006-2023 Potsdam Institute for Climate Impact Research (PIK)
+*** |  authors, and contributors see CITATION.cff file. This file is part
+*** |  of REMIND and licensed under AGPL-3.0-or-later. Under Section 7 of
+*** |  AGPL-3.0, you are granted additional permissions described in the
+*** |  REMIND License Exception, version 1.0 (see LICENSE file).
+*** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/45_carbonprice/diffLin2Lin/datainput.gms
+***----------------------------------------------------------------------------------------------------------------------------------------------------
+*** regional prices are initially differentiated by GDP/capita and converge using quadratic phase-in, 
+*** global price from cm_CO2priceRegConvEndYr (default = 2050)
+*** carbon price of developed regions increases linearly until peak year (with iterative_target_adj = 9) or until 2100 (with iterative_target_adj = 5)
+*** linear carbon price curve of developed regions starts at 0 in 2020 
+***----------------------------------------------------------------------------------------------------------------------------------------------------
+
+
+*** convergence to global CO2 price depends on GDP per capita (in 1e3 $ PPP 2005).
+*** benchmark year kept at 2015 since 2020 not suitable. 
+p45_gdppcap2015_PPP(regi) = pm_gdp("2015",regi)/pm_shPPPMER(regi) / pm_pop("2015",regi);
+display p45_gdppcap2015_PPP;
+
+*** Selection of differentiation scheme via cm_co2_tax_spread
+if(cm_co2_tax_spread eq 1,
+p45_phasein_2025ratio(regi) = 1; !! all regions
+);
+
+if(cm_co2_tax_spread eq 10,
+p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) le 3.5) = 0.1; !! SSA
+p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 3.5 and p45_gdppcap2015_PPP(regi) le 5)  = 0.2; !! IND
+p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 5   and p45_gdppcap2015_PPP(regi) le 10) = 0.3; !! OAS
+p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 10  and p45_gdppcap2015_PPP(regi) le 15) = 0.5; !! CHA, REF, LAM
+p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 15  and p45_gdppcap2015_PPP(regi) le 20) = 0.7; !! MEA, NEU
+p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 20) = 1; !! EUR, JPN, USA, CAZ
+);
+
+if(cm_co2_tax_spread eq 20,
+p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) le 3.5) = 0.05; !! SSA
+p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 3.5 and p45_gdppcap2015_PPP(regi) le 5)  = 0.1; !! IND
+p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 5   and p45_gdppcap2015_PPP(regi) le 10) = 0.2; !! OAS
+p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 10  and p45_gdppcap2015_PPP(regi) le 15) = 0.4; !! CHA, REF, LAM
+p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 15  and p45_gdppcap2015_PPP(regi) le 20) = 0.6; !! MEA, NEU
+p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 20) = 1; !! EUR, JPN, USA, CAZ
+);
+display p45_phasein_2025ratio;
+
+
+*** for the current implementation, use the following trajectory for rich countries:
+*** price increases linearly from 0 in 2020 (warning: quick fix for more near-term realism. To be changed to NPI fixing) until the pkBudgYr, then increases with c_taxCO2inc_after_peakBudgYr
+if(cm_co2_tax_2020 lt 0,
+  abort "please choose a valid cm_co2_tax_2020"
+elseif cm_co2_tax_2020 ge 0,
+*** convert tax value from $/t CO2eq to T$/GtC
+  p45_CO2priceTrajDeveloped("2040")= 3 * cm_co2_tax_2020 * sm_DptCO2_2_TDpGtC;  !! shifted to 2040 to make sure that even in delay scenarios the fixpoint of the linear price path is inside the "t" range, otherwise the CO2 prices from reference run may be overwritten
+*** The factor 3 is inherited from old fixing to 0 in 2010. Switch cm_co2_tax_2020 should be renamed or removed.
+);
+
+
+
+p45_CO2priceTrajDeveloped(t)$(t.val ge 2020) = p45_CO2priceTrajDeveloped("2040")*( 1 + (t.val-2040) / 20); !! no CO2 price until 2020 and only change CO2 prices after ; 
+*** annual increase by 5% (=1/20) of the 2040 value corresponds to a linear increase from 0 in 2020 to the 2040 value
+
+
+*** Then create regional phase-in:
+*** Set regional CO2 price factor equal to p45_phasein_2025ratio until 2025:
+p45_regCO2priceFactor(t,regi)$(t.val le 2025) = p45_phasein_2025ratio(regi);
+*** Then define quadratic phase-in until cm_CO2priceRegConvEndYr:
+loop(t$((t.val gt 2025) and (t.val le cm_CO2priceRegConvEndYr)),
+  p45_regCO2priceFactor(t,regi) = 
+   min(1,
+       max(0, 
+	        p45_phasein_2025ratio(regi) + (1 - p45_phasein_2025ratio(regi)) * Power( (t.val - 2025) / (cm_CO2priceRegConvEndYr - 2025), 2) 
+       )				 
+   );
+);
+p45_regCO2priceFactor(t,regi)$(t.val ge cm_CO2priceRegConvEndYr) = 1;
+
+
+*** transition to global price - starting point depends on GDP/cap
+pm_taxCO2eq(t,regi) = p45_regCO2priceFactor(t,regi) * p45_CO2priceTrajDeveloped(t);
+
+
+display p45_regCO2priceFactor, p45_CO2priceTrajDeveloped, pm_taxCO2eq;
+*** EOF ./modules/45_carbonprice/diffLin2Lin/datainput.gms

--- a/modules/45_carbonprice/diffLin2Lin/declarations.gms
+++ b/modules/45_carbonprice/diffLin2Lin/declarations.gms
@@ -1,0 +1,24 @@
+*** |  (C) 2006-2023 Potsdam Institute for Climate Impact Research (PIK)
+*** |  authors, and contributors see CITATION.cff file. This file is part
+*** |  of REMIND and licensed under AGPL-3.0-or-later. Under Section 7 of
+*** |  AGPL-3.0, you are granted additional permissions described in the
+*** |  REMIND License Exception, version 1.0 (see LICENSE file).
+*** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/45_carbonprice/diffLin2Lin/declarations.gms
+***----------------------------------------------------------------------------------------------------------------------------------------------------
+*** regional prices are initially differentiated by GDP/capita and converge using quadratic phase-in, 
+*** global price from cm_CO2priceRegConvEndYr (default = 2050)
+*** carbon price of developed regions increases linearly until peak year (with iterative_target_adj = 9) or until 2100 (with iterative_target_adj = 5)
+*** linear carbon price curve of developed regions starts at 0 in 2020 
+***----------------------------------------------------------------------------------------------------------------------------------------------------
+
+parameters
+p45_gdppcap2015_PPP(all_regi)               "2015 GDP per capita (k $ PPP 2005)"
+p45_phasein_2025ratio(all_regi)             "ratio of CO2 price to that of developed region in 2025"
+
+p45_regCO2priceFactor(ttot,all_regi)                    "regional multiplicative factor to the CO2 price of the developed countries"
+p45_CO2priceTrajDeveloped(ttot)                         "CO2 price trajectory for developed/rich countries"
+;
+
+
+*** EOF ./modules/45_carbonprice/diffLin2Lin/declarations.gms

--- a/modules/45_carbonprice/diffLin2Lin/not_used.txt
+++ b/modules/45_carbonprice/diffLin2Lin/not_used.txt
@@ -5,29 +5,22 @@
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
 name,type,reason
-cm_emiscen, switch, ???
-cm_co2_tax_2020, switch, ???
-sm_c_2_co2,switch, ???
-pm_ttot_val,parameter,???
-cm_co2_tax_growth,switch,???
-cm_startyear,switch,???
-cm_iterative_target_adj,switch,???
-cm_expoLinear_yearStart,switch,???
-vm_co2eq,variable,???
-sm_DptCO2_2_TDpGtC,scalar,???
+sm_c_2_co2,input,questionnaire
+vm_co2eq,input,questionnaire
 vm_emiFgas,input,questionnaire
 pm_globalMeanTemperature,input,questionnaire
 pm_temperatureImpulseResponseCO2,input,questionnaire
-pm_consPC,input,questionnaire
 pm_GDPGross,input,questionnaire
-pm_prtp,input,questionnaire
-cm_carbonprice_temperatureLimit,input,questionnaire
+pm_ttot_val,input,questionnaire
 pm_ttot_2_tall,input,questionnaire
-pm_shPPPMER,input,questionnaire
-pm_pop,input,questionnaire
-pm_gdp,input,questionnaire
-cm_CO2priceRegConvEndYr,input,questionnaire
+cm_emiscen,input,questionnaire
+cm_co2_tax_growth,input,questionnaire
+cm_iterative_target_adj,input,questionnaire
+cm_expoLinear_yearStart,input,questionnaire
+cm_carbonprice_temperatureLimit,input,questionnaire
 cm_NDC_divergentScenario,input,questionnaire
+pm_consPC,input,questionnaire
+pm_prtp,input,questionnaire
 vm_demFeSector,input,questionnaire
 pm_emifac,input,questionnaire
-cm_co2_tax_spread,input,no carbon price differentiation in this realization
+cm_startyear,switch,questionnaire

--- a/modules/45_carbonprice/diffLin2Lin/postsolve.gms
+++ b/modules/45_carbonprice/diffLin2Lin/postsolve.gms
@@ -1,0 +1,25 @@
+*** |  (C) 2006-2023 Potsdam Institute for Climate Impact Research (PIK)
+*** |  authors, and contributors see CITATION.cff file. This file is part
+*** |  of REMIND and licensed under AGPL-3.0-or-later. Under Section 7 of
+*** |  AGPL-3.0, you are granted additional permissions described in the
+*** |  REMIND License Exception, version 1.0 (see LICENSE file).
+*** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/45_carbonprice/diffLin2Lin/postsolve.gms
+***----------------------------------------------------------------------------------------------------------------------------------------------------
+*** regional prices are initially differentiated by GDP/capita and converge using quadratic phase-in, 
+*** global price from cm_CO2priceRegConvEndYr (default = 2050)
+*** carbon price of developed regions increases linearly until peak year (with iterative_target_adj = 9) or until 2100 (with iterative_target_adj = 5)
+*** linear carbon price curve of developed regions starts at 0 in 2020 
+***----------------------------------------------------------------------------------------------------------------------------------------------------
+
+*** re-create the regional differentation, use path from developed countries as the basis.
+*** This doesn't need to be a loop, but it will be correct for any cycle of the loop, so also for the last cycle.
+loop(regi$(p45_gdppcap2015_PPP(regi) gt 20),
+  p45_CO2priceTrajDeveloped(t) = pm_taxCO2eq(t,regi);
+);
+
+*** quadratic transition to global price - starting point depends on GDP/cap
+pm_taxCO2eq(t,regi) = p45_regCO2priceFactor(t,regi) * p45_CO2priceTrajDeveloped(t);
+
+display pm_taxCO2eq;
+*** EOF ./modules/45_carbonprice/diffLin2Lin/postsolve.gms

--- a/modules/45_carbonprice/diffLin2Lin/realization.gms
+++ b/modules/45_carbonprice/diffLin2Lin/realization.gms
@@ -1,0 +1,15 @@
+*** |  (C) 2006-2023 Potsdam Institute for Climate Impact Research (PIK)
+*** |  authors, and contributors see CITATION.cff file. This file is part
+*** |  of REMIND and licensed under AGPL-3.0-or-later. Under Section 7 of
+*** |  AGPL-3.0, you are granted additional permissions described in the
+*** |  REMIND License Exception, version 1.0 (see LICENSE file).
+*** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/45_carbonprice/diffLin2Lin/realization.gms
+
+*####################### R SECTION START (PHASES) ##############################
+$Ifi "%phase%" == "declarations" $include "./modules/45_carbonprice/diffLin2Lin/declarations.gms"
+$Ifi "%phase%" == "datainput" $include "./modules/45_carbonprice/diffLin2Lin/datainput.gms"
+$Ifi "%phase%" == "postsolve" $include "./modules/45_carbonprice/diffLin2Lin/postsolve.gms"
+*######################## R SECTION END (PHASES) ###############################
+
+*** EOF ./modules/45_carbonprice/diffLin2Lin/realization.gms

--- a/modules/45_carbonprice/diffLin2Lin/realization.gms
+++ b/modules/45_carbonprice/diffLin2Lin/realization.gms
@@ -6,6 +6,8 @@
 *** |  Contact: remind@pik-potsdam.de
 *** SOF ./modules/45_carbonprice/diffLin2Lin/realization.gms
 
+*#' @description: This realization implements linearly increasing carbon price - either until 2100 or until peak year (constant or linear thereafter). Optional carbon price differentiation and quadratic phase-in can be activated via switch cm_co2_tax_spread.
+
 *####################### R SECTION START (PHASES) ##############################
 $Ifi "%phase%" == "declarations" $include "./modules/45_carbonprice/diffLin2Lin/declarations.gms"
 $Ifi "%phase%" == "datainput" $include "./modules/45_carbonprice/diffLin2Lin/datainput.gms"

--- a/modules/45_carbonprice/exogenous/not_used.txt
+++ b/modules/45_carbonprice/exogenous/not_used.txt
@@ -28,3 +28,4 @@ vm_demFeSector,input,questionnaire
 pm_emifac,input,questionnaire
 sm_DptCO2_2_TDpGtC,input,questionnaire
 cm_startyear,input,questionnaire
+cm_co2_tax_spread,switch,no carbon price differentiation in this realization

--- a/modules/45_carbonprice/expoLinear/not_used.txt
+++ b/modules/45_carbonprice/expoLinear/not_used.txt
@@ -24,3 +24,4 @@ cm_CO2priceRegConvEndYr,input,questionnaire
 cm_NDC_divergentScenario,input,questionnaire
 vm_demFeSector,input,questionnaire
 pm_emifac,input,questionnaire
+cm_co2_tax_spread,input,No carbon price differentiation in this realization

--- a/modules/45_carbonprice/exponential/not_used.txt
+++ b/modules/45_carbonprice/exponential/not_used.txt
@@ -27,3 +27,4 @@ cm_CO2priceRegConvEndYr,input,questionnaire
 cm_NDC_divergentScenario,input,questionnaire
 vm_demFeSector,input,questionnaire
 pm_emifac,input,questionnaire
+cm_co2_tax_spread,input,No carbon price differentiation in this realization

--- a/modules/45_carbonprice/linear/not_used.txt
+++ b/modules/45_carbonprice/linear/not_used.txt
@@ -27,3 +27,4 @@ cm_CO2priceRegConvEndYr,input,questionnaire
 cm_NDC_divergentScenario,input,questionnaire
 vm_demFeSector,input,questionnaire
 pm_emifac,input,questionnaire
+cm_co2_tax_spread,switch,no carbon price differentiation in this realization

--- a/modules/45_carbonprice/module.gms
+++ b/modules/45_carbonprice/module.gms
@@ -24,6 +24,8 @@
 $Ifi "%carbonprice%" == "NDC" $include "./modules/45_carbonprice/NDC/realization.gms"
 $Ifi "%carbonprice%" == "NPi" $include "./modules/45_carbonprice/NPi/realization.gms"
 $Ifi "%carbonprice%" == "diffCurvPhaseIn2Lin" $include "./modules/45_carbonprice/diffCurvPhaseIn2Lin/realization.gms"
+$Ifi "%carbonprice%" == "diffExp2Lin" $include "./modules/45_carbonprice/diffExp2Lin/realization.gms"
+$Ifi "%carbonprice%" == "diffLin2Lin" $include "./modules/45_carbonprice/diffLin2Lin/realization.gms"
 $Ifi "%carbonprice%" == "exogenous" $include "./modules/45_carbonprice/exogenous/realization.gms"
 $Ifi "%carbonprice%" == "expoLinear" $include "./modules/45_carbonprice/expoLinear/realization.gms"
 $Ifi "%carbonprice%" == "exponential" $include "./modules/45_carbonprice/exponential/realization.gms"

--- a/modules/45_carbonprice/temperatureNotToExceed/not_used.txt
+++ b/modules/45_carbonprice/temperatureNotToExceed/not_used.txt
@@ -22,3 +22,4 @@ cm_CO2priceRegConvEndYr,input,questionnaire
 cm_NDC_divergentScenario,input,questionnaire
 vm_demFeSector,input,questionnaire
 pm_emifac,input,questionnaire
+cm_co2_tax_spread,input,no carbon price differentiation in this realization


### PR DESCRIPTION
## Purpose of this PR

1. Enable stronger carbon price differentiation - see new switch cm_co2_tax_spread (introduced by Nico)
2. Combine exponentially increasing carbon prices and carbon price differentiation which is needed for overshoot scenarios in ScenarioMIP - see new realization diffExp2Lin (with cm_iterative_target_adj = 5)
3. Enable exponentially increasing carbon prices until peak year that remain constant thereafter (or increase linearly at fixed slope) - this corresponds to theoretically optimal Hotelling's rule - see new realization diffExp2Lin (with cm_iterative_target_adj = 9 and cm_co2_tax_spread = 1)
4. Creating new realization diffLin2Lin based on current default diffCurvPhaseIn2Lin. The changes concern 1., minor code clean up and a quick fix for more near-term realism in PkBudg runs - see also [this issue](https://github.com/remindmodel/development_issues/issues/295#issuecomment-2150247905). More changes are expected in the next weeks. The goal is that diffLin2Lin will eventually replace diffCurvPhaseIn2Lin as the default forPkBudg runs. 
5. Updating default growth rate for exponential carbon pricing (cm_co2_tax_growth) to 4.5% instead of 5% in order to be consistent with [this change](https://gitlab.pik-potsdam.de/REMIND/wiki/-/wikis/REMIND-Meeting-Minutes#remarks-on-code-development). Note that this does not affect any AMT runs.

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] New feature 
- [x] Minor change (default scenarios show only small differences)
- [ ] This change requires a documentation update (to be judged by reviewers)


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (to be judged by reviewers in needed)

## Further information (optional):

At Reviewers: It's my first pull request, so I am thankful for a careful check and for any feedback!
* Test runs are here: /p/tmp/laurinko/hpc/remind/output (folders created on 03-07-2024 use the latestversion)
* Comparison of results (what changes by this PR?): Default runs are not affected by the PR. Scenario comparison PDFs are in /p/tmp/laurinko/hpc/remind/ (see pages 52-53 for carbon prices):
**Further scenario comparison PDFs in comments below together with plots and explanations**
(1) Exponential carbon pricing in end-of-century budget runs with different budgets (500, 650, 1050) and different carbon price differentiation spread (1, 10, 20): compScen-EocBudg-2024-07-02_12.57.31-H12.pdf
(2) Exponential carbon pricing in  peak budget runs with different budgets (500, 650, 1050) and different carbon price differentiation spread (1, 10, 20): compScen-PkBudg-exp-2024-07-02_12.58.44-H12.pdf
(3) Comparison of linear and exponential carbon pricing in 650 peak budget runs with different carbon price differentiation spread (1, 10, 20): compScen-PkBudg650-2024-07-02_13.00.26-H12.pdf
(4) Comparison of linear and exponential carbon pricing in 1050 peak budget runs with different carbon price differentiation spread (1, 10, 20): compScen-PkBudg1050-2024-07-02_12.59.32-H12.pdf