### PR TITLE
Switch off gash2 technology 

### DIFF
--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -70,6 +70,10 @@ vm_deltaCap.fx(t,regi,"pcc",rlf) = 0;
 vm_cap.fx(t,regi,"pco",rlf)     = 0;
 vm_deltaCap.fx(t,regi,"pco",rlf) = 0;
 
+*' Switch off grey hydrogen investments in gash2 technology from 2025. Our current seh2 hydrogen represents only additional (clean) hydrogen use cases to current ones
+*' and there are no plans to expand grey hydrogen production for that.
+*' It is allowed before 2020 to not make the model infeasible for low demands of hydrogen in that year.
+vm_deltaCap.up(t,regi,"gash2",rlf)$((t.val ge 2025)) = 1e-8;
 *' @stop
 
 *** -----------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
By small upper bound on investments from 2025. This was done as our current seh2 hydrogen represents only additional (clean) hydrogen use cases relative to the current ones and there are not plans to expand grey hydrogen production for that.

## Purpose of this PR


## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)


- [x] Minor change (default scenarios show only small differences)



## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Test runs are here: 
``/p/tmp/schreyer/Modeling/remind/Current/output/SSP2-Npi_nogash2_2024-07-18_13.44.18``
* Comparison of results (what changes by this PR?): 

