### PR TITLE
Bugfix in SCC calculation related to change in preference parameters

### DIFF
--- a/modules/51_internalizeDamages/BurkeLikeItr/postsolve.gms
+++ b/modules/51_internalizeDamages/BurkeLikeItr/postsolve.gms
@@ -20,7 +20,7 @@ p51_sccLastItr(tall) = p51_scc(tall);
 
 p51_sccParts(tall,tall2,regi2)$((tall.val ge 2010) and (tall.val le 2150) and (tall2.val ge tall.val) and (tall2.val le 2250)) = 
 	 (1 + pm_prtp(regi2) )**(-(tall2.val - tall.val))
-	* pm_consPC(tall,regi2)/pm_consPC(tall2,regi2) 
+	* (pm_consPC(tall,regi2)/(pm_consPC(tall2,regi2) + sm_eps))**(1/pm_ies(regi2))
         * pm_damage(tall2,regi2) * pm_GDPGross(tall2,regi2) 
 	* p51_marginalDamageCumul(tall,tall2,regi2) 
 ;

--- a/modules/51_internalizeDamages/DiceLikeItr/postsolve.gms
+++ b/modules/51_internalizeDamages/DiceLikeItr/postsolve.gms
@@ -11,7 +11,7 @@ p51_scc(tall)$((tall.val ge 2025) and (tall.val le 2150)) = 1000 *
     sum(regi2,
     sum(tall2$( (tall2.val ge tall.val) and (tall2.val le (tall.val + cm_damages_SccHorizon)) ),   !! add this for limiting horizon of damage consideration: and (tall2.val le 2150)
 	 (1 + pm_prtp(regi2))**(-(tall2.val - tall.val))
-	* pm_consPC(tall,regi2)/pm_consPC(tall2,regi2) 
+	* (pm_consPC(tall,regi2)/(pm_consPC(tall2,regi2) + sm_eps))**(1/pm_ies(regi2))
         * pm_GDPGross(tall2,regi2) 
 	* pm_temperatureImpulseResponseCO2(tall2,tall)
 	* pm_damageMarginal(tall2,"USA") !! USA stands as a dummy for a global value here

--- a/modules/51_internalizeDamages/KWTCintItr/postsolve.gms
+++ b/modules/51_internalizeDamages/KWTCintItr/postsolve.gms
@@ -34,7 +34,7 @@ p51_sccPartsTC(tall,tall2,regi2)$((tall.val ge 2010) and (tall.val le 2150) and 
 
 p51_sccParts(tall,tall2,regi2)$((tall.val ge 2010) and (tall.val le 2150) and (tall2.val ge tall.val) and (tall2.val le 2250)) = 
 	 (1 + pm_prtp(regi2) )**(-(tall2.val - tall.val))
-	* pm_consPC(tall,regi2)/pm_consPC(tall2,regi2) 
+	* (pm_consPC(tall,regi2)/(pm_consPC(tall2,regi2) + sm_eps))**(1/pm_ies(regi2))
         * pm_damageProd(tall2,regi2) * pm_GDPGross(tall2,regi2) 
 	* (p51_marginalDamageCumulKW(tall,tall2,regi2)+p51_sccPartsTC(tall,tall2,regi2)) 
 ;

--- a/modules/51_internalizeDamages/KW_SEitr/postsolve.gms
+++ b/modules/51_internalizeDamages/KW_SEitr/postsolve.gms
@@ -11,7 +11,7 @@ p51_sccLastItr(tall) = p51_scc(tall);
 
 p51_sccParts(tall,tall2,regi2)$((tall.val ge 2010) and (tall.val le 2150) and (tall2.val ge tall.val) and (tall2.val le 2250)) = 
 	 (1 + pm_prtp(regi2) )**(-(tall2.val - tall.val))
-	* pm_consPC(tall,regi2)/pm_consPC(tall2,regi2) 
+	* (pm_consPC(tall,regi2)/(pm_consPC(tall2,regi2) + sm_eps))**(1/pm_ies(regi2))
         * pm_GDPGross(tall2,regi2) 
 	* (pm_damage(tall2,regi2)-pm_damageImp(tall,tall2,regi2)) 
 ;

--- a/modules/51_internalizeDamages/KWlikeItr/postsolve.gms
+++ b/modules/51_internalizeDamages/KWlikeItr/postsolve.gms
@@ -20,7 +20,7 @@ p51_sccLastItr(tall) = p51_scc(tall);
 * Add an epsilon to pm_consPC to avoid division by zero in case of INFES in the reference data
 p51_sccParts(tall,tall2,regi2)$((tall.val ge 2010) and (tall.val le 2150) and (tall2.val ge tall.val) and (tall2.val le 2250)) = 
 	 (1 + pm_prtp(regi2) )**(-(tall2.val - tall.val))
-	* pm_consPC(tall,regi2)/(pm_consPC(tall2,regi2) + 0.0000001) 
+	* (pm_consPC(tall,regi2)/(pm_consPC(tall2,regi2) + sm_eps))**(1/pm_ies(regi2))
         * pm_damage(tall2,regi2) * pm_GDPGross(tall2,regi2) 
 	* p51_marginalDamageCumul(tall,tall2,regi2) 
 	* pm_sccIneq(tall2,regi2)

--- a/modules/51_internalizeDamages/KWlikeItrCPnash/not_used.txt
+++ b/modules/51_internalizeDamages/KWlikeItrCPnash/not_used.txt
@@ -21,3 +21,5 @@ pm_GDPGrossIso,input,questionnaire
 pm_damageImp,input,questionnaire
 pm_damageIso,input,questionnaire
 pm_damageGrowthRateIso,input,questionnaire
+pm_ies,input,questionnaire
+sm_eps,input,questionnaire

--- a/modules/51_internalizeDamages/KWlikeItrCPreg/postsolve.gms
+++ b/modules/51_internalizeDamages/KWlikeItrCPreg/postsolve.gms
@@ -21,7 +21,7 @@ p51_sccLastItr(tall,regi) = p51_scc(tall,regi);
 p51_sccParts(tall,tall2,regi)$((tall.val ge 2010) and (tall.val le 2150) and (tall2.val ge tall.val) and (tall2.val le 2250)) = 
 	sum(regi2,
 	 (1 + pm_prtp(regi2) )**(-(tall2.val - tall.val))
-	* pm_consPC(tall,regi)/pm_consPC(tall2,regi2) 
+	* (pm_consPC(tall,regi))**(1/pm_ies(regi))/(pm_consPC(tall2,regi2) + sm_eps))**(1/pm_ies(regi2))
         * pm_damage(tall2,regi2) * pm_GDPGross(tall2,regi2) 
 	* p51_marginalDamageCumul(tall,tall2,regi2) 
 	* pm_sccIneq(tall2,regi2)

--- a/modules/51_internalizeDamages/KotzWenzCPreg/postsolve.gms
+++ b/modules/51_internalizeDamages/KotzWenzCPreg/postsolve.gms
@@ -15,7 +15,7 @@ p51_scc(tall,regi)$((tall.val ge 2020) and (tall.val le 2150)) = 1000 *
     sum(regi2,
     sum(tall2$( (tall2.val ge tall.val) and (tall2.val le (tall.val + cm_damages_SccHorizon))),   !! add this for limiting horizon of damage consideration: and (tall2.val le 2150)
 	(1 + pm_prtp(regi2) )**(-(tall2.val - tall.val))
-	* pm_consPC(tall,regi)/pm_consPC(tall2,regi2) 
+	* (pm_consPC(tall,regi))**(1/pm_ies(regi))/(pm_consPC(tall2,regi2) + sm_eps))**(1/pm_ies(regi2))
 	* pm_GDPGross(tall2,regi2)
 	* pm_temperatureImpulseResponseCO2(tall2,tall)
 	* pm_damageMarginal(tall2,regi2)

--- a/modules/51_internalizeDamages/KotzWenzItr/postsolve.gms
+++ b/modules/51_internalizeDamages/KotzWenzItr/postsolve.gms
@@ -15,7 +15,7 @@ p51_scc(tall)$((tall.val ge 2020) and (tall.val le 2150)) = 1000 *
     sum(regi2,
     sum(tall2$( (tall2.val ge tall.val) and (tall2.val le (tall.val + cm_damages_SccHorizon))),   !! add this for limiting horizon of damage consideration: and (tall2.val le 2150)
 	(1 + pm_prtp(regi2) )**(-(tall2.val - tall.val))
-	* pm_consPC(tall,regi2)/pm_consPC(tall2,regi2) 
+	* (pm_consPC(tall,regi2)/(pm_consPC(tall2,regi2) + sm_eps))**(1/pm_ies(regi2))
 	* pm_GDPGross(tall2,regi2)
 	* pm_temperatureImpulseResponseCO2(tall2,tall)
 	* pm_damageMarginal(tall2,regi2)

--- a/modules/51_internalizeDamages/LabItr/postsolve.gms
+++ b/modules/51_internalizeDamages/LabItr/postsolve.gms
@@ -50,7 +50,7 @@ p51_scc(tall)$((tall.val ge 2020) and (tall.val le 2150)) = 1000 *
     sum(regi2,
     sum(tall2$( (tall2.val ge tall.val) and (tall2.val le (tall.val + cm_damages_SccHorizon)) ),   !! add this for limiting horizon of damage consideration: and (tall2.val le 2150)
 	 (1 + pm_prtp(regi2))**(-(tall2.val - tall.val))
-	* pm_consPC(tall,regi2)/(pm_consPC(tall2,regi2)+1e-8) 
+	* (pm_consPC(tall,regi2)/(pm_consPC(tall2,regi2) + sm_eps))**(1/pm_ies(regi2))
 	* p51_sccParts(tall,tall2,regi2)
     )
    )

--- a/modules/51_internalizeDamages/TCitr/postsolve.gms
+++ b/modules/51_internalizeDamages/TCitr/postsolve.gms
@@ -31,7 +31,7 @@ p51_scc(tall)$((tall.val ge 2020) and (tall.val le 2150)) = 1000 *
     sum(regi2,
     sum(tall2$( (tall2.val ge tall.val) and (tall2.val le (tall.val + cm_damages_SccHorizon))),   !! add this for limiting horizon of damage consideration: and (tall2.val le 2150)
 	(1 + pm_prtp(regi2) )**(-(tall2.val - tall.val))
-	* pm_consPC(tall,regi2)/pm_consPC(tall2,regi2) 
+	* (pm_consPC(tall,regi2)/(pm_consPC(tall2,regi2) + sm_eps))**(1/pm_ies(regi2))
 	* p51_sccParts(tall,tall2,regi2)
     )
    )

--- a/modules/51_internalizeDamages/off/not_used.txt
+++ b/modules/51_internalizeDamages/off/not_used.txt
@@ -34,3 +34,5 @@ pm_damageIso,input,questionnaire
 pm_damageGrowthRateIso,input,questionnaire
 pm_sccIneq,input,questionnaire
 sm_c_2_co2,input,questionnaire
+pm_ies,input,questionnaire
+sm_eps,input,questionnaire


### PR DESCRIPTION
## Purpose of this PR
The calculation of the SCC needed to endogenize damages in the optimization did not reflect fully the change in preference parameters, in particular the change of pm_ies from 1.

## Type of change

- [x] Bug fix 


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas



