### PR TITLE
Add switch to load pm_cesdata from input gdx

### DIFF
--- a/main.gms
+++ b/main.gms
@@ -1863,6 +1863,7 @@ $setGLobal cm_debug_preloop  off    !! def = off  !! regexp = off|on
 *' (MFR): Maximum Feasible Reductions
 $setGlobal cm_APscen  SSP2          !! def = SSP2
 $setglobal cm_CES_configuration  indu_subsectors-buil_simple-tran_edge_esm-POP_pop_SSP2-GDP_gdp_SSP2-En_gdp_SSP2-Kap_debt_limit-Reg_62eff8f7   !! this will be changed by start_run()
+$setglobal cm_CES_load_cesdata_from_input_gdx  0  !! def = 0
 $setglobal c_CES_calibration_iterations  10     !!  def  =  10
 $setglobal c_CES_calibration_industry_FE_target  1
 *' setting which region is to be tested in the one-region test run (80_optimization = testOneRegi)

--- a/main.gms
+++ b/main.gms
@@ -1863,7 +1863,7 @@ $setGLobal cm_debug_preloop  off    !! def = off  !! regexp = off|on
 *' (MFR): Maximum Feasible Reductions
 $setGlobal cm_APscen  SSP2          !! def = SSP2
 $setglobal cm_CES_configuration  indu_subsectors-buil_simple-tran_edge_esm-POP_pop_SSP2-GDP_gdp_SSP2-En_gdp_SSP2-Kap_debt_limit-Reg_62eff8f7   !! this will be changed by start_run()
-$setglobal cm_CES_load_cesdata_from_input_gdx  0  !! def = 0
+$setglobal cm_CES_load_cesdata_from_input_gdx  1  !! def = 0
 $setglobal c_CES_calibration_iterations  10     !!  def  =  10
 $setglobal c_CES_calibration_industry_FE_target  1
 *' setting which region is to be tested in the one-region test run (80_optimization = testOneRegi)

--- a/modules/29_CES_parameters/load/datainput.gms
+++ b/modules/29_CES_parameters/load/datainput.gms
@@ -9,6 +9,9 @@
 *** Load CES parameters based on current model configuration
 $include "./modules/29_CES_parameters/load/input/%cm_CES_configuration%.inc"
 
+*** If desired, load pm_cesdata from input gdx
+$if %cm_CES_load_cesdata_from_input_gdx% = 1 Execute_loadpoint 'input' pm_cesdata;
+
 option pm_cesdata:8:3:1;
 display "loaded pm_cesdata", pm_cesdata;
 


### PR DESCRIPTION
Add switch to enable loading `pm_cesdata` from the input gdx.

This switch should be particularly useful when passing "exploratory" calibration runs (by that I mean calibrations with code changes not reflected in the CES_configuration string) to a policy cascade. Instead of having to make sure that an appropriate .inc file exists, `pm_cesdata` is simply loaded from the input gdx (easily specified in path_gdx). This also allows for the calibration and policy runs to be submitted in a cascade in a single config.

For now, I'm not worrying about avoiding all the steps linked to the CES_configuration string and a now-useless .inc file. Instead `pm_cesdata` is simply loaded right after the loading from the .inc file. Do you think this is OK? Or do you see potential issues? Any comment/suggestion is welcome! 