### PR TITLE
Ignore missing `historical.mif` in tests because it is an optional input file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     [[#1818](https://github.com/remindmodel/remind/pull/1818)]
 - **scripts** fail transparently if cm_startyear is earlier than that of path_gdx_ref
     [[#1851](https://github.com/remindmodel/remind/pull/1851)]
-
+- **testthat** ignore missing historical.mif in tests because it is an optional input file
+    [[#1857](https://github.com/remindmodel/remind/pull/1857)]
+    
 ### fixed
 - included CCS from plastic waste incineration in CCS mass flows so it is
     subject to injection constraints (but did not add CCS costs, see

--- a/scripts/start/updateInputData.R
+++ b/scripts/start/updateInputData.R
@@ -21,7 +21,7 @@ updateInputData <- function(cfg, remindPath = ".", gamsCompile = FALSE) {
   }
   regicode <- madrat::regionscode(file.path(remindPath, cfg$regionmapping))
   input_new <- c(paste0("rev",cfg$inputRevision,"_",regicode,"_", tolower(cfg$model_name),".tgz"),
-                 paste0("rev",cfg$inputRevision,"_",regicode,ifelse(cfg$extramappings_historic == "","",paste0("-", madrat::regionscode(cfg$extramappings_historic))),"_", tolower(cfg$validationmodel_name),".tgz"),
+                 paste0("rev",cfg$inputRevision,"_",regicode,ifelse(cfg$extramappings_historic == "","",paste0("-", madrat::regionscode(cfg$extramappings_historic))),"_", tolower(cfg$validationmodel_name),".tzz"),
                  paste0("CESparametersAndGDX_",cfg$CESandGDXversion,".tgz"))
   
   # Specify for each element of input_new whether to stop if the respective file could not be downloaded

--- a/scripts/start/updateInputData.R
+++ b/scripts/start/updateInputData.R
@@ -21,7 +21,7 @@ updateInputData <- function(cfg, remindPath = ".", gamsCompile = FALSE) {
   }
   regicode <- madrat::regionscode(file.path(remindPath, cfg$regionmapping))
   input_new <- c(paste0("rev",cfg$inputRevision,"_",regicode,"_", tolower(cfg$model_name),".tgz"),
-                 paste0("rev",cfg$inputRevision,"_",regicode,ifelse(cfg$extramappings_historic == "","",paste0("-", madrat::regionscode(cfg$extramappings_historic))),"_", tolower(cfg$validationmodel_name),".tzz"),
+                 paste0("rev",cfg$inputRevision,"_",regicode,ifelse(cfg$extramappings_historic == "","",paste0("-", madrat::regionscode(cfg$extramappings_historic))),"_", tolower(cfg$validationmodel_name),".tgz"),
                  paste0("CESparametersAndGDX_",cfg$CESandGDXversion,".tgz"))
   
   # Specify for each element of input_new whether to stop if the respective file could not be downloaded

--- a/tests/testthat/test_01-inputdata.R
+++ b/tests/testthat/test_01-inputdata.R
@@ -8,9 +8,16 @@ test_that("Are all input data files present?", {
   missinginput <- missingInputData(path = "../..")
   if (length(missinginput) > 0) {
     lockID <- gms::model_lock(folder = "../..")
-    updateInputData(cfg = gms::readDefaultConfig("../.."), remindPath = "../..")
+    w <- capture_warning(updateInputData(cfg = gms::readDefaultConfig("../.."), remindPath = "../.."))
+    # ignore warning about missing historical.mif, raise warning if there were other wargnings
+    ignore <- "File historical.mif seems to be missing!"
+    if (!w$message %in% ignore) {
+      warning(paste0("'updateInputData' raised the following wargnings\n", paste(w, collapse = "\n")))
+    }
     gms::model_unlock(lockID)
     missinginput <- missingInputData(path = "../..")
+    # remove historical.mif since it is optional
+    missinginput <- grep("historical.mif", missinginput, invert = TRUE, value = TRUE)
     if (length(missinginput) > 0) {
       warning("Missing input files: ", paste(missinginput, collapse = ", "))
     }

--- a/tests/testthat/test_01-inputdata.R
+++ b/tests/testthat/test_01-inputdata.R
@@ -11,7 +11,7 @@ test_that("Are all input data files present?", {
     w <- capture_warnings(updateInputData(cfg = gms::readDefaultConfig("../.."), remindPath = "../.."))
     # ignore warning about missing historical.mif, raise warning if there were other wargnings
     ignore <- "File historical.mif seems to be missing!"
-    if (!w %in% ignore) {
+    if (length(w) > 0 && !w %in% ignore) {
       warning(paste0("'updateInputData' raised the following wargnings\n", paste(w, collapse = "\n")))
     }
     gms::model_unlock(lockID)

--- a/tests/testthat/test_01-inputdata.R
+++ b/tests/testthat/test_01-inputdata.R
@@ -9,7 +9,7 @@ test_that("Are all input data files present?", {
   if (length(missinginput) > 0) {
     lockID <- gms::model_lock(folder = "../..")
     w <- capture_warnings(updateInputData(cfg = gms::readDefaultConfig("../.."), remindPath = "../.."))
-    # ignore warning about missing historical.mif, raise warning if there were other wargnings
+    # ignore warning about missing historical.mif, raise warning if there were other warnings
     ignore <- "File historical.mif seems to be missing!"
     w <- setdiff(w, ignore)
     if (length(w) > 0) {

--- a/tests/testthat/test_01-inputdata.R
+++ b/tests/testthat/test_01-inputdata.R
@@ -8,10 +8,10 @@ test_that("Are all input data files present?", {
   missinginput <- missingInputData(path = "../..")
   if (length(missinginput) > 0) {
     lockID <- gms::model_lock(folder = "../..")
-    w <- capture_warning(updateInputData(cfg = gms::readDefaultConfig("../.."), remindPath = "../.."))
+    w <- capture_warnings(updateInputData(cfg = gms::readDefaultConfig("../.."), remindPath = "../.."))
     # ignore warning about missing historical.mif, raise warning if there were other wargnings
     ignore <- "File historical.mif seems to be missing!"
-    if (!w$message %in% ignore) {
+    if (!w %in% ignore) {
       warning(paste0("'updateInputData' raised the following wargnings\n", paste(w, collapse = "\n")))
     }
     gms::model_unlock(lockID)

--- a/tests/testthat/test_01-inputdata.R
+++ b/tests/testthat/test_01-inputdata.R
@@ -11,8 +11,9 @@ test_that("Are all input data files present?", {
     w <- capture_warnings(updateInputData(cfg = gms::readDefaultConfig("../.."), remindPath = "../.."))
     # ignore warning about missing historical.mif, raise warning if there were other wargnings
     ignore <- "File historical.mif seems to be missing!"
-    if (length(w) > 0 && !w %in% ignore) {
-      warning(paste0("'updateInputData' raised the following wargnings\n", paste(w, collapse = "\n")))
+    w <- setdiff(w, ignore)
+    if (length(w) > 0) {
+      warning(paste0("'updateInputData' raised the following warnings\n", paste(w, collapse = "\n")))
     }
     gms::model_unlock(lockID)
     missinginput <- missingInputData(path = "../..")


### PR DESCRIPTION
## Purpose of this PR

Ignore missing `historical.mif` in tests, because we are not allowed to publish the `validation.tgz` (that contains the `historical.mif`) to external users, but `make test` should still pass all tests also for external users.

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)