### PR TITLE
Updated documentation on `cm_prtpScen` switch that sets the pure rate of time preference

### DIFF
--- a/main.gms
+++ b/main.gms
@@ -685,7 +685,7 @@ parameter
   cm_prtpScen               "pure rate of time preference standard values"
 ;
   cm_prtpScen         = 1;         !! def = 1  !! regexp = 1|3
-*' *  (1): 1 %
+*' *  (1): 1.5 %
 *' *  (3): 3 %
 *'
 parameter


### PR DESCRIPTION
## Purpose of this PR

Just a small correction of the inline documentation for the switch `cm_prtpScen` which sets the pure rate of time preference. The description of the default option said "1%", but it is actually set to 1.5%:

(from `core/datainput.gms`)
```
*** define pm_prtp according to cm_prtpScen:
if(cm_prtpScen eq 1, pm_prtp(regi) = 0.015);
if(cm_prtpScen eq 3, pm_prtp(regi) = 0.03);
```

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Documentation fix 


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed (not needed)
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches (not needed)
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)



