### PR TITLE
update generation of custom-region historical.mif in IIASA tutorial

### DIFF
--- a/tutorials/13_Submit_to_IIASA_database.md
+++ b/tutorials/13_Submit_to_IIASA_database.md
@@ -101,10 +101,12 @@ If you like to generate a 'historical.mif' file for a different regional resolut
 ```
 library(madrat)
 library(mrremind)
-setConfig(regionmapping = system.file("regionmapping/ISO_2_R10.csv", package = "piamInterfaces"))
+stopifnot(utils::packageVersion("piamInterfaces") >= "0.35.3")
+setConfig(regionmapping = system.file("regionmapping/ISO_2_ISO.csv", package = "piamInterfaces"))
 d <- madrat::retrieveData("VALIDATIONREMIND")
 system(paste("tar xvf", d))
-quitte::write.mif(piamInterfaces::convertHistoricalData("historical.mif", "ScenarioMIP"), "historical_R10.mif")
+quitte::write.mif(piamInterfaces::convertHistoricalData("historical.mif", "ScenarioMIP", "ISO_2_R10"), "historical_R10.mif")
+quitte::write.mif(piamInterfaces::convertHistoricalData("historical.mif", "ScenarioMIP", "ISO_2_R5"), "historical_R5.mif")
 ```
 
 ## Further Information


### PR DESCRIPTION
## Purpose of this PR

the options to convert to ISO first and then aggregate keeps much more data (including Eurostats) which is dropped if one small country is NA

## Type of change

- [x] tutorial update only
