### PR TITLE
Apply initial spreads for CO2 price differentiation in 2030 instead of 2025

### DIFF
--- a/modules/45_carbonprice/diffExp2Lin/datainput.gms
+++ b/modules/45_carbonprice/diffExp2Lin/datainput.gms
@@ -21,51 +21,53 @@
 *** Step 1: Define regional multiplicative factors between regional CO2 price and CO2 price of the developed countries
 *** Warning regarding code changes: This first step also appears in diffLin2Lin and should be changed simultaneously.
 
-*** Step 1.1: Define regional multiplicative CO2 price factors for 2025
+*** Step 1.1: Define initial regional multiplicative CO2 price factors
 
 *** based on GDP per capita (in 1e3 $ PPP 2005) in 2015 (benchmark year kept at 2015 since 2020 not suitable) 
 p45_gdppcap2015_PPP(regi) = pm_gdp("2015",regi)/pm_shPPPMER(regi) / pm_pop("2015",regi);
 
 *** Selection of differentiation scheme via cm_co2_tax_spread
 if(cm_co2_tax_spread eq 1,
-p45_phasein_2025ratio(regi) = 1; !! all regions
+p45_phasein_ratio(regi) = 1; !! all regions
 );
 
 if(cm_co2_tax_spread eq 10,
-p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) le 3.5) = 0.1; !! SSA
-p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 3.5 and p45_gdppcap2015_PPP(regi) le 5)  = 0.2; !! IND
-p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 5   and p45_gdppcap2015_PPP(regi) le 10) = 0.3; !! OAS
-p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 10  and p45_gdppcap2015_PPP(regi) le 15) = 0.5; !! CHA, LAM, MEA
-p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 15  and p45_gdppcap2015_PPP(regi) le 20) = 0.7; !! REF
-p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 20) = 1; !! EUR, JPN, USA, CAZ, NEU
+p45_phasein_ratio(regi)$(p45_gdppcap2015_PPP(regi) le 3.5) = 0.1; !! SSA
+p45_phasein_ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 3.5 and p45_gdppcap2015_PPP(regi) le 5)  = 0.2; !! IND
+p45_phasein_ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 5   and p45_gdppcap2015_PPP(regi) le 10) = 0.3; !! OAS
+p45_phasein_ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 10  and p45_gdppcap2015_PPP(regi) le 15) = 0.5; !! CHA, LAM, MEA
+p45_phasein_ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 15  and p45_gdppcap2015_PPP(regi) le 20) = 0.7; !! REF
+p45_phasein_ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 20) = 1; !! EUR, JPN, USA, CAZ, NEU
 );
 
 if(cm_co2_tax_spread eq 20,
-p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) le 3.5) = 0.05; !! SSA
-p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 3.5 and p45_gdppcap2015_PPP(regi) le 5)  = 0.1; !! IND
-p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 5   and p45_gdppcap2015_PPP(regi) le 10) = 0.2; !! OAS
-p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 10  and p45_gdppcap2015_PPP(regi) le 15) = 0.4; !! CHA, LAM, MEA
-p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 15  and p45_gdppcap2015_PPP(regi) le 20) = 0.6; !! REF
-p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 20) = 1; !! EUR, JPN, USA, CAZ, NEU
+p45_phasein_ratio(regi)$(p45_gdppcap2015_PPP(regi) le 3.5) = 0.05; !! SSA
+p45_phasein_ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 3.5 and p45_gdppcap2015_PPP(regi) le 5)  = 0.1; !! IND
+p45_phasein_ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 5   and p45_gdppcap2015_PPP(regi) le 10) = 0.2; !! OAS
+p45_phasein_ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 10  and p45_gdppcap2015_PPP(regi) le 15) = 0.4; !! CHA, LAM, MEA
+p45_phasein_ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 15  and p45_gdppcap2015_PPP(regi) le 20) = 0.6; !! REF
+p45_phasein_ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 20) = 1; !! EUR, JPN, USA, CAZ, NEU
 );
 
-*** Step 1.2: Create regional multiplicative CO2 price factors from 2030 onward
+*** Step 1.2: Create regional multiplicative CO2 price factors for quadratic convergence between s45_CO2priceRegConvStartYr and cm_CO2priceRegConvEndYr
 
-*** Set regional CO2 price factor equal to p45_phasein_2025ratio until 2025:
-p45_regCO2priceFactor(t,regi)$(t.val le 2025) = p45_phasein_2025ratio(regi);
-*** Create quadratic phase-in until cm_CO2priceRegConvEndYr:
-loop(t$((t.val gt 2025) and (t.val le cm_CO2priceRegConvEndYr)),
+*** Set year until which initial ratios of CO2 prices are applied and after which convergence starts to 2030
+s45_CO2priceRegConvStartYr = 2030;
+*** Set regional CO2 price factor equal to p45_phasein_ratio until s45_CO2priceRegConvStartYr:
+p45_regCO2priceFactor(t,regi)$(t.val le s45_CO2priceRegConvStartYr) = p45_phasein_ratio(regi);
+*** Create quadratic phase-in between s45_CO2priceRegConvStartYr and cm_CO2priceRegConvEndYr:
+loop(t$((t.val gt s45_CO2priceRegConvStartYr) and (t.val le cm_CO2priceRegConvEndYr)),
   p45_regCO2priceFactor(t,regi) = 
    min(1,
        max(0, 
-	        p45_phasein_2025ratio(regi) + (1 - p45_phasein_2025ratio(regi)) * Power( (t.val - 2025) / (cm_CO2priceRegConvEndYr - 2025), 2) 
+	        p45_phasein_ratio(regi) + (1 - p45_phasein_ratio(regi)) * Power( (t.val - s45_CO2priceRegConvStartYr) / (cm_CO2priceRegConvEndYr - s45_CO2priceRegConvStartYr), 2) 
        )				 
    );
 );
 *** Set regional CO2 price factor equal to 1 after cm_CO2priceRegConvEndYr:
 p45_regCO2priceFactor(t,regi)$(t.val gt cm_CO2priceRegConvEndYr) = 1;
 
-display p45_gdppcap2015_PPP, p45_phasein_2025ratio, p45_regCO2priceFactor;
+display p45_gdppcap2015_PPP, p45_phasein_ratio, p45_regCO2priceFactor;
 
 *** Step 2: Create CO2 price trajectory for developed countries
 

--- a/modules/45_carbonprice/diffExp2Lin/declarations.gms
+++ b/modules/45_carbonprice/diffExp2Lin/declarations.gms
@@ -18,7 +18,7 @@
 ***--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 parameters
 p45_gdppcap2015_PPP(all_regi)               "2015 GDP per capita (k $ PPP 2005)"
-p45_phasein_2025ratio(all_regi)             "ratio of CO2 price to that of developed region in 2025"
+p45_phasein_ratio(all_regi)                 "inital ratio of CO2 price to that of developed region"
 
 p45_regCO2priceFactor(ttot,all_regi)        "regional multiplicative factor to the CO2 price of the developed countries"
 p45_CO2priceTrajDeveloped(ttot)             "CO2 price trajectory for developed/rich countries"
@@ -26,6 +26,7 @@ p45_CO2priceTrajDeveloped(ttot)             "CO2 price trajectory for developed/
 
 scalars
 s45_co2_tax_startyear                       "level of CO2 tax in start year converted from $/t CO2eq to T$/GtC"
+s45_CO2priceRegConvStartYr                  "year until which initial ratios of CO2 prices are applied and after which convergence starts"
 ;
 
 *** EOF ./modules/45_carbonprice/diffExp2Lin/declarations.gms

--- a/modules/45_carbonprice/diffLin2Lin/datainput.gms
+++ b/modules/45_carbonprice/diffLin2Lin/datainput.gms
@@ -18,53 +18,55 @@
 ***--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 *** Step 1: Define regional multiplicative factors between regional CO2 price and CO2 price of the developed countries
-*** Warning regarding code changes: This first step also appears in diffExp2Lin and should be changed simultaneously.
+*** Warning regarding code changes: This first step also appears in diffLin2Lin and should be changed simultaneously.
 
-*** Step 1.1: Define regional multiplicative CO2 price factors for 2025
+*** Step 1.1: Define initial regional multiplicative CO2 price factors
 
 *** based on GDP per capita (in 1e3 $ PPP 2005) in 2015 (benchmark year kept at 2015 since 2020 not suitable) 
 p45_gdppcap2015_PPP(regi) = pm_gdp("2015",regi)/pm_shPPPMER(regi) / pm_pop("2015",regi);
 
 *** Selection of differentiation scheme via cm_co2_tax_spread
 if(cm_co2_tax_spread eq 1,
-p45_phasein_2025ratio(regi) = 1; !! all regions
+p45_phasein_ratio(regi) = 1; !! all regions
 );
 
 if(cm_co2_tax_spread eq 10,
-p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) le 3.5) = 0.1; !! SSA
-p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 3.5 and p45_gdppcap2015_PPP(regi) le 5)  = 0.2; !! IND
-p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 5   and p45_gdppcap2015_PPP(regi) le 10) = 0.3; !! OAS
-p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 10  and p45_gdppcap2015_PPP(regi) le 15) = 0.5; !! CHA, LAM, MEA
-p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 15  and p45_gdppcap2015_PPP(regi) le 20) = 0.7; !! REF
-p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 20) = 1; !! EUR, JPN, USA, CAZ, NEU
+p45_phasein_ratio(regi)$(p45_gdppcap2015_PPP(regi) le 3.5) = 0.1; !! SSA
+p45_phasein_ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 3.5 and p45_gdppcap2015_PPP(regi) le 5)  = 0.2; !! IND
+p45_phasein_ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 5   and p45_gdppcap2015_PPP(regi) le 10) = 0.3; !! OAS
+p45_phasein_ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 10  and p45_gdppcap2015_PPP(regi) le 15) = 0.5; !! CHA, LAM, MEA
+p45_phasein_ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 15  and p45_gdppcap2015_PPP(regi) le 20) = 0.7; !! REF
+p45_phasein_ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 20) = 1; !! EUR, JPN, USA, CAZ, NEU
 );
 
 if(cm_co2_tax_spread eq 20,
-p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) le 3.5) = 0.05; !! SSA
-p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 3.5 and p45_gdppcap2015_PPP(regi) le 5)  = 0.1; !! IND
-p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 5   and p45_gdppcap2015_PPP(regi) le 10) = 0.2; !! OAS
-p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 10  and p45_gdppcap2015_PPP(regi) le 15) = 0.4; !! CHA, LAM, MEA
-p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 15  and p45_gdppcap2015_PPP(regi) le 20) = 0.6; !! REF
-p45_phasein_2025ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 20) = 1; !! EUR, JPN, USA, CAZ, NEU
+p45_phasein_ratio(regi)$(p45_gdppcap2015_PPP(regi) le 3.5) = 0.05; !! SSA
+p45_phasein_ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 3.5 and p45_gdppcap2015_PPP(regi) le 5)  = 0.1; !! IND
+p45_phasein_ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 5   and p45_gdppcap2015_PPP(regi) le 10) = 0.2; !! OAS
+p45_phasein_ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 10  and p45_gdppcap2015_PPP(regi) le 15) = 0.4; !! CHA, LAM, MEA
+p45_phasein_ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 15  and p45_gdppcap2015_PPP(regi) le 20) = 0.6; !! REF
+p45_phasein_ratio(regi)$(p45_gdppcap2015_PPP(regi) gt 20) = 1; !! EUR, JPN, USA, CAZ, NEU
 );
 
-*** Step 1.2: Create regional multiplicative CO2 price factors from 2030 onward
+*** Step 1.2: Create regional multiplicative CO2 price factors for quadratic convergence between s45_CO2priceRegConvStartYr and cm_CO2priceRegConvEndYr
 
-*** Set regional CO2 price factor equal to p45_phasein_2025ratio until 2025:
-p45_regCO2priceFactor(t,regi)$(t.val le 2025) = p45_phasein_2025ratio(regi);
-*** Create quadratic phase-in until cm_CO2priceRegConvEndYr:
-loop(t$((t.val gt 2025) and (t.val le cm_CO2priceRegConvEndYr)),
+*** Set year until which initial ratios of CO2 prices are applied and after which convergence starts to 2030
+s45_CO2priceRegConvStartYr = 2030;
+*** Set regional CO2 price factor equal to p45_phasein_ratio until s45_CO2priceRegConvStartYr:
+p45_regCO2priceFactor(t,regi)$(t.val le s45_CO2priceRegConvStartYr) = p45_phasein_ratio(regi);
+*** Create quadratic phase-in between s45_CO2priceRegConvStartYr and cm_CO2priceRegConvEndYr:
+loop(t$((t.val gt s45_CO2priceRegConvStartYr) and (t.val le cm_CO2priceRegConvEndYr)),
   p45_regCO2priceFactor(t,regi) = 
    min(1,
        max(0, 
-	        p45_phasein_2025ratio(regi) + (1 - p45_phasein_2025ratio(regi)) * Power( (t.val - 2025) / (cm_CO2priceRegConvEndYr - 2025), 2) 
+	        p45_phasein_ratio(regi) + (1 - p45_phasein_ratio(regi)) * Power( (t.val - s45_CO2priceRegConvStartYr) / (cm_CO2priceRegConvEndYr - s45_CO2priceRegConvStartYr), 2) 
        )				 
    );
 );
 *** Set regional CO2 price factor equal to 1 after cm_CO2priceRegConvEndYr:
 p45_regCO2priceFactor(t,regi)$(t.val gt cm_CO2priceRegConvEndYr) = 1;
 
-display p45_gdppcap2015_PPP, p45_phasein_2025ratio, p45_regCO2priceFactor;
+display p45_gdppcap2015_PPP, p45_phasein_ratio, p45_regCO2priceFactor;
 
 
 *** Step 2: Define CO2 price trajectory for developed countries

--- a/modules/45_carbonprice/diffLin2Lin/declarations.gms
+++ b/modules/45_carbonprice/diffLin2Lin/declarations.gms
@@ -19,7 +19,7 @@
 
 parameters
 p45_gdppcap2015_PPP(all_regi)               "2015 GDP per capita (k $ PPP 2005)"
-p45_phasein_2025ratio(all_regi)             "ratio of CO2 price to that of developed region in 2025"
+p45_phasein_ratio(all_regi)                 "inital ratio of CO2 price to that of developed region"
 
 p45_regCO2priceFactor(ttot,all_regi)        "regional multiplicative factor to the CO2 price of the developed countries"
 p45_CO2priceTrajDeveloped(ttot)             "CO2 price trajectory for developed/rich countries"
@@ -31,6 +31,7 @@ scalars
 s45_year_co2_tax_hist                       "year of s45_co2_tax_hist"
 s45_co2_tax_hist                            "historical level of CO2 tax converted from $/t CO2eq to T$/GtC"
 s45_co2_tax_startyear                       "level of CO2 tax in start year converted from $/t CO2eq to T$/GtC"
+s45_CO2priceRegConvStartYr                  "year until which initial ratios of CO2 prices are applied and after which convergence starts"
 ;
 
 *** EOF ./modules/45_carbonprice/diffLin2Lin/declarations.gms


### PR DESCRIPTION
## Purpose of this PR

With many climate policy scenarios now starting in 2030, the initial spreads for the CO2 price differentiation are now being applied in 2030 instead of 2025. For example, using `45_carbonprice `with realization `diffLin2Lin `, `cm_co2_tax_spread = 10` and `cm_CO2priceRegConvEndYr=2050` (this is the REMIND default for peak budget runs), the spread of 10 previous between the CO2 price of developed regions (such as EUR) and SSA was previously applied in 2025, followed by a quadratic convergence until 2050. With this PR, the spread of 10 is applied in 2025 and 2030, followed by a quadratic convergence until 2050. 

## Type of change

- [x] Minor change (default scenarios show only small differences)

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

