### PR TITLE
Limits on upscaling for enhanced weathering

### DIFF
--- a/main.gms
+++ b/main.gms
@@ -903,6 +903,12 @@ parameter
 ;
   cm_LimRock               = 1000;   !! def = 1000
 *'
+
+parameter
+  cm_33_EW_upScalingRateLimit    "Annual growth rate limit on upscaling of mining & spreading rocks on fields"
+;
+  cm_33_EW_upScalingRateLimit = 0.2;  !! def = 20% 
+
 parameter
   cm_expoLinear_yearStart   "time at which carbon price increases linearly instead of exponentially"
 ;

--- a/main.gms
+++ b/main.gms
@@ -909,6 +909,11 @@ parameter
 ;
   cm_33_EW_upScalingRateLimit = 0.2;  !! def = 20% 
 
+parameter 
+  cm_33_EW_shortTermLimit         "Limit on 2030 potential for enhanced weathering, defined as % of land on which EW is applied. Default 0.5% of land"
+;
+  cm_33_EW_shortTermLimit = 0.005; 
+
 parameter
   cm_expoLinear_yearStart   "time at which carbon price increases linearly instead of exponentially"
 ;

--- a/main.gms
+++ b/main.gms
@@ -907,7 +907,7 @@ parameter
 parameter
   cm_33_EW_upScalingRateLimit    "Annual growth rate limit on upscaling of mining & spreading rocks on fields"
 ;
-  cm_33_EW_upScalingRateLimit = 0.2;  !! def = 20% 
+  cm_33_EW_upScalingRateLimit = 0.2;  !! def = 20% !! regexp = is.nonnegative
 
 parameter 
   cm_33_EW_shortTermLimit         "Limit on 2030 potential for enhanced weathering, defined as % of land on which EW is applied. Default 0.5% of land"

--- a/main.gms
+++ b/main.gms
@@ -912,7 +912,7 @@ parameter
 parameter 
   cm_33_EW_shortTermLimit         "Limit on 2030 potential for enhanced weathering, defined as % of land on which EW is applied. Default 0.5% of land"
 ;
-  cm_33_EW_shortTermLimit = 0.005; 
+  cm_33_EW_shortTermLimit = 0.005; !! def = 0.5% !! regexp = is.nonnegative
 
 parameter
   cm_expoLinear_yearStart   "time at which carbon price increases linearly instead of exponentially"

--- a/modules/33_CDR/portfolio/datainput.gms
+++ b/modules/33_CDR/portfolio/datainput.gms
@@ -53,6 +53,9 @@ p33_LimRock(regi) = pm_pop("2005",regi) / sum(regi2,pm_pop("2005",regi2));
 *' Annual growth rate limit on upscaling of mining & spreading rocks on fields
 p33_EW_upScalingLimit(ttot) = cm_33_EW_upScalingRateLimit;
 
+*' Calculation of short term limit on rocks spread on field in terms of Gt rocks that can be spread. 
+p33_EW_shortTermEW_Limit(regi) = cm_33_EW_shortTermLimit * sum(rlf, f33_maxProdGradeRegiWeathering(regi, rlf));
+
 *** ocean alkalinity enhancement input data (Kowalczyk et al., 2024)
 
 !! An assumption; generally the efficiency might vary between 0.9-1.4 tCO2/tCaO (1.2-1.8 molCO2/molCaO),

--- a/modules/33_CDR/portfolio/datainput.gms
+++ b/modules/33_CDR/portfolio/datainput.gms
@@ -50,6 +50,9 @@ p33_fedem("weathering", "fedie") = 0.3;
 *' Factor distributing the global rock limit across regions according to population
 p33_LimRock(regi) = pm_pop("2005",regi) / sum(regi2,pm_pop("2005",regi2));
 
+*' Annual growth rate limit on upscaling of mining & spreading rocks on fields
+p33_EW_upScalingLimit(ttot) = cm_33_EW_upScalingRateLimit;
+
 *** ocean alkalinity enhancement input data (Kowalczyk et al., 2024)
 
 !! An assumption; generally the efficiency might vary between 0.9-1.4 tCO2/tCaO (1.2-1.8 molCO2/molCaO),

--- a/modules/33_CDR/portfolio/declarations.gms
+++ b/modules/33_CDR/portfolio/declarations.gms
@@ -24,6 +24,7 @@ p33_fedem(all_te,all_enty)               "final energy demand of each technology
 p33_LimRock(all_regi)                    "regional share of EW limit [fraction], calculated ex ante for a maximal annual amount of 8 Gt rock in D:\projects\CEMICS\paper_technical\supply_curve_transport_remind_regions.m"
 p33_co2_rem_rate(rlf)                    "carbon removal rate [fraction of annual reduction of total carbon removal potential], multiplied with grade factor"
 p33_EW_upScalingLimit(ttot)              "Annual growth rate limit on upscaling of mining & spreading rocks on fields"
+p33_EW_shortTermEW_Limit(all_regi)       "Limit on 2030 potential for enhanced weathering, defined in Gt rocks, based on % of land on which EW is applied"
 ;
 
 positive variables
@@ -56,6 +57,8 @@ q33_EW_FEdemand(ttot,all_regi,all_enty)  "calculates final energy demand from en
 q33_EW_potential(ttot,all_regi,rlf)  "limits the total potential of EW per region and grade"
 q33_EW_emi(ttot,all_regi)  "calculates amount of carbon captured by EW"
 q33_EW_LimEmi(ttot,all_regi)  "limits EW to a maximal annual amount of ground rock of cm_LimRock"
+q33_EW_upscaling_rate(ttot, all_regi) "limits spreading of rock to a steep but credible upscaling rate"
+q33_EW_ShortTermBound(ttot,all_regi)   "Limits short term potential for enhanced weathering"
 
 q33_OAE_FEdemand(ttot,all_regi,all_enty,all_te) "calculates final energy demand for ocean alkalinity enhancement"
 q33_OAE_co2emi_non_atm_calcination(ttot,all_regi,all_te)   "calculates the CO2 that comes from calcination (limestone decomposition)"

--- a/modules/33_CDR/portfolio/declarations.gms
+++ b/modules/33_CDR/portfolio/declarations.gms
@@ -23,6 +23,7 @@ parameters
 p33_fedem(all_te,all_enty)               "final energy demand of each technology [EJ/GtC] (for EW the unit is [EJ/Gt stone])"
 p33_LimRock(all_regi)                    "regional share of EW limit [fraction], calculated ex ante for a maximal annual amount of 8 Gt rock in D:\projects\CEMICS\paper_technical\supply_curve_transport_remind_regions.m"
 p33_co2_rem_rate(rlf)                    "carbon removal rate [fraction of annual reduction of total carbon removal potential], multiplied with grade factor"
+p33_EW_upScalingLimit(ttot)              "Annual growth rate limit on upscaling of mining & spreading rocks on fields"
 ;
 
 positive variables

--- a/modules/33_CDR/portfolio/equations.gms
+++ b/modules/33_CDR/portfolio/equations.gms
@@ -190,6 +190,16 @@ q33_EW_LimEmi(t,regi)..
     cm_LimRock * p33_LimRock(regi)
     ;
 	
+***---------------------------------------------------------------------------
+*' Limits on the upscaling rate of mining and spreading of rocks. 
+*' Current cost parameters do not include cost of additional mining being developed, 
+*' thus adjustment cost are not effective.
+***---------------------------------------------------------------------------	
+q33_EW_upscaling_rate(ttot,regi)$(ord(ttot) lt card(ttot) AND pm_ttot_val(ttot) gt 2030)..
+   sum((rlf_cz33, rlf), v33_EW_onfield(ttot,regi,rlf_cz33,rlf))
+    =l=
+   (1+p33_EW_upScalingLimit(ttot))**pm_dt(ttot) * sum((rlf_cz33, rlf), v33_EW_onfield(ttot-1,regi,rlf_cz33,rlf))
+;
 
 ***---------------------------------------------------------------------------
 *' #### OAE equations

--- a/modules/33_CDR/portfolio/equations.gms
+++ b/modules/33_CDR/portfolio/equations.gms
@@ -189,7 +189,17 @@ q33_EW_LimEmi(t,regi)..
     =l=
     cm_LimRock * p33_LimRock(regi)
     ;
-	
+
+***---------------------------------------------------------------------------
+*' Short term bound on spreading of rock
+***---------------------------------------------------------------------------
+
+q33_EW_ShortTermBound(t, regi)$(t.val eq 2030)..
+    sum((rlf_cz33, rlf), v33_EW_onfield(t,regi,rlf_cz33,rlf))
+    =l=
+    p33_EW_shortTermEW_Limit(regi) 
+    ;
+
 ***---------------------------------------------------------------------------
 *' Limits on the upscaling rate of mining and spreading of rocks. 
 *' Current cost parameters do not include cost of additional mining being developed, 


### PR DESCRIPTION
## Purpose of this PR
This PR adds two constraints for the upscaling of enhanced weathering:

**(1) Short term limit for rock spreading:** 
Spreading of rock for EW is set to 0 until 2025, and the 2030 time step was left largely unconstrained. Now, _**q33_EW_ShortTermBound**_ limits the maximum amount of rock spread per year in 2030 (aggregate across climate and transport grades).
_**cm_33_EW_shortTermLimit**_ defines the share of the total rock-on-field capacity of each region that is assumed possible to be used already in 2030. In default, cm_33_EW_shortTermLimit is set to 0.005, i.e. in 2030 it is assumed that 
rocks are spread on maximum 0.5% of fields.

**(2) explicit maximum upscaling rate for rock spreading:** 
The current parametrization assumes the use of existing infrastructure. Thus, the CAPEX for mining, grinding, and 
spreading are so low that the adjustment cost do not constrain upscaling. This leads to very high upscaling rates 
of >50% per year in some regions. At the scales reached, the use of existing infrastructure is not realistic in many regions. 
We want to update the parametrization of cost (see [issue 329](https://github.com/remindmodel/development_issues/issues/329)). However, there is no easily accessible data such that a cost-based adjustment cannot be made short term.
In the meantime, we thus implement _**q33_EW_upscaling_rate**_ that limits the upscaling of total annual rock spreading (v33_EW_onfield) based on ah explicitly set maximum upscaling rate. 
The maximum annual rate can be changed through **_cm_33_EW_upScalingRateLimit_**. The default is 20%

Through these two changes, enhanced weathering in PB650 runs scales up later and slower, but to approximately the same level.

## Type of change
- [x] Bug fix 
- [x] New feature 
- [x] Minor change (default scenarios show only small differences)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Test runs are here: /p/tmp/tabeado/EW_upscalingLimit/remind
* Comparison of results (what changes by this PR?): /p/tmp/tabeado/EW_upscalingLimit/remind/compScen-PB650main-2024-10-15_11.06.42-CDR.pdf

