### PR TITLE
Bug fix in 45_carbonprice realization "expoLinear"

### DIFF
--- a/modules/45_carbonprice/expoLinear/datainput.gms
+++ b/modules/45_carbonprice/expoLinear/datainput.gms
@@ -21,12 +21,12 @@ elseif cm_co2_tax_startyear gt 0,
 *LB* calculate tax path until cm_expoLinear_yearStart (defaults to 2060)
 pm_taxCO2eq(ttot,regi)$(ttot.val ge cm_startyear) = s45_co2_tax_startyear*cm_co2_tax_growth**(ttot.val-cm_startyear);
 *LB* use linear tax path from cm_expoLinear_yearStart on
-p45_tau_co2_tax_inc(regi) = sum(ttot$(ttot.val eq cm_expoLinear_yearStart),((pm_taxCO2eq(ttot, regi) - pm_taxCO2eq(ttot - 1, regi)) / (pm_ttot_val(ttot) - pm_ttot_val(ttot - 1)))); 
-pm_taxCO2eq(ttot,regi)$(ttot.val gt cm_expoLinear_yearStart) = sum(t$(t.val eq cm_expoLinear_yearStart), pm_taxCO2eq(t, regi) +  p45_tau_co2_tax_inc(regi) * (pm_ttot_val(ttot) - pm_ttot_val(t)))  ;
+s45_tau_co2_tax_inc = sum(ttot$(ttot.val eq cm_expoLinear_yearStart),((pm_taxCO2eq(ttot, regi) - pm_taxCO2eq(ttot - 1, regi)) / (pm_ttot_val(ttot) - pm_ttot_val(ttot - 1)))); 
+pm_taxCO2eq(ttot,regi)$(ttot.val gt cm_expoLinear_yearStart) = sum(t$(t.val eq cm_expoLinear_yearStart), pm_taxCO2eq(t, regi) +  s45_tau_co2_tax_inc * (pm_ttot_val(ttot) - pm_ttot_val(t)))  ;
 *** set carbon price constant after 2110 to prevent huge carbon prices which lead to convergence problems
 pm_taxCO2eq(ttot,regi)$(ttot.val gt 2110) = pm_taxCO2eq("2110",regi);
 
 display pm_taxCO2eq;
-display p45_tau_co2_tax_inc;
+display s45_tau_co2_tax_inc;
 
 *** EOF ./modules/45_carbonprice/expoLinear/datainput.gms


### PR DESCRIPTION
## Purpose of this PR

Bug fix in 45_carbonprice realization "expoLinear": Changing a parameter into a scalar (because it does not depend on the region) in a previous PR was incomplete and is fixed now.

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):


