### PR TITLE
New cluster: explicitly request email notification for failed runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ test-coupled:    ## Test if the coupling with MAgPIE works. Takes significantly
 test-coupled-slurm: ## test-coupled, but on slurm
 	$(info Coupling tests take around 75 minutes to run. Sent to slurm, find log in test-coupled.log)
 	make ensure-reqs
-	@sbatch --qos=priority --wrap="make test-coupled" --job-name=test-coupled --mail-type=END --output=test-coupled.log --comment="test-coupled.log"
+	@sbatch --qos=priority --wrap="make test-coupled" --job-name=test-coupled --mail-type=END,FAIL --output=test-coupled.log --comment="test-coupled.log"
 
 test-full:       ## Run all tests, including coupling tests and a default
                  ## REMIND scenario. Takes several hours to run.
@@ -101,7 +101,7 @@ test-full:       ## Run all tests, including coupling tests and a default
 
 test-full-slurm: ##test-full, but on slurm
 	$(info Full tests take more than an hour to run, please be patient)
-	@sbatch --qos=priority --wrap="make test-full" --job-name=test-full --mail-type=END --output=test-full.log --comment="test-full.log"
+	@sbatch --qos=priority --wrap="make test-full" --job-name=test-full --mail-type=END,FAIL --output=test-full.log --comment="test-full.log"
 
 test-validation: ## Run validation tests, requires a full set of runs in the output folder
 	$(info Run validation tests, requires a full set of runs in the output folder)

--- a/output.R
+++ b/output.R
@@ -314,7 +314,7 @@ if (comp %in% c("comparison", "export")) {
           logfile <- file.path(outputdir, "log_output.txt")
           Rscripts <- paste0("Rscript scripts/output/single/", name, " outputdir=", outputdir, collapse = "; ")
           slurmcmd <- paste0("sbatch ", slurmConfig, " --job-name=", logfile, " --output=", logfile,
-                       " --mail-type=END --comment=output.R --wrap='", Rscripts, "'")
+                       " --mail-type=END,FAIL --comment=output.R --wrap='", Rscripts, "'")
           message("Sending to slurm: ", paste(name, collapse = ", "), ". Find log in ", logfile)
           system(slurmcmd)
         }

--- a/scripts/output/comparison/compareScenarios2.R
+++ b/scripts/output/comparison/compareScenarios2.R
@@ -60,7 +60,7 @@ startComp <- function(
       " --comment=compareScenarios2",
       " --output=", jobName, ".out",
       " --error=", jobName, ".out",
-      " --mail-type=END --time=200 --mem-per-cpu=8000",
+      " --mail-type=END,FAIL --time=200 --mem-per-cpu=8000",
       " --wrap=\"Rscript ", script,
       " outputDirs=", paste(outputDirs, collapse = ","),
       " profileName=", profileName,

--- a/scripts/start/submit.R
+++ b/scripts/start/submit.R
@@ -132,7 +132,7 @@ submit <- function(cfg, restart = FALSE, stopOnFolderCreateError = TRUE) {
     exitCode <- system(paste0("sbatch --job-name=",
                               cfg$title,
                               " --output=log.txt --open-mode=append", # append for requeued jobs
-                              " --mail-type=END",
+                              " --mail-type=END,FAIL",
                               " --comment=REMIND",
                               " --wrap=\"Rscript prepareAndRun.R \" ",
                               cfg$slurmConfig))

--- a/start_bundle_coupled.R
+++ b/start_bundle_coupled.R
@@ -638,7 +638,7 @@ for (scen in common) {
         runEnv$qos <- if (is.null(attr(sq, "status")) && sum(grepl("^priority ", sq)) < 4) "priority" else "short"
       }
       slurmOptions <- combine_slurmConfig(paste0("--qos=", runEnv$qos, " --job-name=", fullrunname, " --output=", logfile,
-        " --open-mode=append --mail-type=END --comment=REMIND-MAgPIE --tasks-per-node=", runEnv$numberOfTasks,
+        " --open-mode=append --mail-type=END,FAIL --comment=REMIND-MAgPIE --tasks-per-node=", runEnv$numberOfTasks,
         if (runEnv$numberOfTasks == 1) " --mem=8000"), runEnv$sbatch)
       slurmCommand <- paste0("sbatch ", slurmOptions, " --wrap=\"Rscript start_coupled.R coupled_config=", Rdatafile, "\"")
       message(slurmCommand)
@@ -656,7 +656,7 @@ if (! "--test" %in% flags && ! "--gamscompile" %in% flags) {
   cs_name <- paste0("compScen-all-rem-", max_iterations)
   cs_qos <- if (! isFALSE(run_compareScenarios)) run_compareScenarios else "short"
   cs_command <- paste0("sbatch --qos=", cs_qos, " --job-name=", cs_name, " --output=", cs_name, ".out --error=",
-    cs_name, ".out --mail-type=END --time=60 --mem=8000 --wrap='Rscript scripts/cs2/run_compareScenarios2.R outputDirs=",
+    cs_name, ".out --mail-type=END,FAIL --time=60 --mem=8000 --wrap='Rscript scripts/cs2/run_compareScenarios2.R outputDirs=",
     cs_runs, " profileName=REMIND-MAgPIE outFileName=", cs_name,
     " regionList=World,LAM,OAS,SSA,EUR,NEU,MEA,REF,CAZ,CHA,IND,JPN,USA mainRegName=World'")
   message("\n### To start a compareScenario once everything is finished, run:")

--- a/start_coupled.R
+++ b/start_coupled.R
@@ -260,7 +260,7 @@ start_coupled <- function(path_remind, path_magpie, cfg_rem, cfg_mag, runname, m
           subseq.env$qos <- if (is.null(attr(sq, "status")) && sum(grepl("^priority ", sq)) < 4) "priority" else "short"
         }
         slurmOptions <- combine_slurmConfig(paste0("--qos=", subseq.env$qos, " --job-name=", subseq.env$fullrunname, " --output=", logfile,
-           " --open-mode=append --mail-type=END --comment=REMIND-MAgPIE --tasks-per-node=", subseq.env$numberOfTasks,
+           " --open-mode=append --mail-type=END,FAIL --comment=REMIND-MAgPIE --tasks-per-node=", subseq.env$numberOfTasks,
           if (subseq.env$numberOfTasks == 1) " --mem=8000"), subseq.env$sbatch)
         subsequentcommand <- paste0("sbatch ", slurmOptions, " --wrap=\"Rscript start_coupled.R coupled_config=", RData_file, "\"")
         message(subsequentcommand)
@@ -312,7 +312,7 @@ start_coupled <- function(path_remind, path_magpie, cfg_rem, cfg_mag, runname, m
       cs_name <- paste0("compScen-rem-1-", max_iterations, "_", runname)
       cs_qos <- if (!isFALSE(run_compareScenarios)) run_compareScenarios else "short"
       cs_command <- paste0("sbatch --qos=", cs_qos, " --job-name=", cs_name, " --output=", cs_name, ".out --error=",
-      cs_name, ".out --mail-type=END --time=60 --mem=8000 --wrap='Rscript scripts/cs2/run_compareScenarios2.R outputDirs=",
+      cs_name, ".out --mail-type=END,FAIL --time=60 --mem=8000 --wrap='Rscript scripts/cs2/run_compareScenarios2.R outputDirs=",
       paste(cs_runs, collapse=","), " profileName=REMIND-MAgPIE outFileName=", cs_name,
       " regionList=World,LAM,OAS,SSA,EUR,NEU,MEA,REF,CAZ,CHA,IND,JPN,USA mainRegName=World'")
       if (! isFALSE(run_compareScenarios)) {


### PR DESCRIPTION
With the slurm version on the new cluster you have to explicitly request email notification for failed runs. Providing the additional argument "FAIL" also works on the old cluster.
