### PR TITLE
Bugfix: windoff capacity factor was too low

### DIFF
--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -1003,8 +1003,10 @@ $offdelim
 pm_dataren(all_regi,"maxprod",rlf,"windoff") = sm_EJ_2_TWa * f_maxProdGradeRegiWindOff(all_regi,"maxprod",rlf);
 pm_dataren(all_regi,"nur",rlf,"windoff")     = 1.25 * f_maxProdGradeRegiWindOff(all_regi,"nur",rlf);  !! increase wind offshore capacity factors by 25% as the NREL values seem to underestimate offshore capacity factors compared to historic values
 
-pm_shareWindPotentialOff2On(all_regi) = sum(rlf,f_maxProdGradeRegiWindOff(all_regi,"maxprod",rlf)$(rlf.val le 8)) /
-                      sum(rlf,f_maxProdGradeRegiWindOn(all_regi,"maxprod",rlf)$(rlf.val le 8));
+pm_shareWindPotentialOff2On(all_regi) =
+    sum(rlf $ (rlf.val le 8), f_maxProdGradeRegiWindOff(all_regi,"maxprod",rlf))
+  /
+    sum(rlf $ (rlf.val le 8), f_maxProdGradeRegiWindOn( all_regi,"maxprod",rlf));
 
 pm_shareWindOff("2010",regi) = 0.05;
 pm_shareWindOff("2015",regi) = 0.1;
@@ -1055,20 +1057,28 @@ display p_datapot, pm_dataren;
 *** --------------------------------------------------------------------------
 loop(regi,
   loop(teReNoBio(te),
-    p_aux_capToDistr(regi,te) = pm_histCap("2015",regi,te)$(pm_histCap("2015",regi,te) gt 1e-10);
-    s_aux_cap_remaining = p_aux_capToDistr(regi,te);
-*RP* fill up the renewable grades to calculate the total capacity needed to produce the amount calculated in initialcap2,
-***    assuming the best grades are filled first (with 20% of each grade not yet used)
+    p_aux_capToDistr(regi,te) = pm_histCap("2015",regi,te) $ (pm_histCap("2015",regi,te) gt 1e-10);
 
-    loop(teRe2rlfDetail(te,rlf)$(pm_dataren(regi,"nur",rlf,te) > 0),
+*** Knowing the historical capacity (pm_histCap) in 2015, let us estimate on which grades this capacity was distributed.
+*** We assume that the best grades were filled first, but only up to 80% of their potential.
+    s_aux_cap_remaining = p_aux_capToDistr(regi,te);
+    loop(teRe2rlfDetail(te,rlf) $ (pm_dataren(regi,"nur",rlf,te) > 0),
       if(s_aux_cap_remaining > 0,
-        p_aux_capThisGrade(regi,te,rlf) = min(s_aux_cap_remaining, ( (pm_dataren(regi,"maxprod",rlf,te) * 0.8) / pm_dataren(regi,"nur",rlf,te) ) );
-        s_aux_cap_remaining         = s_aux_cap_remaining - p_aux_capThisGrade(regi,te,rlf);
+        p_aux_capThisGrade(regi,te,rlf) = min(
+            s_aux_cap_remaining,
+            0.8 * pm_dataren(regi,"maxprod",rlf,te) / pm_dataren(regi,"nur",rlf,te)); !! installedCapacity = maxprod / capacityFactor 
+        s_aux_cap_remaining = s_aux_cap_remaining - p_aux_capThisGrade(regi,te,rlf);
       );
     );  !! teRe2rlfDetail
 
-    p_avCapFac2015(regi,te) = sum(teRe2rlfDetail(te,rlf), p_aux_capThisGrade(regi,te,rlf) * pm_dataren(regi,"nur",rlf,te) )
-                                 / ( sum(teRe2rlfDetail(te,rlf), p_aux_capThisGrade(regi,te,rlf) ) + 1e-10)
+*** With this estimated distribution of capacity across grades (p_aux_capThisGrade),
+*** let us compute the average capacity factor of each technology in 2015 (p_avCapFac2015).
+    p_avCapFac2015(regi,te) =
+        sum(teRe2rlfDetail(te,rlf),
+          p_aux_capThisGrade(regi,te,rlf) * pm_dataren(regi,"nur",rlf,te))
+      / 
+        (sum(teRe2rlfDetail(te,rlf), p_aux_capThisGrade(regi,te,rlf))
+        + 1e-10)
   );    !! teReNoBio
 );      !! regi
 
@@ -1093,11 +1103,15 @@ p_histCapFac(tall,all_regi,"wind") = 0;
 *** (potentially partially due to assumed low-wind turbine set-ups in the NREL data)
 *** Because of the lag effect (turbines in the 2000s were much smaller and thus yielded lower CFs),
 *** only implement half of the calculated ratio of historic to REMIND capFac as rescaling for the new CFs - realised as (x+1)/2
+*** Analogously for wind and spv: calibrate 2015, and assume gradual phase-in of grade-based CF (until 2035 for wind, until 2030 for spv)
+p_aux_capacityFactorHistOverREMIND(regi,"spv") $ p_avCapFac2015(regi,"spv") = p_histCapFac("2015",regi,"spv") / p_avCapFac2015(regi,"spv");
+pm_cf("2015",regi,"spv") = pm_cf("2015",regi,"spv") * p_aux_capacityFactorHistOverREMIND(regi,"spv");
+pm_cf("2020",regi,"spv") = pm_cf("2020",regi,"spv") * (p_aux_capacityFactorHistOverREMIND(regi,"spv")+1)/2;
+pm_cf("2025",regi,"spv") = pm_cf("2025",regi,"spv") * (p_aux_capacityFactorHistOverREMIND(regi,"spv")+3)/4;
 
-*cb* CF calibration analogously for wind and spv: calibrate 2015, and assume gradual phase-in of grade-based CF (until 2045 for wind, until 2030 for spv)
-p_aux_capacityFactorHistOverREMIND(regi,"windon")  $ p_avCapFac2015(regi,"windon")  = p_histCapFac("2015",regi,"windon")  / p_avCapFac2015(regi,"windon");
-p_aux_capacityFactorHistOverREMIND(regi,"windoff") $ p_avCapFac2015(regi,"windoff") = p_histCapFac("2015",regi,"windoff") / p_avCapFac2015(regi,"windoff");
 
+p_aux_capacityFactorHistOverREMIND(regi,teWind) = 1;
+p_aux_capacityFactorHistOverREMIND(regi,teWind) $ p_avCapFac2015(regi,teWind) = p_histCapFac("2015",regi,teWind) / p_avCapFac2015(regi,teWind);
 *** linear phase-in of Remind capacity factors instead of historical ones
 loop(t$(t.val ge 2015 AND t.val le 2035),
   pm_cf(t,regi,teWind) =
@@ -1110,10 +1124,6 @@ loop(t$(t.val ge 2015 AND t.val le 2035),
 pm_cf(t,regi,"storwindoff") = pm_cf(t,regi,"storwindon");
 pm_cf(t,regi,"gridwindoff") = pm_cf(t,regi,"gridwindon");
 
-p_aux_capacityFactorHistOverREMIND(regi,"spv")$p_avCapFac2015(regi,"spv") =  p_histCapFac("2015",regi,"spv") / p_avCapFac2015(regi,"spv");
-pm_cf("2015",regi,"spv") = pm_cf("2015",regi,"spv") * p_aux_capacityFactorHistOverREMIND(regi,"spv");
-pm_cf("2020",regi,"spv") = pm_cf("2020",regi,"spv") * (p_aux_capacityFactorHistOverREMIND(regi,"spv")+1)/2;
-pm_cf("2025",regi,"spv") = pm_cf("2025",regi,"spv") * (p_aux_capacityFactorHistOverREMIND(regi,"spv")+3)/4;
 
 
 display p_aux_capacityFactorHistOverREMIND, pm_dataren;

--- a/core/declarations.gms
+++ b/core/declarations.gms
@@ -144,16 +144,17 @@ p_ef_dem(all_regi,all_enty)                                 "Demand side emissio
 pm_secBioShare(ttot,all_regi,all_enty,emi_sectors)           "share of biomass per carrier for each sector"
 
 p_avCapFac2015(all_regi,all_te)                             "average capacity factor of non-bio renewables in 2015 in REMIND"
-p_aux_capToDistr(all_regi,all_te)                           "aux. param. to calculate p_avCapFac2015; The historic capacity in 2015"
-s_aux_cap_remaining                                         "aux. param. to calculate p_avCapFac2015; countdown parameter"
-p_aux_capThisGrade(all_regi,all_te,rlf)                     "aux. param. to calculate p_avCapFac2015; How the historic 2015 capacity is distributed among grades"
-p_aux_capacityFactorHistOverREMIND(all_regi,all_te)         "aux. param. to calculate capacity factors correction (wind and spv): the ratio of historic over REMIND CapFac in 2015"
-p_aux_scaleEmiHistorical_n2o(all_regi)                      "aux. param. to rescale MAgPIE n2o emissions to historical values"
-p_aux_scaleEmiHistorical_ch4(all_regi)                      "aux. param. to rescale MAgPIE ch4 emissions to historical values"
+p_aux_capToDistr(all_regi,all_te)                           "auxiliary parameter to calculate p_avCapFac2015; The historic capacity in 2015"
+s_aux_cap_remaining                                         "auxiliary parameter to calculate p_avCapFac2015; countdown parameter"
+p_aux_capThisGrade(all_regi,all_te,rlf)                     "auxiliary parameter to calculate p_avCapFac2015; How the historic 2015 capacity is distributed among grades"
+p_aux_capacityFactorHistOverREMIND(all_regi,all_te)         "auxiliary parameter to calculate capacity factors correction (wind and spv): the ratio of historic over REMIND CapFac in 2015"
+
+p_aux_scaleEmiHistorical_n2o(all_regi)                      "auxiliary parameter to rescale MAgPIE n2o emissions to historical values"
+p_aux_scaleEmiHistorical_ch4(all_regi)                      "auxiliary parameter to rescale MAgPIE ch4 emissions to historical values"
 
 *** windoffshore-todo
-pm_shareWindPotentialOff2On(all_regi)                 "ratio of technical potential of windoff to windon"
-pm_shareWindOff(ttot,all_regi)                        "windoff rollout as a fraction of technical potential"
+pm_shareWindPotentialOff2On(all_regi)                "ratio of technical potential of windoff to windon"
+pm_shareWindOff(ttot,all_regi)                       "windoff rollout as a fraction of technical potential"
 
 pm_fe2es(tall,all_regi,all_teEs)                     "Conversion factor from final energies to energy services. Default is 1."
 


### PR DESCRIPTION
## Purpose of this PR

This PR puts fixes vm_capFac windoff that had very low near-term values in most regions. I think it is good to integrate this PR as part of the release validation.

VRE capacity factors are interpolated between historical values (p_aux_capacityFactorHistOverREMIND) and a default factor 1. For offshore however, p_aux_capacityFactorHistOverREMIND was not set in some regions, therefore taking the value zero and leading to very low capacity factors in the near-term:

``` py
# /p/projects/remind/modeltests/remind/output/SSP2-PkBudg650-AMT_2024-09-28_01.49.00/
# dumpgdx fulldata.gdx vm_capFac 202.*,windoff,l,
# 2020
2020  LAM  windoff  L  0.25
2020  OAS  windoff  L  0.25
2020  SSA  windoff  L  0.25
2020  EUR  windoff  L  0.772409095660856
2020  NEU  windoff  L  0.25
2020  MEA  windoff  L  0.25
2020  REF  windoff  L  0.25
2020  CAZ  windoff  L  0.25
2020  CHA  windoff  L  0.59905006244186
2020  IND  windoff  L  0.25
2020  JPN  windoff  L  0.25
2020  USA  windoff  L  0.25
# 2025
2025  LAM  windoff  L  0.5
2025  OAS  windoff  L  0.5
2025  SSA  windoff  L  0.5
2025  EUR  windoff  L  0.848272730440571
2025  NEU  windoff  L  0.5
2025  MEA  windoff  L  0.5
2025  REF  windoff  L  0.5
2025  CAZ  windoff  L  0.5
2025  CHA  windoff  L  0.732700041627907
2025  IND  windoff  L  0.5
2025  JPN  windoff  L  0.5
2025  USA  windoff  L  0.5
```



## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix 
- [x] Refactoring
- [ ] New feature 
- [ ] Minor change (default scenarios show only small differences)
- [ ] Fundamental change
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Test runs are here: `/p/tmp/fabricel/offshoreRemind09/compScen-windFixCFall-2024-10-07_17.28.43-H12-short.pdf` Scenarios `xxx.1` are the ones with the corrected capacity factors.
* Comparison of results (what changes by this PR?): Minor differences in NPi.
* A lot changes in the energy mix of Peak650. More offshore and less onshore, especially in some regions like JPN. Fossils go down more quickly and stay longer in the mix. Carbon price in 2050 is way lower, 650 instead of 870. But all of that could be due to other PRs in the meantime. I think it is good to integrate this PR as part of the release validation.


### SE electricity
![image](https://github.com/user-attachments/assets/35dda97e-82fb-4dda-b756-decc92382cce)

### PE
![image](https://github.com/user-attachments/assets/59236407-3fa9-416b-982c-6b9dd96590c9)
