### PR TITLE
Enable bioigcc early retirement

### DIFF
--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -348,6 +348,8 @@ vm_capEarlyReti.up(ttot,regi,te) = 1e-6;
 vm_capEarlyReti.up(ttot,regi,te)$(teFosNoCCS(te)) = 1;
 *** FS: allow nuclear early retirement (for nucscen 7)
 vm_capEarlyReti.up(ttot,regi,"tnrs") = 1;
+*** allow early retirement of biomass used in electricity
+vm_capEarlyReti.up(ttot,regi,"bioigcc") = 1;
 
 ***restrict early retirement to the modeling time frame (to reduce runtime, the early retirement equations are phased out after 2110)
 vm_capEarlyReti.up(ttot,regi,te)$(ttot.val lt 2009 or ttot.val gt 2111) = 0;

--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -758,7 +758,7 @@ pm_regiEarlyRetiRate(t,regi,"biochp")  = 0.5 * pm_regiEarlyRetiRate(t,regi,"bioc
 pm_regiEarlyRetiRate(t,regi,"gashp")   = 0.5 * pm_regiEarlyRetiRate(t,regi,"gashp") ; !! chp should only be phased out slowly, as district heating networks/ industry uses are designed to a specific heat input
 pm_regiEarlyRetiRate(t,regi,"coalhp")  = 0.5 * pm_regiEarlyRetiRate(t,regi,"coalhp"); !! chp should only be phased out slowly, as district heating networks/ industry uses are designed to a specific heat input
 pm_regiEarlyRetiRate(t,regi,"biohp")   = 0.5 * pm_regiEarlyRetiRate(t,regi,"biohp") ; !! chp should only be phased out slowly, as district heating networks/ industry uses are designed to a specific heat input
-
+pm_regiEarlyRetiRate(t,regi,"bioigcc")   = 0.25 * pm_regiEarlyRetiRate(t,regi,"bioigcc") ; !! reduce bio early retirement rate
 
 $ifthen.tech_earlyreti not "%c_tech_earlyreti_rate%" == "off"
 loop((ext_regi,te)$p_techEarlyRetiRate(ext_regi,te),


### PR DESCRIPTION
## Purpose of this PR

- Enable `bioigcc` early retirement as discussed in ARIADNE scenarios.

- Comments from Felix on the subject:
```
I have always wondered a bit why we do not allow for early retirement of biomass technologies as there could be benefits of shifting biomass supply to other sectors / technologies. 
I had tested this already, but this time it actually makes a difference as the model shifts biomass out of power plants without carbon capture into either bioh2 or bioliquids plants with carbon capture. 
This higher availability of captured biogenic CO2 (with the same biomass feedstock) makes DAC superfluous and decreases carbon prices of a near fossil-free 2050 system notably to ~650. 
As we do not have retrofits of current biomass power plants for carbon capture, we might underestimate this flexibility. 
Also REMIND builds some of these plants quite recently and in the real world they might be older and reach their end of lifetime earlier. 
At the same time, I vaguely remember that @amerfort made some assumption in her CDR potential study on Germany that not all biomass will be available for carbon capture plants. 
So, I am raising the question of whether we want to allow for flexibility for shifting biomass. 
```

## Type of change

- [x] Minor change (default scenarios show only small differences)

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)

## Further information (optional):

* Test runs are here: 
`/p/projects/ecemf/REMIND/2040_scenarios/v09_2024_08_02 `

