### PR TITLE
limit slurm runtime of output.R scripts to 5 hours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     [[#1718](https://github.com/remindmodel/remind/pull/1718)]
 - **scripts** REMIND-MAgPIE start scripts now correctly use all non-gms cfg switches
     [[#1768](https://github.com/remindmodel/remind/pull/1768)]
-- **scripts** limit slurm runtime of output.R scripts to 5 hours
+- **scripts** limit slurm runtime of output.R scripts to 2 hours
     [[1783](https://github.com/remindmodel/remind/pull/1783)]
 
 ### removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - included CCS from plastic waste incineration in CCS mass flows so it is
     subject to injection constraints (but did not add CCS costs, see
     https://github.com/remindmodel/development_issues/issues/274
-- **MAGICC7** fix climate data for t < cm_startyear on reference run
+- **MAGICC7** fix climate data for time before cm_startyear on reference run
     [[#1744](https://github.com/remindmodel/remind/pull/1744)]
 - **scripts** fix tax convergence reporting in modelSummary
     [[#1728](https://github.com/remindmodel/remind/pull/1728)]
@@ -47,6 +47,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     [[#1718](https://github.com/remindmodel/remind/pull/1718)]
 - **scripts** REMIND-MAgPIE start scripts now correctly use all non-gms cfg switches
     [[#1768](https://github.com/remindmodel/remind/pull/1768)]
+- **scripts** limit slurm runtime of output.R scripts to 5 hours
+    [[1783](https://github.com/remindmodel/remind/pull/1783)]
 
 ### removed
 

--- a/output.R
+++ b/output.R
@@ -235,7 +235,7 @@ if (comp %in% c("comparison", "export")) {
     # choose the slurm options
     if (!exists("slurmConfig")) {
       slurmConfig <- choose_slurmConfig_output(output = output)
-      if (slurmConfig != "direct") slurmConfig <- combine_slurmConfig("--nodes=1 --tasks-per-node=1", slurmConfig)
+      if (slurmConfig != "direct") slurmConfig <- combine_slurmConfig("--nodes=1 --tasks-per-node=1 --time=300", slurmConfig)
     }
     if (slurmConfig %in% c("priority", "short", "standby")) {
       slurmConfig <- paste0("--nodes=1 --tasks-per-node=1 --qos=", slurmConfig)

--- a/output.R
+++ b/output.R
@@ -235,7 +235,7 @@ if (comp %in% c("comparison", "export")) {
     # choose the slurm options
     if (!exists("slurmConfig")) {
       slurmConfig <- choose_slurmConfig_output(output = output)
-      if (slurmConfig != "direct") slurmConfig <- combine_slurmConfig("--nodes=1 --tasks-per-node=1 --time=300", slurmConfig)
+      if (slurmConfig != "direct") slurmConfig <- combine_slurmConfig("--nodes=1 --tasks-per-node=1 --time=120", slurmConfig)
     }
     if (slurmConfig %in% c("priority", "short", "standby")) {
       slurmConfig <- paste0("--nodes=1 --tasks-per-node=1 --qos=", slurmConfig)

--- a/scripts/output/single/MAGICC7_AR6.R
+++ b/scripts/output/single/MAGICC7_AR6.R
@@ -104,7 +104,7 @@ if (is.null(cfg$climate_assessment_magicc_bin)) cfg$climate_assessment_magicc_bi
 if (is.null(cfg$climate_assessment_magicc_prob_file_reporting)) cfg$climate_assessment_magicc_prob_file_reporting <- "/p/projects/rd3mod/climate-assessment-files/parsets/0fd0f62-derived-metrics-id-f023edb-drawnset.json"
 
 # All climate-assessment files will be written to this folder
-climateAssessmentFolder <- normalizePath(file.path(outputdir, "climate-assessment-data"))
+climateAssessmentFolder <- normalizePath(file.path(outputdir, "climate-assessment-data"), mustWork = FALSE)
 dir.create(climateAssessmentFolder, showWarnings = FALSE)
 
 # The base name, that climate-assessment uses to derive it's output names


### PR DESCRIPTION
## Purpose of this PR

- With the frequent cluster closures, it becomes annoying that all REMIND output scripts selected via `output.R` (compareScenarios2, reporting, MAGICC7_AR6, …) reserve 24 hours cluster time, so you always have to [adjust the time](https://github.com/pik-piam/discussions/discussions/9) in order to not have them pending.
- Therefore, set a time limit of 2 hours (--time=120) which is a worst case estimate (selecting everything + 200% spare time to avoid anyone running into timeouts)
- avoid warning in MAGICC7_AR6 because folder does not yet exist

## Type of change

- [x] make it easier to live with cluster mess

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`): `[ FAIL 0 | WARN 0 | SKIP 6 | PASS 88 ]`
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)