### PR TITLE
add support for switch to force monotonously decreasing solids fossil use per region

### DIFF
--- a/core/declarations.gms
+++ b/core/declarations.gms
@@ -565,6 +565,9 @@ $IFTHEN.sehe_upper not "%cm_sehe_upper%" == "off"
 q_heat_limit(ttot,all_regi)  "equation to limit maximum level of secondary energy district heating and heat pumps use"
 $ENDIF.sehe_upper
 
+$ifthen.limitSolidsFossilRegi not %cm_limitSolidsFossilRegi% == "off"
+  q_fossilSolidsLimitReg(ttot,all_regi,all_enty,all_enty,emi_sectors,all_emiMkt)  "limit solids fossil to be lower or equal to previous year values"
+$endif.limitSolidsFossilRegi
 ;
 ***----------------------------------------------------------------------------------------
 ***                                   SCALARS

--- a/core/declarations.gms
+++ b/core/declarations.gms
@@ -566,7 +566,7 @@ q_heat_limit(ttot,all_regi)  "equation to limit maximum level of secondary energ
 $ENDIF.sehe_upper
 
 $ifthen.limitSolidsFossilRegi not %cm_limitSolidsFossilRegi% == "off"
-  q_fossilSolidsLimitReg(ttot,all_regi,all_enty,all_enty,emi_sectors,all_emiMkt)  "limit solids fossil to be lower or equal to previous year values"
+  q_fossilSolidsLimitReg(ttot,all_regi,all_enty,all_enty,emi_sectors,all_emiMkt)  "limit solids fossil to be lower or equal to previous year values in each (sector x emiMkt) combination"
 $endif.limitSolidsFossilRegi
 ;
 ***----------------------------------------------------------------------------------------

--- a/core/equations.gms
+++ b/core/equations.gms
@@ -1133,7 +1133,7 @@ q_shbiofe_lo(t,regi,entyFe,sector,emiMkt)$(pm_secBioShare(t,regi,entyFe,sector) 
 $ifthen.limitSolidsFossilRegi not %cm_limitSolidsFossilRegi% == "off"
 q_fossilSolidsLimitReg(ttot,regi,entySe,entyFe,sector,emiMkt)$(limitSolidsFossilRegi(regi) and (ttot.val ge max(2020, cm_startyear)) AND sefe(entySe,entyFe) AND sector2emiMkt(sector,emiMkt) AND (sameas(sector,"indst") OR sameas(sector,"build")) AND sameas(entySe,"sesofos"))..
   vm_demFeSector_afterTax(ttot,regi,entySe,entyFe,sector,emiMkt)
-  =l=
+  =le=
   vm_demFeSector_afterTax(ttot-1,regi,entySe,entyFe,sector,emiMkt);
 $endif.limitSolidsFossilRegi
 

--- a/core/equations.gms
+++ b/core/equations.gms
@@ -1127,4 +1127,14 @@ q_shbiofe_lo(t,regi,entyFe,sector,emiMkt)$(pm_secBioShare(t,regi,entyFe,sector) 
   sum((entySeBio,te)$se2fe(entySeBio,entyFe,te), vm_demFeSector_afterTax(t,regi,entySeBio,entyFe,sector,emiMkt))
 ;
 
+***---------------------------------------------------------------------------
+*' Limit solids fossil to be lower or equal to previous year values  
+***---------------------------------------------------------------------------
+$ifthen.limitSolidsFossilRegi not %cm_limitSolidsFossilRegi% == "off"
+q_fossilSolidsLimitReg(ttot,regi,entySe,entyFe,sector,emiMkt)$(limitSolidsFossilRegi(regi) and (ttot.val ge max(2020, cm_startyear)) AND sefe(entySe,entyFe) AND sector2emiMkt(sector,emiMkt) AND (sameas(sector,"indst") OR sameas(sector,"build")) AND sameas(entySe,"sesofos"))..
+  vm_demFeSector_afterTax(ttot,regi,entySe,entyFe,sector,emiMkt)
+  =l=
+  vm_demFeSector_afterTax(ttot-1,regi,entySe,entyFe,sector,emiMkt);
+$endif.limitSolidsFossilRegi
+
 *** EOF ./core/equations.gms

--- a/core/sets.gms
+++ b/core/sets.gms
@@ -922,6 +922,15 @@ set
 ;
 $endif.altFeEmiFac
 
+$ifthen.limitSolidsFossilRegi not %cm_limitSolidsFossilRegi% == "off"
+  set limitSolidsFossilextRegi(ext_regi) "set to store ext_regi regions that should have solids fossil upper bound limited by previous year" / %cm_limitSolidsFossilRegi% /
+      limitSolidsFossilRegi(all_regi)    "set to store regi regions that should have solids fossil upper bound limited by previous year"
+  ;
+  loop(ext_regi$limitSolidsFossilextRegi(ext_regi),
+    limitSolidsFossilRegi(all_regi)$(regi_group(ext_regi,all_regi)) = YES;
+  );
+$endif.limitSolidsFossilRegi
+
 ***###############################################################################
 ***######################## R SECTION START (MODULES) ###############################
 *** THIS CODE IS CREATED AUTOMATICALLY, DO NOT MODIFY THESE LINES DIRECTLY

--- a/core/sets.gms
+++ b/core/sets.gms
@@ -923,8 +923,8 @@ set
 $endif.altFeEmiFac
 
 $ifthen.limitSolidsFossilRegi not %cm_limitSolidsFossilRegi% == "off"
-  set limitSolidsFossilextRegi(ext_regi) "set to store ext_regi regions that should have solids fossil upper bound limited by previous year" / %cm_limitSolidsFossilRegi% /
-      limitSolidsFossilRegi(all_regi)    "set to store regi regions that should have solids fossil upper bound limited by previous year"
+  set limitSolidsFossilextRegi(ext_regi) "set to store ext_regi regions where fossil solids use in each (sector x emiMkt) is limited by the amount used in the previous year" / %cm_limitSolidsFossilRegi% /
+      limitSolidsFossilRegi(all_regi)    "set to store regi regions where fossil solids use in each (sector x emiMkt) is limited by the amount used in the previous year"
   ;
   loop(ext_regi$limitSolidsFossilextRegi(ext_regi),
     limitSolidsFossilRegi(all_regi)$(regi_group(ext_regi,all_regi)) = YES;

--- a/main.gms
+++ b/main.gms
@@ -1762,6 +1762,9 @@ $setglobal cm_INCONV_PENALTY_FESwitch  on !! def = on  !! regexp = off|on
 *** *JH/LB* Activate MOFEX partial fossil fuel extraction cost minimization model
 *** * Warning: Use a well-converged run since the model uses vm_prodPe from the input GDX
 $setGlobal cm_MOFEX  off        !! def = off  !! regexp = off|on
+*** cm_limitSolidsFossilRegi off   !! def=off
+*** ext_regi value, e.g. "EUR_regi, USA"   "solids fossil in industry and buildings for regions within EUR_regi and USA are forced to be monotonuosly decreasing from 2020 or cm_startyear onward."
+$setGlobal cm_limitSolidsFossilRegi off
 *** cm_Full_Integration
 ***    use "on" to treat wind and solar as fully dispatchable electricity production technologies
 $setGlobal cm_Full_Integration  off     !! def = off  !! regexp = off|on

--- a/main.gms
+++ b/main.gms
@@ -1763,7 +1763,9 @@ $setglobal cm_INCONV_PENALTY_FESwitch  on !! def = on  !! regexp = off|on
 *** * Warning: Use a well-converged run since the model uses vm_prodPe from the input GDX
 $setGlobal cm_MOFEX  off        !! def = off  !! regexp = off|on
 *** cm_limitSolidsFossilRegi off   !! def=off
-*** ext_regi value, e.g. "EUR_regi, USA"   "solids fossil in industry and buildings for regions within EUR_regi and USA are forced to be monotonuosly decreasing from 2020 or cm_startyear onward."
+*** starting in max(2020, cm_startyear), fossil solids use in each (sector x emiMkt) has to decrease compared to the previous time step for each region included in the switch cm_limitSolidsFossilRegi
+*** aceptable values: any of the ext_regi set elements
+*** e.g. "EUR_regi, USA"  "solids fossil in industry and buildings for regions within EUR_regi and USA have to be lower or equal to the previous time step from 2020 or cm_startyear onward."
 $setGlobal cm_limitSolidsFossilRegi off
 *** cm_Full_Integration
 ***    use "on" to treat wind and solar as fully dispatchable electricity production technologies


### PR DESCRIPTION
## Purpose of this PR

- Add switch to force monotonously decreasing solids fossil use per region to avoid zig-zag temporal behavior in the model for decarbonization scenarios

## Type of change

- [x] New feature 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)

## Further information (optional):

* Test runs are here: 
`/p/projects/ecemf/REMIND/2040_scenarios/_mergeTest/remind_seFeSectorSharePenalization_2025/output`

