### PR TITLE
Use server link für NGFS and ELEVATE iiasatemplate

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,7 +51,7 @@ Imports:
     nleqslv,
     optparse,
     piamenv (>= 0.4.0),
-    piamInterfaces (>= 0.20.21),
+    piamInterfaces (>= 0.21.0),
     piamPlotComparison (>= 0.0.10),
     piamutils,
     plotly,

--- a/scripts/output/export/xlsx_IIASA.R
+++ b/scripts/output/export/xlsx_IIASA.R
@@ -32,14 +32,14 @@ lucode2::readArgs("project")
 
 projects <- list(
   ELEVATE    = list(mapping = c("NAVIGATE", "ELEVATE"),
-                    iiasatemplate = "elevate-workflow/definitions/variable/variable.yaml"),
+                    iiasatemplate = "https://files.ece.iiasa.ac.at/elevate/elevate-template.xlsx"),
   ENGAGE_4p5 = list(mapping = c("AR6", "AR6_NGFS"),
                     iiasatemplate = "ENGAGE_CD-LINKS_template_2019-08-22.xlsx",
                     removeFromScen = "_diff|_expoLinear|-all_regi"),
   NAVIGATE_coupled = list(mapping = c("NAVIGATE", "NAVIGATE_coupled")),
   NGFS       = list(model = "REMIND-MAgPIE 3.3-4.8",
                     mapping = c("AR6", "AR6_NGFS"),
-                    iiasatemplate = "../iiasa-workflow/definitions/variable/variables.yaml",
+                    iiasatemplate = "https://files.ece.iiasa.ac.at/ngfs-phase-5/ngfs-phase-5-template.xlsx",
                     removeFromScen = "C_|_bIT|_bit|_bIt"),
   SHAPE      = list(mapping = c("NAVIGATE", "SHAPE")),
   TESTTHAT   = list(mapping = "AR6")


### PR DESCRIPTION
## Purpose of this PR

- move from relative path to server link for NGFS and ELEVATE iiasatemplate
- needs https://github.com/pik-piam/piamInterfaces/pull/348

## Type of change

- [x] Not sure this can be counted as a "change" at all

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`) --- cluster is down, but I can't see this affecting anything
- [x] The changelog `CHANGELOG.md` [has not been updated](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
