### PR TITLE
reset renv/activate.R before sourcing it

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -16,16 +16,20 @@ options(renv.config.synchronized.check = FALSE)
 # always set the renv project to the current directory (formerly done by renv/activate.R under version 0.16.0) 
 Sys.setenv("RENV_PROJECT" = getwd())
 
+# when increasing renvVersion first commit new version's activate script and
+# put that commit's hash into the git checkout call below
+renvVersion <- "1.0.7"
+
+# reset renv/activate.R to match renv 1.0.7
+if (Sys.getenv("RESET_RENV_ACTIVATE_SCRIPT", unset = "TRUE") == "TRUE") {
+  system("git checkout b83bb1811ff08d8ee5ba8e834af5dd0080d10e66 -- renv/activate.R")
+}
+
 source("renv/activate.R")
 
-# when increasing renvVersion first commit new version's activate script and
-# put that commit's hash into the download.file call below
-renvVersion <- "1.0.7"
 if (packageVersion("renv") != renvVersion) {
   renvLockExisted <- file.exists(renv::paths$lockfile())
   renv::install(paste0("renv@", renvVersion))
-  message("Downloading 'renv/activate.R' of renv version 1.0.7")
-  download.file("https://raw.githubusercontent.com/remindmodel/remind/b83bb1811ff08d8ee5ba8e834af5dd0080d10e66/renv/activate.R", "renv/activate.R")
   if (!renvLockExisted) {
     unlink(renv::paths$lockfile())
   }
@@ -39,7 +43,7 @@ if (!"https://rse.pik-potsdam.de/r/packages" %in% getOption("repos")) {
 if (isTRUE(rownames(installed.packages(priority = "NA")) == "renv")) {
   message("R package dependencies are not installed in this renv, installing now...")
   renv::install("rmarkdown", prompt = FALSE) # rmarkdown is required to find dependencies in Rmd files
-  renv::hydrate() # auto-detect and install all dependencies
+  renv::hydrate(prompt = FALSE, report = FALSE) # auto-detect and install all dependencies
   message("Finished installing R package dependencies.")
 }
 


### PR DESCRIPTION
## Purpose of this PR
reset renv/activate.R before sourcing it, preventing the error `object '..version..' not found` that comes up when jumping from renv version 0.16.0 to 1.0.7 (maybe also vice versa)

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix 
- [ ] Refactoring
- [ ] New feature 
- [ ] Minor change (default scenarios show only small differences)
- [ ] Fundamental change
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [ ] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

