### PR TITLE
 copy config files to coupled output folder; fix deletion of testthat files

### DIFF
--- a/scripts/input/create_input_for_45_carbonprice_exogenous.R
+++ b/scripts/input/create_input_for_45_carbonprice_exogenous.R
@@ -42,7 +42,7 @@ create_input_for_45_carbonprice_exogenous<-function(gdx){
   cat("*=              Exogenous CO2 tax level                      =*\n", file = p_fpath, append = TRUE)
   cat("*=============================================================*\n", file = p_fpath, append = TRUE)
   cat("*= author: dklein@pik-potsdam.de                             =*\n", file = p_fpath, append = TRUE)
-  cat(paste("*= date  : ", Sys.time(), "                               =*\n", sep=""), file = p_fpath, append = TRUE)
+  cat(paste("*= date  : ", round(Sys.time()), "                               =*\n", sep=""), file = p_fpath, append = TRUE)
   cat("*= generated with:                                           =*\n", file = p_fpath, append = TRUE)
   cat("*= scripts/input/create_input_for_45_carbonprice_exogenous.R =*\n", file = p_fpath, append = TRUE)
   cat(paste0("*= from file: ", normalizePath(gdx), " =*\n"), file = p_fpath, append = TRUE)

--- a/scripts/output/single/reporting.R
+++ b/scripts/output/single/reporting.R
@@ -47,7 +47,7 @@ if (length(remind_policy_reporting_file) > 0) {
 }
 
 # produce REMIND reporting *.mif based on gdx information
-message("\n### start generation of mif files at ", Sys.time())
+message("\n### start generation of mif files at ", round(Sys.time()))
 convGDX2MIF(gdx, gdx_refpolicycost = gdx_refpolicycost, file = remind_reporting_file, scenario = scenario, gdx_ref = gdx_ref)
 
 # MAGICC code not working with REMIND-EU
@@ -134,20 +134,20 @@ if (! is.null(magpie_reporting_file) && file.exists(magpie_reporting_file)) {
 # warn if duplicates in mif
 reportDuplicates(read.quitte(sub("\\.mif$", "_withoutPlus.mif", remind_reporting_file), check.duplicates = FALSE))
 
-message("### end generation of mif files at ", Sys.time())
+message("### end generation of mif files at ", round(Sys.time()))
 
 ## produce REMIND LCOE reporting *.csv based on gdx information
-message("### start generation of LCOE reporting at ", Sys.time())
+message("### start generation of LCOE reporting at ", round(Sys.time()))
 tmp <- try(convGDX2CSV_LCOE(gdx, file = LCOE_reporting_file, scen = scenario)) # execute convGDX2MIF_LCOE
-message("### end generation of LCOE reporting at ", Sys.time())
+message("### end generation of LCOE reporting at ", round(Sys.time()))
 
 ## generate DIETER reporting if it is needed
 ## the reporting is appended to REMIND_generic_<scenario>.MIF in "DIETER" Sub Directory
 DIETERGDX <- "report_DIETER.gdx"
 if(file.exists(file.path(outputdir, DIETERGDX))){
-  message("### start generation of DIETER reporting at ", Sys.time())
+  message("### start generation of DIETER reporting at ", round(Sys.time()))
   remind2::reportDIETER(DIETERGDX,outputdir)
-  message("### end generation of DIETER reporting at ", Sys.time())
+  message("### end generation of DIETER reporting at ", round(Sys.time()))
 }
 
 message("### reporting finished.")

--- a/scripts/output/single/reportingREMIND2MAgPIE.R
+++ b/scripts/output/single/reportingREMIND2MAgPIE.R
@@ -32,7 +32,7 @@ load(configfile, envir = envir)
 remind_reporting_file <- file.path(outputdir,paste0("REMIND_generic_",scenario,".mif"))
 
 # produce REMIND reporting *.mif based on gdx information
-message("\n### start generation of mif files at ", Sys.time())
+message("\n### start generation of mif files at ", round(Sys.time()))
 convGDX2MIF_REMIND2MAgPIE(gdx, file = remind_reporting_file, scenario = scenario)
 
 magpie_reporting_file <- envir$cfg$pathToMagpieReport
@@ -53,5 +53,5 @@ if (! is.null(magpie_reporting_file) && file.exists(magpie_reporting_file)) {
   piamutils::deletePlus(remind_reporting_file, writemif = TRUE)
 }
 
-message("### end generation of mif files at ", Sys.time())
+message("### end generation of mif files at ", round(Sys.time()))
 message("### reporting finished.")

--- a/start_bundle_coupled.R
+++ b/start_bundle_coupled.R
@@ -368,6 +368,7 @@ for(scen in common){
   cfg_rem <- cfg
   rm(cfg)
   cfg_rem$title <- scen
+  cfg_rem$files2export$start <- c(cfg_rem$files2export$start, path_settings_coupled, path_settings_remind)
   rem_filesstart <- cfg_rem$files2export$start     # save to reset it to that later
 
   source(file.path(path_magpie, "config", "default.cfg")) # retrieve MAgPIE settings

--- a/tests/testthat/test_01-manipulateConfig.R
+++ b/tests/testthat/test_01-manipulateConfig.R
@@ -57,6 +57,6 @@ test_that("manipulate config with default configuration does not change main.gms
 
   # cleanup if no error found
   if (length(addedgms) + length(removedgms) + length(contentdiff) + length(diffresult) == 0) {
-    file.remove(list.files(pattern = "main-TESTTHAT.*gms"))
+    file.remove(list.files(path = "../..", pattern = "main-TESTTHAT.*gms", full.names = TRUE))
   }
 })


### PR DESCRIPTION
## Purpose of this PR

- Make sure the remind coupled config files are copied to the output folder as is the case [for standalone runs already](https://github.com/remindmodel/remind/blob/6aceebbdb1afa406c8e2a62f065f087e38285ca3/scripts/start/configureCfg.R#L120)
- Fix the deletion of TESTTHAT files by searching in the correct folder
- Avoid that log contains mikrosecond precision when mif creation starts or ended.

## Type of change

- [x] Bug fix 
- [x] New feature 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
