### PR TITLE
45_carbonprice: Introduce option to manually choose regional carbon prices in cm_startyear

### DIFF
--- a/main.gms
+++ b/main.gms
@@ -1702,12 +1702,16 @@ $setglobal cm_taxCO2_regiDiff         initialSpread10    !! def = "initialSpread
 *** cm_taxCO2_regiDiff_endYr "switch for choosing convergence year of regionally differentiated carbon prices when using initialSpread10 or initialSpread20 in 45_carbonprice/functionalForm"
 *** Setting cm_taxCO2_regiDiff_endYr to GLO 2050, IND 2070, SSA 2100 means that convergence year is delayed for IND to 2070 and for SSA to 2100
 $setglobal cm_taxCO2_regiDiff_endYr   "GLO 2050"    !! def = "GLO 2050"
-*** cm_co2_tax_interpolation "switch for interpolation between (a) carbonprice trajectory given by path_gdx_ref and (b) carbonprice trajectory defined in 45_carbonprice"
+*** cm_co2_tax_interpolation "switch for interpolation between (a) carbonprice trajectory given by path_gdx_ref (or manually chosen regional carbon price in cm_startyear - see cm_taxCO2_startYearValue) and (b) carbonprice trajectory defined in 45_carbonprice"
 *** (off): no interpolation, i.e. (b) is used from cm_startyear onward
 *** (one_step): linear interpolation within 10 years between (a) and (b). For example, if cm_startyear = 2030, it uses (a) until 2025, the average of (a) and (b) in 2030, and (b) from 2035.
 *** (two_steps): linear interpolation within 15 years between (a) and (b). For example, if cm_startyear = 2030, it uses (a) until 2025, weighted averages of (a) and (b) in 2030 and 2035, and (b) from 2040.
 *** Setting cm_co2_tax_interpolation to GLO.2025.2050 2, EUR.2025.2040 1 means that interpolation between (a) and (b) in quadratic [exponent = 2], starts in 2025, and ends in 2050 for all regions, except for Europe that has linear interpolation [exponent = 1] starting in 2025 and ending in 2040
-$setglobal cm_taxCO2_interpolation  off    !! def = "one_step"
+$setglobal cm_taxCO2_interpolation  off    !! def = "off"
+*** cm_taxCO2_startYearValue  "switch for manually choosing regional carbon prices in cm_startyear that are used as starting point for interpolation"
+*** (off): no manual values provided, i.e. carbonprice trajectory given by path_gdx_ref is used for interpolation
+*** Setting cm_taxCO2_startYearValue to GLO 50, SSA 5, CHA 40 means that in cm_startyear, SSA has carbon price of 5$/tCO2,  CHA has carbon price of 40$/tCO2, and all other regions have carbon price of 50$/tCO2.
+$setglobal cm_taxCO2_startYearValue !! def = "off"
 *** cm_taxCO2_lowerBound_path_gdx_ref "switch for choosing if carbon price trajectories from path_gdx_ref are used as lower bound"
 *** (on): carbon price trajectories (pm_taxCO2eq) from path_gdx_ref is used as lower bound for pm_taxCO2eq
 *** (off): no lower bound

--- a/modules/45_carbonprice/functionalForm/datainput.gms
+++ b/modules/45_carbonprice/functionalForm/datainput.gms
@@ -202,9 +202,23 @@ loop((ext_regi,ttot,ttot2)$p45_interpolation_data(ext_regi,ttot,ttot2),
   );
 );
 $endIf.CO2taxInterpolation2
+
+$ifThen.taxCO2startYearValue2 "%cm_taxCO2_startYearValue%" == "off"
+$else.taxCO2startYearValue2
+*** Set manually chosen regional carbon price in cm_startyear
+loop((ext_regi)$p45_taxCO2eq_startYearValue_data(ext_regi),
+  loop(regi$regi_groupExt(ext_regi,regi),
+    p45_taxCO2eq_startYearValue(regi) = p45_taxCO2eq_startYearValue_data(ext_regi) * sm_DptCO2_2_TDpGtC; !! Converted from $/t CO2eq to T$/GtC  
+  );
+);
+display p45_taxCO2eq_startYearValue;
+*** Set interpolation start to cm_startyear
+p45_interpolation_startYr(regi) = cm_startyear;
+$endIf.taxCO2startYearValue2
 display p45_interpolation_exponent, p45_interpolation_startYr, p45_interpolation_endYr;
 
 *** Step IV.2: Create interpolation
+$ifThen.taxCO2startYearValue3 "%cm_taxCO2_startYearValue%" == "off"
 loop(regi,
   pm_taxCO2eq(ttot,regi) = p45_taxCO2eq_path_gdx_ref(ttot,regi); !! Initialize pm_taxCO2eq with p45_taxCO2eq_path_gdx_ref. Then overwrite all time steps after cm_startyear and p45_interpolation_startYr(regi) 
   pm_taxCO2eq(t,regi)$((t.val ge p45_interpolation_startYr(regi)) and (t.val lt p45_interpolation_endYr(regi))) = 
@@ -214,6 +228,17 @@ loop(regi,
       * rPower( (t.val - p45_interpolation_startYr(regi)) / (p45_interpolation_endYr(regi) - p45_interpolation_startYr(regi)), p45_interpolation_exponent(regi));
   pm_taxCO2eq(t,regi)$(t.val ge p45_interpolation_endYr(regi)) = p45_taxCO2eq_regiDiff(t,regi);
 );
+$else.taxCO2startYearValue3
+loop(regi,
+  pm_taxCO2eq(ttot,regi) = p45_taxCO2eq_path_gdx_ref(ttot,regi); !! Initialize pm_taxCO2eq with p45_taxCO2eq_path_gdx_ref. Then overwrite all time steps after cm_startyear
+  pm_taxCO2eq(t,regi)$(t.val lt p45_interpolation_endYr(regi)) = 
+      p45_taxCO2eq_startYearValue(regi)
+      * (1 - rPower( (t.val - cm_startyear) / (p45_interpolation_endYr(regi) - cm_startyear), p45_interpolation_exponent(regi)))
+    + sum(t2$(t2.val eq p45_interpolation_endYr(regi)), p45_taxCO2eq_regiDiff(t2,regi)) !! value of p45_taxCO2eq_regiDiff in p45_interpolation_endYr
+      * rPower( (t.val - cm_startyear) / (p45_interpolation_endYr(regi) - cm_startyear), p45_interpolation_exponent(regi));
+  pm_taxCO2eq(t,regi)$(t.val ge p45_interpolation_endYr(regi)) = p45_taxCO2eq_regiDiff(t,regi);
+);
+$endIf.taxCO2startYearValue3
 display pm_taxCO2eq;
 
 *** Step IV.3: Lower bound pm_taxCO2eq by p45_taxCO2eq_path_gdx_ref if switch cm_taxCO2_lowerBound_path_gdx_ref is on

--- a/modules/45_carbonprice/functionalForm/declarations.gms
+++ b/modules/45_carbonprice/functionalForm/declarations.gms
@@ -51,6 +51,13 @@ $else.taxCO2interpolation1
 p45_interpolation_data(ext_regi,ttot,ttot2)  "regional exponent and timewindow for interpolation"
 / %cm_taxCO2_interpolation% /
 $endIf.taxCO2interpolation1
+*** Only assigning values to p45_taxCO2eq_startYearValue if cm_taxCO2_startYearValue is not off
+$ifThen.taxCO2startYearValue1 "%cm_taxCO2_startYearValue%" == "off"
+$else.taxCO2startYearValue1
+p45_taxCO2eq_startYearValue_data(ext_regi)    "input data for manually chosen regional carbon price in cm_startyear in $/t CO2eq"
+/ %cm_taxCO2_startYearValue% /
+p45_taxCO2eq_startYearValue(all_regi)         "manually chosen regional carbon price in cm_startyear in $/t CO2eq"
+$endIf.taxCO2startYearValue1
 ;          
 
 

--- a/modules/45_carbonprice/functionalForm/postsolve.gms
+++ b/modules/45_carbonprice/functionalForm/postsolve.gms
@@ -354,6 +354,7 @@ display p45_taxCO2eq_regiDiff;
 ***-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 *** Re-reate interpolation for all timesteps after cm_startyear
+$ifThen.taxCO2startYearValue4 "%cm_taxCO2_startYearValue%" == "off"
 loop(regi,
   pm_taxCO2eq(t,regi)$(t.val lt p45_interpolation_startYr(regi)) = p45_taxCO2eq_path_gdx_ref(t,regi);
   pm_taxCO2eq(t,regi)$((t.val ge p45_interpolation_startYr(regi)) and (t.val lt p45_interpolation_endYr(regi))) = 
@@ -363,6 +364,17 @@ loop(regi,
       * rPower( (t.val - p45_interpolation_startYr(regi)) / (p45_interpolation_endYr(regi) - p45_interpolation_startYr(regi)), p45_interpolation_exponent(regi));
   pm_taxCO2eq(t,regi)$(t.val ge p45_interpolation_endYr(regi)) = p45_taxCO2eq_regiDiff(t,regi);
 );
+$else.taxCO2startYearValue4
+loop(regi,
+  pm_taxCO2eq(t,regi)$(t.val lt p45_interpolation_startYr(regi)) = p45_taxCO2eq_path_gdx_ref(t,regi);
+  pm_taxCO2eq(t,regi)$(t.val lt p45_interpolation_endYr(regi)) = 
+      p45_taxCO2eq_startYearValue(regi)
+      * (1 - rPower( (t.val - cm_startyear) / (p45_interpolation_endYr(regi) - cm_startyear), p45_interpolation_exponent(regi)))
+    + sum(t2$(t2.val eq p45_interpolation_endYr(regi)), p45_taxCO2eq_regiDiff(t2,regi)) !! value of p45_taxCO2eq_regiDiff in p45_interpolation_endYr
+      * rPower( (t.val - cm_startyear) / (p45_interpolation_endYr(regi) - cm_startyear), p45_interpolation_exponent(regi));
+  pm_taxCO2eq(t,regi)$(t.val ge p45_interpolation_endYr(regi)) = p45_taxCO2eq_regiDiff(t,regi);
+);
+$endIf.taxCO2startYearValue4
 display pm_taxCO2eq;
 
 *** Re-introduce lower bound pm_taxCO2eq by p45_taxCO2eq_path_gdx_ref if switch cm_taxCO2_lowerBound_path_gdx_ref is on


### PR DESCRIPTION
## Purpose of this PR

- Introduce option to manually choose regional carbon prices in `cm_startyear` via switch `cm_taxCO2_startYearValue`

## Type of change

- [x] New feature (default scenarios show no differences)

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [ ] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information:

* Test runs are here:  `/p/tmp/laurinko/hpc/remind/`
[scenario_config_45-startYearValue.csv](https://github.com/user-attachments/files/18036095/scenario_config_45-startYearValue.csv)
![Screenshot 2024-12-06 103605](https://github.com/user-attachments/assets/419f19d6-db9c-4062-9198-9d39327e4612)





