### PR TITLE
Introduced a new constraint that sets coal use for steel making as lo…

### DIFF
--- a/modules/24_trade/capacity/not_used.txt
+++ b/modules/24_trade/capacity/not_used.txt
@@ -13,3 +13,5 @@ sm_trillion_2_non, parameter, not needed
 sm_GJ_2_TWa, parameter, not needed
 sm_TWa_2_kWh, parameter, not needed
 sm_h2kg_2_h2kWh, parameter, not needed
+pm_specFeDem,parameter,only used in standard realization
+vm_outflowPrc, variable, only used in standard realization

--- a/modules/24_trade/se_trade/not_used.txt
+++ b/modules/24_trade/se_trade/not_used.txt
@@ -11,3 +11,6 @@ pm_omeg,parameter,only used in capacity realization
 pm_data,parameter,only used in capacity realization
 pm_tsu2opTimeYr,parameter,only used in capacity realization
 pm_ttot_val,parameter,only used in capacity realization
+pm_specFeDem,parameter,only used in standard realization
+vm_outflowPrc, variable, only used in standard realization
+

--- a/modules/24_trade/standard/datainput.gms
+++ b/modules/24_trade/standard/datainput.gms
@@ -27,6 +27,18 @@ $ondelim
 $include "./modules/24_trade/standard/input/pm_costsTradePeFinancial.cs3r"
 $offdelim
 ;
+
+*NB* import assumptions for the activation of trade constraints
+parameter p24_trade_constraints(all_regi,all_enty,tradeConst)  "parameter for the region specific trade constraints, values different to 1 activate constraints and the value is used as effectiveness to varying degress such as percentage numbers"
+/
+$ondelim
+$include "./modules/24_trade/standard/input/p24_trade_constraints.cs4r"
+$offdelim
+/
+;
+
+display p24_trade_constraints;
+
 pm_costsTradePeFinancial(regi,"XportElasticity", tradePe(enty)) = 100;
 pm_costsTradePeFinancial(regi, "tradeFloor", tradePe(enty))     = 0.0125;
 pm_costsTradePeFinancial(regi,"Mport","peur")                   = 1e-06;

--- a/modules/24_trade/standard/declarations.gms
+++ b/modules/24_trade/standard/declarations.gms
@@ -29,7 +29,7 @@ vm_capacityTradeBalance(tall,all_regi)      "Capacity trade balance term"
 
 
 Equations
-q24_peimport_demandside(tall,all_regi,all_enty)   "Constraint on imports due to domestic requirements"
+q24_peimport_demandside(tall,all_regi,all_enty,tradeConst)   "Constraint on imports due to domestic requirements"
 ;
 
 *** EOF ./modules/24_trade/standard/declarations.gms

--- a/modules/24_trade/standard/declarations.gms
+++ b/modules/24_trade/standard/declarations.gms
@@ -27,4 +27,9 @@ vm_costTradeCap(ttot,all_regi,all_enty)     "Trade technology and transportation
 vm_capacityTradeBalance(tall,all_regi)      "Capacity trade balance term"
 ;
 
+
+Equations
+q24_peimport_demandside(tall,all_regi,all_enty)   "Constraint on imports due to domestic requirements"
+;
+
 *** EOF ./modules/24_trade/standard/declarations.gms

--- a/modules/24_trade/standard/equations.gms
+++ b/modules/24_trade/standard/equations.gms
@@ -1,0 +1,37 @@
+*** |  (C) 2006-2024 Potsdam Institute for Climate Impact Research (PIK)
+*** |  authors, and contributors see CITATION.cff file. This file is part
+*** |  of REMIND and licensed under AGPL-3.0-or-later. Under Section 7 of
+*** |  AGPL-3.0, you are granted additional permissions described in the
+*** |  REMIND License Exception, version 1.0 (see LICENSE file).
+*** |  Contact: remind@pik-potsdam.de
+*** SOF ./modules/24_trade/standard/equations.gms
+
+*' @equations
+
+*** ---------------------------------------------------------------------------
+***        Trade Constraints
+*** ---------------------------------------------------------------------------
+
+***------------------------------------------------------
+*' Imports constrained by demand side of import country
+***------------------------------------------------------
+
+*Coal used in steel making is imported due to minimum quality requiremend (that is India)
+* active only after 2020; otherwise potential interference with constrained historic vm_Mport()
+* The constraint avoids Indian coal imports to drop to zero immediately
+
+q24_peimport_demandside(t,regi,enty)$(t.val gt 2020 AND sameas(regi, "IND") AND sameas(enty, "pecoal"))..
+   vm_Mport(t,regi,enty) 
+   =g= 
+   sum((secInd37_tePrc("steel",tePrc),
+        tePrc2opmoPrc(tePrc,opmoPrc)),
+           pm_specFeDem(t,regi,"fesos",tePrc,opmoPrc) *
+           vm_outflowPrc(t,regi,tePrc,opmoPrc)
+   )
+;
+
+
+*' @stop
+*** EOF ./modules/24_trade/standard/equations.gms
+
+

--- a/modules/24_trade/standard/equations.gms
+++ b/modules/24_trade/standard/equations.gms
@@ -20,10 +20,11 @@
 * active only after 2020; otherwise potential interference with constrained historic vm_Mport()
 * The constraint avoids Indian coal imports to drop to zero immediately
 
-q24_peimport_demandside(t,regi,enty)$(t.val gt 2020 AND sameas(regi, "IND") AND sameas(enty, "pecoal"))..
+q24_peimport_demandside(t,regi,enty,tradeConst)$(t.val gt 2020 AND p24_trade_constraints(regi,enty,tradeConst) ne 0)..
    vm_Mport(t,regi,enty) 
    =g= 
-   sum((secInd37_tePrc("steel",tePrc),
+   p24_trade_constraints(regi,enty,tradeConst)*
+      sum((secInd37_tePrc("steel",tePrc),
         tePrc2opmoPrc(tePrc,opmoPrc)),
            pm_specFeDem(t,regi,"fesos",tePrc,opmoPrc) *
            vm_outflowPrc(t,regi,tePrc,opmoPrc)

--- a/modules/24_trade/standard/realization.gms
+++ b/modules/24_trade/standard/realization.gms
@@ -10,6 +10,7 @@
 $Ifi "%phase%" == "sets" $include "./modules/24_trade/standard/sets.gms"
 $Ifi "%phase%" == "declarations" $include "./modules/24_trade/standard/declarations.gms"
 $Ifi "%phase%" == "datainput" $include "./modules/24_trade/standard/datainput.gms"
+$Ifi "%phase%" == "equations" $include "./modules/24_trade/standard/equations.gms"
 $Ifi "%phase%" == "bounds" $include "./modules/24_trade/standard/bounds.gms"
 $Ifi "%phase%" == "presolve" $include "./modules/24_trade/standard/presolve.gms"
 $Ifi "%phase%" == "postsolve" $include "./modules/24_trade/standard/postsolve.gms"

--- a/modules/24_trade/standard/sets.gms
+++ b/modules/24_trade/standard/sets.gms
@@ -35,6 +35,11 @@ tradeCap(all_enty)          "Commodities traded via capacity mode."
 /
     null
 /
-;
+
+tradeConst
+
+/
+import_cokecoal              "constrained to require cokeing coal to be imported, important for India"
+/;
 
 *** EOF ./modules/24_trade/standard/sets.gms


### PR DESCRIPTION
…wer bound for coal imports in India (only), due to low domestic coal quality.

## Purpose of this PR


## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [ ] Bug fix 
- [ ] Refactoring
- [x ] New feature 
- [ x] Minor change (default scenarios show only small differences)
- [ ] Fundamental change
- [ ] This change requires a documentation update


## Checklist:

- [x ] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x ] I performed a self-review of my own code
- [x ] I explained my changes within the PR, particularly in hard-to-understand areas
- [ NA] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Test runs are here: /p/projects/remind/users/nicolasb/remind3p2p2_prep/remind-1/output/SSP2-NPi_2024-08-23_14.02.35
* Comparison of results (what changes by this PR?): 

