### PR TITLE
input data rev7.11, new CES parameters for SSP2, SSP2-EU21, SSP1, SSP2_lowEn, SSP5

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -28,10 +28,10 @@ cfg$regionmapping <- "config/regionmappingH12.csv"
 cfg$extramappings_historic <- ""
 
 #### Current input data revision (<mainrevision>.<subrevision>) ####
-cfg$inputRevision <- "7.1"
+cfg$inputRevision <- "7.11"
 
 #### Current CES parameter and GDX revision (commit hash) ####
-cfg$CESandGDXversion <- "f75d13da9c2efe3ffd2eaa5dbc29f98a8e87a6b8"
+cfg$CESandGDXversion <- "84b10b9308f97fae38923762b840b8dffd456568"
 
 #### Force the model to download new input data ####
 cfg$force_download <- FALSE


### PR DESCRIPTION
## Purpose of this PR
* new input data rev7.11 
* new CES parameters and gdx files for SSP2, SSP2-EU21, SSP1, SSP2_lowEn and SSP5, calibration runs here: /p/tmp/lavinia/REMIND/REMIND_calibration_2024_11_04/remind/

## Type of change

- [x] Minor change (default scenarios show only small differences)
- [ ] Fundamental change
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

