### PR TITLE
harmonise options format for output.R script

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,7 @@ Imports:
     knitr,
     lazyeval,
     lpjclass,
-    lucode2 (>= 0.47.9),
+    lucode2 (>= 0.47.11),
     luplot,
     luscale,
     lusweave,

--- a/output.R
+++ b/output.R
@@ -26,31 +26,50 @@ helpText <- "
 #'
 #' [options] can be the following flags:
 #'
-#'   --help, -h:      show this help text and exit
-#'   --test, -t:      tests output.R without actually starting any run
-#'   --renv=<path>    load the renv located at <path>, incompatible with --update
-#'   --update         update packages in renv first, incompatible with --renv=<path>
+#'   --help, -h   show this help text and exit
+#'   --test, -t   tests output.R without actually starting any run
+#'   --update     update packages in renv first, incompatible with --renv=<path>
 #'
 #' [options] can also specify the following variables. If they are not specified
 #' but needed, the scripts will ask the user.
 #'
-#'   comp=             comp=single means output for single runs (reporting, …)
-#'                     comp=comparison means scripts to compare runs (compareScenarios2, …)
-#'                     comp=export means scripts to export runs (xlsx_IIASA, …)
-#'   filename_prefix=  string to be added to filenames by some output scripts
-#'                     (compareScenarios, xlsx_IIASA)
-#'   output=           output=compareScenarios2 directly selects the specific script
-#'   outputdir=        Can be used to specify the output directories to be used.
-#'                     Example: outputdir=./output/SSP2-Base-rem-1,./output/NDC-rem-1
-#'   remind_dir=       path to remind or output folder(s) where runs can be found.
-#'                     Defaults to ./output but can also be used to specify multiple
-#'                     folders, comma-separated, such as remind_dir=.,../otherremind
-#'   slurmConfig=      use slurmConfig=priority, short or standby to specify slurm
-#'                     selection. You may also pass complicated arguments such as
-#'                     slurmConfig='--qos=priority --mem=8000'
+#'   --comp=              comp=single means output for single runs
+#'                        (e.g. reporting, ...)
+#'                        comp=comparison means scripts to compare runs
+#'                        (e.g. compareScenarios2, ...)
+#'                        comp=export means scripts to export runs
+#'                        (e..g xlsx_IIASA, ...)
+#'
+#'   --filename_prefix=   string to be added to filenames by some output scripts
+#'                        (compareScenarios, xlsx_IIASA)
+#'
+#'   --output=            output=compareScenarios2 directly selects the specific
+#'                        script
+#'
+#'   --outputdir=         Can be used to specify the output directories to be
+#'                        used directly, bypassing run selection, as a
+#'                        comma-separated list
+#'                        (e.g. outputdir=./output/SSP2-Base-rem-1,./output/NDC-rem-1)
+#'
+#'   --remind_dir=        path to remind or output directories where runs can be
+#'                        found.  Defaults to ./output but can also be used to
+#'                        specify multiple  folders, comma-separated, such as
+#'                        remind_dir=.,../otherremind
+#'
+#'   --renv=<path>        load the renv located at <path>, incompatible with
+#'                        --update
+#'
+#'   --slurmConfig=       use slurmConfig=priority, short or standby to specify
+#'                        slurm selection.  You may also pass complicated
+#'                        arguments such as slurmConfig='--qos=priority --mem=8000'
 "
 
 argv <- get0("argv", ifnotfound = commandArgs(trailingOnly = TRUE))
+
+if (any(c("-h", "--help") %in% argv)) {
+  message(gsub("#' ?", '', helpText))
+  q()
+}
 
 # run updates before loading any packages
 if ("--update" %in% argv) {
@@ -77,11 +96,6 @@ if (!exists("source_include")) {
   # line arguments and let the user choose the slurm options
   flags <- readArgs("outputdir", "output", "comp", "remind_dir", "slurmConfig", "filename_prefix",
                     .flags = c(t = "--test", h = "--help"))
-}
-
-if ("--help" %in% flags) {
-  message(gsub("#' ?", '', helpText))
-  q()
 }
 
 choose_slurmConfig_output <- function(output) {


### PR DESCRIPTION
- lucode2 0.47.11 (echt Köllnisch Wasser) accepts both option=value and --option=value formats, so does output.R
- this enables bash completion for all these options
- bumped help up to start without loading pointless packages