### PR TITLE
new input data (rev7.14) and new CES parameters for SSP2, SSP2-EU21, SSP1 and SSP2_lowEn

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -28,10 +28,10 @@ cfg$regionmapping <- "config/regionmappingH12.csv"
 cfg$extramappings_historic <- ""
 
 #### Current input data revision (<mainrevision>.<subrevision>) ####
-cfg$inputRevision <- "7.13"
+cfg$inputRevision <- "7.14"
 
 #### Current CES parameter and GDX revision (commit hash) ####
-cfg$CESandGDXversion <- "914fb7db0701f0c5b4f4f1314dea1e8401ce11a6"
+cfg$CESandGDXversion <- "dada5401be0ff890f001342b55e4491292ed5e85"
 
 #### Force the model to download new input data ####
 cfg$force_download <- FALSE


### PR DESCRIPTION
## Purpose of this PR
* new input data (rev7.14) 
* new CES parameters and gdx files for input data rev7.14 for SSP2, SSP2-EU21, SSP1 and SSP2_lowEn, 
* calibration runs: /p/tmp/lavinia/REMIND/REMIND_calibration_2024_11_23/remind/output

## Type of change

- [x] Minor change (default scenarios show only small differences)

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code


## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

