### PR TITLE
avoiding infeasibilities for years defined at c_H2InBuildOnlyAfter

### DIFF
--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -535,8 +535,8 @@ v_shfe.lo(t,regi,entyFe,sector)$pm_shfe_lo(t,regi,entyFe,sector) = pm_shfe_lo(t,
 v_shGasLiq_fe.up(t,regi,sector)$pm_shGasLiq_fe_up(t,regi,sector) = pm_shGasLiq_fe_up(t,regi,sector);
 v_shGasLiq_fe.lo(t,regi,sector)$pm_shGasLiq_fe_lo(t,regi,sector) = pm_shGasLiq_fe_lo(t,regi,sector);
 
-*** RH: Fix H2 in buildings to zero until given year (always zero by default)
-vm_demFeSector.up(t,regi,"seh2","feh2s","build",emiMkt)$(t.val le c_H2InBuildOnlyAfter) = 0;
+*** Set H2 upper bound in buildings for years defined at c_H2InBuildOnlyAfter
+vm_demFeSector.up(t,regi,"seh2","feh2s","build",emiMkt)$(t.val le c_H2InBuildOnlyAfter) = 1e-6;
 
 ***----------------------------------------------------------------------------
 ***  Controlling if active, dampening factor to align edge-t non-energy transportation costs with historical GDP data

--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -535,8 +535,8 @@ v_shfe.lo(t,regi,entyFe,sector)$pm_shfe_lo(t,regi,entyFe,sector) = pm_shfe_lo(t,
 v_shGasLiq_fe.up(t,regi,sector)$pm_shGasLiq_fe_up(t,regi,sector) = pm_shGasLiq_fe_up(t,regi,sector);
 v_shGasLiq_fe.lo(t,regi,sector)$pm_shGasLiq_fe_lo(t,regi,sector) = pm_shGasLiq_fe_lo(t,regi,sector);
 
-*** Set H2 upper bound in buildings for years defined at c_H2InBuildOnlyAfter
-vm_demFeSector.up(t,regi,"seh2","feh2s","build",emiMkt)$(t.val le c_H2InBuildOnlyAfter) = 1e-6;
+*** Set H2 upper bound in buildings for years defined at cm_H2InBuildOnlyAfter
+vm_demFeSector.up(t,regi,"seh2","feh2s","build",emiMkt)$(t.val le cm_H2InBuildOnlyAfter) = 1e-6;
 
 ***----------------------------------------------------------------------------
 ***  Controlling if active, dampening factor to align edge-t non-energy transportation costs with historical GDP data

--- a/main.gms
+++ b/main.gms
@@ -1001,9 +1001,9 @@ parameter
 *' * (4) Energy Efficiency policy: higher discount rate until cm_startyear, decreasing to 25% value linearly until 2030.
 *'
 parameter
-  c_H2InBuildOnlyAfter "Switch to fix H2 in buildings to zero until given year"
+  cm_H2InBuildOnlyAfter "Switch to fix H2 in buildings to zero until given year"
 ;
-  c_H2InBuildOnlyAfter = 2150;   !! def = 2150 (rule out H2 in buildings)
+  cm_H2InBuildOnlyAfter = 2150;   !! def = 2150 (rule out H2 in buildings)
 *' For all years until the given year, FE demand for H2 in buildings is set to zero
 parameter
   cm_peakBudgYr       "date of net-zero CO2 emissions for peak budget runs without overshoot"

--- a/modules/29_CES_parameters/calibrate/datainput.gms
+++ b/modules/29_CES_parameters/calibrate/datainput.gms
@@ -305,17 +305,17 @@ $ifthen.build_H2_offset "%buildings%" == "simple"
 *);
 
 *** RK: feh2b offset scaled from 1% in 2025 to 50% in 2050 of fegab quantity
-pm_cesdata(t,regi,"feh2b","offset_quantity")$(t.val gt c_H2InBuildOnlyAfter) =
+pm_cesdata(t,regi,"feh2b","offset_quantity")$(t.val gt cm_H2InBuildOnlyAfter) =
   - (0.05 + 0.45 * min(1, max(0, (t.val - 2025) / (2050 - 2025))))
     * pm_cesdata(t,regi,"fegab","quantity")
   - pm_cesdata(t,regi,"feh2b","quantity");
-pm_cesdata(t,regi,"feh2b","quantity")$(t.val gt c_H2InBuildOnlyAfter) = 
+pm_cesdata(t,regi,"feh2b","quantity")$(t.val gt cm_H2InBuildOnlyAfter) = 
   (0.05 + 0.45 * min(1, max(0, (t.val - 2025) / (2050 - 2025))))
     * pm_cesdata(t,regi,"fegab","quantity");
 
 *** for the years that H2 buildings is fixed to zero, set offset to the exact value of the calibrated quantity to ignore it after calibration
-pm_cesdata(t,regi,"feh2b","quantity")$(t.val le c_H2InBuildOnlyAfter) = 1e-6;
-pm_cesdata(t,regi,"feh2b","offset_quantity")$(t.val le c_H2InBuildOnlyAfter) = - pm_cesdata(t,regi,"feh2b","quantity");
+pm_cesdata(t,regi,"feh2b","quantity")$(t.val le cm_H2InBuildOnlyAfter) = 1e-6;
+pm_cesdata(t,regi,"feh2b","offset_quantity")$(t.val le cm_H2InBuildOnlyAfter) = - pm_cesdata(t,regi,"feh2b","quantity");
 
 $endif.build_H2_offset
 

--- a/modules/29_CES_parameters/calibrate/datainput.gms
+++ b/modules/29_CES_parameters/calibrate/datainput.gms
@@ -305,15 +305,18 @@ $ifthen.build_H2_offset "%buildings%" == "simple"
 *);
 
 *** RK: feh2b offset scaled from 1% in 2025 to 50% in 2050 of fegab quantity
-loop ((t,regi),
-	pm_cesdata(t,regi,"feh2b","offset_quantity")
-  = - (0.05 + 0.45 * min(1, max(0, (t.val - 2025) / (2050 - 2025))))
-      * pm_cesdata(t,regi,"fegab","quantity")
-    - pm_cesdata(t,regi,"feh2b","quantity");
-      pm_cesdata(t,regi,"feh2b","quantity")
-  = (0.05 + 0.45 * min(1, max(0, (t.val - 2025) / (2050 - 2025))))
-      * pm_cesdata(t,regi,"fegab","quantity");
-);
+pm_cesdata(t,regi,"feh2b","offset_quantity")$(t.val gt c_H2InBuildOnlyAfter) =
+  - (0.05 + 0.45 * min(1, max(0, (t.val - 2025) / (2050 - 2025))))
+    * pm_cesdata(t,regi,"fegab","quantity")
+  - pm_cesdata(t,regi,"feh2b","quantity");
+pm_cesdata(t,regi,"feh2b","quantity")$(t.val gt c_H2InBuildOnlyAfter) = 
+  (0.05 + 0.45 * min(1, max(0, (t.val - 2025) / (2050 - 2025))))
+    * pm_cesdata(t,regi,"fegab","quantity");
+
+*** for the years that H2 buildings is fixed to zero, set offset to the exact value of the calibrated quantity to ignore it after calibration
+pm_cesdata(t,regi,"feh2b","quantity") = 1e-6;
+pm_cesdata(t,regi,"feh2b","offset_quantity")$(t.val le c_H2InBuildOnlyAfter) = - pm_cesdata(t,regi,"feh2b","quantity");
+
 $endif.build_H2_offset
 
 *** Add an epsilon to the values which are 0 so that they can fit in the CES

--- a/modules/29_CES_parameters/calibrate/datainput.gms
+++ b/modules/29_CES_parameters/calibrate/datainput.gms
@@ -314,7 +314,7 @@ pm_cesdata(t,regi,"feh2b","quantity")$(t.val gt c_H2InBuildOnlyAfter) =
     * pm_cesdata(t,regi,"fegab","quantity");
 
 *** for the years that H2 buildings is fixed to zero, set offset to the exact value of the calibrated quantity to ignore it after calibration
-pm_cesdata(t,regi,"feh2b","quantity") = 1e-6;
+pm_cesdata(t,regi,"feh2b","quantity")$(t.val le c_H2InBuildOnlyAfter) = 1e-6;
 pm_cesdata(t,regi,"feh2b","offset_quantity")$(t.val le c_H2InBuildOnlyAfter) = - pm_cesdata(t,regi,"feh2b","quantity");
 
 $endif.build_H2_offset

--- a/modules/29_CES_parameters/load/not_used.txt
+++ b/modules/29_CES_parameters/load/not_used.txt
@@ -22,3 +22,4 @@ pm_calibrate_eff_scale,parameter,not needed
 pm_fedemand,parameter,not needed
 pm_energy_limit,,
 sm_CES_calibration_iteration,scalar,only applicable during calibration
+cm_H2InBuildOnlyAfter,parameter,???

--- a/modules/36_buildings/simple/equations.gms
+++ b/modules/36_buildings/simple/equations.gms
@@ -65,7 +65,7 @@ q36_auxCostAddTeInv(t,regi)..
 
 
 *' Hydrogen fe share in buildings gases use (natural gas + hydrogen)
-q36_H2Share(t,regi)..
+q36_H2Share(t,regi)$(t.val ge 2020)..
   v36_H2share(t,regi) 
   * sum(se2fe(entySe,entyFe,te)$(SAMEAS(entyFe,"feh2s")
                                  OR SAMEAS(entyFe,"fegas")),   


### PR DESCRIPTION
## Purpose of this PR

**Issue:** 

For years defined at `c_H2InBuildOnlyAfter`, H2 was being forced to be exact zero. However at calibration time, `pm_cesdata(t,regi,"feh2b","quantity")` is being set to a value different from zero.

This causes infeasibilities in the model, that can be small enough for certain gdxs to be ignored, but in others not. From my runs this is specially hard for the `IND` region in my current tests.

**Work around:** 

In this pull request:
- I redefine `pm_cesdata(t,regi,"feh2b","quantity")` at calibration time to a small value for years that `c_H2InBuildOnlyAfter´ is active, so the model is calibrated considering values for H2 in buildings, and at the same time I define an offset exactly equal to the quantity value so the model ignores this "calibration" only value in the final energy production balance.
- I relax the zero upper bound to avoid approximation issues in the model and use 1e-6 instead for it in the `core/bounds.gms` file. @robinhasse This should be adjusted to a lower value if 1e-6 is considered yet too big still for H2 use.

Moreover, the entire code block in `Additional hydrogen phase in cost at low H2 penetration levels` has no function at all if H2 is always forced to be zero as it is in the default configuration used right now, and the CES tree branch from hydrogen should be removed if this is the case. To avoid issues with case where historical data is zero for H2 build use, I set the `q36_H2Share` equation to be only calculated from 2020 onward.      


PS: Fixing things to exact zero in  the model should be avoided unless you want to completely remove a variable from the solver. In this case you would need to remove also the above mentioned equations and CES tree branch. 

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)

