### PR TITLE
set cm_abortOnConsecFail to 2

### DIFF
--- a/main.gms
+++ b/main.gms
@@ -459,7 +459,7 @@ parameter
 parameter
   cm_abortOnConsecFail      "number of iterations of consecutive infeasibilities/failures to solve for one region, after which the run automatically switches to serial debug mode"
 ;
-  cm_abortOnConsecFail   = 5;     !! def = 5
+  cm_abortOnConsecFail   = 2;     !! def = 2  !! regexp = [0-9]+
 *'
 parameter
   cm_solver_try_max          "maximum number of inner iterations within one Negishi iteration (<10)"

--- a/tutorials/10_DebuggingREMIND.md
+++ b/tutorials/10_DebuggingREMIND.md
@@ -95,7 +95,8 @@ Also make sure that the R packages installed in your renv are up-to-date. The ED
 
 The file `abort.gdx` contains the latest data at the point GAMS aborted execution, which can be analysed using GAMS Studio.
 
-After a certain number of consecutive infeasibilities (default: `cm_abortOnConsecFail` = 5) REMIND will stop automatically, to avoid loosing too much time on an already doomed run. While REMIND sometimes is able to recover from a region being infes for 1 or 2 iterations, more will likely mean that the run will fail. In this case an `execution error` will be raised and the message `Run was aborted because the maximum number of consecutive failures was reached in at least one region!` can be found in the `full.log` and `full.lst` files. Continue with "Case 3" to solve the infeasibility.
+After a certain number of consecutive infeasibilities (default: `cm_abortOnConsecFail` = 2) REMIND will switch to the debug mode in which infeasibility are listed (and can be shown with `listinfes`).
+In case this does not help, it stops automatically, to avoid loosing too much time on an already doomed run. While REMIND sometimes is able to recover from a region being infes for 1 or 2 iterations, more will likely mean that the run will fail. In this case an `execution error` will be raised and the message `Run was aborted because the maximum number of consecutive failures was reached in at least one region!` can be found in the `full.log` and `full.lst` files. Continue with "Case 3" to solve the infeasibility.
 
 ### Case 2c: GDX or R file missing
 


### PR DESCRIPTION
## Purpose of this PR

- after 5 failed iterations, the chance that debugging serves any purpose is small.
- and correct documentation 

## Type of change

- [x] parameter change

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
