### PR TITLE
remove --partition= specification, as problem is solved

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ test-coupled:    ## Test if the coupling with MAgPIE works. Takes significantly
 test-coupled-slurm: ## test-coupled, but on slurm
 	$(info Coupling tests take around 75 minutes to run. Sent to slurm, find log in test-coupled.log)
 	make ensure-reqs
-	@sbatch --qos=priority --partition=priority --wrap="make test-coupled" --job-name=test-coupled --mail-type=END,FAIL --output=test-coupled.log --comment="test-coupled.log"
+	@sbatch --qos=priority --wrap="make test-coupled" --job-name=test-coupled --mail-type=END,FAIL --output=test-coupled.log --comment="test-coupled.log"
 
 test-full:       ## Run all tests, including coupling tests and a default
                  ## REMIND scenario. Takes several hours to run.
@@ -102,7 +102,7 @@ test-full:       ## Run all tests, including coupling tests and a default
 test-full-slurm: ##test-full, but on slurm
 	$(info Full tests take more than an hour to run, please be patient)
 	make ensure-reqs
-	@sbatch --qos=priority --partition=priority --wrap="make test-full" --job-name=test-full --mail-type=END,FAIL --output=test-full.log --comment="test-full.log"
+	@sbatch --qos=priority --wrap="make test-full" --job-name=test-full --mail-type=END,FAIL --output=test-full.log --comment="test-full.log"
 
 test-validation: ## Run validation tests, requires a full set of runs in the output folder
 	$(info Run validation tests, requires a full set of runs in the output folder)

--- a/config/tests/scenario_config_default.csv
+++ b/config/tests/scenario_config_default.csv
@@ -1,2 +1,2 @@
 title;start;slurmConfig
-default;1;--qos=standby --nodes=1 --tasks-per-node=12 --wait
+default;1;--qos=standby --partition=priority --nodes=1 --tasks-per-node=12 --wait

--- a/config/tests/scenario_config_default.csv
+++ b/config/tests/scenario_config_default.csv
@@ -1,2 +1,2 @@
 title;start;slurmConfig
-default;1;--qos=standby --partition=priority --nodes=1 --tasks-per-node=12 --wait
+default;1;--qos=standby --nodes=1 --tasks-per-node=12 --wait

--- a/config/tests/scenario_config_quick.csv
+++ b/config/tests/scenario_config_quick.csv
@@ -1,2 +1,2 @@
 title;start;cm_nash_mode;cm_iteration_max;optimization;results_folder;output;cm_quick_mode;force_replace;slurmConfig
-testOneRegi;1;1;1;testOneRegi;output/testOneRegi;reportingREMIND2MAgPIE;on;TRUE;--qos=priority --partition=priority --nodes=1 --tasks-per-node=1 --mem=8000 --time=60 --wait
+testOneRegi;1;1;1;testOneRegi;output/testOneRegi;reportingREMIND2MAgPIE;on;TRUE;--qos=priority --nodes=1 --tasks-per-node=1 --mem=8000 --time=60 --wait

--- a/output.R
+++ b/output.R
@@ -85,9 +85,9 @@ if ("--help" %in% flags) {
 }
 
 choose_slurmConfig_output <- function(output) {
-  slurm_options <- c("--qos=priority --partition=priority", "--qos=short", "--qos=standby --partition=priority",
-                     "--qos=priority --partition=priority --mem=8000", "--qos=short --mem=8000",
-                     "--qos=standby --partition=priority --mem=8000", "--qos=priority --partition=priority --mem=32000")
+  slurm_options <- c("--qos=priority", "--qos=short", "--qos=standby",
+                     "--qos=priority --mem=8000", "--qos=short --mem=8000",
+                     "--qos=standby --mem=8000", "--qos=priority --mem=32000")
 
   if (!isSlurmAvailable())
     return("direct")
@@ -198,8 +198,7 @@ if (comp %in% c("comparison", "export")) {
   }
   if (exists("slurmConfig")) {
     if (slurmConfig %in% c("priority", "short", "standby")) {
-      slurmConfig <- paste0("--qos=", slurmConfig,
-                            if (slurmConfig %in% c("priority", "standby")) " --partition=priority")
+      slurmConfig <- paste0("--qos=", slurmConfig)
     }
   }
 
@@ -239,8 +238,7 @@ if (comp %in% c("comparison", "export")) {
       if (slurmConfig != "direct") slurmConfig <- combine_slurmConfig("--nodes=1 --tasks-per-node=1", slurmConfig)
     }
     if (slurmConfig %in% c("priority", "short", "standby")) {
-      slurmConfig <- paste0("--nodes=1 --tasks-per-node=1 --qos=", slurmConfig,
-                            if (slurmConfig %in% c("priority", "standby")) " --partition=priority")
+      slurmConfig <- paste0("--nodes=1 --tasks-per-node=1 --qos=", slurmConfig)
     }
     if (isTRUE(slurmConfig %in% "direct")) {
       flags <- c(flags, "--interactive") # to tell scripts they can run in interactive mode

--- a/output.R
+++ b/output.R
@@ -85,9 +85,9 @@ if ("--help" %in% flags) {
 }
 
 choose_slurmConfig_output <- function(output) {
-  slurm_options <- c("--qos=priority --partition=priority", "--qos=short", "--qos=standby",
+  slurm_options <- c("--qos=priority --partition=priority", "--qos=short", "--qos=standby --partition=priority",
                      "--qos=priority --partition=priority --mem=8000", "--qos=short --mem=8000",
-                     "--qos=standby --mem=8000", "--qos=priority --partition=priority --mem=32000")
+                     "--qos=standby --partition=priority --mem=8000", "--qos=priority --partition=priority --mem=32000")
 
   if (!isSlurmAvailable())
     return("direct")
@@ -198,7 +198,8 @@ if (comp %in% c("comparison", "export")) {
   }
   if (exists("slurmConfig")) {
     if (slurmConfig %in% c("priority", "short", "standby")) {
-      slurmConfig <- paste0("--qos=", slurmConfig)
+      slurmConfig <- paste0("--qos=", slurmConfig,
+                            if (slurmConfig %in% c("priority", "standby")) " --partition=priority")
     }
   }
 
@@ -238,7 +239,8 @@ if (comp %in% c("comparison", "export")) {
       if (slurmConfig != "direct") slurmConfig <- combine_slurmConfig("--nodes=1 --tasks-per-node=1", slurmConfig)
     }
     if (slurmConfig %in% c("priority", "short", "standby")) {
-      slurmConfig <- paste0("--qos=", slurmConfig, " --nodes=1 --tasks-per-node=1")
+      slurmConfig <- paste0("--nodes=1 --tasks-per-node=1 --qos=", slurmConfig,
+                            if (slurmConfig %in% c("priority", "standby")) " --partition=priority")
     }
     if (isTRUE(slurmConfig %in% "direct")) {
       flags <- c(flags, "--interactive") # to tell scripts they can run in interactive mode

--- a/scripts/start/choose_slurmConfig.R
+++ b/scripts/start/choose_slurmConfig.R
@@ -55,10 +55,10 @@ choose_slurmConfig <- function(identifier = FALSE, flags = NULL) {
                     "2" = "--qos=standby --nodes=1 --tasks-per-node=13"  , # SLURM standby  - task per node: 13 (nash H12 coupled)
                     "3" = "--qos=standby --nodes=1 --tasks-per-node=16"  , # SLURM standby  - task per node: 16 (nash H12+)
                     "4" = "--qos=standby --nodes=1 --tasks-per-node=1 --mem=8000"   , # SLURM standby  - task per node:  1 (nash debug, test one regi)
-                    "5" = "--qos=priority --partition=priority --nodes=1 --tasks-per-node=12" , # SLURM priority - task per node: 12 (nash H12) [recommended]
-                    "6" = "--qos=priority --partition=priority --nodes=1 --tasks-per-node=13" , # SLURM priority - task per node: 13 (nash H12 coupled)
-                    "7" = "--qos=priority --partition=priority --nodes=1 --tasks-per-node=16" , # SLURM priority - task per node: 16 (nash H12+)
-                    "8" = "--qos=priority --partition=priority --nodes=1 --tasks-per-node=1 --mem=8000"  , # SLURM priority - task per node:  1 (nash debug, test one regi)
+                    "5" = "--qos=priority --nodes=1 --tasks-per-node=12" , # SLURM priority - task per node: 12 (nash H12) [recommended]
+                    "6" = "--qos=priority --nodes=1 --tasks-per-node=13" , # SLURM priority - task per node: 13 (nash H12 coupled)
+                    "7" = "--qos=priority --nodes=1 --tasks-per-node=16" , # SLURM priority - task per node: 16 (nash H12+)
+                    "8" = "--qos=priority --nodes=1 --tasks-per-node=1 --mem=8000"  , # SLURM priority - task per node:  1 (nash debug, test one regi)
                     "9" = "--qos=short --nodes=1 --tasks-per-node=12"    , # SLURM short    - task per node: 12 (nash H12)
                    "10" = "--qos=short --nodes=1 --tasks-per-node=16"    , # SLURM short    - task per node: 16 (nash H12+)
                    "11" = "--qos=short --nodes=1 --tasks-per-node=1 --mem=8000"     , # SLURM short    - task per node:  1 (nash debug, test one regi)

--- a/scripts/utils/climate_assessment/submit_climate_assessment.sh
+++ b/scripts/utils/climate_assessment/submit_climate_assessment.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #SBATCH --qos=priority
-#SBATCH --partition=priority
 #SBATCH --time=06:00:00
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=12

--- a/start_bundle_coupled.R
+++ b/start_bundle_coupled.R
@@ -665,7 +665,8 @@ for (scen in common) {
         sq <- system(paste0("squeue -u ", Sys.info()[["user"]], " -o '%q %j'"), intern = TRUE)
         runEnv$qos <- if (is.null(attr(sq, "status")) && sum(grepl("^priority ", sq)) < 4) "priority" else "short"
       }
-      slurmOptions <- combine_slurmConfig(paste0("--qos=", runEnv$qos, if (runEnv$qos %in% "priority") " --partition=priority",
+      slurmOptions <- combine_slurmConfig(paste0("--qos=", runEnv$qos,
+        if (runEnv$qos %in% c("priority", "standby")) " --partition=priority",
         " --job-name=", fullrunname, " --output=", logfile,
         " --open-mode=append --mail-type=END,FAIL --comment=REMIND-MAgPIE --tasks-per-node=", runEnv$numberOfTasks,
         if (runEnv$numberOfTasks == 1) " --mem=8000"), runEnv$sbatch)

--- a/start_bundle_coupled.R
+++ b/start_bundle_coupled.R
@@ -666,7 +666,6 @@ for (scen in common) {
         runEnv$qos <- if (is.null(attr(sq, "status")) && sum(grepl("^priority ", sq)) < 4) "priority" else "short"
       }
       slurmOptions <- combine_slurmConfig(paste0("--qos=", runEnv$qos,
-        if (runEnv$qos %in% c("priority", "standby")) " --partition=priority",
         " --job-name=", fullrunname, " --output=", logfile,
         " --open-mode=append --mail-type=END,FAIL --comment=REMIND-MAgPIE --tasks-per-node=", runEnv$numberOfTasks,
         if (runEnv$numberOfTasks == 1) " --mem=8000"), runEnv$sbatch)

--- a/start_coupled.R
+++ b/start_coupled.R
@@ -260,7 +260,6 @@ start_coupled <- function(path_remind, path_magpie, cfg_rem, cfg_mag, runname, m
           subseq.env$qos <- if (is.null(attr(sq, "status")) && sum(grepl("^priority ", sq)) < 4) "priority" else "short"
         }
         slurmOptions <- combine_slurmConfig(paste0("--qos=", subseq.env$qos,
-           if (subseq.env$qos %in% c("priority", "standby")) " --partition=priority",
            " --job-name=", subseq.env$fullrunname, " --output=", logfile,
            " --open-mode=append --mail-type=END,FAIL --comment=REMIND-MAgPIE --tasks-per-node=", subseq.env$numberOfTasks,
           if (subseq.env$numberOfTasks == 1) " --mem=8000"), subseq.env$sbatch)

--- a/start_coupled.R
+++ b/start_coupled.R
@@ -259,7 +259,8 @@ start_coupled <- function(path_remind, path_magpie, cfg_rem, cfg_mag, runname, m
           sq <- system(paste0("squeue -u ", Sys.info()[["user"]], " -o '%q %j' | grep -v ", fullrunname), intern = TRUE)
           subseq.env$qos <- if (is.null(attr(sq, "status")) && sum(grepl("^priority ", sq)) < 4) "priority" else "short"
         }
-        slurmOptions <- combine_slurmConfig(paste0("--qos=", subseq.env$qos, if (subseq.env$qos %in% "priority") " --partition=priority",
+        slurmOptions <- combine_slurmConfig(paste0("--qos=", subseq.env$qos,
+           if (subseq.env$qos %in% c("priority", "standby")) " --partition=priority",
            " --job-name=", subseq.env$fullrunname, " --output=", logfile,
            " --open-mode=append --mail-type=END,FAIL --comment=REMIND-MAgPIE --tasks-per-node=", subseq.env$numberOfTasks,
           if (subseq.env$numberOfTasks == 1) " --mem=8000"), subseq.env$sbatch)


### PR DESCRIPTION
## Purpose of this PR

- undo adding --partition=priority for --qos=priority
- https://mattermost.pik-potsdam.de/cluster-users/pl/uytyiqp46frhje6ohgj4aoimye

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
