### PR TITLE
Reduce tolerance in bioenergy phaseout scenario

### DIFF
--- a/modules/30_biomass/magpie_40/bounds.gms
+++ b/modules/30_biomass/magpie_40/bounds.gms
@@ -113,7 +113,7 @@ if (cm_phaseoutBiolc eq 1,
             loop(te(teBioPebiolc),
                 loop(rlf,
                     if(vm_deltaCap.up(t,regi,te,rlf) eq INF,
-                       vm_deltaCap.up(t,regi,te,rlf) = 1e-5;
+                       vm_deltaCap.up(t,regi,te,rlf) = 1e-6;
                     );
                 );
             );


### PR DESCRIPTION
## Purpose of this PR
This is a super minor PR, in which the numerical tolerance for still allowed capacity additions in the 2nd generation bioenergy phaseout scenario (set via `cm_phaseoutBiolc <- 1`) is reduced from `1e-5` to `1e-6`. This was necessary because runs with very ambitious climate scenarios were still showing some (too high) levels of bioenergy deployment (see figure below; red = original tolerance of `1e-5`; blue = new tolerance of `1e-6`).
Given that this switch is disabled by default, it does not affect default runs.

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [ ] Bug fix 
- [ ] Refactoring
- [ ] New feature 
- [x] Minor change (default scenarios show only small differences)
- [ ] Fundamental change
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Test runs are here: 
`/p/projects/dipol/paperLandMatters/v5/rem_standalone/remind_test_biolc_po`
* Comparison of results (what changes by this PR?): 
![image](https://github.com/user-attachments/assets/25eba561-63ea-4dc0-9974-185c39278f11)
