### PR TITLE
Define vm_emiAll as sum over vm_emiAllMkt and ...

### DIFF
--- a/core/equations.gms
+++ b/core/equations.gms
@@ -754,18 +754,13 @@ q_emiCdrAll(t,regi)..
 
 
 ***------------------------------------------------------
-*' Total regional emissions are the sum of emissions from technologies, MAC-curves, CDR-technologies and emissions that are exogenously given for REMIND.
+*' Total regional emissions are computed as the sum of total emissions over all emission markets.
 ***------------------------------------------------------
-*LB* calculate total emissions for each region at each time step
-q_emiAll(t,regi,emi(enty))..
-  vm_emiAll(t,regi,enty)
+q_emiAll(t,regi,emi)..
+  vm_emiAll(t,regi,emi)
   =e=
-    vm_emiTe(t,regi,enty)
-  + vm_emiMac(t,regi,enty)
-  + vm_emiCdr(t,regi,enty)
-  + pm_emiExog(t,regi,enty)
+  sum(emiMkt, vm_emiAllMkt(t,regi,emi,emiMkt))
 ;
-
 
 ***------------------------------------------------------
 *' Total regional emissions in CO2 equivalents that are part of the climate policy  are computed based on regional GHG

--- a/modules/45_carbonprice/NDC/not_used.txt
+++ b/modules/45_carbonprice/NDC/not_used.txt
@@ -21,9 +21,6 @@ pm_gdp,input,questionnaire
 cm_peakBudgYr,input,added by codeCheck
 fm_taxCO2eqHist,input,not needed
 sm_budgetCO2eqGlob,input,no iterative target adjustment
-vm_emiTe,input,no iterative target adjustment
-vm_emiCdr,input,no iterative target adjustment
-vm_emiMac,input,no iterative target adjustment
 vm_emiAll,input,no iterative target adjustment
 pm_budgetCO2eq,input,no iterative target adjustment
 pm_ts,input,no iterative target adjustment

--- a/modules/45_carbonprice/NPi/not_used.txt
+++ b/modules/45_carbonprice/NPi/not_used.txt
@@ -29,9 +29,6 @@ cm_startyear,input,added by codeCheck
 cm_peakBudgYr,input,added by codeCheck
 fm_taxCO2eqHist,input,not needed
 sm_budgetCO2eqGlob,input,no iterative target adjustment
-vm_emiTe,input,no iterative target adjustment
-vm_emiCdr,input,no iterative target adjustment
-vm_emiMac,input,no iterative target adjustment
 vm_emiAll,input,no iterative target adjustment
 pm_budgetCO2eq,input,no iterative target adjustment
 pm_ts,input,no iterative target adjustment

--- a/modules/45_carbonprice/NPi2025/not_used.txt
+++ b/modules/45_carbonprice/NPi2025/not_used.txt
@@ -29,9 +29,6 @@ pm_emifac,input,questionnaire
 cm_peakBudgYr,input,not needed
 sm_D2005_2_D2017,input,not needed
 sm_budgetCO2eqGlob,input,added by codeCheck
-vm_emiTe,input,added by codeCheck
-vm_emiCdr,input,added by codeCheck
-vm_emiMac,input,added by codeCheck
 vm_emiAll,input,added by codeCheck
 pm_taxCO2eq_anchor_iterationdiff,input,added by codeCheck
 pm_taxCO2eq_anchor_iterationdiff_tmp,input,added by codeCheck

--- a/modules/45_carbonprice/NPi2025expo/not_used.txt
+++ b/modules/45_carbonprice/NPi2025expo/not_used.txt
@@ -29,9 +29,6 @@ pm_emifac,input,questionnaire
 cm_peakBudgYr,input,not needed
 sm_D2005_2_D2017,input,not needed
 sm_budgetCO2eqGlob,input,no iterative target adjustment
-vm_emiTe,input,no iterative target adjustment
-vm_emiCdr,input,no iterative target adjustment
-vm_emiMac,input,no iterative target adjustment
 vm_emiAll,input,no iterative target adjustment
 pm_budgetCO2eq,input,no iterative target adjustment
 pm_ts,input,no iterative target adjustment

--- a/modules/45_carbonprice/NPiexpo/not_used.txt
+++ b/modules/45_carbonprice/NPiexpo/not_used.txt
@@ -30,9 +30,6 @@ cm_peakBudgYr,input,added by codeCheck
 fm_taxCO2eqHist,input,not needed
 sm_D2005_2_D2017,input,not needed
 sm_budgetCO2eqGlob,input,no iterative target adjustment
-vm_emiTe,input,no iterative target adjustment
-vm_emiCdr,input,no iterative target adjustment
-vm_emiMac,input,no iterative target adjustment
 vm_emiAll,input,no iterative target adjustment
 pm_budgetCO2eq,input,no iterative target adjustment
 pm_ts,input,no iterative target adjustment

--- a/modules/45_carbonprice/exogenous/not_used.txt
+++ b/modules/45_carbonprice/exogenous/not_used.txt
@@ -29,9 +29,6 @@ cm_peakBudgYr,input,added by codeCheck
 sm_D2005_2_D2017,input,not needed
 fm_taxCO2eqHist,input,not needed
 sm_budgetCO2eqGlob,input,no iterative target adjustment
-vm_emiTe,input,no iterative target adjustment
-vm_emiCdr,input,no iterative target adjustment
-vm_emiMac,input,no iterative target adjustment
 vm_emiAll,input,no iterative target adjustment
 pm_budgetCO2eq,input,no iterative target adjustment
 pm_ts,input,no iterative target adjustment

--- a/modules/45_carbonprice/expoLinear/not_used.txt
+++ b/modules/45_carbonprice/expoLinear/not_used.txt
@@ -26,9 +26,6 @@ cm_peakBudgYr,input,added by codeCheck
 sm_D2005_2_D2017,input,not needed
 fm_taxCO2eqHist,input,not needed
 sm_budgetCO2eqGlob,input,no iterative target adjustment
-vm_emiTe,input,no iterative target adjustment
-vm_emiCdr,input,no iterative target adjustment
-vm_emiMac,input,no iterative target adjustment
 vm_emiAll,input,no iterative target adjustment
 pm_budgetCO2eq,input,no iterative target adjustment
 pm_ts,input,no iterative target adjustment

--- a/modules/45_carbonprice/functionalForm/postsolve.gms
+++ b/modules/45_carbonprice/functionalForm/postsolve.gms
@@ -13,7 +13,7 @@
 *** `p45_actualbudgetco2(ttot)` includes emissions from 2020 to `ttot` (inclusive).
 p45_actualbudgetco2(ttot)$( 2020 lt ttot.val )
   = sum((regi,ttot2)$( 2020 le ttot2.val AND ttot2.val le ttot.val ),
-      ( vm_emiTe.l(ttot2,regi,"co2") + vm_emiCdr.l(ttot2,regi,"co2") + vm_emiMac.l(ttot2,regi,"co2"))
+      vm_emiAll.l(ttot2,regi,"co2")
       * ( (0.5 + pm_ts(ttot2) / 2)$( ttot2.val eq 2020 ) !! second half of the 2020 period (mid 2020 - end 2022) plus 0.5 to account fo beginning 2020 - mid 2020  
         + (pm_ts(ttot2))$( 2020 lt ttot2.val AND ttot2.val lt ttot.val ) !! entire middle periods
         + ((pm_ttot_val(ttot) - pm_ttot_val(ttot-1)) / 2 + 0.5)$(ttot2.val eq ttot.val ) !! first half of the final period plus 0.5 to account fo mid - end of final year

--- a/modules/45_carbonprice/none/not_used.txt
+++ b/modules/45_carbonprice/none/not_used.txt
@@ -31,9 +31,6 @@ cm_peakBudgYr,input,added by codeCheck
 sm_D2005_2_D2017,input,not needed
 fm_taxCO2eqHist,input,not needed
 sm_budgetCO2eqGlob,input,no iterative target adjustment
-vm_emiTe,input,no iterative target adjustment
-vm_emiCdr,input,no iterative target adjustment
-vm_emiMac,input,no iterative target adjustment
 vm_emiAll,input,no iterative target adjustment
 pm_budgetCO2eq,input,no iterative target adjustment
 pm_ts,input,no iterative target adjustment

--- a/modules/45_carbonprice/temperatureNotToExceed/not_used.txt
+++ b/modules/45_carbonprice/temperatureNotToExceed/not_used.txt
@@ -23,9 +23,6 @@ cm_peakBudgYr,input,added by codeCheck
 sm_D2005_2_D2017,input,not needed
 fm_taxCO2eqHist,input,not needed
 sm_budgetCO2eqGlob,input,no iterative target adjustment
-vm_emiTe,input,no iterative target adjustment
-vm_emiCdr,input,no iterative target adjustment
-vm_emiMac,input,no iterative target adjustment
 vm_emiAll,input,no iterative target adjustment
 pm_budgetCO2eq,input,no iterative target adjustment
 pm_ts,input,no iterative target adjustment


### PR DESCRIPTION
… ensure consistent use of `vm_emiAll` in `45_carbonprice/functionalForm/postsolve.gms`

## Purpose of this PR

See [Mattermost exchange](https://mattermost.pik-potsdam.de/rd3/pl/et44y3w3n3ntunc8my7jftd15w) for background

- Correct error in computation of `vm_emiAll`
- Make sure that `45_carbonprice/functionalForm/postsolve.gms` only uses `vm_emiAll` for CO2 budget computation.

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)


## Further information (optional):

* Test runs are here: `/p/tmp/laurinko/hpc/remind/output/SSP2-PkBudg650_2024-12-12_11.36.21`
* Comparison of results (what changes by this PR?): `/p/tmp/laurinko/hpc/remind/compScen-develop-vs-release3p4-2024-12-12_14.50.29-H12.pdf` (SSP2-PkBudg650.1: release version 3.4.0, SSP2-PkBudg650: new runs including changes)

