### PR TITLE
NDC update 2024-08-31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - CES parameter and gdx files calibrated with new default diffLin2Lin for NPi 
     [[#1747](https://github.com/remindmodel/remind/pull/1747)] and
     [[#1757](https://github.com/remindmodel/remind/pull/1757)]
+- Update of NDC goals with cutoff data August 31, 2024
+    [[#1816](https://github.com/remindmodel/remind/pull/1816)]
 
 ### changed
 - plastic waste by default does not lag plastics production by ten years

--- a/core/sets.gms
+++ b/core/sets.gms
@@ -1038,7 +1038,14 @@ RCP_regions_world(RCP_regions_world_bunkers) "five RCP regions plus total (world
 ***-----------------------------------------------------------------------------
 Sets
   counter   "helper set to facilitate looping in defined order"   / 1 * 20 /
-  NDC_version "NDC data version for NDC realizations of 40_techpol and 45_carbonprice"  /2018_cond, 2018_uncond, 2021_cond, 2021_uncond, 2022_cond, 2022_uncond, 2023_cond, 2023_uncond/
+  NDC_version "NDC data version for NDC realizations of 40_techpol and 45_carbonprice"
+  /
+    2018_cond, 2018_uncond,
+    2021_cond, 2021_uncond,
+    2022_cond, 2022_uncond,
+    2023_cond, 2023_uncond,
+    2024_cond, 2024_uncond
+  /
   bounds "helper set to define upper and lower bounds read in from input data" /low, up/
 ;
 

--- a/main.gms
+++ b/main.gms
@@ -1207,10 +1207,12 @@ $setglobal cm_MAgPIE_coupling  off     !! def = "off"  !! regexp = off|on
 *' *  (rcp85): RCP8.5
 $setglobal cm_rcp_scen  none         !! def = "none"  !! regexp = none|rcp20|rcp26|rcp37|rcp45|rcp60|rcp85
 *' cm_NDC_version            "choose version year of NDC targets as well as conditional vs. unconditional targets"
+*' *  (2024_cond):   all NDCs conditional to international financial support published until August 31, 2024
+*' *  (2024_uncond): all NDCs independent of international financial support published until August 31, 2024
 *' *  (2023_cond):   all NDCs conditional to international financial support published until December 31, 2023
 *' *  (2023_uncond): all NDCs independent of international financial support published until December 31, 2023
 *' *  Other supported years are 2022, 2021 and 2018, always containing NDCs published until December 31 of that year
-$setglobal cm_NDC_version  2023_cond    !! def = "2023_cond"  !! regexp = 20(18|2[1-3])_(un)?cond
+$setglobal cm_NDC_version  2023_cond    !! def = "2023_cond"  !! regexp = 20(18|2[1-4])_(un)?cond
 *' cm_netZeroScen     "choose scenario of net zero targets of netZero realization of module 46_carbonpriceRegi"
 *'
 *'  (NGFS_v4):        settings used for NGFS v4, 2023

--- a/modules/45_carbonprice/NDC/realization.gms
+++ b/modules/45_carbonprice/NDC/realization.gms
@@ -12,11 +12,11 @@
 *' @limitations The NDC emission target refers to GHG emissions w/o land-use change and international bunkers. However, the submitted NDC targets of
 *' several countries include land-use emissions (e.g. Australia and US). See https://www4.unfccc.int/sites/NDCStaging/Pages/All.aspx. To be checked!
 
-*** Next update (2023):
-*** - Add NDC_2024.xlsx in /p/projects/rd3mod/inputdata/sources/UNFCCC_NDC/ on cluster, see README.txt in this folder
+*** Next update (2025):
+*** - Add NDC_2025-12-31.xlsx in /p/projects/rd3mod/inputdata/sources/UNFCCC_NDC/ on cluster, see README.txt in this folder
 *** - Set switch cm_NDC_version in ./main.gms to new year
-*** - add 2024_cond, 2024_uncond to set NDC_version in ./core/sets.gms
-*** - Add new 2024 option in mrremind: calcEmiTarget, calcCapTarget, readUNFCCC_NDC
+*** - add 2025_cond, 2025_uncond to set NDC_version in ./core/sets.gms
+*** - Add new 2026 option in mrremind: calcEmiTarget, calcCapTarget, readUNFCCC_NDC
 
 
 *####################### R SECTION START (PHASES) ##############################


### PR DESCRIPTION
## Purpose of this PR

- https://github.com/pik-piam/mrremind/pull/539
- changing the default to `2024` should only happen once new input data is made available

## Type of change

- [x] Minor change

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
