### PR TITLE
Multiple fixes and improvements on MAGICC for damages

### DIFF
--- a/modules/51_internalizeDamages/KWlikeItr/postsolve.gms
+++ b/modules/51_internalizeDamages/KWlikeItr/postsolve.gms
@@ -17,10 +17,10 @@ p51_marginalDamageCumul(tall,tall2,regi2)$((tall2.val ge tall.val) and (tall.val
 ;
 
 p51_sccLastItr(tall) = p51_scc(tall);
-
+* Add an epsilon to pm_consPC to avoid division by zero in case of INFES in the reference data
 p51_sccParts(tall,tall2,regi2)$((tall.val ge 2010) and (tall.val le 2150) and (tall2.val ge tall.val) and (tall2.val le 2250)) = 
 	 (1 + pm_prtp(regi2) )**(-(tall2.val - tall.val))
-	* pm_consPC(tall,regi2)/pm_consPC(tall2,regi2) 
+	* pm_consPC(tall,regi2)/(pm_consPC(tall2,regi2) + 0.0000001) 
         * pm_damage(tall2,regi2) * pm_GDPGross(tall2,regi2) 
 	* p51_marginalDamageCumul(tall,tall2,regi2) 
 	* pm_sccIneq(tall2,regi2)

--- a/scripts/input/climate_assessment_openscm_run.py
+++ b/scripts/input/climate_assessment_openscm_run.py
@@ -18,8 +18,8 @@ import json
 
 # TONN REMOVE start
 # If these are already set, it shouldn't override it. We actually may not want to have a default but just throw an error if not set
-os.environ["MAGICC_EXECUTABLE_7"]       =   "/p/projects/piam/abrahao/scratch/module_climate_tests/climate-assessment-files/magicc-v7.5.3/bin/magicc"
-os.environ["MAGICC_WORKER_ROOT_DIR"]    =   "/p/projects/piam/abrahao/scratch/methane/methane_scm/workers"
+os.environ["MAGICC_EXECUTABLE_7"]       =   "/p/projects/rd3mod/climate-assessment-files/magicc-v7.5.3/bin/magicc"
+os.environ["MAGICC_WORKER_ROOT_DIR"]    =   os.environ["PTMP"] + "/"
 
 LOGGER = logging.getLogger(__name__) # We don't need this
 # TONN REMOVE end
@@ -189,10 +189,3 @@ runresults.filter(region = "World"
                   ).to_excel(
                       outfilename
                       )
-
-# # # %%
-# # # Show basic results
-# # runresults.filter(
-# #     variable = "Surface Air Temperature Change",
-# #     region = "World"
-# #     ).lineplot()

--- a/scripts/input/climate_assessment_openscm_run.py
+++ b/scripts/input/climate_assessment_openscm_run.py
@@ -23,11 +23,12 @@ class EnvironmentError(Exception):
 for env_var in ["MAGICC_EXECUTABLE_7", "MAGICC_WORKER_ROOT_DIR"]:  
     if os.environ.get(env_var, '') == '':  
         # If clause covers both cases in which the env var is not set at all 
-        # as well as the case in which it is set to an empty string  
-        raise EnvironmentError(f"{env_var} does not exist")  
+        # as well as the case in which it is set to an empty string
         # If these are already set, it shouldn't override it. We actually may not want to have a default but just throw an error if not set
         os.environ["MAGICC_EXECUTABLE_7"]       =   "/p/projects/rd3mod/climate-assessment-files/magicc-v7.5.3/bin/magicc"
-        os.environ["MAGICC_WORKER_ROOT_DIR"]    =   os.environ["PTMP"] + "/"
+        os.environ["MAGICC_WORKER_ROOT_DIR"]    =   os.environ["PTMP"] + "/"  
+        raise EnvironmentError(f"{env_var} does not exist")  
+
 
     # Optional debug prints  
     print(f"Found '{env_var}' = '{os.environ.get(env_var)}' ") 
@@ -182,6 +183,7 @@ runresults = openscm_runner.run(
     },
     output_variables=(
         "Surface Air Temperature Change",
+        "Effective Radiative Forcing|Anthropogenic",
         "Net Atmosphere to Land Flux|CO2"
     ),
 scenarios = scmdata.ScmRun(basescen)

--- a/scripts/input/climate_assessment_openscm_run.py
+++ b/scripts/input/climate_assessment_openscm_run.py
@@ -17,9 +17,20 @@ import xarray as xr
 import json
 
 # TONN REMOVE start
-# If these are already set, it shouldn't override it. We actually may not want to have a default but just throw an error if not set
-os.environ["MAGICC_EXECUTABLE_7"]       =   "/p/projects/rd3mod/climate-assessment-files/magicc-v7.5.3/bin/magicc"
-os.environ["MAGICC_WORKER_ROOT_DIR"]    =   os.environ["PTMP"] + "/"
+class EnvironmentError(Exception):  
+    pass  
+
+for env_var in ["MAGICC_EXECUTABLE_7", "MAGICC_WORKER_ROOT_DIR"]:  
+    if os.environ.get(env_var, '') == '':  
+        # If clause covers both cases in which the env var is not set at all 
+        # as well as the case in which it is set to an empty string  
+        raise EnvironmentError(f"{env_var} does not exist")  
+        # If these are already set, it shouldn't override it. We actually may not want to have a default but just throw an error if not set
+        os.environ["MAGICC_EXECUTABLE_7"]       =   "/p/projects/rd3mod/climate-assessment-files/magicc-v7.5.3/bin/magicc"
+        os.environ["MAGICC_WORKER_ROOT_DIR"]    =   os.environ["PTMP"] + "/"
+
+    # Optional debug prints  
+    print(f"Found '{env_var}' = '{os.environ.get(env_var)}' ") 
 
 LOGGER = logging.getLogger(__name__) # We don't need this
 # TONN REMOVE end

--- a/scripts/input/climate_assessment_run.R
+++ b/scripts/input/climate_assessment_run.R
@@ -223,7 +223,7 @@ runClimateEmulatorCmd <- paste(
   normalizePath(file.path(climateTempDir, paste0(baseFn, "_harmonized_infilled.csv"))),
   "--climatetempdir", climateTempDir,
   # Note: Option --year-filter-last requires https://github.com/gabriel-abrahao/climate-assessment/tree/yearfilter
-  "--endyear", 2200,
+  "--endyear", 2250,
   "--num-cfgs", nparsets,
   "--scenario-batch-size", 1,
   "--probabilistic-file", probabilisticFile


### PR DESCRIPTION
## Purpose of this PR
Fixes some file paths in the climate_assessment python file to be more generic. We still want it to work outside the cluster @tonnrueter , but that will need some improvements in the interfacing. This change here is better than what we currently have.

Also @fpiontek , you proposed the quickfix with the epsilon value a while ago, but it really doesn't work without it. Should we merge this and make it semi-permanent for now? I found myself always having to stash and reapply this line when I change branches, which feels like a bad sign

Furthermore, this PR makes the standard, between-iteration MAGICC for non-internalized damages use the same Python script used for the TIRF. This allows us a lot more flexibility, and now all MAGICC-related GDXs have yearly data at least until 2200. 

@fpiontek this leaves the matter of what emissions to assume after 2150. Right now it's basically assuming all emissions stop after that, but we can also assume them constant with 2150 or 2100 values. It probably won't make much of a difference given the discounting, but we should have a sensible assumption here anyway.  

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [X] Bug fix 
- [ ] Refactoring
- [ ] New feature 
- [ ] Minor change (default scenarios show only small differences)
- [ ] Fundamental change
- [ ] This change requires a documentation update


## Checklist:

- [ ] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [ ] I explained my changes within the PR, particularly in hard-to-understand areas
- [ ] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

