### PR TITLE
Bugfix coalh2

### DIFF
--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -90,8 +90,10 @@ vm_prodSe.fx(t,regi,"pewin","seel","wind") = 0;
 *' which cannot be fully met by incoming low-carbon H2 techologies. This should be removed once FE H2 industry input data is adapted.
 *' It is allowed before 2020 to not make the model infeasible for low demands of hydrogen in that year.
 *' After 2020/2030, it is not fixed to 0 but rather kept below 1e-7 to prevent infeasibilities with the lower bound on vm_cap for all techs.
-vm_deltaCap.up(t,regi,"coalh2",rlf)$(t.val ge 2020) = 1e-7;
-vm_deltaCap.up(t,regi,"gash2",rlf)$(t.val gt 2030)  = 1e-7;
+vm_deltaCap.fx(t,regi,"coalh2",rlf)$(t.val ge 2020) = 0;
+vm_deltaCap.fx(t,regi,"gash2",rlf)$(t.val gt 2030)  = 0;
+vm_cap.lo(t,regi,"coalh2",rlf)$(t.val ge 2020) = 0;
+vm_cap.lo(t,regi,"gash2",rlf)$(t.val gt 2030)  = 0;
 
 
 *' upper bound of 0.5 EJ/yr on grey hydrogen to prevent building too much grey H2 before 2020, distributed to regions via GDP share

--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -85,11 +85,10 @@ vm_prodSe.fx(t,regi,"pecoal","seel","pco") = 0;
 vm_demPe.fx(t,regi,"pewin","seel","wind") = 0;
 vm_prodSe.fx(t,regi,"pewin","seel","wind") = 0;
 
-*' Almost completely switch off coal-h2 hydrogen investments. Our current seh2 hydrogen represents only additional (clean) hydrogen use cases to current ones.
+*' Switch off coal-h2 hydrogen investments after 2020, and gas-h2 investments after 2030. Our current seh2 hydrogen represents only additional (clean) hydrogen use cases to current ones.
 *' However, as we have too high H2 demand in 2025 and 2030 from the input data, we need to allow grey hydrogen for these time periods to meet the hydrogen demand
 *' which cannot be fully met by incoming low-carbon H2 techologies. This should be removed once FE H2 industry input data is adapted.
 *' It is allowed before 2020 to not make the model infeasible for low demands of hydrogen in that year.
-*' After 2020/2030, it is not fixed to 0 but rather kept below 1e-7 to prevent infeasibilities with the lower bound on vm_cap for all techs.
 vm_deltaCap.fx(t,regi,"coalh2",rlf)$(t.val ge 2020) = 0;
 vm_deltaCap.fx(t,regi,"gash2",rlf)$(t.val gt 2030)  = 0;
 vm_cap.lo(t,regi,"coalh2",rlf)$(t.val ge 2020) = 0;


### PR DESCRIPTION
## Purpose of this PR

go back to bringing coalh2 and gash2 investments to 0 after 2030/2020, but this time without potential for INFES

## Type of change

- [x] Minor change (default scenarios show only small differences)

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
