### PR TITLE
bug-fix typo in equation definition

### DIFF
--- a/core/equations.gms
+++ b/core/equations.gms
@@ -1233,7 +1233,7 @@ $endif.penSeFeSectorShareDevCost
 $ifthen.limitSolidsFossilRegi not %cm_limitSolidsFossilRegi% == "off"
 q_fossilSolidsLimitReg(ttot,regi,entySe,entyFe,sector,emiMkt)$(limitSolidsFossilRegi(regi) and (ttot.val ge max(2020, cm_startyear)) AND sefe(entySe,entyFe) AND sector2emiMkt(sector,emiMkt) AND (sameas(sector,"indst") OR sameas(sector,"build")) AND sameas(entySe,"sesofos"))..
   vm_demFeSector_afterTax(ttot,regi,entySe,entyFe,sector,emiMkt)
-  =le=
+  =l=
   vm_demFeSector_afterTax(ttot-1,regi,entySe,entyFe,sector,emiMkt);
 $endif.limitSolidsFossilRegi
 


### PR DESCRIPTION
## Purpose of this PR

- Fix typo in equation defintiion (it does not affect current default runs).
- There is no =le= in GAMS equations. =l= already represents lower or equal equations.

## Type of change

- [x] Bug fix 
