### PR TITLE
 check for duplicates in mif, reduce coupled test slurm time

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,7 +56,7 @@ Imports:
     piamutils,
     plotly,
     purrr,
-    quitte (>= 0.3128.4),
+    quitte (>= 0.3137.0),
     R.utils,
     raster,
     readr,

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ test-coupled:    ## Test if the coupling with MAgPIE works. Takes significantly
 test-coupled-slurm: ## test-coupled, but on slurm
 	$(info Coupling tests take around 75 minutes to run. Sent to slurm, find log in test-coupled.log)
 	make ensure-reqs
-	@sbatch --qos=priority --wrap="make test-coupled" --job-name=test-coupled --mail-type=END,FAIL --output=test-coupled.log --comment="test-coupled.log"
+	@sbatch --qos=priority --wrap="make test-coupled" --job-name=test-coupled --mail-type=END,FAIL --time=180 --output=test-coupled.log --comment="test-coupled.log"
 
 test-full:       ## Run all tests, including coupling tests and a default
                  ## REMIND scenario. Takes several hours to run.

--- a/config/tests/scenario_config_coupled_shortCascade.csv
+++ b/config/tests/scenario_config_coupled_shortCascade.csv
@@ -1,4 +1,4 @@
 title;start;qos;sbatch;magpie_scen;config/scenario_config.csv;magpie_empty;no_ghgprices_land_until;max_iterations;oldrun;path_gdx;path_gdx_ref;path_gdx_bau;path_report;cm_nash_autoconverge_lastrun;path_mif_ghgprice_land;cfg_mag$gms$s56_minimum_cprice;cfg_mag$damping_factor;cfg_mag$gms$s56_cprice_red_factor
-TESTTHAT-SSP2-Base;1;auto;--wait --mail-type=FAIL;SSP2|NPI;SDP-MC;TRUE;y2150;2;;;;;;2;;;;
-TESTTHAT-SSP2-NDC;1;auto;--wait --mail-type=FAIL;SSP2|NDC;;TRUE;y2150;2;;;;;;2;TESTTHAT-SSP2-Base;;0.80;0.5
-TESTTHAT-SSP2-Policy;2;auto;--wait --mail-type=FAIL;SSP2|NDC;SDP-MC;TRUE;y2150;2;TESTTHAT-SSP2-Base;;;;;;output/C_TESTTHAT-SSP2-Base-rem-1/REMIND_generic_C_TESTTHAT-SSP2-Base-rem-1.mif;20;;
+TESTTHAT-SSP2-Base;1;auto;--wait --mail-type=FAIL --time=60;SSP2|NPI;SDP-MC;TRUE;y2150;2;;;;;;2;;;;
+TESTTHAT-SSP2-NDC;1;auto;--wait --mail-type=FAIL --time=60;SSP2|NDC;;TRUE;y2150;2;;;;;;2;TESTTHAT-SSP2-Base;;0.80;0.5
+TESTTHAT-SSP2-Policy;2;auto;--wait --mail-type=FAIL --time=60;SSP2|NDC;SDP-MC;TRUE;y2150;2;TESTTHAT-SSP2-Base;;;;;;output/C_TESTTHAT-SSP2-Base-rem-1/REMIND_generic_C_TESTTHAT-SSP2-Base-rem-1.mif;20;;

--- a/scripts/output/single/reporting.R
+++ b/scripts/output/single/reporting.R
@@ -124,6 +124,8 @@ if (! is.null(magpie_reporting_file) && file.exists(magpie_reporting_file)) {
   piamutils::deletePlus(remind_reporting_file, writemif = TRUE)
 }
 
+invisible(quitte::reportDuplicates(piamutils::deletePlus(quitte::read.quitte(remind_reporting_file, check.duplicates = FALSE))))
+
 message("### end generation of mif files at ", Sys.time())
 
 ## produce REMIND LCOE reporting *.csv based on gdx information

--- a/tests/testthat/test_06-output.R
+++ b/tests/testthat/test_06-output.R
@@ -9,10 +9,12 @@ skipIfPreviousFailed()
 
 test_that("output.R -> single -> reporting works", {
   output <- localSystem2("Rscript", c("output.R", "comp=single", "output=reporting", "outputdir=output/testOneRegi",
-                                      "slurmConfig='--qos=priority --mem=8000 --wait'"))
+                                      "slurmConfig='--qos=priority --mem=8000 --wait --time=120'"))
   printIfFailed(output)
   expectSuccessStatus(output)
-  expect_true(file.exists("../../output/testOneRegi/REMIND_generic_testOneRegi.mif"))
+  remind_reporting_file <- "../../output/testOneRegi/REMIND_generic_testOneRegi.mif"
+  expect_true(file.exists(remind_reporting_file))
+  expect_no_warning(quitte::reportDuplicates(piamutils::deletePlus(quitte::read.quitte(remind_reporting_file, check.duplicates = FALSE))))
 })
 
 test_that("output.R -> export -> xlsx_IIASA works", {

--- a/tests/testthat/test_20-coupled.R
+++ b/tests/testthat/test_20-coupled.R
@@ -142,6 +142,7 @@ test_that("runs coupled to MAgPIE work", {
     expect_true(lengthwithmag > lengthwithoutmag && lengthwithmag > 700000)
     # check main mif
     qscen <- quitte::as.quitte(paste0("../../output/C_", scen, ".mif"))
+    expect_no_warning(quitte::reportDuplicates(piamutils::deletePlus(qscen)))
     expect_true(all(grepl("^REMIND-MAgPIE", levels(qscen$model))))
     expect_true(nrow(qscen) == lengthwithmag)
     # here we could add checks which variables etc. must be in the mif file


### PR DESCRIPTION
## Purpose of this PR

- warn in reporting.R if duplicates are introduced
- add that check to tests as well
- needs https://github.com/pik-piam/quitte/pull/98
- reduce coupled test slurm time

Current warning:
```
  Duplicated data found for REMIND testOneRegi:
Variables: Emi|CO2|Energy|Demand|Transport (Mt CO2/yr), Emi|CO2|Energy|Demand|Transport|Gases (Mt CO2/yr), Emi|CO2|Energy|Demand|Transport|Liquids (Mt CO2/yr)
```

`make test` still succeeds, but `make test-full` and `make test-coupled` fail on the new test until this problem is solved.

## Type of change

- [x] New feature 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`). Actually, `make test-full` now has another fail
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
