### PR TITLE
new input data rev6.96, related CES parameter and gdx files for SSP2, SSP2-EU21, SSP1, SSP2_lowEn and SSP5

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -28,10 +28,10 @@ cfg$regionmapping <- "config/regionmappingH12.csv"
 cfg$extramappings_historic <- ""
 
 #### Current input data revision (<mainrevision>.<subrevision>) ####
-cfg$inputRevision <- "6.95"
+cfg$inputRevision <- "6.96"
 
 #### Current CES parameter and GDX revision (commit hash) ####
-cfg$CESandGDXversion <- "ffbff5da0c24de39586df082716e5af449f5f231"
+cfg$CESandGDXversion <- "bbf47b596d6f54c364086cbcde12d5ffee5fb167"
 
 #### Force the model to download new input data ####
 cfg$force_download <- FALSE


### PR DESCRIPTION
## Purpose of this PR
* new input data rev6.96 fixing bug in unit shift for transport sector;
* related CES parameter and gdx files for input data rev6.96 for SSP2, SSP2-EU21, SSP1, SSP2_lowEn and SSP5, calibration runs: /p/tmp/lavinia/REMIND/REMIND_calibration_2024_09_27/remind

## Type of change

- [x] Bug fix 


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

