### PR TITLE
fix MAGICC7 variables to reference run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     [[#1723](https://github.com/remindmodel/remind/pull/1723)]
 - **scripts** define defaults for script selections in output.R
     [[#1739](https://github.com/remindmodel/remind/pull/1739)]
-- **scripts** fail transparently on duplicated column names in scenario_config*.csv files
+- **scripts** fail transparently on duplicated column names in `scenario_config*.csv` files
     [[#1742](https://github.com/remindmodel/remind/pull/1742)]
 
 ### fixed
 - included CCS from plastic waste incineration in CCS mass flows so it is
     subject to injection constraints (but did not add CCS costs, see
     https://github.com/remindmodel/development_issues/issues/274
+- **MAGICC7** fix climate data for t < cm_startyear on reference run
+    [[#1744](https://github.com/remindmodel/remind/pull/1744)]
 - **scripts** fix tax convergence reporting in modelSummary
     [[#1728](https://github.com/remindmodel/remind/pull/1728)]
 - **scripts** cleanup non-existing realizations from settings_config.csv

--- a/scripts/output/single/fixOnRef.R
+++ b/scripts/output/single/fixOnRef.R
@@ -38,8 +38,8 @@ findRefMif <- function(outputdir, envi) {
 }
 
 fixMAGICC <- function(d, dref, startyear, scen) {
-  magiccgrep <- "^Forcing|^Temperature|^Concentration"
-  message("Fixing MAGICC6 data before ", startyear)
+  magiccgrep <- "^Forcing|^Temperature|^Concentration|^MAGICC7 AR6"
+  message("Fixing MAGICC6 and 7 data before ", startyear)
   dnew <-
     rbind(
       filter(dref, grepl(magiccgrep, .data$variable),


### PR DESCRIPTION
## Purpose of this PR

- somehow, MAGICC7 does not produce the exact same output as the reference run for all timesteps before cm_startyear, see `less /p/projects/remind/modeltests/remind/output/SSP2-PkBudg650-AMT_2024-07-11_14.44.30/log.txt`.
- Many of the deviations are very small, well below 1%, while some specific Aerosol Forcing variables in the 90th percentile are as big as 40%.
- part of https://github.com/remindmodel/development_issues/issues/220

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`): `[ FAIL 0 | WARN 0 | SKIP 6 | PASS 83 ]`
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
