### PR TITLE
add 2040 to the EU27 comparison scenario plots

### DIFF
--- a/scripts/cs2/profiles.json
+++ b/scripts/cs2/profiles.json
@@ -30,7 +30,7 @@
 		"reg": "c('DEU', 'ECE', 'ECS', 'ENC', 'ESC', 'ESW', 'EU27', 'EWN', 'FRA')",
 		"yearsScen": "seq(2005, 2050, 5)",
 		"yearsHist": "c(seq(1990, 2024, 1), seq(2025, 2050, 5))",
-		"yearsBarPlot": "c(2020, 2030, 2050)",
+		"yearsBarPlot": "c(2020, 2030, 2040, 2050)",
 		"mainReg": "'EU27'"
 	},
 	"AriadneDEU": {


### PR DESCRIPTION
## Purpose of this PR

- Add the year 2040 to EU27 comparison scenario bar plots.

## Type of change

- [x] Minor change
