### PR TITLE
Hotfix: restrict 1st gen. biofuels from 2030 on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **scripts** REMIND-MAgPIE start scripts now correctly use all non-gms cfg switches
     [[#1768](https://github.com/remindmodel/remind/pull/1768)]
 - **scripts** limit slurm runtime of output.R scripts to 2 hours
-    [[1783](https://github.com/remindmodel/remind/pull/1783)]
+    [[#1783](https://github.com/remindmodel/remind/pull/1783)]
+- **30_biomass** reset 1st gen. biofuel bound from 2045 to 2030
+    [[#1890](https://github.com/remindmodel/remind/pull/1890)]
 
 ### removed
 - **45_carbonprice** removed superseded realizations linear, exponential and diffCurvPhaseIn2Lin

--- a/modules/30_biomass/magpie_40/bounds.gms
+++ b/modules/30_biomass/magpie_40/bounds.gms
@@ -10,20 +10,24 @@
 *** -------------------------------------------------------------
 *'  #### Bounds on 1st generation biomass annual production
 *** -------------------------------------------------------------
-
-*' Prescribe upper and lower limit for first generation biomass from 2045 on, so REMIND has freedom before.
-*' To avoid infeasibilities it was necessary to modify the initial vintage structure for bioeths.
-*' FS: changed the bounds to start only in 2045 in REMIND-EU to rule out some infeasibilities with EDGE-T
-*'
-vm_fuExtr.up(t,regi,"pebios","5")$(t.val ge 2045)  = p30_datapebio(regi,"pebios","5","maxprod",t);
-vm_fuExtr.up(t,regi,"pebioil","5")$(t.val ge 2045) = p30_datapebio(regi,"pebioil","5","maxprod",t);
+*' Prescribe upper and lower limit for first generation biomass from 2030 on,
+*' so REMIND has some freedom before. After 2030 the production of 1st
+*' generation biofuels should be fixed (within a 90-100% range to avoid
+*' infeasibilities), since production values are exogenously harmonized with
+*' MAgPIE.
+*' Note: these bounds need to be updated since they are, in some regions, too
+*' strict to be compatible with historically installed capacities, such that
+*' the bounds in its current form can only be satisfied in combination with
+*' early retirement.
+vm_fuExtr.up(t,regi,"pebios","5")$(t.val ge 2030)  = p30_datapebio(regi,"pebios","5","maxprod",t);
+vm_fuExtr.up(t,regi,"pebioil","5")$(t.val ge 2030) = p30_datapebio(regi,"pebioil","5","maxprod",t);
 
 if(cm_1stgen_phaseout=0,
-    vm_fuExtr.lo(t,regi,"pebios","5")$(t.val ge 2045)  = 0.9 * p30_datapebio(regi,"pebios","5","maxprod",t);
-    vm_fuExtr.lo(t,regi,"pebioil","5")$(t.val ge 2045) = 0.9 * p30_datapebio(regi,"pebioil","5","maxprod",t);
+    vm_fuExtr.lo(t,regi,"pebios","5")$(t.val ge 2030)  = 0.9 * p30_datapebio(regi,"pebios","5","maxprod",t);
+    vm_fuExtr.lo(t,regi,"pebioil","5")$(t.val ge 2030) = 0.9 * p30_datapebio(regi,"pebioil","5","maxprod",t);
 else                                                     
-    vm_fuExtr.lo(t,regi,"pebios","5")$(t.val eq 2045)  = 0.9 * p30_datapebio(regi,"pebios","5","maxprod",t);
-    vm_fuExtr.lo(t,regi,"pebioil","5")$(t.val eq 2045) = 0.9 * p30_datapebio(regi,"pebioil","5","maxprod",t);
+    vm_fuExtr.lo(t,regi,"pebios","5")$(t.val eq 2030)  = 0.9 * p30_datapebio(regi,"pebios","5","maxprod",t);
+    vm_fuExtr.lo(t,regi,"pebioil","5")$(t.val eq 2030) = 0.9 * p30_datapebio(regi,"pebioil","5","maxprod",t);
 );
 
 


### PR DESCRIPTION
## Purpose of this PR
This PR resets the bounds on 1st generation biofuels (that are exogenously prescribed and harmonized with MAgPIE) such that they are correctly applied already from 2030 on instead of only from 2045 on. This solves the [issue](https://github.com/remindmodel/development_issues/issues/350) of excessive 1st generation biofuel production in between 2030 and 2045.
This PR is only a hotfix, as it comes with the caveat that Baseline runs (and other runs that do not allow for early retirement of technologies) will be infeasible, since the bounds themselves are outdated and partially too low to reflect historic capacities.

Apart from that there is the problem (has been there before, though) that some regions phase out some capacities of `pebioil` and `pebios` technologies even in historic time steps (i.e. before 2020, see [here](https://github.com/remindmodel/development_issues/issues/350#issuecomment-2490666412)). 

In a follow-up process, these bounds need to be adjusted such that they a) do not violate historic capacities, b) are in line with current policies (e.g. limits set by the EU) and c) are better in line with updated data on 1st gen. biofuel sustainability constraints (which is the main motivation for limiting 1st gen. biofuels).
Once that is done, I would suggest to constrain REMIND such that early retirement in historic time steps is forbidden.

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix 
- [ ] Refactoring
- [ ] New feature 
- [ ] Minor change (default scenarios show only small differences)
- [x] Fundamental change
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed (NA)
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches (NA)
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Test runs are here: 
`/p/tmp/merfort/REMIND_bugfix_1stgen/remind`
This fix has quite some impacts on the model results in runs with a tight carbon budget.

PkBudg500:
![image](https://github.com/user-attachments/assets/b466e207-4d6c-400b-a165-95401f0feff2)
Red: original REMIND version, bound only applied in 2045
Green: new, bound applied from 2030 on
Blue: new, bound applied from 2030on + phase-out afterwards (cm_1stgen_phaseout <- 1)

PkBudg650:
![image](https://github.com/user-attachments/assets/068b7955-da11-4f65-9602-23b6b3b8ef6a)
Red: original REMIND version, bound only applied in 2045
Green: new, bound applied from 2030 on
Blue: new, bound applied from 2030on + phase-out afterwards (cm_1stgen_phaseout <- 1)

For a more detailed discussion on the changes, please refer to the respective [issue](https://github.com/remindmodel/development_issues/issues/350).

