### PR TITLE
adjust NPi + NDC carbon prices from 2005 to 2017

### DIFF
--- a/modules/45_carbonprice/NDC/datainput.gms
+++ b/modules/45_carbonprice/NDC/datainput.gms
@@ -12,9 +12,9 @@ Execute_Loadpoint "input_ref" p45_taxCO2eq_bau = pm_taxCO2eq;
 pm_taxCO2eq(t,regi) = p45_taxCO2eq_bau(t,regi)
 
 *** parameters for exponential increase after NDC targets
-Scalar p45_taxCO2eqGlobal2030 "startprice in 2030 (unit TDpGtC) of global CO2eq taxes towards which countries converge";
-p45_taxCO2eqGlobal2030 = 30 * sm_DptCO2_2_TDpGtC;
-Scalar p45_taxCO2eqYearlyIncrease "yearly multiplicative increase of co2 tax, write 3% as 1.03" /1.0125/;
+Scalar p45_taxCO2eqGlobal2030 "startprice in 2030 of global CO2eq taxes towards which countries converge [T$/GtC]";
+p45_taxCO2eqGlobal2030 = 30 * sm_D2005_2_D2017 * sm_DptCO2_2_TDpGtC;
+Scalar p45_taxCO2eqYearlyIncrease "yearly multiplicative increase of co2 tax, write 3% as 1.03 [1]" /1.0125/;
 
 Scalar p45_taxCO2eqConvergenceYear "year until which CO2eq taxes have converged globally" /2100/;
 *** set Years for CO2eq taxes to converge after 2030

--- a/modules/45_carbonprice/NPi/datainput.gms
+++ b/modules/45_carbonprice/NPi/datainput.gms
@@ -12,7 +12,7 @@
 pm_taxCO2eq(ttot,regi)$( (ttot.val ge 2025) AND (ttot.val le 2100)) =
   pm_taxCO2eq("2020",regi) 
   + ( 
-      ( 25 * sm_DptCO2_2_TDpGtC - pm_taxCO2eq("2020",regi) )
+      ( 25 * sm_D2005_2_D2017 * sm_DptCO2_2_TDpGtC - pm_taxCO2eq("2020",regi) )
       * ( 
           (ttot.val - 2020) / (2100 - 2020)
         ) ** 2 

--- a/modules/45_carbonprice/diffCurvPhaseIn2Lin/not_used.txt
+++ b/modules/45_carbonprice/diffCurvPhaseIn2Lin/not_used.txt
@@ -28,3 +28,4 @@ cm_co2_tax_startyear,input,added by codeCheck
 cm_peakBudgYr,input,added by codeCheck
 cm_startyear,input,added by codeCheck
 cm_taxCO2inc_after_peakBudgYr,input,added by codeCheck
+sm_D2005_2_D2017,input,not needed

--- a/modules/45_carbonprice/diffExp2Lin/not_used.txt
+++ b/modules/45_carbonprice/diffExp2Lin/not_used.txt
@@ -22,3 +22,4 @@ pm_ttot_2_tall,input,questionnaire
 cm_NDC_divergentScenario,input,questionnaire
 vm_demFeSector,input,questionnaire
 pm_emifac,input,questionnaire
+sm_D2005_2_D2017,input,not needed

--- a/modules/45_carbonprice/diffLin2Lin/not_used.txt
+++ b/modules/45_carbonprice/diffLin2Lin/not_used.txt
@@ -23,3 +23,4 @@ pm_prtp,input,questionnaire
 vm_demFeSector,input,questionnaire
 pm_emifac,input,questionnaire
 cm_co2_tax_2020,input,replaced by cm_co2_tax_startyear in this realization
+sm_D2005_2_D2017,input,not needed

--- a/modules/45_carbonprice/exogenous/not_used.txt
+++ b/modules/45_carbonprice/exogenous/not_used.txt
@@ -32,3 +32,4 @@ cm_co2_tax_spread,switch,no carbon price differentiation in this realization
 cm_co2_tax_startyear,input,added by codeCheck
 cm_peakBudgYr,input,added by codeCheck
 cm_taxCO2inc_after_peakBudgYr,input,added by codeCheck
+sm_D2005_2_D2017,input,not needed

--- a/modules/45_carbonprice/expoLinear/not_used.txt
+++ b/modules/45_carbonprice/expoLinear/not_used.txt
@@ -28,3 +28,4 @@ cm_co2_tax_spread,input,No carbon price differentiation in this realization
 cm_peakBudgYr,input,added by codeCheck
 cm_co2_tax_2020,input,added by codeCheck
 cm_taxCO2inc_after_peakBudgYr,input,added by codeCheck
+sm_D2005_2_D2017,input,not needed

--- a/modules/45_carbonprice/exponential/not_used.txt
+++ b/modules/45_carbonprice/exponential/not_used.txt
@@ -31,3 +31,4 @@ cm_co2_tax_spread,input,No carbon price differentiation in this realization
 cm_co2_tax_startyear,input,added by codeCheck
 cm_peakBudgYr,input,added by codeCheck
 cm_taxCO2inc_after_peakBudgYr,input,added by codeCheck
+sm_D2005_2_D2017,input,not needed

--- a/modules/45_carbonprice/linear/not_used.txt
+++ b/modules/45_carbonprice/linear/not_used.txt
@@ -31,3 +31,4 @@ cm_co2_tax_spread,switch,no carbon price differentiation in this realization
 cm_co2_tax_startyear,input,added by codeCheck
 cm_peakBudgYr,input,added by codeCheck
 cm_taxCO2inc_after_peakBudgYr,input,added by codeCheck
+sm_D2005_2_D2017,input,not needed

--- a/modules/45_carbonprice/none/not_used.txt
+++ b/modules/45_carbonprice/none/not_used.txt
@@ -34,3 +34,4 @@ cm_co2_tax_spread,input,no carbon price differentiation in this realization
 cm_co2_tax_startyear,input,added by codeCheck
 cm_peakBudgYr,input,added by codeCheck
 cm_taxCO2inc_after_peakBudgYr,input,added by codeCheck
+sm_D2005_2_D2017,input,not needed

--- a/modules/45_carbonprice/temperatureNotToExceed/not_used.txt
+++ b/modules/45_carbonprice/temperatureNotToExceed/not_used.txt
@@ -26,3 +26,4 @@ cm_co2_tax_spread,input,no carbon price differentiation in this realization
 cm_co2_tax_startyear,input,added by codeCheck
 cm_peakBudgYr,input,added by codeCheck
 cm_taxCO2inc_after_peakBudgYr,input,added by codeCheck
+sm_D2005_2_D2017,input,not needed

--- a/modules/47_regipol/regiCarbonPrice/datainput.gms
+++ b/modules/47_regipol/regiCarbonPrice/datainput.gms
@@ -82,7 +82,7 @@ p47_taxemiMkt_init(ttot,regi,emiMkt)$(p47_taxCO2eq_ref(ttot,regi) and (NOT(p47_t
   loop((ttot,ttot2,ext_regi,emiMktExt,target_type_47,emi_type_47)$pm_emiMktTarget(ttot,ttot2,ext_regi,emiMktExt,target_type_47,emi_type_47),
     loop(regi$regi_groupExt(ext_regi,regi),
       loop(emiMkt$emiMktGroup(emiMktExt,emiMkt), 
-        p47_taxemiMkt_init(t,regi,emiMkt)$(t.val gt 2020) = (20*sm_DptCO2_2_TDpGtC) + (1*sm_DptCO2_2_TDpGtC)*(t.val-2020);
+        p47_taxemiMkt_init(t,regi,emiMkt)$(t.val gt 2020) = (20*sm_D2005_2_D2017*sm_DptCO2_2_TDpGtC) + (1*sm_DptCO2_2_TDpGtC)*(t.val-2020);
       );
     );
   );
@@ -93,23 +93,23 @@ p47_taxemiMkt_init(ttot,regi,emiMkt)$(p47_taxCO2eq_ref(ttot,regi) and (NOT(p47_t
     loop(regi$(regi_groupExt(ext_regi,regi) and regi_groupExt("EUR_regi",regi)), !!second condition is necessary to support also country targets
       if((cm_startyear le 2010),
         p47_taxemiMkt_init("2010",regi,emiMkt) = 0;
-        p47_taxemiMkt_init("2010",regi,"ETS")  = 15*sm_DptCO2_2_TDpGtC;
+        p47_taxemiMkt_init("2010",regi,"ETS")  = 15*sm_D2005_2_D2017*sm_DptCO2_2_TDpGtC;
       );
       if((cm_startyear le 2015),
         p47_taxemiMkt_init("2015",regi,emiMkt) = 0;
-        p47_taxemiMkt_init("2015",regi,"ETS")  = 8*sm_DptCO2_2_TDpGtC;
+        p47_taxemiMkt_init("2015",regi,"ETS")  = 8*sm_D2005_2_D2017*sm_DptCO2_2_TDpGtC;
       );
       if((cm_startyear le 2020),
         p47_taxemiMkt_init("2020",regi,emiMkt) = 0;
 ***     p47_taxemiMkt_init("2020",regi,"ETS")   = 41.28*sm_DptCO2_2_TDpGtC; !! 2018 = 16.5€/tCO2, 2019 = 25€/tCO2, 2020 = 25€/tCO2, 2021 = 53.65€/tCO2, 2022 = 80€/tCO2 -> average 2020 = 40€/tCO2 -> 40*1.032 $/tCO2 = 41.28 $/t CO2
-        p47_taxemiMkt_init("2020",regi,"ETS")  = 30*sm_DptCO2_2_TDpGtC;
+        p47_taxemiMkt_init("2020",regi,"ETS")  = 30*sm_D2005_2_D2017*sm_DptCO2_2_TDpGtC;
 ***     p47_taxemiMkt_init("2020",regi,"ES")   = 30*sm_DptCO2_2_TDpGtC;
 ***     p47_taxemiMkt_init("2020",regi,"other")= 30*sm_DptCO2_2_TDpGtC;
       );
 ***   intialize EUR price trajectory after 2020 with an yearly increase of 1$/tCO2 from a base value of 30$/tCO2 when no price is available.
 ***   p47_taxemiMkt_init(t,regi,emiMkt)$(not(p47_taxemiMkt_init(t,regi,emiMkt)) and (t.val gt 2020)) = (30*sm_DptCO2_2_TDpGtC) + (1*sm_DptCO2_2_TDpGtC)*(t.val-2020);
 ***   intialize EUR price trajectory after 2020 with a yearly increase of 1$/tCO2 from a base value of 30$/tCO2
-      p47_taxemiMkt_init(t,regi,emiMkt)$(t.val gt 2020) = (30*sm_DptCO2_2_TDpGtC) + (1*sm_DptCO2_2_TDpGtC)*(t.val-2020);
+      p47_taxemiMkt_init(t,regi,emiMkt)$(t.val gt 2020) = (30*sm_D2005_2_D2017*sm_DptCO2_2_TDpGtC) + (1*sm_D2005_2_D2017*sm_DptCO2_2_TDpGtC)*(t.val-2020);
     );
   );
 


### PR DESCRIPTION
## Purpose of this PR

Avoid that US$2005 -> US$2017 update changes NPi and NDC ambition. I'm not sure whether this should be adjusted in regipol as well. The plot is done after converting both to a common unit using the NAVIGATE mapping.

![image](https://github.com/user-attachments/assets/a2b18c80-27e2-4af2-8190-8f36504eb32e)

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
