### PR TITLE
Update input revision to 6.85

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -27,7 +27,7 @@ cfg$regionmapping <- "config/regionmappingH12.csv"
 ### Additional (optional) region mapping, so that those validation data can be loaded that contain the corresponding additional regions.
 cfg$extramappings_historic <- ""
 #### Current input data revision (<mainrevision>.<subrevision>) ####
-cfg$inputRevision <- "6.84"
+cfg$inputRevision <- "6.85"
 
 #### Current CES parameter and GDX revision (commit hash) ####
 cfg$CESandGDXversion <- "d4c62a8f11e8a6827310519df09c98eb425a4070"

--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -889,7 +889,7 @@ if(pm_NuclearConstraint("2020",regi,"tnrs")<0,
 parameter pm_boundCapCCS(ttot,all_regi,bounds)        "installed and planned capacity of CCS"
 /
 $ondelim
-$include "./core/input/pm_boundCapCCS.cs4r"
+$include "./core/input/p_boundCapCCS.cs4r"
 $offdelim
 /
 ;

--- a/core/input/files
+++ b/core/input/files
@@ -33,7 +33,7 @@ p_macBase1990.cs4r
 p_macBase2005.cs4r
 p_macBaseVanv.cs4r
 p_macPolCO2luc.cs4r
-pm_boundCapCCS.cs4r
+p_boundCapCCS.cs4r
 pm_dataccs.cs3r
 f_fedemand.cs4r
 f_fedemand_build.cs4r


### PR DESCRIPTION
## Purpose of this PR
Update data input to `rev6.85` and rename input data file according to [mrremind#527](https://github.com/pik-piam/mrremind/pull/527)

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
