### PR TITLE
let IKEA pass tests; improve selection process + logging in output.R; damage bugfix

### DIFF
--- a/config/tests/scenario_config_quick.csv
+++ b/config/tests/scenario_config_quick.csv
@@ -1,2 +1,2 @@
 title;start;cm_nash_mode;cm_iteration_max;optimization;results_folder;output;cm_quick_mode;force_replace;slurmConfig
-testOneRegi;1;1;1;testOneRegi;output/testOneRegi;NA;on;TRUE;--qos=priority --nodes=1 --tasks-per-node=1 --mem=8000 --time=60 --wait
+testOneRegi;1;1;1;testOneRegi;output/testOneRegi;reportingREMIND2MAgPIE;on;TRUE;--qos=priority --nodes=1 --tasks-per-node=1 --mem=8000 --time=60 --wait

--- a/modules/37_industry/subsectors/bounds.gms
+++ b/modules/37_industry/subsectors/bounds.gms
@@ -118,7 +118,7 @@ vm_cesIO.lo(t,regi_dyn29(regi),in_industry_dyn37(in))$(
 *' higher) of baseline solids
 *' Cement CCS might otherwise become a compelling BioCCS option under very high
 *' carbon prices due to missing adjustment costs.
-if (cm_startyear gt 2005,   !! not a baeline or NPi scenario
+if (cm_startyear gt 2005,   !! not a baseline or NPi scenario
   vm_demFeSector_afterTax.up(t,regi,"sesobio","fesos","indst","ETS")
   = max(0.25 , smax(t2, pm_secBioShare(t2,regi,"fesos","indst") ) )
     * p37_BAU_industry_ETS_solids(t,regi);

--- a/modules/51_internalizeDamages/KWlikeItrCPreg/postsolve.gms
+++ b/modules/51_internalizeDamages/KWlikeItrCPreg/postsolve.gms
@@ -40,7 +40,7 @@ display p51_scc;
 p51_scc(tall,regi) = p51_sccLastItr(tall,regi) *  min(max( (p51_scc(tall,regi)/max(p51_sccLastItr(tall,regi),1e-8)),1 - 0.5*0.95**iteration.val),1 + 0.95**iteration.val);
 
 pm_taxCO2eqSCC(ttot,regi) = 0;
-pm_taxCO2eqSCC(t,regi)$(t.val ge 2025) = max(0, p51_scc(t) * sm_c_2_co2/1000);
+pm_taxCO2eqSCC(t,regi)$(t.val ge 2025) = max(0, p51_scc(t,regi) * sm_c_2_co2/1000);
 
 *);
 

--- a/output.R
+++ b/output.R
@@ -125,7 +125,8 @@ if (exists("source_include")) {
   comp <- "single"
 } else if (! exists("comp")) {
   modes <- c("single" = "Output for single run", "comparison" = "Comparison across runs", "export" = "Export", "exit" = "Exit")
-  comp <- names(modes)[which(chooseFromList(unname(modes), type = "output mode", multiple = FALSE, returnBoolean = TRUE))]
+  comp <- names(modes)[which(chooseFromList(unname(modes), type = "output mode", multiple = FALSE, returnBoolean = TRUE, userinfo = "Leave empty for 'single'."))]
+  if (length(comp) == 0) comp <- names(modes)[[1]]
   if (comp == "exit") q()
 }
 if (isFALSE(comp)) comp <- "single" # legacy from times only two comp modes existed
@@ -133,9 +134,12 @@ if (isTRUE(comp)) comp <- "comparison"
 
 if (! exists("output")) {
   # search for R scripts in scripts/output subfolders
-  modules <- gsub("\\.R$", "", grep("\\.R$", list.files(paste0("./scripts/output/", if (isFALSE(comp)) "single" else comp)), value = TRUE))
+  modules <- gsub("\\.R$", "", grep("\\.R$", list.files(paste0("./scripts/output/", comp)), value = TRUE))
   # if more than one option exists, let user choose
-  output <- if (length(modules) == 1) modules else chooseFromList(modules, type = "modules to be used for output generation", addAllPattern = FALSE)
+  defaultoutput <- switch(comp, "single" = gms::readDefaultConfig(".")$output, "comparison" = "compareScenarios2", "export" = "xlsx_IIASA")
+  userinfo <- paste("Leave empty for", paste(defaultoutput, collapse = ", "))
+  output <- if (length(modules) == 1) modules else chooseFromList(modules, type = "modules to be used for output generation", addAllPattern = FALSE, userinfo = userinfo)
+  if (length(output) == 0) output <- defaultoutput
   # move "reporting" to first position, if it exists
   output <- c(if ("reporting" %in% output) "reporting", output[! output %in% "reporting"])
 }
@@ -209,7 +213,7 @@ if (comp %in% c("comparison", "export")) {
       if ("--test" %in% flags) {
         message("Test mode, not executing ", paste0("scripts/output/", comp, "/", name))
       } else {
-        message(paste("Executing", name))
+        message("\n\n## Executing ", name)
         tmp.env <- new.env()
         tmp.error <- try(sys.source(paste0("scripts/output/", comp, "/", name), envir = tmp.env))
         rm(tmp.env)

--- a/scripts/output/single/fixOnRef.R
+++ b/scripts/output/single/fixOnRef.R
@@ -13,7 +13,7 @@ suppressPackageStartupMessages(library(tidyverse))
 if(! exists("source_include")) {
   # Define arguments that can be read from command line
   outputdir <- "."
-  flags <- readArgs("outputdir", .flags = c(i = "--interactive"))
+  flags <- lucode2::readArgs("outputdir", .flags = c(i = "--interactive"))
 }
 
 findRefMif <- function(outputdir, envi) {

--- a/scripts/output/single/rds_report.R
+++ b/scripts/output/single/rds_report.R
@@ -61,3 +61,4 @@ if(file.exists(runstatistics) & dir.exists(resultsarchive)) {
   system("find -type f -name '1*.rds' -printf '%f\n' | sort > fileListForShinyresults")
   setwd(cwd)
 }
+message("report.rds written and data submitted to runstatistics")

--- a/tests/testthat/test_03-quick.R
+++ b/tests/testthat/test_03-quick.R
@@ -9,4 +9,5 @@ test_that("start.R config/tests/scenario_config_quick.csv works", {
   output <- localSystem2("Rscript", c("start.R", "config/tests/scenario_config_quick.csv"))
   printIfFailed(output)
   expectSuccessStatus(output)
+  expect_true(file.exists("../../output/testOneRegi/REMIND_generic_testOneRegi.mif"))
 })

--- a/tests/testthat/test_04-gamscompile.R
+++ b/tests/testthat/test_04-gamscompile.R
@@ -34,9 +34,10 @@ test_that("start.R --gamscompile works on all configs and scenarios", {
   testthat::with_mocked_bindings(
     for (csvfile in csvfiles) {
       test_that(paste("perform start.R --gamscompile with", basename(csvfile)), {
+        startgroup <- if (grepl("scenario_config_IKEA", csvfile)) "1" else "*"
         titletag <- paste0("titletag=TESTTHAT-", gsub(".csv$", "", basename(csvfile)))
         output <- localSystem2("Rscript",
-                             c("start.R", "--gamscompile", "startgroup=*", titletag, csvfile))
+                             c("start.R", "--gamscompile", paste0("startgroup=", startgroup), titletag, csvfile))
         printIfFailed(output)
         expectSuccessStatus(output)
       })


### PR DESCRIPTION
## Purpose of this PR

- complement #1738 to make sure that only IKEA runs with `start=1` are compiled
- run `reportingREMIND2MAgPIE` as output script to check whether output generation as such works. Takes ~25 seconds, that should be ok
- fix p51_scc error. It is [declared](https://github.com/remindmodel/remind/blob/0fb47cca2854de9724443121fbc588c0072f5f0f/modules/51_internalizeDamages/KWlikeItrCPreg/declarations.gms#L12) with ttot,all_regi
- in output.R, define defaults if you select nothing (`single`; and then: standard reporting, compareScenarios2, xlsx_IIASA)
- adjust logging to make `log.txt` more readable with some space between the output scripts

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
