### PR TITLE
enabling biohp and biochp early retirement

### DIFF
--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -350,6 +350,8 @@ vm_capEarlyReti.up(ttot,regi,te)$(teFosNoCCS(te)) = 1;
 vm_capEarlyReti.up(ttot,regi,"tnrs") = 1;
 *** allow early retirement of biomass used in electricity
 vm_capEarlyReti.up(ttot,regi,"bioigcc") = 1;
+vm_capEarlyReti.up(ttot,regi,"biohp") = 1;
+vm_capEarlyReti.up(ttot,regi,"biochp") = 1;
 
 ***restrict early retirement to the modeling time frame (to reduce runtime, the early retirement equations are phased out after 2110)
 vm_capEarlyReti.up(ttot,regi,te)$(ttot.val lt 2009 or ttot.val gt 2111) = 0;

--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -343,28 +343,33 @@ vm_deltaCap.fx(t,regi,te,rlf)$(t.val le 2025 AND pm_data(regi,"tech_stat",te) eq
 *** allow non zero early retirement for all technologies to avoid mathematical errors
 vm_capEarlyReti.up(ttot,regi,te) = 1e-6;
 
-
 ***generally allow full early retiremnt for all fossil technologies without CCS
-vm_capEarlyReti.up(ttot,regi,te)$(teFosNoCCS(te)) = 1;
-*** FS: allow nuclear early retirement (for nucscen 7)
-vm_capEarlyReti.up(ttot,regi,"tnrs") = 1;
+vm_capEarlyReti.up(t,regi,te)$(teFosNoCCS(te)) = 1;
+*** allow nuclear early retirement
+vm_capEarlyReti.up(t,regi,"tnrs") = 1;
 *** allow early retirement of biomass used in electricity
-vm_capEarlyReti.up(ttot,regi,"bioigcc") = 1;
-vm_capEarlyReti.up(ttot,regi,"biohp") = 1;
-vm_capEarlyReti.up(ttot,regi,"biochp") = 1;
+vm_capEarlyReti.up(t,regi,"bioigcc") = 1;
+*** allow early retirement of biomass used for heat and power
+vm_capEarlyReti.up(t,regi,"biohp") = 1;
+vm_capEarlyReti.up(t,regi,"biochp") = 1;
+
+*** allow early retirement for techs added to the c_tech_earlyreti_rate switch
+$ifthen.tech_earlyreti not "%c_tech_earlyreti_rate%" == "off"
+loop((ext_Regi,te)$p_techEarlyRetiRate(ext_regi,all_te),
+  vm_capEarlyReti.up(t,regi,te)$(regi_group(ext_regi,regi))= 1;
+);
+$endif.tech_earlyreti
 
 ***restrict early retirement to the modeling time frame (to reduce runtime, the early retirement equations are phased out after 2110)
 vm_capEarlyReti.up(ttot,regi,te)$(ttot.val lt 2009 or ttot.val gt 2111) = 0;
 
-*cb 20120224 lower bound of 0.01% to help the model to be aware of the early retirement option
-vm_capEarlyReti.lo(ttot,regi,te)$(teFosNoCCS(te) AND ttot.val gt 2011 AND ttot.val lt 2111) = 0.0001;
-vm_capEarlyReti.lo(ttot,regi,"tnrs")$(ttot.val gt 2011 AND ttot.val lt 2111) = 0.0001;
+* lower bound of 0.01% to help the model to be aware of the early retirement option
+vm_capEarlyReti.lo(t,regi,te)$((vm_capEarlyReti.up(t,regi,te) ge 1) and (t.val gt 2010) and (t.val le 2100)) = 1e-4;
 
 *cb 20120301 no early retirement for dot, they are used despite their economic non-competitiveness for various reasons.
 vm_capEarlyReti.fx(ttot,regi,"dot")=0;
 *rp 20210118 no investment into oil turbines in Europe
 vm_deltaCap.up(t,regi,"dot","1")$( (t.val gt 2005) AND regi_group("EUR_regi",regi) )  = 1e-6;
-
 
 *' @code{extrapage: "00_model_assumptions"}
 *** -----------------------------------------------------------------------------

--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -341,7 +341,7 @@ vm_deltaCap.fx(t,regi,te,rlf)$(t.val le 2025 AND pm_data(regi,"tech_stat",te) eq
 *CB allow for early retirement at the start of free model time
 *CB ------------------------------------------------------------
 *** allow non zero early retirement for all technologies to avoid mathematical errors
-vm_capEarlyReti.up(ttot,regi,te) = 1e-6;
+vm_capEarlyReti.up(t,regi,te) = 1e-6;
 
 ***generally allow full early retiremnt for all fossil technologies without CCS
 vm_capEarlyReti.up(t,regi,te)$(teFosNoCCS(te)) = 1;
@@ -355,7 +355,7 @@ vm_capEarlyReti.up(t,regi,"biochp") = 1;
 
 *** allow early retirement for techs added to the c_tech_earlyreti_rate switch
 $ifthen.tech_earlyreti not "%c_tech_earlyreti_rate%" == "off"
-loop((ext_Regi,te)$p_techEarlyRetiRate(ext_regi,all_te),
+loop((ext_regi,te)$p_techEarlyRetiRate(ext_regi,te),
   vm_capEarlyReti.up(t,regi,te)$(regi_group(ext_regi,regi))= 1;
 );
 $endif.tech_earlyreti
@@ -367,7 +367,7 @@ vm_capEarlyReti.up(ttot,regi,te)$(ttot.val lt 2009 or ttot.val gt 2111) = 0;
 vm_capEarlyReti.lo(t,regi,te)$((vm_capEarlyReti.up(t,regi,te) ge 1) and (t.val gt 2010) and (t.val le 2100)) = 1e-4;
 
 *cb 20120301 no early retirement for dot, they are used despite their economic non-competitiveness for various reasons.
-vm_capEarlyReti.fx(ttot,regi,"dot")=0;
+vm_capEarlyReti.fx(t,regi,"dot")=0;
 *rp 20210118 no investment into oil turbines in Europe
 vm_deltaCap.up(t,regi,"dot","1")$( (t.val gt 2005) AND regi_group("EUR_regi",regi) )  = 1e-6;
 

--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -752,14 +752,14 @@ loop(ext_regi$pm_extRegiEarlyRetiRate(ext_regi),
 );
 *Tech-specific*
 *RP*: reduce early retirement for technologies with additional characteristics that are difficult to represent in REMIND, eg. industries built around heating/CHP plants, or flexibility from ngt plants
-pm_regiEarlyRetiRate(t,regi,"ngt")     = 0.3 * pm_regiEarlyRetiRate(t,regi,"ngt")    ; !! ngt should only be phased out very slowly, as they provide flexibility - which REMIND is not too good at capturing endogeneously
-pm_regiEarlyRetiRate(t,regi,"gaschp")  = 0.5 * pm_regiEarlyRetiRate(t,regi,"gaschp") ; !! chp should only be phased out slowly, as district heating networks/ industry uses are designed to a specific heat input
-pm_regiEarlyRetiRate(t,regi,"coalchp") = 0.5 * pm_regiEarlyRetiRate(t,regi,"coalchp"); !! chp should only be phased out slowly, as district heating networks/ industry uses are designed to a specific heat input
-pm_regiEarlyRetiRate(t,regi,"gashp")   = 0.5 * pm_regiEarlyRetiRate(t,regi,"gashp") ; !! chp should only be phased out slowly, as district heating networks/ industry uses are designed to a specific heat input
-pm_regiEarlyRetiRate(t,regi,"coalhp")  = 0.5 * pm_regiEarlyRetiRate(t,regi,"coalhp"); !! chp should only be phased out slowly, as district heating networks/ industry uses are designed to a specific heat input
-pm_regiEarlyRetiRate(t,regi,"biohp")   = 0.25 * pm_regiEarlyRetiRate(t,regi,"biohp") ; !! chp should only be phased out slowly, as district heating networks/ industry uses are designed to a specific heat input
-pm_regiEarlyRetiRate(t,regi,"biochp")  = 0.25 * pm_regiEarlyRetiRate(t,regi,"biochp") ; !! chp should only be phased out slowly, as district heating networks/ industry uses are designed to a specific heat input
-pm_regiEarlyRetiRate(t,regi,"bioigcc") = 0.25 * pm_regiEarlyRetiRate(t,regi,"bioigcc") ; !! reduce bio early retirement rate
+pm_regiEarlyRetiRate(t,regi,"ngt")     = 0.3 * pm_regiEarlyRetiRate(t,regi,"ngt");      !! ngt should only be phased out very slowly, as they provide flexibility - which REMIND is not too good at capturing endogeneously
+pm_regiEarlyRetiRate(t,regi,"gaschp")  = 0.5 * pm_regiEarlyRetiRate(t,regi,"gaschp");   !! chp should only be phased out slowly, as district heating networks/ industry uses are designed to a specific heat input
+pm_regiEarlyRetiRate(t,regi,"coalchp") = 0.5 * pm_regiEarlyRetiRate(t,regi,"coalchp");  !! chp should only be phased out slowly, as district heating networks/ industry uses are designed to a specific heat input
+pm_regiEarlyRetiRate(t,regi,"gashp")   = 0.5 * pm_regiEarlyRetiRate(t,regi,"gashp");    !! chp should only be phased out slowly, as district heating networks/ industry uses are designed to a specific heat input
+pm_regiEarlyRetiRate(t,regi,"coalhp")  = 0.5 * pm_regiEarlyRetiRate(t,regi,"coalhp");   !! chp should only be phased out slowly, as district heating networks/ industry uses are designed to a specific heat input
+pm_regiEarlyRetiRate(t,regi,"biohp")   = 0.25 * pm_regiEarlyRetiRate(t,regi,"biohp");   !! chp should only be phased out slowly, as district heating networks/ industry uses are designed to a specific heat input
+pm_regiEarlyRetiRate(t,regi,"biochp")  = 0.25 * pm_regiEarlyRetiRate(t,regi,"biochp");  !! chp should only be phased out slowly, as district heating networks/ industry uses are designed to a specific heat input
+pm_regiEarlyRetiRate(t,regi,"bioigcc") = 0.25 * pm_regiEarlyRetiRate(t,regi,"bioigcc"); !! reduce bio early retirement rate
 
 $ifthen.tech_earlyreti not "%c_tech_earlyreti_rate%" == "off"
 loop((ext_regi,te)$p_techEarlyRetiRate(ext_regi,te),

--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -755,11 +755,11 @@ loop(ext_regi$pm_extRegiEarlyRetiRate(ext_regi),
 pm_regiEarlyRetiRate(t,regi,"ngt")     = 0.3 * pm_regiEarlyRetiRate(t,regi,"ngt")    ; !! ngt should only be phased out very slowly, as they provide flexibility - which REMIND is not too good at capturing endogeneously
 pm_regiEarlyRetiRate(t,regi,"gaschp")  = 0.5 * pm_regiEarlyRetiRate(t,regi,"gaschp") ; !! chp should only be phased out slowly, as district heating networks/ industry uses are designed to a specific heat input
 pm_regiEarlyRetiRate(t,regi,"coalchp") = 0.5 * pm_regiEarlyRetiRate(t,regi,"coalchp"); !! chp should only be phased out slowly, as district heating networks/ industry uses are designed to a specific heat input
-pm_regiEarlyRetiRate(t,regi,"biochp")  = 0.5 * pm_regiEarlyRetiRate(t,regi,"biochp") ; !! chp should only be phased out slowly, as district heating networks/ industry uses are designed to a specific heat input
 pm_regiEarlyRetiRate(t,regi,"gashp")   = 0.5 * pm_regiEarlyRetiRate(t,regi,"gashp") ; !! chp should only be phased out slowly, as district heating networks/ industry uses are designed to a specific heat input
 pm_regiEarlyRetiRate(t,regi,"coalhp")  = 0.5 * pm_regiEarlyRetiRate(t,regi,"coalhp"); !! chp should only be phased out slowly, as district heating networks/ industry uses are designed to a specific heat input
-pm_regiEarlyRetiRate(t,regi,"biohp")   = 0.5 * pm_regiEarlyRetiRate(t,regi,"biohp") ; !! chp should only be phased out slowly, as district heating networks/ industry uses are designed to a specific heat input
-pm_regiEarlyRetiRate(t,regi,"bioigcc")   = 0.25 * pm_regiEarlyRetiRate(t,regi,"bioigcc") ; !! reduce bio early retirement rate
+pm_regiEarlyRetiRate(t,regi,"biohp")   = 0.25 * pm_regiEarlyRetiRate(t,regi,"biohp") ; !! chp should only be phased out slowly, as district heating networks/ industry uses are designed to a specific heat input
+pm_regiEarlyRetiRate(t,regi,"biochp")  = 0.25 * pm_regiEarlyRetiRate(t,regi,"biochp") ; !! chp should only be phased out slowly, as district heating networks/ industry uses are designed to a specific heat input
+pm_regiEarlyRetiRate(t,regi,"bioigcc") = 0.25 * pm_regiEarlyRetiRate(t,regi,"bioigcc") ; !! reduce bio early retirement rate
 
 $ifthen.tech_earlyreti not "%c_tech_earlyreti_rate%" == "off"
 loop((ext_regi,te)$p_techEarlyRetiRate(ext_regi,te),


### PR DESCRIPTION
## Purpose of this PR

- Enabling biohp and biochp early retirement so they can be replaced if there is strong pressure for other use of biomass in more stringent mitigation scenarios.
- Similar to: https://github.com/remindmodel/remind/pull/1763/files

- The early retirement for now does not include `biotrmod` for the reasons explained [here](https://github.com/remindmodel/remind/pull/1763#issuecomment-2291413896). This could be changed in the future if enough work is done to make sure the early retirement rates are properly defined.

- Fix c_tech_earlyreti_rate bug.

## Type of change
- [x] Minor change (default scenarios show only small differences)

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

