### PR TITLE
new CES parameter for rev7.18 for SSP2, SSP2-EU21, SSP3, SSP1, SSP5, SSP2_lowEn

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -31,7 +31,7 @@ cfg$extramappings_historic <- ""
 cfg$inputRevision <- "7.18"
 
 #### Current CES parameter and GDX revision (commit hash) ####
-cfg$CESandGDXversion <- "5452a611b8add9f439df0a98a27277a306ece286"
+cfg$CESandGDXversion <- "354727cdf8174836422acc002670b1488410ecfd"
 
 #### Force the model to download new input data ####
 cfg$force_download <- FALSE


### PR DESCRIPTION
## Purpose of this PR
* new CES parameter and gdx files for rev7.18 for SSP2, SSP2-EU21, SSP3, SSP1, SSP5 and SSP2_lowEn, 
* calibration runs: /p/tmp/lavinia/REMIND/REMIND_calibration_2024_12_09/remind/output

## Type of change

- [x] Minor change (default scenarios show only small differences)

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code


## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

