### PR TITLE
Set new default values for cm_seFeSectorShareDevMethod

### DIFF
--- a/main.gms
+++ b/main.gms
@@ -1770,7 +1770,7 @@ $setglobal cm_INCONV_PENALTY_FESwitch  on !! def = on  !! regexp = off|on
 ***  sqSectorAvrgShare "Square deviation from average share penalty. Recomended over sqSectorShare (see above)."
 ***  minMaxAvrgShare   "Min-max deviation from average share penalty."
 *** The relative effect of the penalization term in the objective function is scaled to avoid affecting optimization results. This scaling factor can be defined using the switch c_seFeSectorShareDevScale.
-$setglobal cm_seFeSectorShareDevMethod  off !! def = sqSectorAvrgShare  !! regexp = off|sqSectorShare|sqSectorAvrgShare|minMaxAvrgShare
+$setglobal cm_seFeSectorShareDevMethod  sqSectorAvrgShare !! def = sqSectorAvrgShare  !! regexp = off|sqSectorShare|sqSectorAvrgShare|minMaxAvrgShare
 *** c_seFeSectorShareDevUnit "Defines if the penalization term is applied over fuel shares or energy units." 
 ***  share,  "The square penalization is applied directly to the share values. This results in different-sized regions having varying relative penalization incentives, but the range of penalization values will be more consistent from the solver's perspective."
 ***  energy, "The square penalization is applied to the share values multiplied by the energy demand. This approach scales penalizations better across different-sized regions, but there is a higher risk of the penalizations being ignored and the shares not being enforced if the value range is too small."


### PR DESCRIPTION
## Purpose of this PR

- This PR updates the default value for `cm_seFeSectorShareDevMethod` to improve consistency in sectoral emissions by reducing the model's flexibility to shift biomass and synthetic fuel usage across sectors.
- The default setting for `cm_seFeSectorShareDevMethod` is now `sqSectorAvrgShare` for REMIND runs.
- Detailed formulation changes are documented in [PR #1762 on GitHub](https://github.com/remindmodel/remind/pull/1762).
- This change addresses [issue #322 in development_issues](https://github.com/remindmodel/development_issues/issues/322).

## Type of change

- [x] Fundamental change

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)

## Further information (optional):

* Test runs are here: 
- Still need to be made

