### PR TITLE
Correct the exclusion of industry solids use from inconvenience penalties

### DIFF
--- a/modules/02_welfare/ineqLognormal/bounds.gms
+++ b/modules/02_welfare/ineqLognormal/bounds.gms
@@ -7,10 +7,7 @@
 *** SOF ./modules/02_welfare/ineqLognormal/bounds.gms
 
 $IFTHEN.INCONV %cm_INCONV_PENALTY% == "on"
-v02_sesoInconvPenSlack.lo(t,regi)=0;
-v02_inconvPenCoalSolids.fx("2005",regi) = 0;
-v02_inconvPenCoalSolids.lo(t,regi) = 0;
-v02_inconvPen.lo(t,regi) = 0;
+v02_inconvPenSolidsBuild.fx("2005",regi) = 0;
 v02_inconvPen.fx("2005",regi) = 0;
 $ENDIF.INCONV
 

--- a/modules/02_welfare/ineqLognormal/declarations.gms
+++ b/modules/02_welfare/ineqLognormal/declarations.gms
@@ -53,12 +53,6 @@ v02_energyExp_Add(ttot,all_regi)                  "additional energy expenditure
 v02_distrAlpha(ttot,all_regi)                     "income elasticity of mitigation costs"
 v02_damageConsShare(ttot,all_regi)		  "share of consumption loss from damages in consumption"
 
-
-$ifthen.inconv %cm_INCONV_PENALTY% == "on"
-v02_inconvPen(ttot,all_regi)                      "Inconvenience penalty in the welfare function, e.g. for air pollution. Unit: ?Utils?"
-v02_inconvPenCoalSolids(ttot,all_regi)            "Inconvenience penalty in the welfare function, e.g. for air pollution. Unit: ?Utils?"
-v02_sesoInconvPenSlack(ttot,all_regi)             "Slack to avoid negative inconvenience penalty for Coal Solids"
-$endif.inconv
 ;
 
 positive variables
@@ -66,6 +60,12 @@ v02_distrFinal_sigmaSq(ttot,all_regi)                  "sigma^2 parameter of fin
 v02_distrFinal_sigmaSq_postDam(ttot,all_regi)                  "sigma^2 parameter of final lognormal distribution (after redistributional effects of taxes and damages)"
 v02_distrFinal_sigmaSq_limit(ttot,all_regi)        "Limit past which inequality improvements do not lead to welfare benefits"
 v02_distrFinal_sigmaSq_welfare(ttot,all_regi)       "sigma^2 entering welfare"
+
+
+$ifthen.inconv %cm_INCONV_PENALTY% == "on" 
+v02_inconvPen(ttot,all_regi)                      "Inconvenience penalty on pe2se in the welfare function, e.g. for air pollution, except for biotr and coaltr. Unit: ?Utils?"
+v02_inconvPenSolidsBuild(ttot,all_regi)             "Inconvenience penalty in the welfare function, e.g. for air pollution or inconvenience, for solids used in Buildings. Unit: ?Utils?"
+$endif.inconv
 
 $IFTHEN.INCONV_bioSwitch "%cm_INCONV_PENALTY_FESwitch%" == "on"
 v02_NegInconvPenFeBioSwitch(ttot,all_regi,all_enty,all_enty,emi_sectors,all_emiMkt) "Negative inconvenience penalty in the welfare function for bio/synfuel shares switch between sectors and emissions markets"
@@ -104,7 +104,7 @@ q02_budget_second(ttot,all_regi)                 "making sure budget is positive
 
 $ifthen.inconv %cm_INCONV_PENALTY% == "on"
 q02_inconvPen(ttot,all_regi)                      "Calculate the inconvenience penalty v02_inconvPen"
-q02_inconvPenCoalSolids(ttot,all_regi)            "Calculate the inconvenience penalty v02_inconvPen"
+q02_inconvPenSolidsBuild(ttot,all_regi,all_te)      "Calculate the inconvenience penalty v02_inconvPenSolids for solids used in Buildings"
 $endif.inconv
 
 $IFTHEN.INCONV_bioSwitch "%cm_INCONV_PENALTY_FESwitch%" == "on"

--- a/modules/02_welfare/ineqLognormal/declarations.gms
+++ b/modules/02_welfare/ineqLognormal/declarations.gms
@@ -104,7 +104,7 @@ q02_budget_second(ttot,all_regi)                 "making sure budget is positive
 
 $ifthen.inconv %cm_INCONV_PENALTY% == "on"
 q02_inconvPen(ttot,all_regi)                      "Calculate the inconvenience penalty v02_inconvPen"
-q02_inconvPenSolidsBuild(ttot,all_regi,all_te)      "Calculate the inconvenience penalty v02_inconvPenSolids for solids used in Buildings"
+q02_inconvPenSolidsBuild(ttot,all_regi)      "Calculate the inconvenience penalty v02_inconvPenSolids for solids used in Buildings"
 $endif.inconv
 
 $IFTHEN.INCONV_bioSwitch "%cm_INCONV_PENALTY_FESwitch%" == "on"

--- a/modules/02_welfare/ineqLognormal/equations.gms
+++ b/modules/02_welfare/ineqLognormal/equations.gms
@@ -51,7 +51,8 @@ q02_welfare(regi) ..
           )
         )
 $ifthen %cm_INCONV_PENALTY% == "on"
-      - v02_inconvPen(ttot,regi) - v02_inconvPenCoalSolids(ttot,regi)
+      - v02_inconvPen(ttot,regi)
+      - v02_inconvPenSolidsBuild(ttot,regi)
 $endif
 $ifthen "%cm_INCONV_PENALTY_FESwitch%" == "on"
       - sum((entySe,entyFe,te,sector,emiMkt)$(
@@ -62,7 +63,7 @@ $ifthen "%cm_INCONV_PENALTY_FESwitch%" == "on"
           v02_NegInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt)
           + v02_PosInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt)
           )
-          / 1e3	
+          / 1e3	!! heuristically determined rescaling factor so the dampening doesn't dominate the transformation
 $endif
 $ifthen not "%cm_seFeSectorShareDevMethod%" == "off"
         !! penalizing secondary energy share deviation in sectors  
@@ -295,21 +296,21 @@ q02_budget_second(ttot,regi)$(ttot.val ge cm_startyear)..
 ***---------------------------------------------------------------------------
 $IFTHEN.INCONV %cm_INCONV_PENALTY% == "on"
 q02_inconvPen(t,regi)$(t.val > 2005)..
-    v02_inconvPen(t,regi)
+  v02_inconvPen(t,regi)
   =g=
-*' local air pollution for all entySe production except for coal solids (=sesofos), which is treated separately (see below)
-    SUM(pe2se(enty,entySe,te)$(NOT sameas(entySe,"sesofos")),
-        p02_inconvpen_lap(t,regi,te) * (vm_prodSe(t,regi,enty,entySe,te))
-    )
+*' local air pollution / inconvenience for all entySe production except for coaltr and biotrmod solids, wich are treated separately (see below)
+  SUM(pe2se(enty,entySe,te)$( NOT (sameas(te,"coaltr") OR sameas(te,"biotrmod") ) ),
+    p02_inconvpen_lap(t,regi,te) * vm_prodSe(t,regi,enty,entySe,te)
+  )
 ;
 
-q02_inconvPenCoalSolids(t,regi)$(t.val > 2005)..
-    v02_inconvPenCoalSolids(t,regi)
+q02_inconvPenSolidsBuild(t,regi)$(t.val > 2005)..
+  v02_inconvPenSolidsBuild(t,regi)
   =g=
-*' local air pollution for coal: inconvinienve penalty applies only for buildings use; slack variable ensures that v02_inconvPen can stay > 0
-    p02_inconvpen_lap(t,regi,"coaltr") * (vm_prodSe(t,regi,"pecoal","sesofos","coaltr")
-  - vm_cesIO(t,regi,"fesoi"))
-  + v02_sesoInconvPenSlack(t,regi)
+*' Local air pollution and inconvenience of using coal and (modern) biomass: inconvenience penalty applies only for use in residential/buildings
+*' The inconvenience of using traditional biomass are accounted for in v02_inconvPen, and thus additional to the penalty on using solids in residential
+  p02_inconvpen_lap(t,regi,"coaltr") * vm_demFeSector(t,regi,"sesofos","fesos","build","ES")
+  p02_inconvpen_lap(t,regi,"biotrmod") * vm_demFeSector(t,regi,"sesobio","fesos","build","ES")
 ;
 $ENDIF.INCONV
 

--- a/modules/02_welfare/ineqLognormal/equations.gms
+++ b/modules/02_welfare/ineqLognormal/equations.gms
@@ -310,7 +310,7 @@ q02_inconvPenSolidsBuild(t,regi)$(t.val > 2005)..
 *' Local air pollution and inconvenience of using coal and (modern) biomass: inconvenience penalty applies only for use in residential/buildings
 *' The inconvenience of using traditional biomass are accounted for in v02_inconvPen, and thus additional to the penalty on using solids in residential
   p02_inconvpen_lap(t,regi,"coaltr") * vm_demFeSector(t,regi,"sesofos","fesos","build","ES")
-  p02_inconvpen_lap(t,regi,"biotrmod") * vm_demFeSector(t,regi,"sesobio","fesos","build","ES")
+  + p02_inconvpen_lap(t,regi,"biotrmod") * vm_demFeSector(t,regi,"sesobio","fesos","build","ES")
 ;
 $ENDIF.INCONV
 

--- a/modules/02_welfare/ineqLognormal/not_used.txt
+++ b/modules/02_welfare/ineqLognormal/not_used.txt
@@ -5,4 +5,3 @@
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
 name,type,reason
-pm_cesdata,input,questionnaire

--- a/modules/02_welfare/utilitarian/bounds.gms
+++ b/modules/02_welfare/utilitarian/bounds.gms
@@ -7,10 +7,7 @@
 *** SOF ./modules/02_welfare/utilitarian/bounds.gms
 
 $IFTHEN.INCONV %cm_INCONV_PENALTY% == "on"
-v02_sesoInconvPenSlack.lo(t,regi)=0;
-v02_inconvPenCoalSolids.fx("2005",regi) = 0;
-v02_inconvPenCoalSolids.lo(t,regi) = 0;
-v02_inconvPen.lo(t,regi) = 0;
+v02_inconvPenSolidsBuild.fx("2005",regi) = 0;
 v02_inconvPen.fx("2005",regi) = 0;
 $ENDIF.INCONV
 

--- a/modules/02_welfare/utilitarian/declarations.gms
+++ b/modules/02_welfare/utilitarian/declarations.gms
@@ -58,7 +58,7 @@ q02_welfare                                       "Regional welfare"
 
 $ifthen.inconv %cm_INCONV_PENALTY% == "on"
 q02_inconvPen(ttot,all_regi)                      "Calculate the inconvenience penalty v02_inconvPen"
-q02_inconvPenSolidsBuild(ttot,all_regi,all_te)      "Calculate the inconvenience penalty v02_inconvPenSolids for solids used in Buildings"
+q02_inconvPenSolidsBuild(ttot,all_regi)      "Calculate the inconvenience penalty v02_inconvPenSolids for solids used in Buildings"
 $endif.inconv
 
 $IFTHEN.INCONV_bioSwitch "%cm_INCONV_PENALTY_FESwitch%" == "on"

--- a/modules/02_welfare/utilitarian/declarations.gms
+++ b/modules/02_welfare/utilitarian/declarations.gms
@@ -32,15 +32,17 @@ variables
 v02_welfare(all_regi)                             "Regional welfare"
 vm_welfareGlob                                    "Global welfare"
 
-$ifthen.inconv %cm_INCONV_PENALTY% == "on" 
-v02_inconvPen(ttot,all_regi)                      "Inconvenience penalty in the welfare function, e.g. for air pollution. Unit: ?Utils?"
-v02_inconvPenCoalSolids(ttot,all_regi)            "Inconvenience penalty in the welfare function, e.g. for air pollution. Unit: ?Utils?"
-v02_sesoInconvPenSlack(ttot,all_regi)             "Slack to avoid negative inconvenience penalty for Coal Solids" 
-$endif.inconv
 ;
 
-$IFTHEN.INCONV_bioSwitch "%cm_INCONV_PENALTY_FESwitch%" == "on"
 positive variables
+
+$ifthen.inconv %cm_INCONV_PENALTY% == "on" 
+v02_inconvPen(ttot,all_regi)                      "Inconvenience penalty on pe2se in the welfare function, e.g. for air pollution, except for biotr and coaltr. Unit: ?Utils?"
+v02_inconvPenSolidsBuild(ttot,all_regi)             "Inconvenience penalty in the welfare function, e.g. for air pollution or inconvenience, for solids used in Buildings. Unit: ?Utils?"
+$endif.inconv
+
+$IFTHEN.INCONV_bioSwitch "%cm_INCONV_PENALTY_FESwitch%" == "on"
+
 v02_NegInconvPenFeBioSwitch(ttot,all_regi,all_enty,all_enty,emi_sectors,all_emiMkt) "Negative inconvenience penalty in the welfare function for bio/synfuel shares switch between sectors and emissions markets"
 v02_PosInconvPenFeBioSwitch(ttot,all_regi,all_enty,all_enty,emi_sectors,all_emiMkt) "Positive inconvenience penalty in the welfare function for bio/synfuel shares switch between sectors and emissions markets"
 ;
@@ -56,7 +58,7 @@ q02_welfare                                       "Regional welfare"
 
 $ifthen.inconv %cm_INCONV_PENALTY% == "on"
 q02_inconvPen(ttot,all_regi)                      "Calculate the inconvenience penalty v02_inconvPen"
-q02_inconvPenCoalSolids(ttot,all_regi)            "Calculate the inconvenience penalty v02_inconvPen"
+q02_inconvPenSolidsBuild(ttot,all_regi,all_te)      "Calculate the inconvenience penalty v02_inconvPenSolids for solids used in Buildings"
 $endif.inconv
 
 $IFTHEN.INCONV_bioSwitch "%cm_INCONV_PENALTY_FESwitch%" == "on"

--- a/modules/02_welfare/utilitarian/equations.gms
+++ b/modules/02_welfare/utilitarian/equations.gms
@@ -44,7 +44,7 @@ q02_welfare(regi) ..
         )
 $ifthen %cm_INCONV_PENALTY% == "on"
       - v02_inconvPen(ttot,regi)
-      - v02_inconvPenCoalSolids(ttot,regi)
+      - v02_inconvPenSolidsBuild(ttot,regi)
 $endif
 $ifthen "%cm_INCONV_PENALTY_FESwitch%" == "on"
         !! inconvenience cost for fuel switching in FE between fossil,
@@ -58,7 +58,7 @@ $ifthen "%cm_INCONV_PENALTY_FESwitch%" == "on"
           v02_NegInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt)
           + v02_PosInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt)
           )
-          / 1e3	
+          / 1e3	!! heuristically determined rescaling factor so the dampening doesn't dominate the transformation
 $endif
 $ifthen not "%cm_seFeSectorShareDevMethod%" == "off"
         !! penalizing secondary energy share deviation in sectors  
@@ -73,21 +73,21 @@ $endif
 ***---------------------------------------------------------------------------
 $IFTHEN.INCONV %cm_INCONV_PENALTY% == "on"
 q02_inconvPen(t,regi)$(t.val > 2005)..
-    v02_inconvPen(t,regi)
+  v02_inconvPen(t,regi)
   =g=
-*' local air pollution for all entySe production except for coal solids (=sesofos), which is treated separately (see below)
-    SUM(pe2se(enty,entySe,te)$(NOT sameas(entySe,"sesofos")),
-        p02_inconvpen_lap(t,regi,te) * (vm_prodSe(t,regi,enty,entySe,te))
-    )
+*' local air pollution / inconvenience for all entySe production except for coaltr and biotrmod solids, wich are treated separately (see below)
+  SUM(pe2se(enty,entySe,te)$( NOT (sameas(te,"coaltr") OR sameas(te,"biotrmod") ) ),
+    p02_inconvpen_lap(t,regi,te) * vm_prodSe(t,regi,enty,entySe,te)
+  )
 ;
 
-q02_inconvPenCoalSolids(t,regi)$(t.val > 2005)..
-    v02_inconvPenCoalSolids(t,regi)
+q02_inconvPenSolidsBuild(t,regi)$(t.val > 2005)..
+  v02_inconvPenSolidsBuild(t,regi)
   =g=
-*' local air pollution for coal: inconvinience penalty applies only for buildings use; slack variable ensures that v02_inconvPen can stay > 0 
-    p02_inconvpen_lap(t,regi,"coaltr") * (vm_prodSe(t,regi,"pecoal","sesofos","coaltr") 
-  - (vm_cesIO(t,regi,"fesoi") + pm_cesdata(t,regi,"fesoi","offset_quantity")))
-  + v02_sesoInconvPenSlack(t,regi)
+*' Local air pollution and inconvenience of using coal and (modern) biomass: inconvenience penalty applies only for use in residential/buildings
+*' The inconvenience of using traditional biomass are accounted for in v02_inconvPen, and thus additional to the penalty on using solids in residential
+  p02_inconvpen_lap(t,regi,"coaltr") * vm_demFeSector(t,regi,"sesofos","fesos","build","ES")
+  p02_inconvpen_lap(t,regi,"biotrmod") * vm_demFeSector(t,regi,"sesobio","fesos","build","ES")
 ;
 $ENDIF.INCONV
 

--- a/modules/02_welfare/utilitarian/equations.gms
+++ b/modules/02_welfare/utilitarian/equations.gms
@@ -87,7 +87,7 @@ q02_inconvPenSolidsBuild(t,regi)$(t.val > 2005)..
 *' Local air pollution and inconvenience of using coal and (modern) biomass: inconvenience penalty applies only for use in residential/buildings
 *' The inconvenience of using traditional biomass are accounted for in v02_inconvPen, and thus additional to the penalty on using solids in residential
   p02_inconvpen_lap(t,regi,"coaltr") * vm_demFeSector(t,regi,"sesofos","fesos","build","ES")
-  p02_inconvpen_lap(t,regi,"biotrmod") * vm_demFeSector(t,regi,"sesobio","fesos","build","ES")
+  + p02_inconvpen_lap(t,regi,"biotrmod") * vm_demFeSector(t,regi,"sesobio","fesos","build","ES")
 ;
 $ENDIF.INCONV
 

--- a/modules/02_welfare/utilitarian/not_used.txt
+++ b/modules/02_welfare/utilitarian/not_used.txt
@@ -7,6 +7,7 @@
 name,type,reason
 v02_emitaxredistr,variable,???
 v02_energyExp,variable,???
+vm_cesIO,variable,???
 vm_damageFactor,variable,???
 vm_emiMacSector,variable,???
 vm_emiCdr,variable,???


### PR DESCRIPTION
## Purpose of this PR

There was a piece of code that was supposed to remove the amount of coal used in industry from the inconvenience penalty applied to coal use, but it wasn't formulated correctly for the current REMIND version. The PR ensures that biomass and coal use in residential sees an inconvenience penalty. 

## Type of change

- [x] Bug fix 
- [ ] Minor change (default scenarios show only small differences)

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)

## Further information (optional):

* Test runs are here: /p/projects/remind/users/robertp/REMIND_3px/2025-01-17_inconvPen/new
* Comparison of results (what changes by this PR?):  (will be added once compScens are finished)
/p/projects/remind/users/robertp/REMIND_3px/2025-01-17_inconvPen/new/compScen-Def-Inconv_NPi2025-Pk1000-Pk650-2025-01-20_09.46.11-H12-short

Increase of coal use in buildings solids is stopped/much weaker than before: 
![image](https://github.com/user-attachments/assets/e6a3519e-53c1-45b4-b330-eeea2de26dfd)


