### PR TITLE
delete unused set in CCU module

### DIFF
--- a/modules/39_CCU/on/sets.gms
+++ b/modules/39_CCU/on/sets.gms
@@ -24,17 +24,6 @@ te_ccu39(all_te)                            "CCU technologies"
 /
 
 
-enty_BioSyn_39(all_enty,emi_sectors,emiMkt)	"FE, sector and emissions markets to which constraint on equal share of synfuels in biofuels+synfuels should be applied"
-/
-	fedie.trans.ETS
-	fedie.trans.ES
-	fedie.trans.other
-	fepet.trans.ETS
-	fepet.trans.ES
-	fepet.trans.other
-
-/
-
 ***-------------------------------------------------------------------------
 ***                  module specific mappings
 ***-------------------------------------------------------------------------


### PR DESCRIPTION
## Purpose of this PR
Clean-up: remove an unused set from the 39_CCU module. It was probably the relic of an effort that is now addresses in the q_shSeFeSector approach.

## Type of change
- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
