### PR TITLE
Bugfix the creation of the list of available REMIND reports for shinyresults

### DIFF
--- a/scripts/output/single/rds_report.R
+++ b/scripts/output/single/rds_report.R
@@ -58,6 +58,6 @@ if(file.exists(runstatistics) & dir.exists(resultsarchive)) {
   saveRDS(q,file=paste0(resultsarchive,"/",stats$id,".rds"))
   cwd <- getwd()
   setwd(resultsarchive)
-  system("ls 1*.rds > files")
+  system("find -type f -name '1*.rds' -printf '%f\n' | sort > files")
   setwd(cwd)
 }


### PR DESCRIPTION
The list of REMIND reportings availalbe in shinyresults was empty, because the 'ls' command failed with `sh: /usr/bin/ls: Argument list too long`. This commit fixes it. However, each time an old version of `rds_report.R` is executed, it will empty the list again. This needs another fix.