### PR TITLE
MAgPIE coupling: use defaults from MAgPIE's default.cfg for list of MAgPIE outputs

### DIFF
--- a/start_coupled.R
+++ b/start_coupled.R
@@ -42,7 +42,6 @@ start_coupled <- function(path_remind, path_magpie, cfg_rem, cfg_mag, runname, m
   cfg_mag <- check_config(cfg_mag, file.path(path_magpie, "config", "default.cfg"), file.path(path_magpie,"modules"))
   cfg_mag$sequential <- TRUE
   cfg_mag$force_replace <- TRUE
-  cfg_mag$output     <- c("rds_report") # ,"remind","report") # rds_report: MAgPIE4; remind,report: MAgPIE3 (glo.modelstat.csv)
   # if provided use ghg prices for land (MAgPIE) from a different REMIND run than the one MAgPIE runs coupled to
   use_external_ghgprices <- ifelse(is.na(cfg_mag$path_to_report_ghgprices), FALSE, TRUE)
 


### PR DESCRIPTION
## Purpose of this PR

So far the couplig did not use the list of output scripts as defined in MAgPIE's default.cfg, instead only `rds_report` was specified explicitely overwriting the defaults. Since the list of required/useful output scripts change from time to time we switch to using the defaults from MAgPIE's default.cfg, now including `extra/disaggregation`.