### PR TITLE
Removing unused variable v01_enerSerAdj and set in_enerSerAdj from 01_macro/singleSectorGr

### DIFF
--- a/modules/01_macro/singleSectorGr/declarations.gms
+++ b/modules/01_macro/singleSectorGr/declarations.gms
@@ -34,7 +34,6 @@ vm_invMacro(ttot,all_regi,all_in)                               "Investment for 
 v01_invMacroAdj(ttot,all_regi,all_in)                           "Adjustment costs of macro economic investments"
 vm_invInno(ttot,all_regi,all_in)                                "Investment into innovation"
 vm_invImi(ttot, all_regi,all_in)                                "Investment into imitation" 
-v01_enerSerAdj(tall,all_regi,all_in)                             "adjustment costs for energy service transformations"
 ;
 ***------------------------------------------------------------ -------------------
 ***                                   EQUATIONS 

--- a/modules/01_macro/singleSectorGr/equations.gms
+++ b/modules/01_macro/singleSectorGr/equations.gms
@@ -45,7 +45,6 @@ qm_budget(ttot,regi)$( ttot.val ge cm_startyear ) ..
   + sum(tradeCap, vm_costTradeCap(ttot,regi,tradeCap))
   + vm_taxrev(ttot,regi)$(ttot.val ge 2010)
   + vm_costAdjNash(ttot,regi)
-  + sum(in_enerSerAdj(in), v01_enerSerAdj(ttot,regi,in))
   + sum(teEs, vm_esCapInv(ttot,regi,teEs))
   + vm_costpollution(ttot,regi)
   + pm_totLUcosts(ttot,regi)

--- a/modules/01_macro/singleSectorGr/sets.gms
+++ b/modules/01_macro/singleSectorGr/sets.gms
@@ -29,8 +29,6 @@ ppf(all_in)                           "All primary production factors"
 ipf(all_in)                           "All intermediate production factors"
 ppfKap(all_in)                        "Primary production factors capital"   / kap /
 ppfEn(all_in)                         "Primary production factors energy"
-
-in_enerSerAdj(all_in)                 "Energy services factors which should be constrained by adjustment costs" //
 ;
 
 alias(cesOut2cesIn,cesOut2cesIn2,cesOut2cesIn3);


### PR DESCRIPTION
## Purpose of this PR

Remove old unused variable and set: The variable `v01_enerSerAdj ` was declared but never assigned non-zero values. It appeared only once (in the budget equation), having no effect given all values being zero. The set `in_enerSerAdj` was only used when declaring the above variable. 

## Type of change

- [x] Code cleaning

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)


