### PR TITLE
fix BECCS capacities in 2020 to zero

### DIFF
--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -288,7 +288,7 @@ loop(te$(sameas(te,"ngcc") OR sameas(te,"ngt") OR sameas(te,"gaschp")),
   vm_cap.lo("2020",regi,te,"1")$pm_histCap("2020",regi,te) = 0.95 * pm_histCap("2020",regi,te);
 );
 
-*** fix capacities for BECCS technologies to  zero in 2020
+*** fix capacities for advanced bio carbon capture technologies to zero in 2020 (i.e. no BECCS in 2020)
 vm_cap.fx("2020",regi,te,rlf)$(sameas(te,"bioigccc") OR sameas(te,"bioftcrec") OR sameas(te,"bioh2c") OR sameas(te,"biogasc")) = 0;
 
 *** fix emissions to historical emissions in 2010

--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -288,6 +288,9 @@ loop(te$(sameas(te,"ngcc") OR sameas(te,"ngt") OR sameas(te,"gaschp")),
   vm_cap.lo("2020",regi,te,"1")$pm_histCap("2020",regi,te) = 0.95 * pm_histCap("2020",regi,te);
 );
 
+*** fix capacities for BECCS technologies to  zero in 2020
+vm_cap.fx("2020",regi,te,rlf)$(sameas(te,"bioigccc") OR sameas(te,"bioftcrec") OR sameas(te,"bioh2c") OR sameas(te,"biogasc")) = 0;
+
 *** fix emissions to historical emissions in 2010
 *** RP: turned off in March 2018, as it produces substantial negative side-effects (requiring strong early retirement in 2010, which influences the future investments even in Reference scenarios)
 *** vm_emiTe.up("2010",regi,"co2") = p_boundEmi("2010",regi) ;

--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -289,7 +289,7 @@ loop(te$(sameas(te,"ngcc") OR sameas(te,"ngt") OR sameas(te,"gaschp")),
 );
 
 *** fix capacities for advanced bio carbon capture technologies to zero in 2020 (i.e. no BECCS in 2020)
-vm_cap.fx("2020",regi,te,rlf)$(sameas(te,"bioigccc") OR sameas(te,"bioftcrec") OR sameas(te,"bioh2c") OR sameas(te,"biogasc")) = 0;
+vm_cap.fx("2020",regi,te,rlf)$(teBio(te) AND teCCS(te)) = 0;
 
 *** fix emissions to historical emissions in 2010
 *** RP: turned off in March 2018, as it produces substantial negative side-effects (requiring strong early retirement in 2010, which influences the future investments even in Reference scenarios)


### PR DESCRIPTION
## Purpose of this PR
Currently, all operating CCS projects are set as bounds for 2020 and REMIND decides freely about which capture technologies to use. globally, the split is about 50:50 for BECCS and fossil CCS, leading to 20Mt BECCS in 2020 and 27 Mt in 2025. 
However, in 2020 there were 3 BECCS plants in the USA (ethanol+CC, which we don't model), which total a maximum of 1 Mt captured, and one in Japan (bioigccc with 0.18 Mt).
We thus set vm_cap for all BECCS technologies to 0 in 2020.

For policy runs, this does not make a difference. However, in NPis the head-start for BECCS makes a big difference.

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Minor change (default scenarios show only small differences)

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)

## Further information (optional):
See this [development issue](https://github.com/remindmodel/development_issues/issues/402) for effects on NPi
