### PR TITLE
add empty seleton for industry ccu

### DIFF
--- a/core/sets.gms
+++ b/core/sets.gms
@@ -335,7 +335,7 @@ $ENDIF.WindOff
         seceaf       "Route: Scrap-loaded EAF"
         pcc          "outdated technology, only here to avoid compilation errors if input data containing information for this technology are used"
         pco          "outdated technology, only here to avoid compilation errors if input data containing information for this technology are used"
-*** transport technologies for deleted realization complex of module 35_transport 
+*** transport technologies for deleted realization complex of module 35_transport
 *** only here to make it possible to process input data that still includes data for these obsolete transport technologies
         apCarPeT        "outdated transport technology"
         apCarDiT        "outdated transport technology"
@@ -415,6 +415,8 @@ all_enty             "all types of quantities"
         ueelTt       "transport useful energy for electric trains"
 
         !! materials, feedstock, and industrial goods
+        co2f         "feedstock CO2"
+
         prsteel      "Primary steel"
         sesteel      "Secondary steel"
         dri          "Directly reduced iron"

--- a/core/sets_calculations.gms
+++ b/core/sets_calculations.gms
@@ -37,7 +37,7 @@ peRicardian(enty)    = peBio(enty) + peEx(enty);
 en2se(enty,enty2,te) = pe2se(enty,enty2,te) + se2se(enty,enty2,te);
 
 en2en(enty,enty2,te) = pe2se(enty,enty2,te) + se2se(enty,enty2,te) + se2fe(enty,enty2,te) + fe2ue(enty,enty2,te) + ccs2te(enty,enty2,te) + fe2mat(enty,enty2,te);
-te2rlf(te,rlf)       = teFe2rlf(te,rlf) + teSe2rlf(te,rlf) + teue2rlf(te,rlf) + teCCS2rlf(te,rlf) + teCCU2rlf2(te,rlf) +teNoTransform2rlf(te,rlf) + teFe2rlfH2BI(te,rlf) + teMat2rlf(te,rlf);
+te2rlf(te,rlf)       = teFe2rlf(te,rlf) + teSe2rlf(te,rlf) + teue2rlf(te,rlf) + teCCS2rlf(te,rlf) + teSeCCU2rlf(te,rlf) +teNoTransform2rlf(te,rlf) + teFe2rlfH2BI(te,rlf) + teMat2rlf(te,rlf);
 ***----------------------------------------------------------------------------
 *** Fill sets that were created empty and should be filled from the mappings above
 ***----------------------------------------------------------------------------

--- a/modules/37_industry/subsectors/sets.gms
+++ b/modules/37_industry/subsectors/sets.gms
@@ -381,7 +381,7 @@ $ifthen.cm_subsec_model_steel "%cm_subsec_model_steel%" == "processes"
 $endif.cm_subsec_model_steel
   /
 
-  teCCPrc(tePrc)   "Technologies used in process-based model (only CCS)"
+  teCCPrc(all_te)   "Technologies used in process-based model (only CCS)"
   /
     $$ifthen.cm_subsec_model_steel "%cm_subsec_model_steel%" == "processes"
     bfcc
@@ -389,9 +389,13 @@ $endif.cm_subsec_model_steel
     $$endif.cm_subsec_model_steel
   /
 
+teCUPrc(all_te)   "Technologies using CO2 as a feedstock"
+  /
+  /
 
 mat(all_enty)   "Materials considered in process-based model; Can be input and/or output of a process"
   /
+    co2f
 $ifthen.cm_subsec_model_steel "%cm_subsec_model_steel%" == "processes"
     prsteel
     sesteel
@@ -406,6 +410,7 @@ $endif.cm_subsec_model_steel
 
 matIn(all_enty)   "Materials which serve as input to a process"
   /
+    co2f
 $ifthen.cm_subsec_model_steel "%cm_subsec_model_steel%" == "processes"
     eafscrap   "Steel scrap used in EAF"
     bofscrap   "Steel scrap used in BOF"

--- a/modules/39_CCU/off/sets.gms
+++ b/modules/39_CCU/off/sets.gms
@@ -25,22 +25,28 @@ te_ccu39(all_te)                            "CCU technologies"
 /
 
 
-
 teCCU2rlf(all_te,rlf)				  "mapping for CCU technologies to grades"
+/
+/
+
+
+teSeCCU2rlf(all_te,rlf)				  "mapping for CCU technologies to grades"
 /
       (h22ch4) . 1
       (MeOH) . 1
 /
+
 ;
 
-alias(teCCU2rlf,teCCU2rlf2); 
 
 ***-------------------------------------------------------------------------
 ***  add module specific sets and mappings to the global sets and mappings
 ***-------------------------------------------------------------------------
 
+teCCU2rlf(teSeCCU2rlf)         = YES;
+teCCU2rlf(teCUPrc,"1")         = YES;
 
-enty(enty_ccu39)							   = YES;
-te(te_ccu39)								   = YES;
+enty(enty_ccu3)                = YES;
+te(te_ccu39)                   = YES;
 
 *** EOF ./modules/39_CCU/off/sets.gms

--- a/modules/39_CCU/on/bounds.gms
+++ b/modules/39_CCU/on/bounds.gms
@@ -28,7 +28,7 @@ if(cm_emiscen = 1,
 );
 
 ***----------------------------------------------------------------------------
-*** force synthetic liquids in as a minimum share of total liquids if cm_shSynLiq switch used 
+*** force synthetic liquids in as a minimum share of total liquids if cm_shSynLiq switch used
 ***----------------------------------------------------------------------------
 
 if (cm_shSynLiq gt 0,
@@ -38,7 +38,7 @@ if (cm_shSynLiq gt 0,
 );
 
 ***----------------------------------------------------------------------------
-*** force synthetic gases in as a minimum share of total liquids if cm_shSynGas switch used 
+*** force synthetic gases in as a minimum share of total liquids if cm_shSynGas switch used
 ***----------------------------------------------------------------------------
 
 if (cm_shSynGas gt 0,

--- a/modules/39_CCU/on/equations.gms
+++ b/modules/39_CCU/on/equations.gms
@@ -12,40 +12,46 @@
 *' calculate CCU emissions (= CO2 demand of CCU technologies)
 *** ---------------------------------------------------------
 
-q39_emiCCU(t,regi,te)$(te_ccu39(te)).. 
+q39_emiCCU(t,regi,te)$(te_ccu39(te) OR teCUPrc(te))..
   sum(teCCU2rlf(te,rlf),
     vm_co2CCUshort(t,regi,"cco2","ccuco2short",te,rlf)
   )
   =e=
-  sum(se2se_ccu39(enty,enty2,te), 
-    p39_co2_dem(t,regi,enty,enty2,te) 
+  sum(se2se_ccu39(enty,enty2,te),
+    p39_co2_dem(t,regi,enty,enty2,te)
   * vm_prodSe(t,regi,enty,enty2,te)
   )
+  +
+  sum(tePrc2matIn(tePrc,opmoPrc,mat)$(sameAs(mat,"co2f")),
+    p37_specMatDem(mat,tePrc,opmoPrc)
+  * vm_outflowPrc(t,regi,tePrc,opmoPrc)
+  )
+
 ;
 
-*' calculate v39_shSynLiq, share of synthetic (hydrogen-based) liquids in all SE liquids if cm_shSynLiq switch used 
+*' calculate v39_shSynLiq, share of synthetic (hydrogen-based) liquids in all SE liquids if cm_shSynLiq switch used
 q39_shSynLiq(t,regi)$(cm_shSynLiq gt 0)..
     (
     sum(pe2se(entyPe,entySe,te)$seAgg2se("all_seliq",entySe), vm_prodSe(t,regi,entyPe,entySe,te))
     + sum(se2se(entySe,entySe2,te)$seAgg2se("all_seliq",entySe2), vm_prodSe(t,regi,entySe,entySe2,te))
     ) * v39_shSynLiq(t,regi)
     =e=
-  sum(se2se(entySe,entySe2,te)$(sameAs(entySe, "seh2") AND 
+  sum(se2se(entySe,entySe2,te)$(sameAs(entySe, "seh2") AND
                                 sameAs(entySe2, "seliqsyn") AND
-                                te_ccu39(te)), 
+                                te_ccu39(te)),
     vm_prodSe(t,regi,entySe,entySe2,te))
 ;
 
-*' calculate v39_shSynGas, share of synthetic (hydrogen-based) gas in all SE gases if cm_shSynGas switch used 
+*' calculate v39_shSynGas, share of synthetic (hydrogen-based) gas in all SE gases if cm_shSynGas switch used
 q39_shSynGas(t,regi)$(cm_shSynGas gt 0)..
     (
     sum(pe2se(entyPe,entySe,te)$seAgg2se("all_sega",entySe), vm_prodSe(t,regi,entyPe,entySe,te))
     + sum(se2se(entySe,entySe2,te)$seAgg2se("all_sega",entySe2), vm_prodSe(t,regi,entySe,entySe2,te))
     ) * v39_shSynGas(t,regi)
     =e=
-  sum(se2se(entySe,entySe2,te)$(sameAs(entySe, "seh2") AND 
+  sum(se2se(entySe,entySe2,te)$(sameAs(entySe, "seh2") AND
                                 sameAs(entySe2, "segasyn") AND
-                                te_ccu39(te)), 
+                                te_ccu39(te)),
     vm_prodSe(t,regi,entySe,entySe2,te))
 ;
 

--- a/modules/39_CCU/on/sets.gms
+++ b/modules/39_CCU/on/sets.gms
@@ -48,29 +48,28 @@ se2se_ccu39(all_enty,all_enty,all_te)  			"map secondary energy to secondary ene
 
 teCCU2rlf(all_te,rlf)     "mapping for CCU technologies to grades"
 /
-      (h22ch4) . 1
-	  (MeOH) . 1
 /
 
 
 teSeCCU2rlf(all_te,rlf)     "mapping for secondary energy CCU technologies to grades"
 /
-      (h22ch4) . 1
-	  (MeOH) . 1
+    (h22ch4) . 1
+    (MeOH) . 1
 /
 ;
-
-alias(teCCU2rlf,teCCU2rlf2); 
 
 
 ***-------------------------------------------------------------------------
 ***  add module specific sets and mappings to the global sets and mappings
 ***-------------------------------------------------------------------------
 
-enty(enty_ccu39)							   = YES;
-te(te_ccu39)								   = YES;
-se2se(se2se_ccu39)							   = YES;
-teSe2rlf(teCCU2rlf)					   		   = YES;
+teCCU2rlf(teSeCCU2rlf)         = YES;
+teCCU2rlf(teCUPrc,"1")         = YES;
+
+enty(enty_ccu39)               = YES;
+te(te_ccu39)                   = YES;
+se2se(se2se_ccu39)             = YES;
+teSe2rlf(teCCU2rlf)            = YES;
 
 *** EOF ./modules/39_CCU/on/sets.gms
 


### PR DESCRIPTION
## Purpose of this PR

I don't even want to merge it into develop yet, but would like to discuss the implementation with you.
@whitenightZhang is going to use it for the chemicals branch, and we will merge both together. 
Obviously, `teCUPrc` is supposed to get some entries for process based chemicals. 

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [ ] Bug fix 
- [ ] Refactoring
- [ ] New feature 
- [ ] Minor change (default scenarios show only small differences)
- [ ] Fundamental change
- [ ] This change requires a documentation update


## Checklist:

- [ ] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [ ] I explained my changes within the PR, particularly in hard-to-understand areas
- [ ] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

