### PR TITLE
use also non-gms cfg$ switches in start_bundle_coupled.R

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     [[#1728](https://github.com/remindmodel/remind/pull/1728)]
 - **scripts** cleanup non-existing realizations from settings_config.csv
     [[#1718](https://github.com/remindmodel/remind/pull/1718)]
+- **scripts** REMIND-MAgPIE start scripts now correctly use all non-gms cfg switches
+    [[#1768](https://github.com/remindmodel/remind/pull/1768)]
 
 ### removed
 

--- a/config/tests/scenario_config_coupled_shortCascade.csv
+++ b/config/tests/scenario_config_coupled_shortCascade.csv
@@ -1,4 +1,4 @@
-title;start;qos;sbatch;magpie_scen;config/scenario_config.csv;magpie_empty;no_ghgprices_land_until;max_iterations;oldrun;path_gdx;path_gdx_ref;path_gdx_bau;path_report;cm_nash_autoconverge_lastrun;path_mif_ghgprice_land;cfg_mag$gms$s56_minimum_cprice;cfg_mag$damping_factor
-TESTTHAT-SSP2-Base;1;auto;--wait --mail-type=FAIL;SSP2|NPI;SDP-MC;TRUE;y2150;2;;;;;;2;;;
-TESTTHAT-SSP2-NDC;1;auto;--wait --mail-type=FAIL;SSP2|NDC;;TRUE;y2150;2;;;;;;2;TESTTHAT-SSP2-Base;;0.80
-TESTTHAT-SSP2-Policy;2;auto;--wait --mail-type=FAIL;SSP2|NDC;SDP-MC;TRUE;y2150;2;TESTTHAT-SSP2-Base;;;;;;output/C_TESTTHAT-SSP2-Base-rem-1/REMIND_generic_C_TESTTHAT-SSP2-Base-rem-1.mif;20;
+title;start;qos;sbatch;magpie_scen;config/scenario_config.csv;magpie_empty;no_ghgprices_land_until;max_iterations;oldrun;path_gdx;path_gdx_ref;path_gdx_bau;path_report;cm_nash_autoconverge_lastrun;path_mif_ghgprice_land;cfg_mag$gms$s56_minimum_cprice;cfg_mag$damping_factor;cfg_mag$gms$s56_cprice_red_factor
+TESTTHAT-SSP2-Base;1;auto;--wait --mail-type=FAIL;SSP2|NPI;SDP-MC;TRUE;y2150;2;;;;;;2;;;;
+TESTTHAT-SSP2-NDC;1;auto;--wait --mail-type=FAIL;SSP2|NDC;;TRUE;y2150;2;;;;;;2;TESTTHAT-SSP2-Base;;0.80;0.5
+TESTTHAT-SSP2-Policy;2;auto;--wait --mail-type=FAIL;SSP2|NDC;SDP-MC;TRUE;y2150;2;TESTTHAT-SSP2-Base;;;;;;output/C_TESTTHAT-SSP2-Base-rem-1/REMIND_generic_C_TESTTHAT-SSP2-Base-rem-1.mif;20;;

--- a/start_bundle_coupled.R
+++ b/start_bundle_coupled.R
@@ -420,7 +420,8 @@ for(scen in common){
   }
 
   # Edit remind main model file, region settings and input data revision based on scenarios table, if cell non-empty
-  for (switchname in intersect(c("model", "regionmapping", "extramappings_historic", "inputRevision"), names(settings_remind))) {
+  cfg_rem_options <- c("model", "regionmapping", "extramappings_historic", "inputRevision", setdiff(names(cfg_rem), c("gms", "output")))
+  for (switchname in intersect(cfg_rem_options, names(settings_remind))) {
     if ( ! is.na(settings_remind[scen, switchname] )) {
       cfg_rem[[switchname]] <- settings_remind[scen, switchname]
     }


### PR DESCRIPTION
## Purpose of this PR

- Running REMIND-MAgPIE, not all switches were used from the `scenario_config.csv` file, for example `cfg$fixOnRefAuto` was simply dropped, see https://github.com/remindmodel/development_issues/issues/246#issuecomment-2236592078
- The reason was that in the standalone start scripts, [all names(cfg) are matched](https://github.com/remindmodel/remind/blob/e2e317716f4b85108c4110ff0e5fc9b90646d767/scripts/start/configureCfg.R#L18-L23), while this was missing in `start_bundle_coupled.R`. Therefore, I added them.
- Also add one parameter that we use in NGFS to coupled model tests so we are more quickly aware if that part of the model stops working
- `make test-coupled` works

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
