### PR TITLE
make checkSummationRegional valuable for REMIND-EU21

### DIFF
--- a/scripts/output/single/checkProjectSummations.R
+++ b/scripts/output/single/checkProjectSummations.R
@@ -18,6 +18,8 @@ if(! exists("source_include")) {
 scen <- lucode2::getScenNames(outputdir)
 mif  <- file.path(outputdir, paste0("REMIND_generic_", scen, ".mif"))
 mifdata <- as.quitte(mif)
+envi <- new.env()
+load(file.path(outputdir, "config.Rdata"), env =  envi)
 
 stopmessage <- NULL
 
@@ -57,6 +59,7 @@ for (mapping in c("AR6", "NAVIGATE")) {
     droplevels()
   
   csregi <- d %>%
+    filter(.data$region %in% unique(c("GLO", "World", read.csv2(envi$cfg$regionmapping)$RegionCode))) %>%
     checkSummationsRegional(skipUnits = TRUE) %>%
     rename(World = "total") %>%
     droplevels()


### PR DESCRIPTION
## Purpose of this PR

- the regional checks were useless for REMIND-EU21, because also `EUR` and other aggregated regions were summed, see `/p/projects/remind/modeltests/remind/output/SSP2-EU21-PkBudg500-AMT_2024-07-11_13.55.18/log.txt`. Load the region setting and run checkSummationRegional only on model-native regions + World.

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
