### PR TITLE
bug fix in 45_carbonprice realization expoLinear

### DIFF
--- a/modules/45_carbonprice/expoLinear/datainput.gms
+++ b/modules/45_carbonprice/expoLinear/datainput.gms
@@ -17,14 +17,15 @@ elseif cm_co2_tax_startyear gt 0,
   s45_co2_tax_startyear = cm_co2_tax_startyear * sm_DptCO2_2_TDpGtC;
 );
 
-*LKS* code cleaning: usage of ttot should be replaced by t.
-*LB* calculate tax path until cm_expoLinear_yearStart (defaults to 2060)
-pm_taxCO2eq(ttot,regi)$(ttot.val ge cm_startyear) = s45_co2_tax_startyear*cm_co2_tax_growth**(ttot.val-cm_startyear);
-*LB* use linear tax path from cm_expoLinear_yearStart on
-p45_tau_co2_tax_inc(regi) = sum(ttot$(ttot.val eq cm_expoLinear_yearStart),((pm_taxCO2eq(ttot, regi) - pm_taxCO2eq(ttot - 1, regi)) / (pm_ttot_val(ttot) - pm_ttot_val(ttot - 1)))); 
-pm_taxCO2eq(ttot,regi)$(ttot.val gt cm_expoLinear_yearStart) = sum(t$(t.val eq cm_expoLinear_yearStart), pm_taxCO2eq(t, regi) +  p45_tau_co2_tax_inc(regi) * (pm_ttot_val(ttot) - pm_ttot_val(t)))  ;
+*** calculate tax path until cm_expoLinear_yearStart (defaults to 2060)
+pm_taxCO2eq(t,regi) = s45_co2_tax_startyear*cm_co2_tax_growth**(t.val-cm_startyear);
+*** use linear tax path from cm_expoLinear_yearStart on (with slope given by last timestep before cm_expoLinear_yearStart)
+p45_tau_co2_tax_inc(regi) = sum(ttot$(ttot.val eq cm_expoLinear_yearStart),
+                                ((pm_taxCO2eq(ttot, regi) - pm_taxCO2eq(ttot - 1, regi)) / (pm_ttot_val(ttot) - pm_ttot_val(ttot - 1)))); !! Using ttot to make use of pm_ttot_val
+pm_taxCO2eq(t,regi)$(t.val gt cm_expoLinear_yearStart) = sum(t2$(t2.val eq cm_expoLinear_yearStart), pm_taxCO2eq(t2, regi)) 
+                                                          +  p45_tau_co2_tax_inc(regi) * (t.val - cm_expoLinear_yearStart);
 *** set carbon price constant after 2110 to prevent huge carbon prices which lead to convergence problems
-pm_taxCO2eq(ttot,regi)$(ttot.val gt 2110) = pm_taxCO2eq("2110",regi);
+pm_taxCO2eq(t,regi)$(t.val gt 2110) = pm_taxCO2eq("2110",regi);
 
 display pm_taxCO2eq;
 display p45_tau_co2_tax_inc;

--- a/modules/45_carbonprice/expoLinear/declarations.gms
+++ b/modules/45_carbonprice/expoLinear/declarations.gms
@@ -6,9 +6,11 @@
 *** |  Contact: remind@pik-potsdam.de
 *** SOF ./modules/45_carbonprice/expoLinear/declarations.gms
 
-scalars
-s45_tau_co2_tax_inc                          "Linear annual increase in carbon price T$/GtC/yr"
-s45_co2_tax_startyear                       "level of CO2 tax in start year converted from $/t CO2eq to T$/GtC"
+scalar
+s45_co2_tax_startyear                       "level of CO2 tax in start year in T$/GtC"
+;
+parameter
+p45_tau_co2_tax_inc(all_regi)     "Linear annual increase in carbon price T$/GtC/yr"
 ;
 
 *** EOF ./modules/45_carbonprice/expoLinear/declarations.gms


### PR DESCRIPTION
## Purpose of this PR

Bug fix in 45_carbonprice realization "expoLinear": Changing a parameter into a scalar (because it does not depend on the region) in a previous PR was created a problem and is reversed now.

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

