### PR TITLE
Add warning to RCP scenarios that are not actively maintained.

### DIFF
--- a/main.gms
+++ b/main.gms
@@ -1205,10 +1205,10 @@ $setglobal cm_MAgPIE_coupling  off     !! def = "off"  !! regexp = off|on
 *' *  (none): no RCP scenario, standard setting
 *' *  (rcp20): RCP2.0
 *' *  (rcp26): RCP2.6
-*' *  (rcp37): RCP3.7
+*' *  (rcp37): RCP3.7 [currently not operational: test and verify before using it!]
 *' *  (rcp45): RCP4.5
-*' *  (rcp60): RCP6.0
-*' *  (rcp85): RCP8.5
+*' *  (rcp60): RCP6.0 [currently not operational: test and verify before using it!]
+*' *  (rcp85): RCP8.5 [currently not operational: test and verify before using it!]
 $setglobal cm_rcp_scen  none         !! def = "none"  !! regexp = none|rcp20|rcp26|rcp37|rcp45|rcp60|rcp85
 *' cm_NDC_version            "choose version year of NDC targets as well as conditional vs. unconditional targets"
 *' *  (2024_cond):   all NDCs conditional to international financial support published until August 31, 2024

--- a/scripts/start/checkFixCfg.R
+++ b/scripts/start/checkFixCfg.R
@@ -103,7 +103,10 @@ checkFixCfg <- function(cfg, remindPath = ".", testmode = FALSE) {
     cfg$inputRevision <- sub("^rev", "", cfg$inputRevision)
     warning("cfg$inputRevision started with 'rev', but this will be added automatically. Removed it.")
   }
-
+  # check if RCP scenario other than (none), (rcp20), (rcp26), or (rcp45) is used
+  if (! isTRUE(cfg$gms$cm_rcp_scen %in% c("none","rcp20","rcp26","rcp45") )) {
+    warning("Chosen RCP scenario might currently not be fully operational: test and verify before using it!")
+  }
   # Make sure that an input_bau.gdx has been specified if needed.
   isBauneeded <- isTRUE(length(unlist(lapply(names(needBau), function(x) intersect(cfg$gms[[x]], needBau[[x]])))) > 0)
   if (isBauneeded) {

--- a/scripts/start/checkFixCfg.R
+++ b/scripts/start/checkFixCfg.R
@@ -105,7 +105,7 @@ checkFixCfg <- function(cfg, remindPath = ".", testmode = FALSE) {
   }
   # check if RCP scenario other than (none), (rcp20), (rcp26), or (rcp45) is used
   if (! isTRUE(cfg$gms$cm_rcp_scen %in% c("none","rcp20","rcp26","rcp45") )) {
-    warning("Chosen RCP scenario might currently not be fully operational: test and verify before using it!")
+    warning("Chosen RCP scenario '", cfg$gms$cm_rcp_scen, "' might currently not be fully operational: test and verify before using it!")
   }
   # Make sure that an input_bau.gdx has been specified if needed.
   isBauneeded <- isTRUE(length(unlist(lapply(names(needBau), function(x) intersect(cfg$gms[[x]], needBau[[x]])))) > 0)


### PR DESCRIPTION
## Purpose of this PR

See title and [this issue](https://github.com/remindmodel/development_issues/issues/362).

## Type of change

- [x] Minor addition to documentation 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

