### PR TITLE
remove AR6 from checkProjectSummations, not needed anymore

### DIFF
--- a/scripts/output/single/checkProjectSummations.R
+++ b/scripts/output/single/checkProjectSummations.R
@@ -34,7 +34,6 @@ missingVariables <- checkMissingVars(mifdata, TRUE, sources)
 if (length(missingVariables) > 0) message("Check piamInterfaces::variableInfo('variablename') etc.")
 
 checkMappings <- list( # list(mappings, summationsFile, skipBunkers)
-  list(c("AR6", "AR6_NGFS"), "AR6", TRUE),
   list(c("NAVIGATE", "ELEVATE"), "NAVIGATE", FALSE),
   list("ScenarioMIP", NULL, FALSE)
 )


### PR DESCRIPTION
## Purpose of this PR

- remove AR6 from checkProjectSummations, not needed anymore
- the existence of piam_variables will still be checked by line 33

## Type of change

- [x] Remove feature

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
