### PR TITLE
use piamenv::installDeps

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,7 +53,7 @@ Imports:
     ncdf4,
     nleqslv,
     optparse,
-    piamenv (>= 0.5.4),
+    piamenv (>= 0.6.0),
     piamInterfaces (>= 0.34.1),
     piamPlotComparison (>= 0.0.10),
     piamutils,

--- a/start_bundle_coupled.R
+++ b/start_bundle_coupled.R
@@ -94,19 +94,6 @@ run_compareScenarios <- "short"
 magpie_empty <- FALSE
 
 ########################################################################################################
-#################################  install magpie dependencies  ########################################
-########################################################################################################
-if (!is.null(renv::project())) {
-  magpieDeps <- renv::dependencies(path_magpie)
-  installedPackages <- installed.packages()[, "Package"]
-  missingDeps <- setdiff(unique(magpieDeps$Package), installedPackages)
-  if (length(missingDeps) > 0) {
-    message("Installing missing MAgPIE dependencies ", paste(missingDeps, collapse = ", "))
-    renv::install(missingDeps)
-  }
-}
-
-########################################################################################################
 #################################  load command line arguments  ########################################
 ########################################################################################################
 
@@ -153,6 +140,8 @@ dir.create(file.path(path_remind, "output"), showWarnings = FALSE)
 dir.create(file.path(path_magpie, "output"), showWarnings = FALSE)
 
 ensureRequirementsInstalled(rerunPrompt = "start_bundle_coupled.R")
+
+piamenv::installDeps(path_magpie)
 
 errorsfound <- 0
 startedRuns <- NULL


### PR DESCRIPTION
## Purpose of this PR
To streamline the (coupling) tests that I run before each magpie relase I pulled out the code to install magpie deps into piamenv::installDeps. This way magpie deps can already be installed before submitting a slurm job which runs the coupling tests (which then have no internet connection). piamenv::installDeps is now called after ensureRequirementsInstalled to ensure piamenv@0.6.0 is installed first.

## Type of change

- [x] Refactoring
- [x] Minor change (default scenarios show only small differences)

## Checklist:

- [ ] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [ ] I explained my changes within the PR, particularly in hard-to-understand areas
- [ ] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

