### PR TITLE
Bug fix to ensure that historical CO2 prices from datainput.gms in co…

### DIFF
--- a/modules/21_tax/on/preloop.gms
+++ b/modules/21_tax/on/preloop.gms
@@ -10,10 +10,6 @@
 pm_taxemiMkt(t,regi,emiMkt)$(t.val ge cm_startyear) = 0;
 pm_taxemiMkt_iteration(iteration,t,regi,emiMkt)$(t.val ge cm_startyear) = 0;
 
-*LB* set CO2 tax in 2005 and 2010 to 0
-pm_taxCO2eq("2005",regi)=0;
-pm_taxCO2eq("2010",regi)=0;
-
 ***-------------------------------------------------------------------
 ***           overwrite default targets with gdx values
 ***-------------------------------------------------------------------


### PR DESCRIPTION
…re are not overwritten for 2005 and 2010 in preloop.gms of 21_tax module. 

## Purpose of this PR

Bug fix - see [issue](https://github.com/remindmodel/development_issues/issues/315#issue-2415811980) for description. 

Changes in 2010 values: This only affects the values of pm_taxCO2eq for regions EUR and NEU, which are set to 10$ / t CO2eq (EUR) and 2.5$ / t CO2eq (NEU) in `./core/input/pm_taxCO2eqHist.cs4r`. In 2010, all other regions have CO2 price 0$ .

No changes in 2005 values, which were and remain to be 0$ for all regions.

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

Newcomer question: I suppose this requires re-calibration as it affects the NPi run. Do I need to do take any action on this? My previous PRs did not affect NPi runs, so I am not sure on this.

