### PR TITLE
add EDGE-T to cs2

### DIFF
--- a/scripts/cs2/profiles.json
+++ b/scripts/cs2/profiles.json
@@ -58,6 +58,12 @@
     "sections": "0",
     "userSectionPath": "normalizePath('./scripts/cs2/MAGICC7_AR6.Rmd')"
   },
+	"EDGE-Transport": {
+		"projectLibrary": "'reporttransport'",
+		"reg": "c('OAS', 'MEA', 'SSA', 'LAM', 'REF', 'CAZ', 'CHA', 'IND', 'JPN', 'USA', 'NEU', 'EUR', 'World')",
+		"sections": "c(0,1,2,3,4,5,99)",
+		"mainReg": "World"
+	},
 	"mySection": {
 		"sections": "0",
 		"userSectionPath": "normalizePath('./scripts/cs2/mySection.Rmd')"

--- a/scripts/cs2/run_compareScenarios2.R
+++ b/scripts/cs2/run_compareScenarios2.R
@@ -34,7 +34,12 @@ run_compareScenarios2 <- function(
   outDir <- normalizePath(outFileName, mustWork = TRUE)
 
   outputDirs <- unique(normalizePath(outputDirs, mustWork = TRUE))
-  mifPath <- remind2::getMifScenPath(outputDirs, mustWork = TRUE)
+
+  if (profileName == "EDGE-Transport") {
+    mifPath <- normalizePath(file.path(outputDirs, "EDGE-T", "Transport.mif"), mustWork = TRUE)
+  } else {
+    mifPath <- remind2::getMifScenPath(outputDirs, mustWork = TRUE)
+  }
   histPath <- remind2::getMifHistPath(outputDirs[1], mustWork = TRUE)
   scenConfigPath <- remind2::getCfgScenPath(outputDirs, mustWork = TRUE)
 


### PR DESCRIPTION
## Purpose of this PR


## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [ ] Bug fix 
- [ ] Refactoring
- [ ] New feature 
- [ ] Minor change (default scenarios show only small differences)
- [ ] Fundamental change
- [ ] This change requires a documentation update


## Checklist:

- [ ] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [ ] I explained my changes within the PR, particularly in hard-to-understand areas
- [ ] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

