### PR TITLE
Use the maximum specific energy demand of 2015/2020 to calculate the lower limit of industry subsector specific energy demand for policy scenarios

### DIFF
--- a/modules/37_industry/subsectors/datainput.gms
+++ b/modules/37_industry/subsectors/datainput.gms
@@ -154,10 +154,14 @@ loop (industry_ue_calibration_target_dyn37(out),
 
     !! calculate slope
     p37_energy_limit_slope(ttot,regi,out)$( ttot.val ge 2015 )
-    = ( ( sum(ces_eff_target_dyn37(out,in),
-            p37_cesIO_baseline("2015",regi,in)
+    = ( max(
+          !! use the larger of 2015/2020 specific energy demand
+          ( sum(ces_eff_target_dyn37(out,in), p37_cesIO_baseline("2015",regi,in))
+          / p37_cesIO_baseline("2015",regi,out)
+          ),
+          ( sum(ces_eff_target_dyn37(out,in), p37_cesIO_baseline("2020",regi,in))
+          / p37_cesIO_baseline("2020",regi,out)
           )
-        / p37_cesIO_baseline("2015",regi,out)
         )
       - pm_energy_limit(out)
       )


### PR DESCRIPTION
Works around an issue where SSA cement specific energy demand is unreasonably low in 2015.

Affects all regions and subsectors.

Closes remindmodel/development_issues#413
