### PR TITLE
reset renv/activate.R fix

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -13,7 +13,7 @@ if (file.exists("renv.lock") && file.exists("README.md") && !file.exists("renv/o
 # do not check if library and renv.lock are in sync, because normally renv.lock does not exist
 options(renv.config.synchronized.check = FALSE)
 
-# always set the renv project to the current directory (formerly done by renv/activate.R under version 0.16.0) 
+# always set the renv project to the current directory
 Sys.setenv("RENV_PROJECT" = getwd())
 
 # when increasing renvVersion first commit new version's activate script and
@@ -21,7 +21,9 @@ Sys.setenv("RENV_PROJECT" = getwd())
 renvVersion <- "1.0.7"
 
 # reset renv/activate.R to match renv 1.0.7
-if (Sys.getenv("RESET_RENV_ACTIVATE_SCRIPT", unset = "TRUE") == "TRUE") {
+gitRoot <- system2("git", c("rev-parse", "--show-toplevel"), stdout = TRUE)
+if (Sys.getenv("RESET_RENV_ACTIVATE_SCRIPT", unset = "TRUE") == "TRUE" &&
+      normalizePath(gitRoot) == normalizePath(".")) {
   system("git checkout b83bb1811ff08d8ee5ba8e834af5dd0080d10e66 -- renv/activate.R")
 }
 

--- a/.Rprofile
+++ b/.Rprofile
@@ -24,7 +24,7 @@ renvVersion <- "1.0.7"
 gitRoot <- system2("git", c("rev-parse", "--show-toplevel"), stdout = TRUE)
 if (Sys.getenv("RESET_RENV_ACTIVATE_SCRIPT", unset = "TRUE") == "TRUE" &&
       normalizePath(gitRoot) == normalizePath(".")) {
-  system("git checkout b83bb1811ff08d8ee5ba8e834af5dd0080d10e66 -- renv/activate.R")
+  system2("git", c("checkout", "b83bb1811ff08d8ee5ba8e834af5dd0080d10e66", "--", "renv/activate.R"))
 }
 
 source("renv/activate.R")


### PR DESCRIPTION
## Purpose of this PR
fix issues discussed in #1725 

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [ ] Bug fix 
- [ ] Refactoring
- [ ] New feature 
- [ ] Minor change (default scenarios show only small differences)
- [ ] Fundamental change
- [ ] This change requires a documentation update


## Checklist:

- [ ] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [ ] I explained my changes within the PR, particularly in hard-to-understand areas
- [ ] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

