### PR TITLE
Add switch to change capture rates and remove overwriting parameters in initialCap

### DIFF
--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -559,6 +559,30 @@ pm_share_trans("2130",regi) = 0.865;
 pm_share_trans("2150",regi) = 0.872;
 
 
+$ifthen.tech_CO2capturerate not "%c_tech_CO2capturerate%" == "off"
+p_PECarriers_CarbonContent(peFos)=pm_cintraw(peFos);
+*** From conversation: 25 GtC/ZJ is the assumed carbon content of PE biomass (makes default bioh2c capture rate 90%)
+*** Convert to GtC/TWa
+p_PECarriers_CarbonContent("pebiolc")=25 / s_zj_2_twa;
+loop(pe2se(entyPe,entySe,te)$(p_tech_co2capturerate(te)),
+  if(p_tech_CO2capturerate(te) gt 0,
+    if(p_tech_CO2capturerate(te) ge 1,
+		  abort "Error: Inconsistent switch usage. A CO2 capture rate is greater than 1. Check c_tech_CO2capturerate.";
+	  );
+*** Alter CO2 capture rate in fm_dataemiglob
+*** fm_dataemiglob is given in GtC/ZJ
+    fm_dataemiglob(entyPe,entySe,te,"cco2") = p_tech_CO2capturerate(te) * p_PECarriers_CarbonContent(entyPe) * s_zj_2_twa;
+    if(sameAs(entyPe,"pebiolc"),
+      fm_dataemiglob(entyPe,entySe,te,"co2") = -fm_dataemiglob(entyPe,entySe,te,"cco2") ;
+    else
+    fm_dataemiglob(entyPe,entySe,te,"co2") = p_PECarriers_CarbonContent(entyPe) - fm_dataemiglob(entyPe,entySe,te,"cco2") ;
+	);
+  );
+);
+display fm_dataemiglob;
+$endif.tech_CO2capturerate
+
+
 *JH* CO2 capture rate of CCS technologies (new SSP5 assumptions)
 if (c_ccscapratescen eq 2,
   fm_dataemiglob("pecoal","seel","igccc","co2")    = 0.2;

--- a/core/declarations.gms
+++ b/core/declarations.gms
@@ -119,6 +119,11 @@ p_gdppcap2050_PPP(all_regi)	                     "regional GDP PPP per capita in
 p_maxPPP2050					     "maximum income GDP PPP among regions in 2050"
 p_maxSpvCost                                         "maximum spv investment cost among regions"
 
+$ifthen.tech_CO2capturerate not "%c_tech_CO2capturerate%" == "off"
+p_tech_CO2capturerate(all_te)                 "Technology specific CO2 capture rate" / %c_tech_CO2capturerate% /
+p_PECarriers_CarbonContent(all_enty)	  "Carbon content of PE carriers [GtC/TWa]"
+$endif.tech_CO2capturerate
+
 pm_EN_demand_from_initialcap2(all_regi,all_enty)     "PE demand resulting from the initialcap routine. [EJ, Uranium: MT U3O8]"
 pm_budgetCO2eq(all_regi)                             "budget for regional energy-emissions in period 1"
 p_actualbudgetco2(tall)                              "actual level of cumulated emissions starting from 2020 [GtCO2]"

--- a/main.gms
+++ b/main.gms
@@ -1398,6 +1398,14 @@ $setGlobal cm_VREminShare    off !! def = off
 ***     amount of Carbon Capture and Storage (including DACCS and BECCS) is limited to a maximum of 2GtCO2 per yr globally, and 250 Mt CO2 per yr in EU28.
 ***   This switch only works for model native regions. If you want to apply it to a group region use cm_implicitQttyTarget instead.
 $setGlobal cm_CCSmaxBound    off  !! def = off
+*** c_tech_CO2capturerate "changes CO2 capture rate of carbon capture technologies"
+***   Example on how to use:
+***     c_tech_CO2capturerate   bioh2c 0.8, bioftcrec 0.4
+***   This sets the CO2 capture rate of the bioh2c technology to 80% and the capture of bioftcrec (Bio-based Fischer-Tropsch with carbon capture)
+***   to 40%. The capture rate here is measured as carbon captured relative to the total carbon content of the input fuel (including carbon that is converted into the output fuel).
+***   Note: The change in capture rate via this switch follows directly after reading in the generisdata_emi.prn file. Hence, the subsequent corrections of the capture rate
+***   related to CO2 pipeline leakage still come on top of this.
+$setGlobal c_tech_CO2capturerate    "bioh2c 0.8"  !! def = off
 *** c_CES_calibration_new_structure      <-   0        switch to 1 if you want to calibrate a CES structure different from input gdx
 $setglobal c_CES_calibration_new_structure  0     !!  def  =  0  !! regexp = 0|1
 *** c_CES_calibration_write_prices       <-   0       switch to 1 if you want to generate price file, you can use this as new p29_cesdata_price.cs4r price input file

--- a/modules/05_initialCap/on/preloop.gms
+++ b/modules/05_initialCap/on/preloop.gms
@@ -506,24 +506,14 @@ loop(regi,
 );
 display pm_EN_demand_from_initialcap2, p05_emi2005_from_initialcap2;
 
-*** To be moved to new emiAccounting module
-* Discounting se2fe emissions from pe2se emission factors
-loop(entySe$(sameas(entySe,"segafos") OR sameas(entySe,"seliqfos") OR sameas(entySe,"sesofos")),
-  pm_emifac(ttot,regi,entyPe,entySe,te,"co2")$pm_emifac(ttot,regi,entyPe,entySe,te,"co2") =
-    pm_emifac(ttot,regi,entyPe,entySe,te,"co2")
-    - pm_eta_conv(ttot,regi,te)
-      *( sum(se2fe(entySe,entyFe2,te2)$pm_emifac(ttot,regi,entySe,entyFe2,te2,"co2"), pm_emifac(ttot,regi,entySe,entyFe2,te2,"co2")*pm_eta_conv(ttot,regi,te2))/sum(se2fe(entySe,entyFe2,te2)$pm_emifac(ttot,regi,entySe,entyFe2,te2,"co2"),1)  );
 );
 
-display pm_emifac;
 
-);
 
 *** if cm_startyear > 2005, load outputs of InitialCap from input_ref.gdx
 if (cm_startyear gt 2005,
   Execute_Loadpoint 'input_ref' pm_eta_conv = pm_eta_conv;
   Execute_Loadpoint 'input_ref' o_INI_DirProdSeTe = o_INI_DirProdSeTe;
-  Execute_Loadpoint 'input_ref' pm_emifac = pm_emifac;
   Execute_Loadpoint 'input_ref' pm_EN_demand_from_initialcap2 = pm_EN_demand_from_initialcap2;
   Execute_Loadpoint 'input_ref' pm_pedem_res = pm_pedem_res;
   Execute_Loadpoint 'input_ref' pm_dataeta = pm_dataeta;
@@ -556,5 +546,17 @@ $ifThen %cm_techcosts% == "GLO"
                             OR sameas(te,"ngcc") ) ) = p05_inco0_t_ref(t,regi,te);
 $endIf
 );
+
+*** To be moved to new emiAccounting module
+* Discounting se2fe emissions from pe2se emission factors
+loop(entySe$(sameas(entySe,"segafos") OR sameas(entySe,"seliqfos") OR sameas(entySe,"sesofos")),
+  pm_emifac(ttot,regi,entyPe,entySe,te,"co2")$pm_emifac(ttot,regi,entyPe,entySe,te,"co2") =
+    pm_emifac(ttot,regi,entyPe,entySe,te,"co2")
+    - pm_eta_conv(ttot,regi,te)
+      *( sum(se2fe(entySe,entyFe2,te2)$pm_emifac(ttot,regi,entySe,entyFe2,te2,"co2"), pm_emifac(ttot,regi,entySe,entyFe2,te2,"co2")*pm_eta_conv(ttot,regi,te2))/sum(se2fe(entySe,entyFe2,te2)$pm_emifac(ttot,regi,entySe,entyFe2,te2,"co2"),1)  );
+);
+
+display pm_emifac;
+execute_unload 'after_emifacAdj_IniCap.gdx', pm_emifac, pm_eta_conv ;
 
 *** EOF ./modules/05_initialCap/on/preloop.gms


### PR DESCRIPTION
## Purpose of this PR

Add switch to change capture rates of technologies with carbon capture. Also stop overwriting pm_emifac in initialCap to actually apply these changes in policy runs. 

@robertpietzcker : To finally fully avoid these issues in the future, I'd like to stop overwriting more of the parameters. Some of them do not need initialCap results. What about moving the ``pm_eta_conv`` adaptions and vm_deltaCap fixings out of initialCap, too?

```
  Execute_Loadpoint 'input_ref' pm_eta_conv = pm_eta_conv;
  Execute_Loadpoint 'input_ref' o_INI_DirProdSeTe = o_INI_DirProdSeTe;
  Execute_Loadpoint 'input_ref' pm_EN_demand_from_initialcap2 = pm_EN_demand_from_initialcap2;
  Execute_Loadpoint 'input_ref' pm_pedem_res = pm_pedem_res;
  Execute_Loadpoint 'input_ref' pm_dataeta = pm_dataeta;
  Execute_Loadpoint 'input_ref' pm_aux_capLowerLimit = pm_aux_capLowerLimit;
  Execute_Loadpoint 'input_ref' vm_deltaCap.l = vm_deltaCap.l;
  Execute_Loadpoint 'input_ref' vm_deltaCap.lo = vm_deltaCap.lo;
  Execute_Loadpoint 'input_ref' vm_deltaCap.up = vm_deltaCap.up;
  ```



## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix 
- [x] New feature 



## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Test runs are here: 
Still doing some to make sure it actually changes the parameters. 
* Comparison of results (what changes by this PR?): 

