### PR TITLE
Process based industry general formulation of specific FE demand

### DIFF
--- a/modules/05_initialCap/on/preloop.gms
+++ b/modules/05_initialCap/on/preloop.gms
@@ -121,14 +121,9 @@ display v05_INIdemEn0.l, v05_INIcap0.l;
 
 p05_cap0(regi,te) = v05_INIcap0.l(regi,te);
 
-$ifthen.cm_subsec_model_steel "%cm_subsec_model_steel%" == "processes"
-p05_cap0(regi,'bof') = pm_outflowPrcHist("2005",regi,'bof','unheated') / pm_cf("2005",regi,'bof');
-p05_cap0(regi,'bf')  = pm_outflowPrcHist("2005",regi,'bf','standard')  / pm_cf("2005",regi,'bf');
-p05_cap0(regi,'eaf') = pm_outflowPrcHist("2005",regi,'eaf','sec')      / pm_cf("2005",regi,'eaf');
-p05_cap0(regi,'idr') = 0.;
-p05_cap0(regi,"bfcc") =0.;
-p05_cap0(regi,"idrcc") =0.;
-$endif.cm_subsec_model_steel
+loop(tePrc,
+  p05_cap0(regi,tePrc) = sum(tePrc2opmoPrc(tePrc,opmoPrc), pm_outflowPrcHist("2005",regi,tePrc,opmoPrc)) / pm_cf("2005",regi,tePrc);
+);
 
 *RP keep energy demand for the Kyoto target calibration
 pm_EN_demand_from_initialcap2(regi,enty) = v05_INIdemEn0.l(regi,enty);

--- a/modules/05_initialCap/on/preloop.gms
+++ b/modules/05_initialCap/on/preloop.gms
@@ -48,7 +48,7 @@ q05_eedemini(regi,enty)..
   + sum(tePrc2opmoPrc(tePrc,opmoPrc)$(pm_specFeDem("2005",regi,enty,tePrc,opmoPrc) gt 0.),
       pm_specFeDem("2005",regi,enty,tePrc,opmoPrc)
       *
-      pm_outflowPrcIni(regi,tePrc,opmoPrc)
+      pm_outflowPrcHist("2005",regi,tePrc,opmoPrc)
     )$(entyFeStat(enty))
   ) * s05_inic_switch
     !! Transformation pathways that consume this enty:
@@ -122,9 +122,9 @@ display v05_INIdemEn0.l, v05_INIcap0.l;
 p05_cap0(regi,te) = v05_INIcap0.l(regi,te);
 
 $ifthen.cm_subsec_model_steel "%cm_subsec_model_steel%" == "processes"
-p05_cap0(regi,'bof') = pm_outflowPrcIni(regi,'bof','unheated') / pm_cf("2005",regi,'bof');
-p05_cap0(regi,'bf')  = pm_outflowPrcIni(regi,'bf','standard')  / pm_cf("2005",regi,'bf');
-p05_cap0(regi,'eaf') = pm_outflowPrcIni(regi,'eaf','sec')      / pm_cf("2005",regi,'eaf');
+p05_cap0(regi,'bof') = pm_outflowPrcHist("2005",regi,'bof','unheated') / pm_cf("2005",regi,'bof');
+p05_cap0(regi,'bf')  = pm_outflowPrcHist("2005",regi,'bf','standard')  / pm_cf("2005",regi,'bf');
+p05_cap0(regi,'eaf') = pm_outflowPrcHist("2005",regi,'eaf','sec')      / pm_cf("2005",regi,'eaf');
 p05_cap0(regi,'idr') = 0.;
 p05_cap0(regi,"bfcc") =0.;
 p05_cap0(regi,"idrcc") =0.;
@@ -543,7 +543,7 @@ if (cm_startyear gt 2005,
 *** Only the eta values of chp technologies have been adapted by initialCap script above.
 *** This is to avoid overwriting all of pm_data and make sure that scenario switches which adapt pm_data before this module work as intended.
   Execute_Loadpoint 'input_ref' p05_pmdata_ref = pm_data;
-  pm_data(regi,char,te)$( (sameas(te,"coalchp")  
+  pm_data(regi,char,te)$( (sameas(te,"coalchp")
                               OR sameas(te,"gaschp")
                               OR sameas(te,"biochp") )
                             AND sameas(char,"eta") ) = p05_pmdata_ref(regi,char,te);

--- a/modules/37_industry/fixed_shares/not_used.txt
+++ b/modules/37_industry/fixed_shares/not_used.txt
@@ -12,7 +12,7 @@ pm_emifacNonEnergy,          parameter,  not needed
 pm_exogDemScen,              input,      added by codeCheck
 pm_fedemand,                 parameter,  not needed
 pm_incinerationRate,         parameter,  not needed
-pm_outflowPrcIni,            parameter,  not needed
+pm_outflowPrcHist,           parameter,  not needed
 pm_secBioShare,              parameter,  not needed
 pm_specFeDem,                parameter,  not needed
 pm_tau_ces_tax,              input,      questionnaire

--- a/modules/37_industry/subsectors/bounds.gms
+++ b/modules/37_industry/subsectors/bounds.gms
@@ -137,21 +137,9 @@ $drop cm_indstExogScen_set
 $ifthen.cm_subsec_model_steel "%cm_subsec_model_steel%" == "processes"
 !! fix processes procudction in historic years
 if (cm_startyear eq 2005,
-  loop(regi,
-    loop(tePrc2opmoPrc(tePrc,opmoPrc),
-      vm_outflowPrc.fx("2005",regi,tePrc,opmoPrc) = pm_outflowPrcIni(regi,tePrc,opmoPrc);
+    loop((ttot,regi,tePrc2opmoPrc(tePrc,opmoPrc))$(ttot.val ge 2005 AND ttot.val le 2020),
+      vm_outflowPrc.fx(ttot,regi,tePrc,opmoPrc) = pm_outflowPrcHist(ttot,regi,tePrc,opmoPrc);
     );
-  );
-
-  loop(regi,
-    loop(ttot$(ttot.val ge 2005 AND ttot.val le 2020),
-      vm_outflowPrc.fx(ttot,regi,"eaf","pri") = 0.;
-      vm_outflowPrc.fx(ttot,regi,"idr","ng") = 0.;
-      vm_outflowPrc.fx(ttot,regi,"idr","h2") = 0.;
-      vm_outflowPrc.fx(ttot,regi,"bfcc","standard") = 0.;
-      vm_outflowPrc.fx(ttot,regi,"idrcc","ng") = 0.;
-    );
-  );
 );
 
 !! Switch to turn off steel CCS
@@ -173,7 +161,7 @@ $endif.fixedUE_scenario
 
 *** fix plastic waste to zero until 2010, and possible to reference scenario
 *** values between 2015 and cm_startyear
-v37_plasticWaste.fx(t,regi,entySe,entyFe,emiMkt)$( 
+v37_plasticWaste.fx(t,regi,entySe,entyFe,emiMkt)$(
                             t.val lt max(2015, cm_startyear)
                         AND sefe(entySe,entyFe)
                         AND entyFE2sector2emiMkt_NonEn(entyFe,"indst",emiMkt) )

--- a/modules/37_industry/subsectors/datainput.gms
+++ b/modules/37_industry/subsectors/datainput.gms
@@ -676,6 +676,8 @@ if(sum((tePrc,opmoPrc,mat)$(not matFin(mat)), p37_teMatShareHist(tePrc,opmoPrc,m
   abort "p37_teMatShareHist must only be non-zero for matFin";
 );
 *** --------------------------------
+s37_shareHistFeDemPenalty = 0.6;
+*** --------------------------------
 
 p37_captureRate(all_te) = 0.;
 p37_selfCaptureRate(all_te) = 0.;
@@ -703,46 +705,57 @@ $endif.cm_subsec_model_steel
 *** --------------------------------
 
 pm_specFeDem(tall,all_regi,all_enty,all_te,opmoPrc) = 0.;
-pm_outflowPrcHist(ttot,all_regi,all_te,opmoPrc) = 0.;
+pm_outflowPrcHist(tall,all_regi,all_te,opmoPrc) = 0.;
+p37_matFlowHist(tall,all_regi,mat) = 0.;
 $ifthen.cm_subsec_model_steel "%cm_subsec_model_steel%" == "processes"
 if (cm_startyear eq 2005,
   loop(ttot$(ttot.val ge 2005 AND ttot.val le 2020),
 
-
     !! 2nd stage tech
-    loop((tePrc2matOut(tePrc,opmoPrc,mat), mat2ue(mat,in)),
-      pm_outflowPrcHist(ttot,regi,tePrc,opmoPrc) = pm_fedemand(ttot,regi,in) / p37_mat2ue(mat,in) * p37_teMatShareHist(tePrc,opmoPrc,mat);
+    loop(mat2ue(mat,in),
+      p37_matFlowHist(ttot,regi,mat) = pm_fedemand(ttot,regi,in) / p37_mat2ue(mat,in) * p37_ue_share(mat,in);
+      loop(tePrc2matOut(tePrc,opmoPrc,mat),
+        pm_outflowPrcHist(ttot,regi,tePrc,opmoPrc) = p37_matFlowHist(ttot,regi,mat) * p37_teMatShareHist(tePrc,opmoPrc,mat);
+      );
     );
 
     !! 1st stage tech
+    !! TODO: simply do this loop several times to fill more than two stages?
     loop((tePrc1,opmoPrc1,mat)$(
                     sum((tePrc2,opmoPrc2), tePrc2matIn(tePrc2,opmoPrc2,mat))
                 AND tePrc2matOut(tePrc1,opmoPrc1,mat)),
-      pm_outflowPrcHist(ttot,regi,tePrc1,opmoPrc1)
+      p37_matFlowHist(ttot,regi,mat)
         = sum((tePrc2matOut(tePrc1,opmoPrc1,mat),
                tePrc2matIn(tePrc2,opmoPrc2,mat)),
+            !!TODO: enable p37_teMatShareHist here, too (has to be defined, though)
             p37_specMatDem(mat,tePrc2,opmoPrc2) * pm_outflowPrcHist(ttot,regi,tePrc2,opmoPrc2) );
+      pm_outflowPrcHist(ttot,regi,tePrc1,opmoPrc1) = p37_matFlowHist(ttot,regi,mat);
     );
-    !! CC tech implicitly set to zero, since not part of the above sets
-    pm_specFeDem(ttot,regi,"feh2s","idr","h2") = p37_specFeDemTarget("feh2s","idr","h2");
-    pm_specFeDem(ttot,regi,"feels","idr","h2") = p37_specFeDemTarget("feels","idr","h2");
 
-    pm_specFeDem(ttot,regi,"fegas","idr","ng") = p37_specFeDemTarget("fegas","idr","ng");
-    pm_specFeDem(ttot,regi,"feels","idr","ng") = p37_specFeDemTarget("feels","idr","ng");
+    loop((entyFe,ppfUePrc),
+      p37_demFeTarget(ttot,regi,entyFe,ppfUePrc) = sum(tePrc2ue(tePrc,opmoPrc,ppfUePrc), pm_outflowPrcHist(ttot,regi,tePrc,opmoPrc) * p37_specFeDemTarget(entyFe,tePrc,opmoPrc));
+      p37_demFeActual(ttot,regi,entyFe,ppfUePrc) = sum((fe2ppfen_no_ces_use(entyFe,all_in),ue2ppfenPrc(ppfUePrc,all_in)), pm_fedemand(ttot,regi,all_in) * sm_EJ_2_TWa);
+    );
 
-    pm_specFeDem(ttot,regi,"fegas","bfcc","standard") = p37_specFeDemTarget("fegas","bfcc","standard");
-    pm_specFeDem(ttot,regi,"feels","bfcc","standard") = p37_specFeDemTarget("feels","bfcc","standard");
+    p37_demFeRatio(ttot,regi,ppfUePrc) = sum(entyFe,p37_demFeActual(ttot,regi,entyFe,ppfUePrc)) / sum(entyFe,p37_demFeTarget(ttot,regi,entyFe,ppfUePrc));
 
-    pm_specFeDem(ttot,regi,"fegas","idrcc","ng") = p37_specFeDemTarget("fegas","idrcc","ng");
-    pm_specFeDem(ttot,regi,"feels","idrcc","ng") = p37_specFeDemTarget("feels","idrcc","ng");
+    loop((tePrc2opmoPrc(tePrc,opmoPrc),regi,entyFe)$(p37_specFeDemTarget(entyFe,tePrc,opmoPrc) gt 0.01*sm_eps),
+      if((pm_outflowPrcHist(ttot,regi,tePrc,opmoPrc) gt sm_eps),
+        pm_specFeDem(ttot,regi,entyFe,tePrc,opmoPrc)
+          = p37_specFeDemTarget(entyFe,tePrc,opmoPrc)
+          * sum(tePrc2ue(tePrc,opmoPrc,in),
+              p37_demFeActual(ttot,regi,entyFe,in)
+              / p37_demFeTarget(ttot,regi,entyFe,in));
+      else
+        pm_specFeDem(ttot,regi,entyFe,tePrc,opmoPrc)
+          = p37_specFeDemTarget(entyFe,tePrc,opmoPrc)
+          * (1.
+             + s37_shareHistFeDemPenalty
+             * (sum(tePrc2ue(tePrc,opmoPrc,ppfUePrc), p37_demFeRatio(ttot,regi,ppfUePrc))
+               -1.));
+      );
+    );
 
-    pm_specFeDem(ttot,regi,"fesos","bf","standard") = pm_fedemand(ttot,regi,"feso_steel")         * sm_EJ_2_TWa / ( p37_specMatDem("pigiron","bof","unheated") * pm_fedemand(ttot,regi,"ue_steel_primary") );
-    pm_specFeDem(ttot,regi,"fehos","bf","standard") = pm_fedemand(ttot,regi,"feli_steel")         * sm_EJ_2_TWa / ( p37_specMatDem("pigiron","bof","unheated") * pm_fedemand(ttot,regi,"ue_steel_primary") );
-    pm_specFeDem(ttot,regi,"fegas","bf","standard") = pm_fedemand(ttot,regi,"fega_steel")         * sm_EJ_2_TWa / ( p37_specMatDem("pigiron","bof","unheated") * pm_fedemand(ttot,regi,"ue_steel_primary") );
-    pm_specFeDem(ttot,regi,"feels","bf","standard") = pm_fedemand(ttot,regi,"feel_steel_primary") * sm_EJ_2_TWa / ( p37_specMatDem("pigiron","bof","unheated") * pm_fedemand(ttot,regi,"ue_steel_primary") );
-
-    pm_specFeDem(ttot,regi,"feels","eaf","sec") = pm_fedemand(ttot,regi,"feel_steel_secondary") * sm_EJ_2_TWa / pm_fedemand(ttot,regi,"ue_steel_secondary");
-    pm_specFeDem(ttot,regi,"feels","eaf","pri") = pm_specFeDem(ttot,regi,"feels","eaf","sec");
   );
 
   !! loop over other years and blend

--- a/modules/37_industry/subsectors/datainput.gms
+++ b/modules/37_industry/subsectors/datainput.gms
@@ -647,6 +647,19 @@ $endif.cm_subsec_model_steel
 
 *** --------------------------------
 
+p37_ue_share(all_enty,all_in) = 0.;
+$ifthen.cm_subsec_model_steel "%cm_subsec_model_steel%" == "processes"
+p37_ue_share("sesteel","ue_steel_secondary") = 1.;
+p37_ue_share("prsteel","ue_steel_primary")   = 1.;
+$endif.cm_subsec_model_steel
+loop(ppfUePrc(in),
+  if(abs(sum(mat,p37_ue_share(mat,in))-1.) gt sm_eps,
+    abort "p37_ue_share must add to one for each ue";
+  );
+);
+
+*** --------------------------------
+
 p37_captureRate(all_te) = 0.;
 p37_selfCaptureRate(all_te) = 0.;
 $ifthen.cm_subsec_model_steel "%cm_subsec_model_steel%" == "processes"

--- a/modules/37_industry/subsectors/datainput.gms
+++ b/modules/37_industry/subsectors/datainput.gms
@@ -707,7 +707,6 @@ $endif.cm_subsec_model_steel
 pm_specFeDem(tall,all_regi,all_enty,all_te,opmoPrc) = 0.;
 pm_outflowPrcHist(tall,all_regi,all_te,opmoPrc) = 0.;
 p37_matFlowHist(tall,all_regi,mat) = 0.;
-$ifthen.cm_subsec_model_steel "%cm_subsec_model_steel%" == "processes"
 if (cm_startyear eq 2005,
   loop(ttot$(ttot.val ge 2005 AND ttot.val le 2020),
 
@@ -777,7 +776,6 @@ if (cm_startyear eq 2005,
 if (cm_startyear gt 2005,
   Execute_Loadpoint "input_ref" pm_specFeDem = pm_specFeDem;
 );
-$endif.cm_subsec_model_steel
 
 if (cm_startyear gt 2005,
   execute_load "input_ref.gdx" v37_plasticWaste.l = v37_plasticWaste.l;

--- a/modules/37_industry/subsectors/declarations.gms
+++ b/modules/37_industry/subsectors/declarations.gms
@@ -9,6 +9,7 @@
 Scalar
   s37_clinker_process_CO2   "CO2 emissions per unit of clinker production"
   s37_plasticsShare         "share of carbon cointained in feedstocks for the chemicals subsector that goes to plastics"
+  s37_shareHistFeDemPenalty "Share of the addiotional historic specific FE demand compared with BAT which is applied to non-historic tech"
 ;
 
 Parameters
@@ -26,10 +27,14 @@ Parameters
   !! process-based implementation
   p37_specMatDem(mat,all_te,opmoPrc)                                           "Specific materials demand of a production technology and operation mode [t_input/t_output]"
   pm_specFeDem(tall,all_regi,all_enty,all_te,opmoPrc)                          "Actual specific final-energy demand of a tech; blends between IEA data and Target [TWa/Gt_output]"
+  p37_demFeTarget(tall,all_regi,all_enty,all_in)                               "Total Fe demand that would be have been consumed historically for production of a UE if all tech had BAT efficiency"
+  p37_demFeActual(tall,all_regi,all_enty,all_in)                               "Total historic Fe demand consumed for production of a UE"
   p37_specFeDemTarget(all_enty,all_te,opmoPrc)                                 "Best available technology (will be reached in convergence year) [TWa/Gt_output]"
   pm_outflowPrcHist(tall,all_regi,all_te,opmoPrc)                              "Exogenously prescribed production volume of processes in start year (from IEA data)"
+  p37_matFlowHist(tall,all_regi,all_enty)                                      "Historic material flows"
   p37_mat2ue(all_enty,all_in)                                                  "Contribution of process output to ue in CES tree; Trivial if just one material per UE, as in steel [Gt/Gt]"
   p37_ue_share(all_enty,all_in)                                                "Fixed share of material in ue"
+  p37_demFeRatio(tall,all_regi,all_in)                                         "Ratio of historic Fe demand and Fe demand calculated from historic production and BAT specific demand"
   p37_teMatShareHist(all_te,opmoPrc,mat)                                       "Share that a tePrc/opmoPrc historically contibrutes to production of a matFin"
   p37_captureRate(all_te)                                                      "Capture rate of CCS technology"
   p37_selfCaptureRate(all_te)                                                  "Share of emissions from fossil fuels used for a CCS process which are captured by the CCS process itself"

--- a/modules/37_industry/subsectors/declarations.gms
+++ b/modules/37_industry/subsectors/declarations.gms
@@ -29,6 +29,7 @@ Parameters
   p37_specFeDemTarget(all_enty,all_te,opmoPrc)                                  "Best available technology (will be reached in convergence year) [TWa/Gt_output]"
   pm_outflowPrcIni(all_regi,all_te,opmoPrc)                                    "Exogenously prescribed production volume of processes in start year (from IEA data)"
   p37_mat2ue(all_enty,all_in)                                                  "Contribution of process output to ue in CES tree; Trivial if just one material per UE, as in steel [Gt/Gt]"
+  p37_ue_share(all_enty,all_in)                                                "Fixed share of material in ue"
   p37_captureRate(all_te)                                                      "Capture rate of CCS technology"
   p37_selfCaptureRate(all_te)                                                  "Share of emissions from fossil fuels used for a CCS process which are captured by the CCS process itself"
   p37_priceMat(all_enty)                                                       "Prices of external material input [2005$/kg = trn2005$/Gt]"
@@ -121,7 +122,7 @@ $endif.no_calibration
   !! process-based implementation
   q37_demMatPrc(tall,all_regi,mat)                                                  "Material demand of processes"
   q37_prodMat(tall,all_regi,mat)                                                    "Production volume of processes equals material flow of output material"
-  q37_mat2ue(tall,all_regi,all_in)                                                  "Connect materials production to ue ces tree nodes"
+  q37_mat2ue(tall,all_regi,mat,all_in)                                              "Connect materials production to ue ces tree nodes"
   q37_limitCapMat(tall,all_regi,all_te)                                             "Material-flow conversion is limited by capacities"
   q37_emiPrc(ttot,all_regi,all_enty,all_te,opmoPrc)                                 "Local industry emissions pre-capture; Only used as baseline for CCS [GtC/a]"
   q37_emiCCPrc(tall,all_regi,emiInd37)                                              "Captured emissions from CCS"

--- a/modules/37_industry/subsectors/declarations.gms
+++ b/modules/37_industry/subsectors/declarations.gms
@@ -26,10 +26,11 @@ Parameters
   !! process-based implementation
   p37_specMatDem(mat,all_te,opmoPrc)                                           "Specific materials demand of a production technology and operation mode [t_input/t_output]"
   pm_specFeDem(tall,all_regi,all_enty,all_te,opmoPrc)                          "Actual specific final-energy demand of a tech; blends between IEA data and Target [TWa/Gt_output]"
-  p37_specFeDemTarget(all_enty,all_te,opmoPrc)                                  "Best available technology (will be reached in convergence year) [TWa/Gt_output]"
-  pm_outflowPrcIni(all_regi,all_te,opmoPrc)                                    "Exogenously prescribed production volume of processes in start year (from IEA data)"
+  p37_specFeDemTarget(all_enty,all_te,opmoPrc)                                 "Best available technology (will be reached in convergence year) [TWa/Gt_output]"
+  pm_outflowPrcHist(tall,all_regi,all_te,opmoPrc)                              "Exogenously prescribed production volume of processes in start year (from IEA data)"
   p37_mat2ue(all_enty,all_in)                                                  "Contribution of process output to ue in CES tree; Trivial if just one material per UE, as in steel [Gt/Gt]"
   p37_ue_share(all_enty,all_in)                                                "Fixed share of material in ue"
+  p37_teMatShareHist(all_te,opmoPrc,mat)                                       "Share that a tePrc/opmoPrc historically contibrutes to production of a matFin"
   p37_captureRate(all_te)                                                      "Capture rate of CCS technology"
   p37_selfCaptureRate(all_te)                                                  "Share of emissions from fossil fuels used for a CCS process which are captured by the CCS process itself"
   p37_priceMat(all_enty)                                                       "Prices of external material input [2005$/kg = trn2005$/Gt]"

--- a/modules/37_industry/subsectors/equations.gms
+++ b/modules/37_industry/subsectors/equations.gms
@@ -81,7 +81,7 @@ $endif.exogDem_scen
 *' energy mix, as that is what can be captured); vm_emiIndBase itself is not used for emission
 *' accounting, just as a CCS baseline.
 ***------------------------------------------------------
-q37_emiIndBase(t,regi,enty,secInd37)$(   entyFeCC37(enty) 
+q37_emiIndBase(t,regi,enty,secInd37)$(   entyFeCC37(enty)
                                       OR sameas(enty,"co2cement_process") ) ..
   vm_emiIndBase(t,regi,enty,secInd37)
   =e=
@@ -403,9 +403,10 @@ q37_prodMat(t,regi,mat)$( matOut(mat) ) ..
 ***------------------------------------------------------
 *' Hand-over to CES
 ***------------------------------------------------------
-q37_mat2ue(t,regi,in)$( ppfUePrc(in) ) ..
-    vm_cesIO(t,regi,in)
-    + pm_cesdata(t,regi,in,"offset_quantity")
+q37_mat2ue(t,regi,mat,in)$( ppfUePrc(in) ) ..
+    (vm_cesIO(t,regi,in)
+    + pm_cesdata(t,regi,in,"offset_quantity"))
+    * p37_ue_share(mat,in)
   =e=
     sum(mat2ue(mat,in),
       p37_mat2ue(mat,in)

--- a/modules/37_industry/subsectors/sets.gms
+++ b/modules/37_industry/subsectors/sets.gms
@@ -589,6 +589,16 @@ $ifthen.cm_subsec_model_steel "%cm_subsec_model_steel%" == "processes"
 $endif.cm_subsec_model_steel
   /
 
+ue2ppfenPrc(all_in,all_in)   "correspondant to ces_eff_target_dyn37, but for use in process-based context, i.e. contained subsectors are complements"
+  /
+$ifthen.cm_subsec_model_steel "%cm_subsec_model_steel%" == "processes"
+    ue_steel_primary . (feso_steel, feli_steel, fega_steel, feh2_steel,
+                        feel_steel_primary)
+
+    ue_steel_secondary . feel_steel_secondary
+$endif.cm_subsec_model_steel
+  /
+
 regi_fxDem37(ext_regi) "regions under which we fix UE demand to baseline demand"
   /
 $ifthen.fixedUE_scenario "%cm_fxIndUe%" == "on"


### PR DESCRIPTION
## Purpose of this PR

Generalizes some of the code on specific FE demand in process-based industry, which was so far hardcoded for each tech. 

The biggest algorithmic change is that tech without significant historic use now inherits a fraction of the lacking efficiency compared with the BAT in the historic tech of that sector and region. 

Alleviates the problems in remindmodel/development_issues#303
But at least in the US, I wouldn't speak of a complete fix yet. 

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix 
- [x] Refactoring
- [x] New feature 
- [ ] Minor change (default scenarios show only small differences)
- [ ] Fundamental change
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

![image](https://github.com/user-attachments/assets/c2bc1c2d-0390-43e2-b08a-4045415d270f)
