### PR TITLE
add cm_wastelag to toggle the ten-year timelag between plastics production and plastic waste incineration

### DIFF
--- a/main.gms
+++ b/main.gms
@@ -1627,6 +1627,9 @@ $setglobal cm_ind_energy_limit_manual   "2050 . GLO . (ue_cement, ue_steel_prima
 *** 2050.GLO 0.5, 2050.EUR 0.8: means that 50% of waste incineration emissions are captured for all regions from 2050 onward, except for Europe that has 80% of its waste incineration emissions captured.
 *** The CCS share of waste incineration increases linearly from zero, in 2025, to the value set at the switch, and it is kept constant for years afterwards.
 $setglobal cm_wasteIncinerationCCSshare  off      !! def = off
+*** cm_wastelag, does waste from plastics lag ten years behind plastics
+*** production, or not?
+$setglobal cm_wastelag YES   !! def = YES   !! regexp = YES|NO
 *** cm_feedstockEmiUnknownFate, account for chemical feedstock emissions with unknown fate
 *** off: assume that these emissions are trapped and do not account for total anthropogenic emissions
 *** on: account for chemical feedstock emissions with unknown fate as re-emitted to the atmosphere

--- a/modules/37_industry/subsectors/equations.gms
+++ b/modules/37_industry/subsectors/equations.gms
@@ -278,22 +278,28 @@ q37_plasticsCarbon(t,regi,sefe(entySe,entyFe),emiMkt)$(
   * s37_plasticsShare
 ;
 
-*' calculate plastic waste generation, shifted by mean lifetime of plastic products
-*' shift by 2 time steps when we have 5-year steps and 1 when we have 10-year steps
-*' allocate averge of 2055 and 2060 to 2070
+*' calculate plastic waste generation, shifted by mean lifetime of plastic
+*' products shift by 2 time steps when we have 5-year steps and 1 when we have
+*' 10-year steps allocate averge of 2055 and 2060 to 2070, unless `cm_wastelag`
+*' is `NO`, in which case waste is incurred in the same period plastics are
+*' produced
 q37_plasticWaste(ttot,regi,sefe(entySe,entyFe),emiMkt)$(
                          entyFE2sector2emiMkt_NonEn(entyFe,"indst",emiMkt)
                      AND ttot.val ge max(2015, cm_startyear)               ) ..
   v37_plasticWaste(ttot,regi,entySe,entyFe,emiMkt)
   =e=
-    v37_plasticsCarbon(ttot-2,regi,entySe,entyFe,emiMkt)$( ttot.val lt 2070 )
-  + ( ( v37_plasticsCarbon(ttot-2,regi,entySe,entyFe,emiMkt)
-      + v37_plasticsCarbon(ttot-1,regi,entySe,entyFe,emiMkt)
-      )
-    / 2
-    )$( ttot.val eq 2070 )
-  + v37_plasticsCarbon(ttot-1,regi,entySe,entyFe,emiMkt)$( ttot.val gt 2070 )
-  ;
+    !! prompt waste
+    v37_plasticsCarbon(ttot,regi,entySe,entyFe,emiMkt)$( NOT %cm_wastelag% )
+    !! lagged waste
+  + ( v37_plasticsCarbon(ttot-2,regi,entySe,entyFe,emiMkt)$( ttot.val lt 2070 )
+    + ( ( v37_plasticsCarbon(ttot-2,regi,entySe,entyFe,emiMkt)
+        + v37_plasticsCarbon(ttot-1,regi,entySe,entyFe,emiMkt)
+        )
+      / 2
+      )$( ttot.val eq 2070 )
+    + v37_plasticsCarbon(ttot-1,regi,entySe,entyFe,emiMkt)$( ttot.val gt 2070 )
+    )$( %cm_wastelag% )
+;
 
 *' emissions from plastics incineration as a share of total plastic waste,
 *' discounted by captured amount


### PR DESCRIPTION
- [x] New feature 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)