### PR TITLE
Minor parameter adjustments to process-based dri-eaf steel route

### DIFF
--- a/modules/37_industry/subsectors/datainput.gms
+++ b/modules/37_industry/subsectors/datainput.gms
@@ -604,7 +604,7 @@ $ifthen.cm_subsec_model_steel "%cm_subsec_model_steel%" == "processes"
 !! carbon capture mass is given in tCO2 and converted to tC after that
 
 !! reduction: 504 m^3; heat 242 m^3; conversion: x / 11.126 m^3/kg * 0.0333 MWh/kg
-p37_specFeDemTarget("feh2s","idr","h2")           = 2.09 / (sm_TWa_2_MWh/sm_giga_2_non);    !! Source: POSTED / Rechberger et al 2020, Section 4.2 (per tDRI)
+p37_specFeDemTarget("feh2s","idr","h2")           = 2.23 / (sm_TWa_2_MWh/sm_giga_2_non);    !! Source: POSTED / Rechberger et al 2020, Section 4.2 (per tDRI)
 p37_specFeDemTarget("feels","idr","h2")           = 0.08 / (sm_TWa_2_MWh/sm_giga_2_non);    !! Source: POSTED / Hölling et al 2017, Just before Table 1 (per tHBI)
 
 p37_specFeDemTarget("fegas","idr","ng")           = 2.69 / (sm_TWa_2_MWh/sm_giga_2_non);    !! Source: POSTED / Hölling et al 2017, Page 7 (9.7 GJ) (per tHBI)

--- a/modules/37_industry/subsectors/datainput.gms
+++ b/modules/37_industry/subsectors/datainput.gms
@@ -604,7 +604,7 @@ $ifthen.cm_subsec_model_steel "%cm_subsec_model_steel%" == "processes"
 !! carbon capture mass is given in tCO2 and converted to tC after that
 
 !! reduction: 504 m^3; heat 242 m^3; conversion: x / 11.126 m^3/kg * 0.0333 MWh/kg
-p37_specFeDemTarget("feh2s","idr","h2")           = 2.23 / (sm_TWa_2_MWh/sm_giga_2_non);    !! Source: POSTED / Rechberger et al 2020, Section 4.2 (per tDRI)
+p37_specFeDemTarget("feh2s","idr","h2")           = 2.09 / (sm_TWa_2_MWh/sm_giga_2_non);    !! Source: POSTED / Rechberger et al 2020, Section 4.2 (per tDRI)
 p37_specFeDemTarget("feels","idr","h2")           = 0.08 / (sm_TWa_2_MWh/sm_giga_2_non);    !! Source: POSTED / Hölling et al 2017, Just before Table 1 (per tHBI)
 
 p37_specFeDemTarget("fegas","idr","ng")           = 2.69 / (sm_TWa_2_MWh/sm_giga_2_non);    !! Source: POSTED / Hölling et al 2017, Page 7 (9.7 GJ) (per tHBI)
@@ -614,8 +614,8 @@ p37_specFeDemTarget("feels","idr","ng")           = 0.08 / (sm_TWa_2_MWh/sm_giga
 !! Birat2010, p. 11: 0.97 MWh total, only 0.44 MWh of which is electrical
 !! EU JRC BAT says 0.404–0.748 (only EAF, elec) / Otto et al. say 0.92
 !! --> have declining curve?
-p37_specFeDemTarget("feels","eaf","pri")          = 0.67 / (sm_TWa_2_MWh/sm_giga_2_non);    !! Source: POSTED / Copy from secondary (Agora Energiewende, 2022 give similar values, between w and w/o reheating)
-p37_specFeDemTarget("feels","eaf","sec")          = 0.67 / (sm_TWa_2_MWh/sm_giga_2_non);    !! Source: POSTED / Vogl et al 2018, Section 3.1
+p37_specFeDemTarget("feels","eaf","pri")          = 0.75 / (sm_TWa_2_MWh/sm_giga_2_non);    !! Source: POSTED / Vogl et al 2018, Section 3.1 
+p37_specFeDemTarget("feels","eaf","sec")          = 0.67 / (sm_TWa_2_MWh/sm_giga_2_non);    !! Source: POSTED / Vogl et al 2018, Section 3.1 / EAF from scrap requires less energy.
 
 !! Otto et al. Fig 3: 10.303 GJ coke (from 13.24 GJ coal, see Menendez2015 Fig 3) + 4.67 GJ coal dust -> 18 GJ
 !! Birat2010, p.11 says best performers have 17 GJ, out of which 16 GJ coal

--- a/modules/37_industry/subsectors/datainput.gms
+++ b/modules/37_industry/subsectors/datainput.gms
@@ -610,12 +610,17 @@ p37_specFeDemTarget("feels","idr","h2")           = 0.08 / (sm_TWa_2_MWh/sm_giga
 p37_specFeDemTarget("fegas","idr","ng")           = 2.69 / (sm_TWa_2_MWh/sm_giga_2_non);    !! Source: POSTED / Hölling et al 2017, Page 7 (9.7 GJ) (per tHBI)
 p37_specFeDemTarget("feels","idr","ng")           = 0.08 / (sm_TWa_2_MWh/sm_giga_2_non);    !! Source: POSTED / Hölling et al 2017, Page 7 (9.7 GJ) (per tHBI)
 
-!! To do: Does not include casting and rolling;
+!! From Vogl et al 2018 (Section 3.1), primary DRI requires 0.75 MWh/t, and secondary DRI 0.67 MWh/t.
+!! Casting and rolling requires an additional 0.01 and 0.105 MWh/t of electricity demand, respectively (IEA GHG 2013).
+!! Casting and rolling also requires heat, which we assume to come from ng: 0.006 and 0.468 MWh/t, respectively (IEA GHG 2013)
 !! Birat2010, p. 11: 0.97 MWh total, only 0.44 MWh of which is electrical
 !! EU JRC BAT says 0.404–0.748 (only EAF, elec) / Otto et al. say 0.92
 !! --> have declining curve?
-p37_specFeDemTarget("feels","eaf","pri")          = 0.75 / (sm_TWa_2_MWh/sm_giga_2_non);    !! Source: POSTED / Vogl et al 2018, Section 3.1 
-p37_specFeDemTarget("feels","eaf","sec")          = 0.67 / (sm_TWa_2_MWh/sm_giga_2_non);    !! Source: POSTED / Vogl et al 2018, Section 3.1 / EAF from scrap requires less energy.
+p37_specFeDemTarget("feels","eaf","pri")          = 0.87 / (sm_TWa_2_MWh/sm_giga_2_non);    !! Source: POSTED / Vogl et al 2018, Section 3.1 and IEAGHG 2013, Vol 1 Section D Table D-13 and D-15 
+p37_specFeDemTarget("feels","eaf","sec")          = 0.79 / (sm_TWa_2_MWh/sm_giga_2_non);    !! Source: POSTED / Vogl et al 2018, Section 3.1 and IEAGHG 2013, Vol 1 Section D Table D-13 and D-15
+
+p37_specFeDemTarget("fegas","eaf","pri")          = 0.47 / (sm_TWa_2_MWh/sm_giga_2_non);    !! Source: POSTED / IEA GHG 2013, Vol 1 Section D Table D-13 and D-15
+p37_specFeDemTarget("fegas","eaf","sec")          = 0.47 / (sm_TWa_2_MWh/sm_giga_2_non);    !! Source: POSTED / IEA GHG 2013, Vol 1 Section D Table D-13 and D-15
 
 !! Otto et al. Fig 3: 10.303 GJ coke (from 13.24 GJ coal, see Menendez2015 Fig 3) + 4.67 GJ coal dust -> 18 GJ
 !! Birat2010, p.11 says best performers have 17 GJ, out of which 16 GJ coal


### PR DESCRIPTION
## Purpose of this PR

I made some corrections to dri-eaf parameters in process-based steel based on POSTED literature, and also added the additional electricity and heat demand for casting and rolling to eaf (this was already included in the bf-bof route).

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [ ] Bug fix 
- [ ] Refactoring
- [ ] New feature 
- [x] Minor change (default scenarios show only small differences)
- [ ] Fundamental change
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Changes to process-based steel:
Uptake of DRI-NG / DRI-NG-CCS is reduced and replaced by a larger uptake of H2-DRI, and some small amount of BF-BOF-CCS (especially in MEA).
![image](https://github.com/user-attachments/assets/d56f1d8c-c16b-49dc-ad56-ded3252413cb)
