### PR TITLE
add support for regionally differentiated cm_PriceDurSlope_elh2

### DIFF
--- a/main.gms
+++ b/main.gms
@@ -1009,13 +1009,6 @@ parameter
   cm_H2targets = 0; !! def 0
 *'
 parameter
-  cm_PriceDurSlope_elh2       "slope of price duration curve of electrolysis"
-;
-  cm_PriceDurSlope_elh2 = 15;  !! def = 15
-*' cm_PriceDurSlope_elh2, slope of price duration curve for electrolysis (increase means more flexibility subsidy for electrolysis H2)
-*' This switch only has an effect if the flexibility tax is on by cm_flex_tax set to 1
-*' Default value is based on data from German Langfristszenarien (see ./modules/32_power/IntC/datainput.gms).
-parameter
   cm_FlexTaxFeedback          "switch deciding whether flexibility tax feedback on buildings and industry electricity prices is on"
 ;
   cm_FlexTaxFeedback = 0;  !! def = 0  !! regexp = 0|1
@@ -1401,6 +1394,10 @@ $setGlobal cm_import_EU  off !! def off
 *** (on) ARIADNE-specific H2 imports for Germany, rest EU has H2 imports from cm_import_EU switch
 *** (off) no ARIADNE-specific H2 imports for Germany
 $setGlobal cm_import_ariadne  off !! def off
+*** cm_PriceDurSlope_elh2, slope of price duration curve for electrolysis (increase means more flexibility subsidy for electrolysis H2)
+*** This switch only has an effect if the flexibility tax is on by cm_flex_tax set to 1
+*** Default value is based on data from German Langfristszenarien (see ./modules/32_power/IntC/datainput.gms).
+$setGlobal cm_PriceDurSlope_elh2 GLO 15 !! def = GLO 15
 *** cm_trade_SE_exog
 *** set exogenous SE trade scenarios (requires se_trade realization of modul 24 to be active)
 *** e.g. "2030.2050.MEA.DEU.seh2 0.5", means import of SE hydrogen from MEA to Germany from 2050 onwards of 0.5 EJ/yr,

--- a/modules/32_power/DTcoup/datainput.gms
+++ b/modules/32_power/DTcoup/datainput.gms
@@ -86,6 +86,12 @@ display p32_flex_maxdiscount;
 $offtext
 
 *** initialize p32_PriceDurSlope parameter
-p32_PriceDurSlope(regi,"elh2") = cm_PriceDurSlope_elh2;
+parameter f32_cm_PriceDurSlope_elh2(ext_regi) "slope of price duration curve for electrolysis [#]" / %cm_PriceDurSlope_elh2% /;
+p32_PriceDurSlope(regi,"elh2") = f32_cm_PriceDurSlope_elh2("GLO");
+loop(ext_regi$f32_cm_PriceDurSlope_elh2(ext_regi),
+  loop(regi$regi_groupExt(ext_regi,regi),
+    p32_PriceDurSlope(regi,"elh2") = f32_cm_PriceDurSlope_elh2(ext_regi);
+  );
+); 
 
 *** EOF ./modules/32_power/DTcoup/datainput.gms

--- a/modules/32_power/IntC/datainput.gms
+++ b/modules/32_power/IntC/datainput.gms
@@ -104,7 +104,13 @@ $offtext
 
 *** This parameter determines by the maximum electricity price reduction for electrolysis at 100% VRE share and 0% share of electrolysis in total electricity demand.
 *** Standard value is derived based on the regression of the German Langfristzenarien.
-p32_PriceDurSlope(regi,"elh2") = cm_PriceDurSlope_elh2;
+parameter f32_cm_PriceDurSlope_elh2(ext_regi) "slope of price duration curve for electrolysis [#]" / %cm_PriceDurSlope_elh2% /;
+p32_PriceDurSlope(regi,"elh2") = f32_cm_PriceDurSlope_elh2("GLO");
+loop(ext_regi$f32_cm_PriceDurSlope_elh2(ext_regi),
+  loop(regi$regi_groupExt(ext_regi,regi),
+    p32_PriceDurSlope(regi,"elh2") = f32_cm_PriceDurSlope_elh2(ext_regi);
+  );
+); 
 
 *** Slope of increase of electricity price for electrolysis with increasing share of electrolysis in power system
 *** The value of 1.1 is derived from the regression of the German Langfristzenarien.

--- a/modules/32_power/RLDC/not_used.txt
+++ b/modules/32_power/RLDC/not_used.txt
@@ -9,6 +9,5 @@ pm_IO_input,input,questionnaire
 vm_flexAdj,input,questionnaire
 cm_VRE_supply_assumptions,input,questionnaire
 cm_flex_tax,input,questionnaire
-cm_PriceDurSlope_elh2,input,questionnaire
 cm_FlexTaxFeedback,input,questionnaire
 vm_shDemSeel,input,only used in IntC realization

--- a/standalone/MOFEX/MOFEX.gms
+++ b/standalone/MOFEX/MOFEX.gms
@@ -200,7 +200,6 @@ cm_biotrade_phaseout        "switch for phaseing out biomass trade in the respec
 cm_bioprod_histlim			"regional parameter to limit biomass (pebiolc.1) production to a multiple of the 2015 production"
 cm_flex_tax                 "switch for enabling flexibility tax"
 cm_H2targets                "switches on capacity targets for electrolysis in NDC techpol following national Hydrogen Strategies"
-cm_PriceDurSlope_elh2       "slope of price duration curve of electrolysis"
 cm_FlexTaxFeedback          "switch deciding whether flexibility tax feedback on buildings and industry electricity prices is on"
 cm_VRE_supply_assumptions        "default (0), optimistic (1), sombre (2), or bleak (3) assumptions on VRE supply"
 cm_build_H2costAddH2Inv     "additional h2 distribution costs for low diffusion levels (default value: 6.5$/ 100 /Kwh)"
@@ -365,8 +364,9 @@ $setGlobal cm_import_EU  off !! def off
 
 *** flex tax switches
 cm_flex_tax = 0; !! def 0
-cm_PriceDurSlope_elh2 = 20; !! def 10
+$setGlobal cm_PriceDurSlope_elh2  GLO 15 !! def = GLO 15
 cm_FlexTaxFeedback = 0; !! def 0
+
 
 *** VRE switch
 cm_VRE_supply_assumptions = 0; !! 0 - default, 1 - optimistic, 2 - sombre, 3 - bleak

--- a/standalone/trade/trade.gms
+++ b/standalone/trade/trade.gms
@@ -204,7 +204,6 @@ cm_biotrade_phaseout        "switch for phaseing out biomass trade in the respec
 cm_bioprod_histlim			"regional parameter to limit biomass (pebiolc.1) production to a multiple of the 2015 production"
 cm_flex_tax                 "switch for enabling flexibility tax"
 cm_H2targets                "switches on capacity targets for electrolysis in NDC techpol following national Hydrogen Strategies"
-cm_PriceDurSlope_elh2       "slope of price duration curve of electrolysis"
 cm_FlexTaxFeedback          "switch deciding whether flexibility tax feedback on buildings and industry electricity prices is on"
 cm_VRE_supply_assumptions        "default (0), optimistic (1), sombre (2), or bleak (3) assumptions on VRE supply"
 cm_build_H2costAddH2Inv     "additional h2 distribution costs for low diffusion levels (default value: 6.5$/ 100 /Kwh)"
@@ -372,7 +371,7 @@ $setGlobal cm_import_EU  off !! def off
 
 *** flex tax switches
 cm_flex_tax = 0; !! def 0
-cm_PriceDurSlope_elh2 = 20; !! def 10
+$setGlobal cm_PriceDurSlope_elh2  GLO 15 !! def = GLO 15
 cm_FlexTaxFeedback = 0; !! def 0
 
 *** VRE switch


### PR DESCRIPTION
## Purpose of this PR

- add support for regionally differentiated cm_PriceDurSlope_elh2

## Type of change

- [x] New feature 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)

## Further information (optional):

* Test runs are here: 
`/p/projects/ecemf/REMIND/2040_scenarios/v08_2024_06_14_REMIND_3.3.1/output/08_Nzero_57_bio7p5_20PriceDurSlope_2024-07-11_20.23.08`


