### PR TITLE
check configs for undefined scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     [[#1790](https://github.com/remindmodel/remind/pull/1790)]
 - **scripts** add interactive plotting script 'selectPlots'
     [[#1815](https://github.com/remindmodel/remind/pull/1815)]
+- **scripts** in readCheckScenarioConfig() while running tests, check if all scenarios stated in path_gdx* columns exist
+    [[#1818](https://github.com/remindmodel/remind/pull/1818)]
 
 ### fixed
 - included CCS from plastic waste incineration in CCS mass flows so it is

--- a/config/scenario_config_coupled_GCS.csv
+++ b/config/scenario_config_coupled_GCS.csv
@@ -1,5 +1,5 @@
 title;start;qos;oldrun;path_report;config/scenario_config.csv;config/projects/scenario_config_gcs.csv;no_ghgprices_land_until;path_gdx;path_gdx_ref;path_gdx_bau;path_mif_ghgprice_land
-SSP2-Base;0;priority;;;SSP2|NPI|nocc;;y2150;/p/projects/piam/abrahao/runs_gcsf/phase2_dec/remind/output/C_SSP2-Base-rem-1/fulldata.gdx;;;
+SSP2-Base;0;priority;;;SSP2|NPI|nocc;;y2150;;;;
 SSP2-Tall-PkBudg750;0;priority;;;SSP2|NDC|cc|rcp1p9;Tland|GCSF;y2020;SSP2-NDC;SSP2-NPi;SSP2-Base;
 SSP2-NDC;0;short;;;SSP2|NDC|cc|rcp4p5;GCSF;y2150;SSP2-Base;SSP2-Base;SSP2-Base;
 SSP2-NPi;0;priority;;;SSP2|NPI|cc|rcp4p5;GCSF;y2150;SSP2-NDC;SSP2-Base;SSP2-Base;
@@ -8,7 +8,7 @@ SSP2-ENEcp;0;short;;;SSP2|NPI|cc|rcp2p6;GCSF;y2150;SSP2-NDC;SSP2-NPi;SSP2-Base;
 SSP2-ENEelec;0;short;;;SSP2|NPI|cc|rcp2p6;GCSF;y2150;SSP2-NDC;SSP2-NPi;SSP2-Base;
 SSP2-ENEcp-ENEcc;0;short;;;SSP2|NPI|cc|rcp2p6;GCSF;y2150;SSP2-NDC;SSP2-NPi;SSP2-Base;
 SSP2-Tene;0;priority;;;SSP2|NPI|cc|rcp2p6;GCSF;y2150;SSP2-NDC;SSP2-NPi;SSP2-Base;
-SSP2-Tpc;0;priority;;;SSP2|NPI|cc|rcp2p6;GCSF;y2150;/p/projects/piam/abrahao/runs_gcsf/phase2_biofix/remind/output/bkp_tpcfix/C_SSP2-Tpc-rem-5/fulldata.gdx;SSP2-NPi;SSP2-Base;
+SSP2-Tpc;0;priority;;;SSP2|NPI|cc|rcp2p6;GCSF;y2150;SSP2-NDC;SSP2-NPi;SSP2-Base;
 SSP2-LNDcp;0;short;;;SSP2|NPI|cc|rcp2p6;GCSF;y2020;SSP2-Tall-PkBudg750;SSP2-NPi;SSP2-Base;SSP2-Tall-PkBudg750
 SSP2-LNDndc;0;short;;;SSP2|NDC|cc|rcp2p6;GCSF;y2150;SSP2-NDC;SSP2-NPi;SSP2-Base;
 SSP2-LNDlbs;0;short;;;SSP2|NPI|cc|rcp2p6;LNDlbs|GCSF;y2020;SSP2-Tall-PkBudg750;SSP2-NPi;SSP2-Base;SSP2-Tall-PkBudg750
@@ -26,7 +26,7 @@ SDP-Tall-PkBudg750;0;short;;;SDP|NDC|cc|rcp1p9;Tland|GCSF;y2020;SSP2-NDC;SSP2-NP
 SDP-Tall-exoCP;0;short;;;SDP|NDC|cc|rcp1p9;Tland|GCSF;y2020;SSP2-Tall-PkBudg750;SSP2-NPi;SSP2-Base;SSP2-Tall-PkBudg750
 SSP1-Tall-exoCP;0;short;;;SSP1|NDC|cc|rcp1p9;Tland|GCSF;y2020;SSP2-Tall-PkBudg750;SSP2-NPi;SSP2-Base;SSP2-Tall-PkBudg750
 SSP2-Tene-rcp45;0;short;;;SSP2|NPI|cc|rcp4p5;GCSF;y2150;SSP2-NDC;SSP2-NPi;SSP2-Base;
-SSP2-Tpc-rcp45;0;priority;;;SSP2|NPI|cc|rcp4p5;GCSF;y2150;/p/projects/piam/abrahao/runs_gcsf/phase2_biofix/remind/output/bkp_tpcfix/C_SSP2-Tpc-rem-5/fulldata.gdx;SSP2-NPi;SSP2-Base;
+SSP2-Tpc-rcp45;0;priority;;;SSP2|NPI|cc|rcp4p5;GCSF;y2150;SSP2-NDC;SSP2-NPi;SSP2-Base;
 SSP2-Tland-rcp45;0;short;;;SSP2|NDC|cc|rcp4p5;Tland|GCSF;y2020;SSP2-Tall-PkBudg750;SSP2-NPi;SSP2-Base;SSP2-Tall-PkBudg750
 SSP2-LNDndc-rcp45;0;short;;;SSP2|NDC|cc|rcp4p5;GCSF;y2150;SSP2-NDC;SSP2-NPi;SSP2-Base;
 SSP2-LNDlbs-rcp45;0;short;;;SSP2|NPI|cc|rcp4p5;LNDlbs|GCSF;y2020;SSP2-Tall-PkBudg750;SSP2-NPi;SSP2-Base;SSP2-Tall-PkBudg750
@@ -42,7 +42,7 @@ SSP2-notrans-PkBudg750;0;short;;;SSP2|NDC|cc|rcp2p6;GCSF;y2020;SSP2-Tall-PkBudg7
 SSP2-notrans-PkBudg500;0;short;;;SSP2|NDC|cc|rcp2p6;GCSF;y2020;SSP2-Tall-PkBudg750;SSP2-NPi;SSP2-Base;
 SSP2-CPonly;0;short;;;SSP2|NPI|cc|rcp2p6;GCSF;y2020;SSP2-Tall-PkBudg750;SSP2-NPi;SSP2-Base;SSP2-Tall-PkBudg750
 SSP2-lowEnBase;0;short;;;SSP2|NPI|nocc;GCSF;y2150;;;;
-SSP2-sens-Tall-PkBudg750;0;short;;;SSP2|NDC|cc|rcp1p9;Tland|GCSF;y2020;/p/projects/piam/abrahao/runs_gcsf/phase2_dec/remind/output/C_SSP2-Tall-PkBudg820-rem-5/fulldata.gdx;SSP2-Base;SSP2-Base;
-SSP2-sens-Tall-PkBudg700;0;short;;;SSP2|NDC|cc|rcp1p9;Tland|GCSF;y2020;/p/projects/piam/abrahao/runs_gcsf/phase2_dec/remind/output/C_SSP2-Tall-PkBudg820-rem-5/fulldata.gdx;SSP2-Base;SSP2-Base;
-SSP2-sens-Tall-PkBudg650;0;short;;;SSP2|NDC|cc|rcp1p9;Tland|GCSF;y2020;/p/projects/piam/abrahao/runs_gcsf/phase2_dec/remind/output/C_SSP2-Tall-PkBudg820-rem-5/fulldata.gdx;SSP2-Base;SSP2-Base;
-SSP2-sens-Tall-PkBudg600;0;short;;;SSP2|NDC|cc|rcp1p9;Tland|GCSF;y2020;/p/projects/piam/abrahao/runs_gcsf/phase2_dec/remind/output/C_SSP2-Tall-PkBudg820-rem-5/fulldata.gdx;SSP2-Base;SSP2-Base;
+SSP2-sens-Tall-PkBudg750;0;short;;;SSP2|NDC|cc|rcp1p9;Tland|GCSF;y2020;SSP2-Tall-PkBudg750;SSP2-Base;SSP2-Base;
+SSP2-sens-Tall-PkBudg700;0;short;;;SSP2|NDC|cc|rcp1p9;Tland|GCSF;y2020;SSP2-Tall-PkBudg750;SSP2-Base;SSP2-Base;
+SSP2-sens-Tall-PkBudg650;0;short;;;SSP2|NDC|cc|rcp1p9;Tland|GCSF;y2020;SSP2-Tall-PkBudg750;SSP2-Base;SSP2-Base;
+SSP2-sens-Tall-PkBudg600;0;short;;;SSP2|NDC|cc|rcp1p9;Tland|GCSF;y2020;SSP2-Tall-PkBudg750;SSP2-Base;SSP2-Base;

--- a/scripts/start/readCheckScenarioConfig.R
+++ b/scripts/start/readCheckScenarioConfig.R
@@ -116,6 +116,17 @@ readCheckScenarioConfig <- function(filename, remindPath = ".", testmode = FALSE
             paste0(names(needBau), ": ", sapply(needBau, paste, collapse = ", "), ".", collapse = " "))
   }
 
+  if (isTRUE(testmode)) {
+    for (n in intersect(names(path_gdx_list), names(scenConf))) {
+      missingPath <- ! (is.na(scenConf[, n]) | scenConf[, n] %in% rownames(scenConf))
+      if (any(missingPath)) {
+         warning("Those scenarios link to a non-existing ", n, ": ",
+                 paste0(rownames(scenConf)[missingPath], collapse = ", "))
+         pathgdxerrors <- pathgdxerrors + sum(missingPath)
+      }
+    }
+  }
+
   # collect errors
   errorsfound <- length(colduplicates) + sum(toolong) + sum(regionname) + sum(nameisNA) + sum(illegalchars) + whitespaceErrors + copyConfigFromErrors + pathgdxerrors + missingRealizations
 

--- a/tests/testthat/test_01-readCheckScenarioConfig.R
+++ b/tests/testthat/test_01-readCheckScenarioConfig.R
@@ -25,7 +25,7 @@ test_that("readCheckScenarioConfig fails on error-loaden config", {
                "NDC_but_bau_missing;1;;;;;NDC;;"),
              con = csvfile, sep = "\n")
   w <- capture_warnings(m <- capture_messages(scenConf <- readCheckScenarioConfig(csvfile, remindPath = "../../", testmode = TRUE)))
-  expect_match(w, "12 errors found", all = FALSE, fixed = TRUE)
+  expect_match(w, "21 errors found", all = FALSE, fixed = TRUE)
   expect_match(w, "These titles are too long", all = FALSE, fixed = TRUE)
   expect_match(w, "These titles may be confused with regions", all = FALSE, fixed = TRUE)
   expect_match(w, "These titles contain illegal characters", all = FALSE, fixed = TRUE)
@@ -37,6 +37,10 @@ test_that("readCheckScenarioConfig fails on error-loaden config", {
   expect_match(w, "a reference gdx in 'path_gdx_bau'", all = FALSE, fixed = TRUE)
   expect_match(w, "Do not use 'NA' as scenario name", all = FALSE, fixed = TRUE)
   expect_match(w, "For module carbonprice.*notNDC_but_has_path_gdx_bau", all = FALSE, fixed = FALSE)
+  expect_match(w, "Those scenarios link to a non-existing path_gdx: PBS, PBScopy", all = FALSE, fixed = TRUE)
+  expect_match(w, "Those scenarios link to a non-existing path_gdx_ref: PBS, PBScopy", all = FALSE, fixed = TRUE)
+  expect_match(w, "Those scenarios link to a non-existing path_gdx_refpolicycost: PBS, PBScopy", all = FALSE, fixed = TRUE)
+  expect_match(w, "Those scenarios link to a non-existing path_gdx_carbonprice: PBS, glob, PBScopy", all = FALSE, fixed = TRUE)
   expect_match(m, "no column path_gdx_refpolicycost for policy cost comparison found, using path_gdx_ref instead", all = FALSE, fixed = TRUE)
   copiedFromPBS <- c("c_budgetCO2", "path_gdx", "path_gdx_ref")
   expect_identical(unlist(scenConf["PBS", copiedFromPBS]),


### PR DESCRIPTION
## Purpose of this PR

- avoid problems such as #1817 
- check whether all path_gdx* columns are actually defined as a scenario in that file
- do this check only when running `make test`, because in normal operation mode you might have specified a path to some old run etc. But that should rather not find its way into the repository

## Type of change

- [x] New feature 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
