### PR TITLE
add 45_carbonprice/NPi2025

### DIFF
--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -1369,14 +1369,14 @@ $if %carbonprice% == "NPi"      pm_macSwitch(emiMacMagpie) = 0;
 
 *** Load historical carbon prices defined in $/t CO2, need to be rescaled to right unit
 pm_taxCO2eq(ttot,regi)$(ttot.val le 2020) = 0;
-parameter f_taxCO2eqHist(ttot,all_regi)       "historic CO2 prices ($/tCO2)"
+parameter fm_taxCO2eqHist(ttot,all_regi)       "historic CO2 prices ($/tCO2)"
 /
 $ondelim
 $include "./core/input/pm_taxCO2eqHist.cs4r"
 $offdelim
 /
 ;
-pm_taxCO2eq(ttot,regi)$(ttot.val le 2020) = f_taxCO2eqHist(ttot,regi) * sm_DptCO2_2_TDpGtC;
+pm_taxCO2eq(ttot,regi)$(ttot.val le 2020) = fm_taxCO2eqHist(ttot,regi) * sm_DptCO2_2_TDpGtC;
 
 
 *DK* LU emissions are abated in MAgPIE in coupling mode

--- a/modules/45_carbonprice/NDC/not_used.txt
+++ b/modules/45_carbonprice/NDC/not_used.txt
@@ -22,3 +22,4 @@ pm_pop,input,questionnaire
 pm_gdp,input,questionnaire
 cm_CO2priceRegConvEndYr,input,questionnaire
 cm_co2_tax_spread,switch,no carbon price differentiation in this realization
+fm_taxCO2eqHist,input,not needed

--- a/modules/45_carbonprice/NPi/not_used.txt
+++ b/modules/45_carbonprice/NPi/not_used.txt
@@ -30,3 +30,4 @@ vm_demFeSector,input,questionnaire
 pm_emifac,input,questionnaire
 cm_startyear,input,added by codeCheck
 cm_co2_tax_spread,input,no carbon price differentiation in this realization
+fm_taxCO2eqHist,input,not needed

--- a/modules/45_carbonprice/NPi2025/datainput.gms
+++ b/modules/45_carbonprice/NPi2025/datainput.gms
@@ -1,0 +1,18 @@
+*** |  (C) 2006-2023 Potsdam Institute for Climate Impact Research (PIK)
+*** |  authors, and contributors see CITATION.cff file. This file is part
+*** |  of REMIND and licensed under AGPL-3.0-or-later. Under Section 7 of
+*** |  AGPL-3.0, you are granted additional permissions described in the
+*** |  REMIND License Exception, version 1.0 (see LICENSE file).
+*** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/45_carbonprice/NPi2025/datainput.gms
+
+***----------------------------
+*** CO2 Tax level growing exponentially from 2025 value taken from input data
+***----------------------------
+
+pm_taxCO2eq(ttot,regi)$(ttot.val le 2025) = fm_taxCO2eqHist(ttot,regi) * sm_DptCO2_2_TDpGtC;
+
+pm_taxCO2eq(t,regi)$(t.val gt 2025) = sum(ttot, pm_taxCO2eq(ttot,regi)$(ttot.val eq 2025)) * cm_co2_tax_growth**(t.val - 2025);
+pm_taxCO2eq(t,regi)$(t.val gt 2110) = pm_taxCO2eq("2110",regi); !! to prevent huge taxes after 2110 and the resulting convergence problems, set taxes after 2110 equal to 2110 value
+
+*** EOF ./modules/45_carbonprice/NPi2025/datainput.gms

--- a/modules/45_carbonprice/NPi2025/not_used.txt
+++ b/modules/45_carbonprice/NPi2025/not_used.txt
@@ -1,4 +1,4 @@
-# |  (C) 2006-2024 Potsdam Institute for Climate Impact Research (PIK)
+# |  (C) 2006-2023 Potsdam Institute for Climate Impact Research (PIK)
 # |  authors, and contributors see CITATION.cff file. This file is part
 # |  of REMIND and licensed under AGPL-3.0-or-later. Under Section 7 of
 # |  AGPL-3.0, you are granted additional permissions described in the
@@ -6,15 +6,12 @@
 # |  Contact: remind@pik-potsdam.de
 name,type,reason
 cm_emiscen, switch, ???
-cm_co2_tax_2020, switch, ???
 sm_c_2_co2,switch, ???
 pm_ttot_val,parameter,???
-cm_co2_tax_growth,switch,???
 cm_startyear,switch,???
 cm_iterative_target_adj,switch,???
 cm_expoLinear_yearStart,switch,???
 vm_co2eq,variable,???
-sm_DptCO2_2_TDpGtC,scalar,???
 vm_emiFgas,input,questionnaire
 pm_globalMeanTemperature,input,questionnaire
 pm_temperatureImpulseResponseCO2,input,questionnaire
@@ -30,5 +27,5 @@ cm_CO2priceRegConvEndYr,input,questionnaire
 cm_NDC_divergentScenario,input,questionnaire
 vm_demFeSector,input,questionnaire
 pm_emifac,input,questionnaire
-cm_co2_tax_spread,input,no carbon price differentiation in this realization
-fm_taxCO2eqHist,input,not needed
+cm_co2_tax_2020,input,not needed
+cm_co2_tax_spread,input,not needed

--- a/modules/45_carbonprice/NPi2025/realization.gms
+++ b/modules/45_carbonprice/NPi2025/realization.gms
@@ -1,0 +1,14 @@
+*** |  (C) 2006-2023 Potsdam Institute for Climate Impact Research (PIK)
+*** |  authors, and contributors see CITATION.cff file. This file is part
+*** |  of REMIND and licensed under AGPL-3.0-or-later. Under Section 7 of
+*** |  AGPL-3.0, you are granted additional permissions described in the
+*** |  REMIND License Exception, version 1.0 (see LICENSE file).
+*** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/45_carbonprice/NPi2025/realization.gms
+
+*#' @description: This realization implements an exponential increase in carbon price from the predefined 2025 level. 
+
+*####################### R SECTION START (PHASES) ##############################
+$Ifi "%phase%" == "datainput" $include "./modules/45_carbonprice/NPiexpo/datainput.gms"
+*######################## R SECTION END (PHASES) ###############################
+*** EOF ./modules/45_carbonprice/NPi2025/realization.gms

--- a/modules/45_carbonprice/diffCurvPhaseIn2Lin/not_used.txt
+++ b/modules/45_carbonprice/diffCurvPhaseIn2Lin/not_used.txt
@@ -25,3 +25,4 @@ vm_demFeSector,input,questionnaire
 pm_emifac,input,questionnaire
 cm_co2_tax_spread,input,added by codeCheck
 cm_startyear,parameter,not needed
+fm_taxCO2eqHist,input,not needed

--- a/modules/45_carbonprice/diffExp2Lin/not_used.txt
+++ b/modules/45_carbonprice/diffExp2Lin/not_used.txt
@@ -23,3 +23,4 @@ pm_ttot_2_tall,input,questionnaire
 cm_NDC_divergentScenario,input,questionnaire
 vm_demFeSector,input,questionnaire
 pm_emifac,input,questionnaire
+fm_taxCO2eqHist,input,not needed

--- a/modules/45_carbonprice/diffLin2Lin/not_used.txt
+++ b/modules/45_carbonprice/diffLin2Lin/not_used.txt
@@ -24,3 +24,4 @@ pm_prtp,input,questionnaire
 vm_demFeSector,input,questionnaire
 pm_emifac,input,questionnaire
 cm_startyear,switch,questionnaire
+fm_taxCO2eqHist,input,not needed

--- a/modules/45_carbonprice/exogenous/not_used.txt
+++ b/modules/45_carbonprice/exogenous/not_used.txt
@@ -29,3 +29,4 @@ pm_emifac,input,questionnaire
 sm_DptCO2_2_TDpGtC,input,questionnaire
 cm_startyear,input,questionnaire
 cm_co2_tax_spread,switch,no carbon price differentiation in this realization
+fm_taxCO2eqHist,input,not needed

--- a/modules/45_carbonprice/expoLinear/not_used.txt
+++ b/modules/45_carbonprice/expoLinear/not_used.txt
@@ -25,3 +25,4 @@ cm_NDC_divergentScenario,input,questionnaire
 vm_demFeSector,input,questionnaire
 pm_emifac,input,questionnaire
 cm_co2_tax_spread,input,No carbon price differentiation in this realization
+fm_taxCO2eqHist,input,not needed

--- a/modules/45_carbonprice/exponential/not_used.txt
+++ b/modules/45_carbonprice/exponential/not_used.txt
@@ -28,3 +28,4 @@ cm_NDC_divergentScenario,input,questionnaire
 vm_demFeSector,input,questionnaire
 pm_emifac,input,questionnaire
 cm_co2_tax_spread,input,No carbon price differentiation in this realization
+fm_taxCO2eqHist,input,not needed

--- a/modules/45_carbonprice/linear/not_used.txt
+++ b/modules/45_carbonprice/linear/not_used.txt
@@ -28,3 +28,4 @@ cm_NDC_divergentScenario,input,questionnaire
 vm_demFeSector,input,questionnaire
 pm_emifac,input,questionnaire
 cm_co2_tax_spread,switch,no carbon price differentiation in this realization
+fm_taxCO2eqHist,input,not needed

--- a/modules/45_carbonprice/temperatureNotToExceed/not_used.txt
+++ b/modules/45_carbonprice/temperatureNotToExceed/not_used.txt
@@ -23,3 +23,4 @@ cm_NDC_divergentScenario,input,questionnaire
 vm_demFeSector,input,questionnaire
 pm_emifac,input,questionnaire
 cm_co2_tax_spread,input,no carbon price differentiation in this realization
+fm_taxCO2eqHist,input,not needed


### PR DESCRIPTION
## Purpose of this PR

- new NPi realization that uses input data also for the 2025 timestep, and then allows to have exponential growth post 2025
- this might replace `NPi` as Current Policy run in projects, we still have to figure out whether we can / should also calibrate on this.

## Type of change

- [x] New feature 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
