### PR TITLE
Adding ScenarioMIP to list of projects for IIASA export

### DIFF
--- a/scripts/output/export/xlsx_IIASA.R
+++ b/scripts/output/export/xlsx_IIASA.R
@@ -21,7 +21,7 @@ model <- paste("REMIND", paste0(strsplit(gms::readDefaultConfig(".")$model_versi
 
 
 removeFromScen <- ""                           # you can use regex such as: "_diff|_expoLinear"
-renameScen <- NULL                             # c(newname1 = "oldname1", …), without the `C_` and `-rem-[0-9]` stuff
+renameScen <- NULL                             # c(oldname1 = "newname1", …), without the `C_` and `-rem-[0-9]` stuff
 addToScen <- NULL                              # is added at the beginning
 
 # filenames relative to REMIND main directory (or use absolute path) 
@@ -46,7 +46,7 @@ projects <- list(
   ScenarioMIP = list(model = "REMIND-MAgPIE 3.4-4.8",
                      mapping = "ScenarioMIP",
                      iiasatemplate = "https://files.ece.iiasa.ac.at/ssp-submission/ssp-submission-template.xlsx",
-                     renameScen = c(laurin = "SMIPv03-M-SSP2-NPi-def"),
+                     renameScen = c("SMIPv03-M-SSP2-NPi-def" = "laurin", "SMIPv03-LOS-SSP2-EcBudg400-def" = "newname"),
                      checkSummation = "NAVIGATE"),
   SHAPE      = list(mapping = c("NAVIGATE", "SHAPE")),
   TESTTHAT   = list(mapping = "AR6")
@@ -138,11 +138,13 @@ withCallingHandlers({ # piping messages to logFile
     mifdata <- rbind(mifdata, thismifdata)
   }
 
-  levels(mifdata$scenario) <- gsub("^C_|-rem-[0-9]+", "", levels(mifdata$scenario))
+  mifdata$scenario <- gsub("^C_", "", mifdata$scenario)
+  message("Old names: ", sort(unique(mifdata$scenario)))
   for (i in names(renameScen)) {
     message("Rename scenario: ", i, " -> ", renameScen[[i]])
-    levels(mifdata$scenario)[i == levels(mifdata$scenario)] == renameScen[[i]]
+    mifdata$scenario[i == mifdata$scenario] <- renameScen[[i]]
   }
+  message("New names: ", sort(unique(mifdata$scenario)))
 
   message("# ", length(temporarydelete), " variables are in the list to be temporarily deleted, ",
           length(unique(mifdata$variable[mifdata$variable %in% temporarydelete])), " were deleted.")

--- a/scripts/output/export/xlsx_IIASA.R
+++ b/scripts/output/export/xlsx_IIASA.R
@@ -139,12 +139,12 @@ withCallingHandlers({ # piping messages to logFile
   }
 
   mifdata$scenario <- gsub("^C_", "", mifdata$scenario)
-  message("Old names: ", sort(unique(mifdata$scenario)))
+  message("Old names: ", paste(sort(unique(mifdata$scenario)), collapse = ", "))
   for (i in names(renameScen)) {
     message("Rename scenario: ", i, " -> ", renameScen[[i]])
     mifdata$scenario[i == mifdata$scenario] <- renameScen[[i]]
   }
-  message("New names: ", sort(unique(mifdata$scenario)))
+  message("New names: ", paste(sort(unique(mifdata$scenario)), collapse = ", "))
 
   message("# ", length(temporarydelete), " variables are in the list to be temporarily deleted, ",
           length(unique(mifdata$variable[mifdata$variable %in% temporarydelete])), " were deleted.")

--- a/scripts/output/export/xlsx_IIASA.R
+++ b/scripts/output/export/xlsx_IIASA.R
@@ -46,7 +46,7 @@ projects <- list(
   ScenarioMIP = list(model = "REMIND-MAgPIE 3.4-4.8",
                      mapping = "ScenarioMIP",
                      iiasatemplate = "https://files.ece.iiasa.ac.at/ssp-submission/ssp-submission-template.xlsx",
-                     renameScen = c("SMIPv03-M-SSP2-NPi-def" = "laurin", "SMIPv03-LOS-SSP2-EcBudg400-def" = "newname"),
+                     renameScen = c("SMIPv03-M-SSP2-NPi-def" = "SSP2 - Medium Emissions", "SMIPv03-LOS-SSP2-EcBudg400-def" = "SSP2 - Low Overshoot", "SMIPv03-ML-SSP2-PkPrice200-fromL" = "SSP2 - Medium-Low Emissions","SMIPv03-L-SSP2-PkPrice265-inc6-def" = "SSP2 - Low Emissions", "SMIPv03-VL-SSP2_SDP_MC-PkPrice300-def" = "SSP2 - Very Low Emissions"),
                      checkSummation = "NAVIGATE"),
   SHAPE      = list(mapping = c("NAVIGATE", "SHAPE")),
   TESTTHAT   = list(mapping = "AR6")

--- a/scripts/output/export/xlsx_IIASA.R
+++ b/scripts/output/export/xlsx_IIASA.R
@@ -21,11 +21,13 @@ model <- paste("REMIND", paste0(strsplit(gms::readDefaultConfig(".")$model_versi
 
 
 removeFromScen <- ""                           # you can use regex such as: "_diff|_expoLinear"
+renameScen <- NULL                             # c(newname1 = "oldname1", …), without the `C_` and `-rem-[0-9]` stuff
 addToScen <- NULL                              # is added at the beginning
 
 # filenames relative to REMIND main directory (or use absolute path) 
 mapping <- NULL                                # file obtained from piamInterfaces, or AR6/SHAPE/NAVIGATE or NULL to get asked
 iiasatemplate <- NULL                          # provided for each project, can be yaml or xlsx with a column 'Variable'
+checkSummation <- TRUE                         # if TRUE, tries to use the one from mapping. Or specify here
 
 # note: you can also pass all these options to output.R, so 'Rscript output.R logFile=mylogfile.txt' works.
 lucode2::readArgs("project")
@@ -41,6 +43,11 @@ projects <- list(
                     mapping = c("AR6", "AR6_NGFS"),
                     iiasatemplate = "https://files.ece.iiasa.ac.at/ngfs-phase-5/ngfs-phase-5-template.xlsx",
                     removeFromScen = "C_|_bIT|_bit|_bIt|_KLW"),
+  ScenarioMIP = list(model = "REMIND-MAgPIE 3.4-4.8",
+                     mapping = "ScenarioMIP",
+                     iiasatemplate = "https://files.ece.iiasa.ac.at/ssp-submission/ssp-submission-template.xlsx",
+                     renameScen = c(laurin = "SMIPv03-M-SSP2-NPi-def"),
+                     checkSummation = "NAVIGATE"),
   SHAPE      = list(mapping = c("NAVIGATE", "SHAPE")),
   TESTTHAT   = list(mapping = "AR6")
 )
@@ -58,14 +65,15 @@ if (! exists("project")) {
 }
 projectdata <- projects[[project]]
 message("# Overwrite settings with project settings for '", project, "'.")
-varnames <- c("mapping", "iiasatemplate", "addToScen", "removeFromScen", "model", "outputFilename", "logFile")
+varnames <- c("mapping", "iiasatemplate", "addToScen", "removeFromScen", "renameScen",
+              "model", "outputFilename", "logFile", "checkSummation")
 for (p in intersect(varnames, names(projectdata))) {
   assign(p, projectdata[[p]])
 }
 
 # overwrite settings with those specified as command-line arguments
-lucode2::readArgs("outputdirs", "filename_prefix", "outputFilename", "model",
-                  "mapping", "logFile", "removeFromScen", "addToScen", "iiasatemplate")
+lucode2::readArgs("outputdirs", "filename_prefix", "outputFilename", "model", "mapping",
+                  "summationFile", "logFile", "removeFromScen", "addToScen", "iiasatemplate")
 
 if (is.null(mapping)) {
   mapping <- gms::chooseFromList(names(piamInterfaces::mappingNames()), type = "mapping")
@@ -130,6 +138,12 @@ withCallingHandlers({ # piping messages to logFile
     mifdata <- rbind(mifdata, thismifdata)
   }
 
+  levels(mifdata$scenario) <- gsub("^C_|-rem-[0-9]+", "", levels(mifdata$scenario))
+  for (i in names(renameScen)) {
+    message("Rename scenario: ", i, " -> ", renameScen[[i]])
+    levels(mifdata$scenario)[i == levels(mifdata$scenario)] == renameScen[[i]]
+  }
+
   message("# ", length(temporarydelete), " variables are in the list to be temporarily deleted, ",
           length(unique(mifdata$variable[mifdata$variable %in% temporarydelete])), " were deleted.")
   write(paste0("  - ", paste(unique(mifdata$variable[mifdata$variable %in% temporarydelete]), collapse = "\n  - "), "\n\n"),
@@ -141,7 +155,7 @@ withCallingHandlers({ # piping messages to logFile
 
   generateIIASASubmission(mifdata, mapping = mapping, model = model,
                           removeFromScen = removeFromScen, addToScen = addToScen,
-                          outputDirectory = outputFolder,
+                          outputDirectory = outputFolder, checkSummation = checkSummation,
                           logFile = logFile, outputFilename = basename(OUTPUT_xlsx),
                           iiasatemplate = iiasatemplate, generatePlots = TRUE)
 


### PR DESCRIPTION
## Purpose of this PR

Transferring addition of ScenarioMIP to project list from project branch to develop. 

## Type of change

- [x] Minor change (only extending export to IIASA database, no effects)

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)


