### PR TITLE
Remove duplicates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Imports:
     data.table,
     devtools,
     dplyr,
-    edgeTransport (>= 2.0),
+    edgeTransport (>= 2.3.0),
     reporttransport (>= 0.0.11),
     flexdashboard,
     GDPuc,

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -150,7 +150,8 @@ cfg$files2export$start <- c("config/conopt3.opt",
                             "modules/35_transport/edge_esm/input/scenSpecEnIntensity.cs4r",
                             "modules/35_transport/edge_esm/input/initialIncoCosts.cs4r",
                             "modules/35_transport/edge_esm/input/annualMileage.cs4r",
-                            "modules/35_transport/edge_esm/input/timeValueCosts.cs4r")
+                            "modules/35_transport/edge_esm/input/timeValueCosts.cs4r",
+                            "modules/29_CES_parameters/calibrate/input/f29_trpdemand.cs4r")
 
 # Files that should be copied after the REMIND run is finished
 cfg$files2export$end <- NULL

--- a/scripts/output/single/reporting.R
+++ b/scripts/output/single/reporting.R
@@ -92,7 +92,7 @@ if(file.exists(edgetOutputDir)) {
 
   REMINDoutput <- as.data.table(read.quitte(file.path(outputdir, paste0("REMIND_generic_", scenario,"_withoutPlus.mif"))))
   sharedVariables <- EDGET_output[variable %in% REMINDoutput$variable | grepl(".*edge", variable)]
-  EDGET_output <- EDGET_output[!variable %in% REMINDoutput$variable]
+  EDGET_output <- EDGET_output[!(variable %in% REMINDoutput$variable | grepl(".*edge", variable))]
   message("The following variables will be dropped from the EDGE-Transport reporting because
                 they are in the REMIND reporting: ", paste(unique(sharedVariables$variable), collapse = ", "))
 

--- a/scripts/output/single/reporting.R
+++ b/scripts/output/single/reporting.R
@@ -91,7 +91,7 @@ if(file.exists(edgetOutputDir)) {
                                       isStored = FALSE)
 
   REMINDoutput <- as.data.table(read.quitte(file.path(outputdir, paste0("REMIND_generic_", scenario,"_withoutPlus.mif"))))
-  sharedVariables <- EDGET_output[variable %in% REMINDoutput$variable & grepl(".*edge", variable)]
+  sharedVariables <- EDGET_output[variable %in% REMINDoutput$variable | grepl(".*edge", variable)]
   EDGET_output <- EDGET_output[!variable %in% REMINDoutput$variable]
   message("The following variables will be dropped from the EDGE-Transport reporting because
                 they are in the REMIND reporting: ", paste(unique(sharedVariables$variable), collapse = ", "))

--- a/scripts/output/single/reporting.R
+++ b/scripts/output/single/reporting.R
@@ -84,18 +84,24 @@ if(file.exists(edgetOutputDir)) {
   }
   message("start generation of EDGE-T reporting")
   EDGET_output <- reportEdgeTransport(edgetOutputDir,
-                                      isTransportExtendedReported = FALSE, 
+                                      isTransportExtendedReported = FALSE,
                                       modelName = "REMIND",
-				      scenarioName = scenario,
+				                              scenarioName = scenario,
                                       gdxPath = file.path(outputdir, "fulldata.gdx"),
                                       isStored = FALSE)
+
+  REMINDoutput <- as.data.table(read.quitte(paste0("REMIND_generic_", scenario,"_withoutPlus.mif")))
+  sharedVariables <- EDGET_output[variable %in% REMINDoutput$variable & grepl(".*edge", variable)]
+  EDGET_output <- EDGET_output[!variable %in% REMINDoutput$variable]
+  message("The following variables will be dropped from the EDGE-Transport reporting because
+                they are in the REMIND reporting: ", paste(unique(sharedVariables$variable), collapse = ", "))
 
   write.mif(EDGET_output, remind_reporting_file, append = TRUE)
   piamutils::deletePlus(remind_reporting_file, writemif = TRUE)
 
   #Generate transport extended mif
   reportEdgeTransport(edgetOutputDir,
-                      isTransportExtendedReported = TRUE, 
+                      isTransportExtendedReported = TRUE,
                       gdxPath = file.path(outputdir, "fulldata.gdx"),
                       isStored = TRUE)
 
@@ -145,3 +151,4 @@ if(file.exists(file.path(outputdir, DIETERGDX))){
 }
 
 message("### reporting finished.")
+

--- a/scripts/output/single/reporting.R
+++ b/scripts/output/single/reporting.R
@@ -90,7 +90,7 @@ if(file.exists(edgetOutputDir)) {
                                       gdxPath = file.path(outputdir, "fulldata.gdx"),
                                       isStored = FALSE)
 
-  REMINDoutput <- as.data.table(read.quitte(paste0("REMIND_generic_", scenario,"_withoutPlus.mif")))
+  REMINDoutput <- as.data.table(read.quitte(file.path(outputdir, paste0("REMIND_generic_", scenario,"_withoutPlus.mif"))))
   sharedVariables <- EDGET_output[variable %in% REMINDoutput$variable & grepl(".*edge", variable)]
   EDGET_output <- EDGET_output[!variable %in% REMINDoutput$variable]
   message("The following variables will be dropped from the EDGE-Transport reporting because


### PR DESCRIPTION
## Purpose of this PR
This PR just removes variables from the transport reporting that are already reported in remind2 + copies f29_trpdemand as it is needed in iterativeEDGETransport after an upcoming PR

A test was performed here /p/projects/edget/testLib/remind/output/default_2024-08-27_15.35.31, which shows that the code runs through and all duplicates are filtered out.

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x ] Bug fix 
- [ ] Refactoring
- [ ] New feature 
- [x ] Minor change (default scenarios show only small differences)
- [ ] Fundamental change
- [ ] This change requires a documentation update


## Checklist:

- [x ] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x ] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x ] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

