### PR TITLE
test that manipulateConfig does not destroy comments and can undo changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### input data/calibration
 - new input data rev6.84 [[#1757]] (https://github.com/remindmodel/remind/pull/1757)
 - CES parameter and gdx files calibrated with new default diffLin2Lin for NPi 
-    [[#1747]] (https://github.com/remindmodel/remind/pull/1747) and
-    [[#1757]] (https://github.com/remindmodel/remind/pull/1757)
+    [[#1747](https://github.com/remindmodel/remind/pull/1747)] and
+    [[#1757](https://github.com/remindmodel/remind/pull/1757)]
 
 ### changed
 - plastic waste by default does not lag plastics production by ten years
@@ -26,8 +26,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     [[#1739](https://github.com/remindmodel/remind/pull/1739)]
 - **scripts** fail transparently on duplicated column names in `scenario_config*.csv` files
     [[#1742](https://github.com/remindmodel/remind/pull/1742)]
-- **testthat** fail if manipulating main.gms with default cfg drops/changes switches
-    [[#1764](https://github.com/remindmodel/remind/pull/1764)]
+- **testthat** fail if manipulating main.gms with default cfg drops/changes switches and comments
+    [[#1764](https://github.com/remindmodel/remind/pull/1764)] and
+    [[#1767](https://github.com/remindmodel/remind/pull/1767)]
 
 ### fixed
 - included CCS from plastic waste incineration in CCS mass flows so it is

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,7 @@ Imports:
     knitr,
     lazyeval,
     lpjclass,
-    lucode2 (>= 0.47.8),
+    lucode2 (>= 0.47.9),
     luplot,
     luscale,
     lusweave,

--- a/scripts/start/choose_slurmConfig.R
+++ b/scripts/start/choose_slurmConfig.R
@@ -35,9 +35,11 @@ choose_slurmConfig <- function(identifier = FALSE, flags = NULL) {
 
     if (! identifier %in% paste(seq(1:16))) {
       wasselect <- TRUE
-      cat("\nCurrent cluster utilization:\n")
-      system("sclass")
-      cat("\n")
+      if (! Sys.which("sclass") == "") {
+        cat("\nCurrent cluster utilization:\n")
+        system("sclass")
+        cat("\n")
+      }
       cat("\nPlease choose the SLURM configuration for your submission:\n")
       cat("    QOS             tasks per node   suitable for\n=======================================================================\n")
       #cat(paste(1:length(modes), modes, sep=": " ),sep="\n")

--- a/tests/testthat/test_01-manipulateConfig.R
+++ b/tests/testthat/test_01-manipulateConfig.R
@@ -3,6 +3,15 @@ test_that("manipulate config with default configuration does not change main.gms
   cfg_init <- gms::readDefaultConfig("../..")
   tmpfile <- tempfile(pattern = "main-TESTTHAT-", tmpdir = "../..", fileext = ".gms")
   file.copy("../../main.gms", tmpfile)
+
+  # generate arbitrary settings, manipulate file, read them again and check identity
+  cfg_new <- cfg_init
+  cfg_new$gms[names(cfg_new$gms)] <- rep(c(0, 1, "asdf", "bc3", "3bc"), length(cfg_new$gms))[1:length(cfg_new$gms)]
+  lucode2::manipulateConfig(tmpfile, cfg_new$gms)
+  cfg_new_after <- gms::readDefaultConfig("../..", basename(tmpfile))
+  expect_equal(cfg_new_after, cfg_new)
+
+  # reset to initial setting and check that nothing has changed at all in the file
   lucode2::manipulateConfig(tmpfile, cfg_init$gms)
   cfg_after <- gms::readDefaultConfig("../..", basename(tmpfile))
 

--- a/tests/testthat/test_01-manipulateConfig.R
+++ b/tests/testthat/test_01-manipulateConfig.R
@@ -10,12 +10,7 @@ test_that("manipulate config with default configuration does not change main.gms
   diffresult <- NULL
   diffavailable <- ! Sys.which("diff") == ""
   if (diffavailable) {
-    diffresult <- suppressWarnings(system(paste("diff -b ../../main.gms", tmpfile), intern = TRUE))
-    # drop all sorts of comments until https://github.com/pik-piam/lucode2/issues/121 is fixed
-    drop <- c("^< \\*\\*\\*", "^> \\*\\*\\*", "^> \\*' \\*", "^< \\*' \\*", "^---$", "^[0-9,]+c[0-9,]+$")
-    for (d in drop) {
-      diffresult <- grep(d, diffresult, value = TRUE, invert = TRUE)
-    }
+    diffresult <- suppressWarnings(system(paste("diff ../../main.gms", tmpfile), intern = TRUE))
     if (length(diffresult) > 0) {
       warning("Applying manipulateConfig with the default configuration leads to this diff between main.gms and ",
               basename(tmpfile), ":\n",

--- a/tests/testthat/test_01-manipulateConfig.R
+++ b/tests/testthat/test_01-manipulateConfig.R
@@ -1,7 +1,7 @@
 test_that("manipulate config with default configuration does not change main.gms", {
   # copy main file and manipulate it based on default settings
   cfg_init <- gms::readDefaultConfig("../..")
-  tmpfile <- tempfile(pattern = "main", tmpdir = "../..", fileext = ".gms")
+  tmpfile <- tempfile(pattern = "main-TESTTHAT-", tmpdir = "../..", fileext = ".gms")
   file.copy("../../main.gms", tmpfile)
   lucode2::manipulateConfig(tmpfile, cfg_init$gms)
   cfg_after <- gms::readDefaultConfig("../..", basename(tmpfile))
@@ -48,6 +48,6 @@ test_that("manipulate config with default configuration does not change main.gms
 
   # cleanup if no error found
   if (length(addedgms) + length(removedgms) + length(contentdiff) + length(diffresult) == 0) {
-    file.remove(tmpfile)
+    file.remove(list.files(pattern = "main-TESTTHAT.*gms"))
   }
 })


### PR DESCRIPTION
## Purpose of this PR

- with https://github.com/pik-piam/lucode2/pull/205, the destruction of comments has ended, as well as whitespace changes
- therefore: remove all exceptions from the test such that also comment changes are tracked
- additionally, overwrite the tmpfile with some rather arbitrary data and check whether reading that again works
- then reset it to the default and check that nothing changes
- make `sclass` call conditional on existence

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`): `[ FAIL 0 | WARN 0 | SKIP 6 | PASS 88 ]`
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)