### PR TITLE
some adjustments to diffCurvPhaseIn2Lin, add Laurin as author

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -105,11 +105,18 @@
     },
     {
       "name": "Klein, David",
-      "affiliation": "Potsdam Institute for Climate Impact Research"
+      "affiliation": "Potsdam Institute for Climate Impact Research",
+      "orcid": "0009-0001-7917-8041"
     },
     {
       "name": "Koch, Johannes",
-      "affiliation": "Potsdam Institute for Climate Impact Research"
+      "affiliation": "Potsdam Institute for Climate Impact Research",
+      "orcid": "0000-0003-2920-8086"
+    },
+    {
+      "name": "Köhler-Schindler, Laurin",
+      "affiliation": "Potsdam Institute for Climate Impact Research",
+      "orcid": "0000-0003-4268-3084"
     },
     {
       "name": "Körner, Alexander"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -116,6 +116,12 @@ authors:
 
 - family-names: "Koch"
   given-names:  "Johannes"
+  orcid: https://orcid.org/0000-0003-2920-8086
+  affiliation: "Potsdam Institute for Climate Impact Research"
+
+- family-names: "Köhler-Schindler"
+  given-names:  "Laurin"
+  orcid: https://orcid.org/0000-0003-4268-3084
   affiliation: "Potsdam Institute for Climate Impact Research"
 
 - family-names: "Körner"

--- a/modules/45_carbonprice/diffCurvPhaseIn2Lin/not_used.txt
+++ b/modules/45_carbonprice/diffCurvPhaseIn2Lin/not_used.txt
@@ -24,3 +24,4 @@ pm_prtp,input,questionnaire
 vm_demFeSector,input,questionnaire
 pm_emifac,input,questionnaire
 cm_co2_tax_spread,input,added by codeCheck
+cm_startyear,parameter,not needed

--- a/scripts/output/single/MAGICC7_AR6.R
+++ b/scripts/output/single/MAGICC7_AR6.R
@@ -152,7 +152,7 @@ runHarmoniseAndInfillCmd <- paste(
 
 runClimateEmulatorCmd <- paste(
   "python", file.path(scriptsFolder, "run_clim.py"),
-  normalizePath(file.path(climateAssessmentFolder, paste0(baseFileName, "_harmonized_infilled.csv"))),
+  normalizePath(file.path(climateAssessmentFolder, paste0(baseFileName, "_harmonized_infilled.csv")), mustWork = FALSE),
   climateAssessmentFolder,
   "--num-cfgs", nparsets,
   "--scenario-batch-size", 1,

--- a/scripts/output/single/fixOnRef.R
+++ b/scripts/output/single/fixOnRef.R
@@ -81,7 +81,7 @@ fixOnMif <- function(outputdir) {
   dref <- quitte::as.quitte(refmif)
   d <- fixMAGICC(d, dref, startyear, title)
   failfile <- file.path(outputdir, "log_fixOnRef.csv")
-  fixeddata <- piamInterfaces::fixOnRef(d, dref, ret = "TRUE_or_fixed", startyear = startyear, failfile = failfile)
+  fixeddata <- piamInterfaces::fixOnRef(d, dref, ret = "TRUE_or_fixed", startyear = startyear, failfile = failfile, relDiff = 0.00002)
 
   update <- paste0("MAGICC data. ", if (! isTRUE(fixeddata)) "Run output.R -> single -> fixOnRef to fix the rest.")
   if (! isTRUE(fixeddata) && isTRUE(envi$cfg$fixOnRefAuto)) {

--- a/tutorials/11_ManagingRenv.md
+++ b/tutorials/11_ManagingRenv.md
@@ -55,7 +55,7 @@ REMIND uses [renv](https://rstudio.github.io/renv/) for managing required R pack
 The `piamenv` functions explained earlier should cover all common tasks, use the following for more control.
 - `renv::install("package@2.3.4")` install specific package version
 - `renv::install("githubuser/package", ref = "<commit hash>")` install package from GitHub, optionally provide commit hash
-- `renv::install("/p/tmp/username/yourpackagefolder")` install package from sources
+- `renv::install("/p/tmp/username/yourpackagefolder")` install package from sources. Always use an absolute path!
 - `renv::remove("package")` uninstall package
 - `renv::update(exclude = "renv")` (`make update-renv-all`) update all packages except renv (please do not update renv itself)
 - `renv::update("package")` update package


### PR DESCRIPTION
## Purpose of this PR

- `ttot$((ttot.val ge cm_startyear)` is `t`
- update docu: convergence year is 2050, not 2040
- fix warning in climate assessment because file does not yet exist
- relax fixOnRef precision to avoid 'errors' such as 0.0000139 % deviation
- add Laurin as new author + add some orcids

## Type of change

- [x] Refactoring
- [x] Author update

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
