### PR TITLE
add validateScenarios to output scripts

### DIFF
--- a/output.R
+++ b/output.R
@@ -147,7 +147,8 @@ if (! exists("output")) {
 # Select output directories if not defined by readArgs
 if (! exists("outputdir")) {
   modulesNeedingMif <- c("compareScenarios2", "xlsx_IIASA", "policyCosts", "Ariadne_output",
-                         "plot_compare_iterations", "varListHtml", "fixOnRef", "MAGICC7_AR6")
+                         "plot_compare_iterations", "varListHtml", "fixOnRef", "MAGICC7_AR6",
+                         "validateScenarios")
   needingMif <- any(modulesNeedingMif %in% output) && ! "reporting" %in% output[[1]]
   if (exists("remind_dir")) {
     dir_folder <- c(file.path(remind_dir, "output"), remind_dir)
@@ -192,7 +193,7 @@ if (comp %in% c("comparison", "export")) {
   }
 
   # choose the slurm options. If you use command line arguments, use slurmConfig=priority or standby
-  modules_using_slurmConfig <- c("compareScenarios2")
+  modules_using_slurmConfig <- c("compareScenarios2", "validateScenarios")
   if (!exists("slurmConfig") && any(modules_using_slurmConfig %in% output)) {
     slurmConfig <- choose_slurmConfig_output(output = output)
   }
@@ -248,7 +249,7 @@ if (comp %in% c("comparison", "export")) {
     slurmConfig <- "direct"
   }
 
-  # Execute outputscripts for all choosen folders
+  # Execute outputscripts for all chosen folders
   for (outputdir in outputdirs) {
 
     if (exists("cfg")) {

--- a/scripts/output/comparison/validateScenarios.R
+++ b/scripts/output/comparison/validateScenarios.R
@@ -1,0 +1,77 @@
+# |  (C) 2006-2024 Potsdam Institute for Climate Impact Research (PIK)
+# |  authors, and contributors see CITATION.cff file. This file is part
+# |  of REMIND and licensed under AGPL-3.0-or-later. Under Section 7 of
+# |  AGPL-3.0, you are granted additional permissions described in the
+# |  REMIND License Exception, version 1.0 (see LICENSE file).
+# |  Contact: remind@pik-potsdam.de
+
+
+  source("./scripts/start/isSlurmAvailable.R")
+
+  # This script expects a variable `outputdirs` to be defined.
+  # Variables `slurmConfig` and `filename_prefix` are used if they defined.
+  if (!exists("outputdirs")) {
+    stop(
+      "Variable outputdirs does not exist. ",
+      "Please call validateScenarios.R via output.R, which defines outputdirs.")
+  }
+
+  # Start validateScenarios
+  startVal <- function(outputDirs, validationConfig) {
+    if (!exists("slurmConfig")) {
+      slurmConfig <- "--qos=standby"
+    }
+    jobName <- paste0(
+      "valScen",
+      "-", nameCore
+    )
+    outFileName <- jobName
+    script <- "scripts/vs/run_validateScenarios.R"
+    cat("Starting ", jobName, "\n")
+    if (isSlurmAvailable() && ! identical(slurmConfig, "direct")) {
+      clcom <- paste0(
+        "sbatch ", slurmConfig,
+        " --job-name=", jobName,
+        " --comment=validateScenarios",
+        " --output=", jobName, ".out",
+        " --error=", jobName, ".out",
+        " --mail-type=END --time=200 --mem-per-cpu=8000",
+        " --wrap=\"Rscript ", script,
+        " outputDirs=", paste(outputDirs, collapse = ","),
+        " validationConfig=", validationConfig,
+        "\"")
+      cat(clcom, "\n")
+      system(clcom)
+    } else {
+      tmpEnv <- new.env()
+      tmpError <- try(sys.source(script, envir = tmpEnv))
+      if (!is.null(tmpError))
+        warning("Script ", script,
+                " was stopped by an error and not executed properly!")
+      rm(tmpEnv)
+    }
+  }
+
+  # choose a config file either from the package or your own
+  if (! exists("validationConfig")) {
+    availableConfigs <- list.files(
+      piamutils::getSystemFile("config/", package = "piamValidation"))
+    config <- gms::chooseFromList(availableConfigs,
+                                  type = "a validation config",
+                                  multiple = FALSE)
+    if (config == "") {
+      q()
+    } else {
+      validationConfig <- config
+    }
+  }
+
+  # Create core of file name / job name.
+  timeStamp <- format(Sys.time(), "%Y-%m-%d_%H.%M.%S")
+  valName <- gsub(".csv", "", gsub("validationConfig_", "", validationConfig))
+  nameCore <- paste0(valName, "-", timeStamp)
+
+  # Start the job
+    startVal(
+      outputDirs = outputdirs,
+      validationConfig = valName)

--- a/scripts/vs/run_validateScenarios.R
+++ b/scripts/vs/run_validateScenarios.R
@@ -1,0 +1,27 @@
+# |  (C) 2006-2024 Potsdam Institute for Climate Impact Research (PIK)
+# |  authors, and contributors see CITATION.cff file. This file is part
+# |  of REMIND and licensed under AGPL-3.0-or-later. Under Section 7 of
+# |  AGPL-3.0, you are granted additional permissions described in the
+# |  REMIND License Exception, version 1.0 (see LICENSE file).
+# |  Contact: remind@pik-potsdam.de
+
+library(piamValidation)
+
+lucode2::readArgs("outputDirs", "validationConfig")
+
+# working directory is assumed to be the remind directory
+outputDirs <- normalizePath(outputDirs, mustWork = TRUE)
+mifPath <- remind2::getMifScenPath(outputDirs, mustWork = TRUE)
+histPath <- remind2::getMifHistPath(outputDirs[1], mustWork = TRUE)
+
+# option 1: HTML validation Report
+piamValidation::validationReport(c(mifPath, histPath), validationConfig)
+
+# option 3: export data (TODO: file location + name)
+valiData <- piamValidation::validateScenarios(c(mifPath, histPath), validationConfig)
+cat(getwd())
+
+# option 2: pass or fail?
+piamValidation::validationPass(valiData)
+
+


### PR DESCRIPTION
## Purpose of this PR

This PR adds an output script to allow using ``piamValidation`` functions like ``validateScenarios()`` or ``validationReport`` directly from a REMIND directory. 

Selecting the ``comparison`` option of ``Rscript output.R`` now offers ``validateScenarios``. The number of runs to choose is not restricted, however the heatmap plots will likely have layout problems when a high number of scenarios is selected.
Currently, the only output that is generated is an .html report with interactive traffic-light heatmaps based on the ``validationConfig`` that is selected. In the future, other output options will be made available.

## Type of change

- [x] New feature 
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)

## Further information (optional):

* Test runs are here: ``/p/tmp/pascalwe/remind_vs``

