### PR TITLE
new input data v7.19 and new CES parameter for SSP2, SSP2-EU21, SSP3, SSP1, SSP5, SSP2_lowEn

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -28,10 +28,10 @@ cfg$regionmapping <- "config/regionmappingH12.csv"
 cfg$extramappings_historic <- ""
 
 #### Current input data revision (<mainrevision>.<subrevision>) ####
-cfg$inputRevision <- "7.18"
+cfg$inputRevision <- "7.19"
 
 #### Current CES parameter and GDX revision (commit hash) ####
-cfg$CESandGDXversion <- "354727cdf8174836422acc002670b1488410ecfd"
+cfg$CESandGDXversion <- "cfe76b2cb670aee30490e8191a5498ff8b0b6421"
 
 #### Force the model to download new input data ####
 cfg$force_download <- FALSE


### PR DESCRIPTION
## Purpose of this PR
* new input data v7.19
* new CES parameter and gdx files for SSP2, SSP2-EU21, SSP3, SSP1, SSP5 and SSP2_lowEn, 
* calibraiton runs: /p/tmp/lavinia/REMIND/REMIND_calibration_2024_12_13/remind/output

## Type of change

- [x] Minor change (default scenarios show only small differences)

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code


## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

