### PR TITLE
new input data rev6.84 and CES parameter for SSP2, SSP2_EU21, SSP1, SDP_MC, SDP_EI, SDP_RC, SSP2_lowEn, SSP5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### input data/calibration
-- new input data rev6.84
+- new input data rev6.84 [[#1757]] (https://github.com/remindmodel/remind/pull/1757)
 - CES parameter and gdx files calibrated with new default diffLin2Lin for NPi 
     [[#1747]] (https://github.com/remindmodel/remind/pull/1747) and
-    
+    [[#1757]] (https://github.com/remindmodel/remind/pull/1757)
 
 ### changed
 - plastic waste by default does not lag plastics production by ten years

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### input data/calibration
+- new input data rev6.84
+- CES parameter and gdx files calibrated with new default diffLin2Lin for NPi 
+    [[#1747]] (https://github.com/remindmodel/remind/pull/1747) and
+    
+
 ### changed
 - plastic waste by default does not lag plastics production by ten years
     anymore; can be re-activated using `cm_wastelag`

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -27,10 +27,10 @@ cfg$regionmapping <- "config/regionmappingH12.csv"
 ### Additional (optional) region mapping, so that those validation data can be loaded that contain the corresponding additional regions.
 cfg$extramappings_historic <- ""
 #### Current input data revision (<mainrevision>.<subrevision>) ####
-cfg$inputRevision <- "6.83edgeTransportReloaded"
+cfg$inputRevision <- "6.84"
 
 #### Current CES parameter and GDX revision (commit hash) ####
-cfg$CESandGDXversion <- "2ca8c53c815df225647013d19fb20b4a8031afe3"
+cfg$CESandGDXversion <- "d4c62a8f11e8a6827310519df09c98eb425a4070"
 
 #### Force the model to download new input data ####
 cfg$force_download <- FALSE


### PR DESCRIPTION
## Purpose of this PR
* new input data rev6.84 
* new CES parameter and gdx files for intput data rev6.84 and with new default diffLin2Lin for NPi for SSP2, SSP2_EU21, SSP1, SDP_MC, SDP_EI, SDP_RC, SSP2_lowEn and SSP5, 
* calibration runs: /p/tmp/lavinia/REMIND/REMIND_calibration_2024_07_23/remind/output

## Type of change

- [x] Minor change (default scenarios show only small differences)


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

