### PR TITLE
new input data rev7.16, new CES parameter for SSP2, SSP2-EU21, SSP3, SSP1, SSP2_lowEn, SSP5

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -28,10 +28,10 @@ cfg$regionmapping <- "config/regionmappingH12.csv"
 cfg$extramappings_historic <- ""
 
 #### Current input data revision (<mainrevision>.<subrevision>) ####
-cfg$inputRevision <- "7.14"
+cfg$inputRevision <- "7.16"
 
 #### Current CES parameter and GDX revision (commit hash) ####
-cfg$CESandGDXversion <- "dada5401be0ff890f001342b55e4491292ed5e85"
+cfg$CESandGDXversion <- "5452a611b8add9f439df0a98a27277a306ece286"
 
 #### Force the model to download new input data ####
 cfg$force_download <- FALSE


### PR DESCRIPTION
…

## Purpose of this PR
* new input data rev7.16
* new CES parameter and gdx files for SSP2, SSP2-EU21, SSP3, SSP1, SSP2_lowEn and SSP5, 
* calibration runs: /p/tmp/lavinia/REMIND/REMIND_calibration_2024_11_30/remind

## Type of change

- [x] Minor change (default scenarios show only small differences)


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code


## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

