### PR TITLE
KotzWenz damages with new MAGICC - temperature fix

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -266,8 +266,8 @@ abstract: REMIND (REgional Model of Investment and Development) is a numerical
   technology, policy and climate constraints. It also accounts for regional trade 
   characteristics on goods, energy fuels, and emissions allowances. All greenhouse 
   gas emissions due to human activities are represented in the model.
-version: "3.3.2.dev125"
-date-released: 2024-07-09
+version: "3.3.2.dev144"
+date-released: 2024-07-10
 repository-code: https://github.com/remindmodel/remind
 keywords:
   - energy

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -71,7 +71,7 @@ cfg$validationmodel_name <- "VALIDATIONREMIND"
 
 #### model version of the overall model (used for run statistics only).
 # automatically generated for development versions, updated by hand for releases
-cfg$model_version <- "3.3.2.dev125"
+cfg$model_version <- "3.3.2.dev144"
 
 #### settings ####
 cfg$gms <- list()

--- a/modules/50_damages/BurkeLike/not_used.txt
+++ b/modules/50_damages/BurkeLike/not_used.txt
@@ -5,7 +5,6 @@
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
 name,type,reason
-pm_damageMarginalIsoPerc,input,questionnaire
 pm_globalMeanTemperatureZeroed1900,input,questionnaire
 pm_damageMarginalT,input,questionnaire
 pm_damageMarginalTm1,input,questionnaire

--- a/modules/50_damages/DiceLike/not_used.txt
+++ b/modules/50_damages/DiceLike/not_used.txt
@@ -5,7 +5,6 @@
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
 name,type,reason
-pm_damageMarginalIsoPerc,input,questionnaire
 pm_regionalTemperature,input,questionnaire
 pm_damageGrowthRate,input,questionnaire
 cm_damages_BurkeLike_specification,input,questionnaire

--- a/modules/50_damages/KWLike/not_used.txt
+++ b/modules/50_damages/KWLike/not_used.txt
@@ -5,7 +5,6 @@
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
 name,type,reason
-pm_damageMarginalIsoPerc,input,questionnaire
 pm_globalMeanTemperatureZeroed1900,input,questionnaire
 cm_damages_BurkeLike_specification,input,questionnaire
 cm_damages_BurkeLike_persistenceTime,input,questionnaire

--- a/modules/50_damages/KWTCint/not_used.txt
+++ b/modules/50_damages/KWTCint/not_used.txt
@@ -5,7 +5,6 @@
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
 name,type,reason
-pm_damageMarginalIsoPerc,input,questionnaire
 cm_damages_BurkeLike_specification,input,questionnaire
 cm_damages_BurkeLike_persistenceTime,input,questionnaire
 pm_damageMarginal,input,questionnaire

--- a/modules/50_damages/KW_SE/not_used.txt
+++ b/modules/50_damages/KW_SE/not_used.txt
@@ -5,7 +5,6 @@
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
 name,type,reason
-pm_damageMarginalIsoPerc,input,questionnaire
 pm_GDPGross,input,questionnaire
 pm_damageMarginalTC,input,questionnaire
 pm_GDPGrossIso,input,questionnaire

--- a/modules/50_damages/KotzWenz/declarations.gms
+++ b/modules/50_damages/KotzWenz/declarations.gms
@@ -2,7 +2,7 @@ Parameters
 pm_GDPfrac(tall,iso)	"GDP fraction of a country in its region"
 p50_damageIsoPerc(tall,iso,percentile)	"damage factor for country and bootstrapping"
 pm_damage(tall,all_regi)	"regional damage factor"
-pm_damageMarginalIsoPerc(tall,iso,percentile)	"marginal damage for country and bootstrapping"
+p50_damageMarginalIsoPerc(tall,iso,percentile)	"marginal damage for country and bootstrapping"
 pm_damageMarginal(tall,all_regi)	"regional marginal damage"
 ;
 

--- a/modules/50_damages/KotzWenz/postsolve.gms
+++ b/modules/50_damages/KotzWenz/postsolve.gms
@@ -1,10 +1,10 @@
 
 execute "Rscript run_KotzWenz_damages.R"
 execute_loadpoint 'pm_KotzWenz_damageIso' p50_damageIsoPerc=pm_damageIso;
-execute_loadpoint 'pm_KotzWenz_damageMarginalIso' pm_damageMarginalIsoPerc=pm_damageMarginalIso;
+execute_loadpoint 'pm_KotzWenz_damageMarginalIso' p50_damageMarginalIsoPerc=pm_damageMarginalIso;
 
 pm_damageMarginal(tall,regi)$(tall.val gt 2020 and tall.val le 2300) = 
-	sum(regi2iso(regi,iso),pm_damageMarginalIsoPerc(tall,iso,"%cm_KotzWenzPerc%")*pm_GDPfrac(tall,iso))
+	sum(regi2iso(regi,iso),p50_damageMarginalIsoPerc(tall,iso,"%cm_KotzWenzPerc%")*pm_GDPfrac(tall,iso))
 ;
 
 *regional damage using SSP country level GDP as weight

--- a/modules/50_damages/Labor/not_used.txt
+++ b/modules/50_damages/Labor/not_used.txt
@@ -5,7 +5,6 @@
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
 name,type,reason
-pm_damageMarginalIsoPerc,input,questionnaire
 pm_globalMeanTemperatureZeroed1900,input,questionnaire
 pm_temperatureImpulseResponseCO2,input,questionnaire
 pm_GDPGross,input,questionnaire

--- a/modules/50_damages/TC/not_used.txt
+++ b/modules/50_damages/TC/not_used.txt
@@ -5,7 +5,6 @@
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
 name,type,reason
-pm_damageMarginalIsoPerc,input,questionnaire
 pm_temperatureImpulseResponseCO2,input,questionnaire
 cm_damages_BurkeLike_specification,input,questionnaire
 cm_damages_BurkeLike_persistenceTime,input,questionnaire

--- a/modules/50_damages/off/not_used.txt
+++ b/modules/50_damages/off/not_used.txt
@@ -5,7 +5,6 @@
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
 name,type,reason
-pm_damageMarginalIsoPerc,input,questionnaire
 pm_globalMeanTemperatureZeroed1900,input,questionnaire
 pm_regionalTemperature,input,questionnaire
 pm_damage,input,questionnaire

--- a/modules/51_internalizeDamages/BurkeLikeItr/datainput.gms
+++ b/modules/51_internalizeDamages/BurkeLikeItr/datainput.gms
@@ -12,9 +12,9 @@ $ifi not %cm_magicc_temperatureImpulseResponse% == 'on' abort "module internaliz
 
 
 *inital guess carbon tax for 1st iter. Does not influence solution point.
-p51_scc(tall,regi) = 0;
-p51_scc("2025",regi) = 20;
-p51_scc(tall,regi)$(tall.val ge 2025 and tall.val le 2150) = p51_scc("2025",regi)*(1+0.025*(tall.val-2025));
+p51_scc(tall) = 0;
+p51_scc("2025") = 20;
+p51_scc(tall)$(tall.val ge 2025 and tall.val le 2150) = p51_scc("2025")*(1+0.025*(tall.val-2025));
 
 pm_taxCO2eqSCC(ttot,regi)$(ttot.val ge 2010) = p51_scc(ttot) * sm_c_2_co2/1000;
 

--- a/modules/51_internalizeDamages/BurkeLikeItr/not_used.txt
+++ b/modules/51_internalizeDamages/BurkeLikeItr/not_used.txt
@@ -5,7 +5,6 @@
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
 name,type,reason
-pm_damageMarginalIsoPerc,input,questionnaire
 pm_damageMarginalT,input,questionnaire
 pm_damageMarginalTm1,input,questionnaire
 pm_damageMarginalTm2,input,questionnaire

--- a/modules/51_internalizeDamages/DiceLikeItr/datainput.gms
+++ b/modules/51_internalizeDamages/DiceLikeItr/datainput.gms
@@ -11,9 +11,9 @@ $ifi not %damages% == 'DiceLike' abort "module internalizeDamages=DiceLikeItr re
 $ifi not %cm_magicc_temperatureImpulseResponse% == 'on' abort "module internalizeDamages=DiceLikeItr requires cm_magicc_temperatureImpulseResponse=on";
 
 *init carbon tax for 1st iter
-p51_scc(tall,regi) = 0;
-p51_scc("2025",regi) = 20;
-p51_scc(tall,regi)$(tall.val ge 2025 and tall.val le 2150) = p51_scc("2025",regi)*(1+0.025*(tall.val-2025));
+p51_scc(tall) = 0;
+p51_scc("2025") = 20;
+p51_scc(tall)$(tall.val ge 2025 and tall.val le 2150) = p51_scc("2025")*(1+0.025*(tall.val-2025));
 
 pm_taxCO2eqSCC(ttot,regi)$(ttot.val ge 2010) = p51_scc(ttot) * sm_c_2_co2/1000;
 

--- a/modules/51_internalizeDamages/DiceLikeItr/not_used.txt
+++ b/modules/51_internalizeDamages/DiceLikeItr/not_used.txt
@@ -5,7 +5,6 @@
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
 name,type,reason
-pm_damageMarginalIsoPerc,input,questionnaire
 pm_tempScaleGlob2Reg,input,questionnaire
 pm_damage,input,questionnaire
 pm_damageGrowthRate,input,questionnaire

--- a/modules/51_internalizeDamages/KWTCintItr/datainput.gms
+++ b/modules/51_internalizeDamages/KWTCintItr/datainput.gms
@@ -12,9 +12,9 @@ $ifi not %cm_magicc_temperatureImpulseResponse% == 'on' abort "module internaliz
 
 
 *inital guess carbon tax for 1st iter. Does not influence solution point.
-p51_scc(tall,regi) = 0;
-p51_scc("2025",regi) = 20;
-p51_scc(tall,regi)$(tall.val ge 2025 and tall.val le 2150) = p51_scc("2025",regi)*(1+0.025*(tall.val-2025));
+p51_scc(tall) = 0;
+p51_scc("2025") = 20;
+p51_scc(tall)$(tall.val ge 2025 and tall.val le 2150) = p51_scc("2025")*(1+0.025*(tall.val-2025));
 
 pm_taxCO2eqSCC(ttot,regi)$(ttot.val ge 2010) = p51_scc(ttot) * sm_c_2_co2/1000;
 

--- a/modules/51_internalizeDamages/KWTCintItr/not_used.txt
+++ b/modules/51_internalizeDamages/KWTCintItr/not_used.txt
@@ -5,7 +5,6 @@
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
 name,type,reason
-pm_damageMarginalIsoPerc,input,questionnaire
 cm_damages_BurkeLike_persistenceTime,input,questionnaire
 pm_damageMarginal,input,questionnaire
 pm_cesdata,input,questionnaire

--- a/modules/51_internalizeDamages/KW_SEitr/datainput.gms
+++ b/modules/51_internalizeDamages/KW_SEitr/datainput.gms
@@ -12,9 +12,9 @@ $ifi not %cm_magicc_temperatureImpulseResponse% == 'on' abort "module internaliz
 
 
 *inital guess carbon tax for 1st iter. Does not influence solution point.
-p51_scc(tall,regi) = 0;
-p51_scc("2025",regi) = 20;
-p51_scc(tall,regi)$(tall.val ge 2025 and tall.val le 2150) = p51_scc("2025",regi)*(1+0.025*(tall.val-2025));
+p51_scc(tall) = 0;
+p51_scc("2025") = 20;
+p51_scc(tall)$(tall.val ge 2025 and tall.val le 2150) = p51_scc("2025")*(1+0.025*(tall.val-2025));
 
 pm_taxCO2eqSCC(ttot,regi)$(ttot.val ge 2010) = p51_scc(ttot) * sm_c_2_co2/1000;
 

--- a/modules/51_internalizeDamages/KW_SEitr/not_used.txt
+++ b/modules/51_internalizeDamages/KW_SEitr/not_used.txt
@@ -5,7 +5,6 @@
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
 name,type,reason
-pm_damageMarginalIsoPerc,input,questionnaire
 cm_damages_BurkeLike_persistenceTime,input,questionnaire
 pm_damageMarginal,input,questionnaire
 pm_cesdata,input,questionnaire

--- a/modules/51_internalizeDamages/KWlikeItr/datainput.gms
+++ b/modules/51_internalizeDamages/KWlikeItr/datainput.gms
@@ -12,9 +12,9 @@ $ifi not %cm_magicc_temperatureImpulseResponse% == 'on' abort "module internaliz
 
 
 *inital guess carbon tax for 1st iter. Does not influence solution point.
-p51_scc(tall,regi) = 0;
-p51_scc("2025",regi) = 20;
-p51_scc(tall,regi)$(tall.val ge 2025 and tall.val le 2150) = p51_scc("2025",regi)*(1+0.025*(tall.val-2025));
+p51_scc(tall) = 0;
+p51_scc("2025") = 20;
+p51_scc(tall)$(tall.val ge 2025 and tall.val le 2150) = p51_scc("2025")*(1+0.025*(tall.val-2025));
 
 pm_taxCO2eqSCC(ttot,regi)$(ttot.val ge 2010) = p51_scc(ttot) * sm_c_2_co2/1000;
 

--- a/modules/51_internalizeDamages/KWlikeItr/not_used.txt
+++ b/modules/51_internalizeDamages/KWlikeItr/not_used.txt
@@ -5,7 +5,6 @@
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
 name,type,reason
-pm_damageMarginalIsoPerc,input,questionnaire
 pm_cesdata,input,questionnaire
 pm_lab,input,questionnaire
 pm_interpolWeight_ttot_tall,input,questionnaire

--- a/modules/51_internalizeDamages/KWlikeItrCPnash/not_used.txt
+++ b/modules/51_internalizeDamages/KWlikeItrCPnash/not_used.txt
@@ -5,7 +5,6 @@
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
 name,type,reason
-pm_damageMarginalIsoPerc,input,questionnaire
 pm_cesdata,input,questionnaire
 pm_lab,input,questionnaire
 pm_interpolWeight_ttot_tall,input,questionnaire

--- a/modules/51_internalizeDamages/KWlikeItrCPreg/not_used.txt
+++ b/modules/51_internalizeDamages/KWlikeItrCPreg/not_used.txt
@@ -5,7 +5,6 @@
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
 name,type,reason
-pm_damageMarginalIsoPerc,input,questionnaire
 cm_damages_BurkeLike_persistenceTime,input,questionnaire
 pm_damageMarginal,input,questionnaire
 pm_cesdata,input,questionnaire

--- a/modules/51_internalizeDamages/KotzWenzCPreg/not_used.txt
+++ b/modules/51_internalizeDamages/KotzWenzCPreg/not_used.txt
@@ -5,7 +5,7 @@
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
 name,type,reason
-pm_damageMarginal,input,questionnaire
+pm_GDPfrac,input,questionnaire
 pm_damageMarginalT,input,questionnaire
 cm_damages_BurkeLike_persistenceTime,input,questionnaire
 pm_tempScaleGlob2Reg,input,questionnaire

--- a/modules/51_internalizeDamages/KotzWenzCPreg/postsolve.gms
+++ b/modules/51_internalizeDamages/KotzWenzCPreg/postsolve.gms
@@ -18,8 +18,7 @@ p51_scc(tall,regi)$((tall.val ge 2020) and (tall.val le 2150)) = 1000 *
 	* pm_consPC(tall,regi)/pm_consPC(tall2,regi2) 
 	* pm_GDPGross(tall2,regi2)
 	* pm_temperatureImpulseResponseCO2(tall2,tall)
-*	* pm_damageMarginal(tall2,regi2)
-	* sum(regi2iso(regi2,iso),pm_damageMarginalIsoPerc(tall2,iso,"%cm_KotzWenzPerc%")*pm_GDPfrac(tall2,iso))
+	* pm_damageMarginal(tall2,regi2)
    ))
 ;
 

--- a/modules/51_internalizeDamages/KotzWenzItr/not_used.txt
+++ b/modules/51_internalizeDamages/KotzWenzItr/not_used.txt
@@ -5,7 +5,7 @@
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
 name,type,reason
-pm_damageMarginal,input,questionnaire
+pm_GDPfrac,input,questionnaire
 cm_damages_BurkeLike_persistenceTime,input,questionnaire
 pm_tempScaleGlob2Reg,input,questionnaire
 pm_damage,input,questionnaire

--- a/modules/51_internalizeDamages/KotzWenzItr/postsolve.gms
+++ b/modules/51_internalizeDamages/KotzWenzItr/postsolve.gms
@@ -18,8 +18,7 @@ p51_scc(tall)$((tall.val ge 2020) and (tall.val le 2150)) = 1000 *
 	* pm_consPC(tall,regi2)/pm_consPC(tall2,regi2) 
 	* pm_GDPGross(tall2,regi2)
 	* pm_temperatureImpulseResponseCO2(tall2,tall)
-*	* pm_damageMarginal(tall2,regi2)
-	* sum(regi2iso(regi2,iso),pm_damageMarginalIsoPerc(tall2,iso,"%cm_KotzWenzPerc%")*pm_GDPfrac(tall2,iso))
+	* pm_damageMarginal(tall2,regi2)
     )
    )
 ;

--- a/modules/51_internalizeDamages/LabItr/datainput.gms
+++ b/modules/51_internalizeDamages/LabItr/datainput.gms
@@ -17,9 +17,9 @@ p51_labEff(ttot,regi) = pm_cesdata(ttot,regi,"lab","eff");
 p51_labEffgr(ttot,regi) = pm_cesdata(ttot,regi,"lab","effgr");
 
 *init carbon tax for 1st iter
-p51_scc(tall,regi) = 0;
-p51_scc("2025",regi) = 20;
-p51_scc(tall,regi)$(tall.val ge 2025 and tall.val le 2150) = p51_scc("2025",regi)*(1+0.025*(tall.val-2025));
+p51_scc(tall) = 0;
+p51_scc("2025") = 20;
+p51_scc(tall)$(tall.val ge 2025 and tall.val le 2150) = p51_scc("2025")*(1+0.025*(tall.val-2025));
 
 pm_taxCO2eqSCC(ttot,regi)$(ttot.val ge 2010) = p51_scc(ttot) * sm_c_2_co2/1000;
 

--- a/modules/51_internalizeDamages/LabItr/not_used.txt
+++ b/modules/51_internalizeDamages/LabItr/not_used.txt
@@ -5,7 +5,6 @@
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
 name,type,reason
-pm_damageMarginalIsoPerc,input,questionnaire
 cm_damages_BurkeLike_persistenceTime,input,questionnaire
 pm_damageGrowthRate,input,questionnaire
 pm_damageMarginalT,input,questionnaire

--- a/modules/51_internalizeDamages/TCitr/datainput.gms
+++ b/modules/51_internalizeDamages/TCitr/datainput.gms
@@ -13,9 +13,9 @@ $ifi not %cm_magicc_temperatureImpulseResponse% == 'on' abort "module internaliz
 
 
 *inital guess carbon tax for 1st iter. Does not influence solution point.
-p51_scc(tall,regi) = 0;
-p51_scc("2025",regi) = 20;
-p51_scc(tall,regi)$(tall.val ge 2025 and tall.val le 2150) = p51_scc("2025",regi)*(1+0.025*(tall.val-2025));
+p51_scc(tall) = 0;
+p51_scc("2025") = 20;
+p51_scc(tall)$(tall.val ge 2025 and tall.val le 2150) = p51_scc("2025")*(1+0.025*(tall.val-2025));
 
 pm_taxCO2eqSCC(ttot,regi)$(ttot.val ge 2010) = p51_scc(ttot) * (44/12)/1000;
 

--- a/modules/51_internalizeDamages/TCitr/not_used.txt
+++ b/modules/51_internalizeDamages/TCitr/not_used.txt
@@ -5,7 +5,6 @@
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
 name,type,reason
-pm_damageMarginalIsoPerc,input,questionnaire
 pm_cesdata,input,questionnaire
 pm_lab,input,questionnaire
 pm_GDPGross,input,questionnaire

--- a/modules/51_internalizeDamages/off/not_used.txt
+++ b/modules/51_internalizeDamages/off/not_used.txt
@@ -5,7 +5,6 @@
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
 name,type,reason
-pm_damageMarginalIsoPerc,input,questionnaire
 pm_temperatureImpulseResponseCO2,input,questionnaire
 pm_tempScaleGlob2Reg,input,questionnaire
 pm_damage,input,questionnaire

--- a/scripts/input/run_KotzWenz_damages.R
+++ b/scripts/input/run_KotzWenz_damages.R
@@ -27,6 +27,9 @@ maxtemp <- read.csv("../../modules/50_damages/KotzWenz/input/f50_KLW_df_maxGMT.c
 #}
 getTemperatureMagicc = function(file="./p15_magicc_temp.gdx"){
   x <- read.gdx("p15_magicc_temp.gdx","pm_globalMeanTemperature") %>% rename(period=tall)
+  if(max(x$period) == 2100){
+    x <- rbind(x,tibble(period= seq(2101,2300,1),value=subset(x,period == 2100)$value))
+  }
   # Get relevant years
   return(subset(x,period >= 2005 & period <= 2300))	
 }


### PR DESCRIPTION
## Purpose of this PR
ensure that damages are calculated after 2100 for KotzWenz damage module with new MAGICC version
fix minor bugs in SCC module

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix 
- [ ] Refactoring
- [ ] New feature 
- [ ] Minor change (default scenarios show only small differences)
- [ ] Fundamental change
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [ ] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

