### PR TITLE
new input data rev7.1 and CES parameter and gdx files for SSP2, SSP2-EU21, SSP1, SSP2_lowEn, SSP5

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -28,10 +28,10 @@ cfg$regionmapping <- "config/regionmappingH12.csv"
 cfg$extramappings_historic <- ""
 
 #### Current input data revision (<mainrevision>.<subrevision>) ####
-cfg$inputRevision <- "6.99"
+cfg$inputRevision <- "7.1"
 
 #### Current CES parameter and GDX revision (commit hash) ####
-cfg$CESandGDXversion <- "26e9d6764caa46c1e1cdedbaae68ddfe122afd29"
+cfg$CESandGDXversion <- "f75d13da9c2efe3ffd2eaa5dbc29f98a8e87a6b8"
 
 #### Force the model to download new input data ####
 cfg$force_download <- FALSE


### PR DESCRIPTION

## Purpose of this PR
new input data rev7.1 and new CES parameter and gdx files for input data rev7.1 for SSP2, SSP2-EU21, SSP1, SSP2_lowEn and SSP5, 
calibration runs: /p/tmp/lavinia/REMIND/REMIND_calibration_2024_10_24/remind/output

## Type of change

- [x] Minor change (default scenarios show only small differences)


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code


## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

