### PR TITLE
Reenable inputcheck in climate-assessment

### DIFF
--- a/scripts/input/climate_assessment_run.R
+++ b/scripts/input/climate_assessment_run.R
@@ -227,14 +227,7 @@ runClimateEmulatorCmd <- paste(
   "--scenario-batch-size", 1,
   "--probabilistic-file", probabilisticFile
 )
-# runClimateEmulatorCmd <- paste(
-#   "python", file.path(scriptsDir, "run_clim.py"),
-#   normalizePath(file.path(climateTempDir, paste0(baseFn, "_harmonized_infilled.csv"))),
-#   climateTempDir,
-#   "--num-cfgs", nparsets,
-#   "--scenario-batch-size", 1,
-#   "--probabilistic-file", probabilisticFile
-# )
+
 
 # Get conda environment folder
 condaDir <- "/p/projects/rd3mod/python/environments/scm_magicc7"

--- a/scripts/input/climate_assessment_run.R
+++ b/scripts/input/climate_assessment_run.R
@@ -214,7 +214,6 @@ runHarmoniseAndInfillCmd <- paste(
   "python", file.path(scriptsDir, "run_harm_inf.py"),
   climateAssessmentEmi,
   climateTempDir,
-  "--no-inputcheck",
   "--infilling-database", infillingDatabaseFile
 )
 

--- a/scripts/output/single/MAGICC7_AR6.R
+++ b/scripts/output/single/MAGICC7_AR6.R
@@ -146,7 +146,6 @@ runHarmoniseAndInfillCmd <- paste(
   "python", file.path(scriptsFolder, "run_harm_inf.py"),
   climateAssessmentEmi,
   climateAssessmentFolder,
-  "--no-inputcheck",
   "--infilling-database", infillingDatabaseFile
 )
 


### PR DESCRIPTION
## Purpose of this PR

Re-enables inputcheck in climate-assessment calls, both within REMIND and in the reporting. Turns out that `--inputcheck` does more than just checks, it also adds non-BECCS CDR variables (`Emissions|CO2|Other`) to the CO2 emissions actually used in MAGICC.

## Type of change

- [X] Bug fix 