### PR TITLE
fix tax convergence reporting in modelSummary

### DIFF
--- a/scripts/start/modelSummary.R
+++ b/scripts/start/modelSummary.R
@@ -98,12 +98,12 @@ modelSummary <- function(folder = ".", gams_runtime = NULL) {
       message("No failed markets in fulldata.gdx.")
     }
     failedtaxes <- quitte::as.quitte(readGDX(file.path(folder, "fulldata.gdx"), "p80_convNashTaxrev_iter"))
-    failedtaxes <- droplevels(dplyr::filter(failedtaxes, !!rlang::sym("value") == 1))
+    failedtaxes <- droplevels(dplyr::filter(failedtaxes, as.numeric(!!rlang::sym("iteration")) == max_iter_fd, abs(!!rlang::sym("value")) > 0.001))
     if (nrow(failedtaxes) > 0) {
       message("Failed tax convergence in fulldata.gdx:")
       for (r in levels(failedtaxes$region)) {
         rf <- failedtaxes$period[failedtaxes$region == r]
-        message(" - ", r, ": ", paste0(rf[1:mif(length(rf), 10)], collapse = ", "), if (length(rf) > 10) " ...")
+        message(" - ", r, ": ", paste0(rf[1:min(length(rf), 10)], collapse = ", "), if (length(rf) > 10) " ...")
       }
     } else {
       message("No failed tax convergence in fulldata.gdx.")


### PR DESCRIPTION
## Purpose of this PR

- was broken since all iterations were tracked, as `p80_convNashTaxrev` was replaced by `p80_convNashTaxrev_iter`
- now again prints the following to the log and to `remindstatus` on the cluster:
```
No failed markets in fulldata.gdx.
Failed tax convergence in fulldata.gdx:
 - IND: 2080
 - MEA: 2070, 2080, 2090
 - REF: 2070, 2080, 2090, 2100, 2110, 2130, 2150
 - SSA: 2070, 2080
 ```

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] No need to update the changelog `CHANGELOG.md`
