### PR TITLE
New source for calculating fuel extraction emission factors

### DIFF
--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -953,14 +953,27 @@ $offdelim
 p_abatparam_CH4(tall,all_regi,all_enty,steps)$(ord(steps) gt 201) = p_abatparam_CH4(tall,all_regi,all_enty,"201");
 p_abatparam_N2O(tall,all_regi,all_enty,steps)$(ord(steps) gt 201) = p_abatparam_N2O(tall,all_regi,all_enty,"201");
 
-parameter p_emiFossilFuelExtr(all_regi,all_enty)          "methane emissions, needed for the calculation of p_efFossilFuelExtr"
+*** Read methane emissions from fossil fuel extraction for calculating emission factors. 
+*** The base year determines whether the data comes from CEDS or EDGAR
+$ifthen %cm_emifacs_baseyear% == "2005" 
+parameter p_emiFossilFuelExtr(all_regi,all_enty)          "methane emissions in 2005 [Mt CH4], needed for the calculation of p_efFossilFuelExtr"
 /
 $ondelim
 $include "./core/input/p_emiFossilFuelExtr.cs4r"
 $offdelim
 /
 ;
+$else
+parameter p_emiFossilFuelExtr(all_regi,all_enty)          "methane emissions in 2020 [Mt CH4], needed for the calculation of p_efFossilFuelExtr"
+/
+$ondelim
+$include "./core/input/p_emiFossilFuelExtr2020.cs4r"
+$offdelim
+/
+;
+$endif
 
+* GA: These hardcoded values were probably assuming 2005 as base year, TODO: check and adjust for 2020 case
 $if %cm_LU_emi_scen% == "SSP1"   p_efFossilFuelExtr(regi,"pebiolc","n2obio") = 0.0047/sm_EJ_2_TWa;
 $if %cm_LU_emi_scen% == "SSP2"   p_efFossilFuelExtr(regi,"pebiolc","n2obio") = 0.0079/sm_EJ_2_TWa;
 $if %cm_LU_emi_scen% == "SSP2_lowEn"   p_efFossilFuelExtr(regi,"pebiolc","n2obio") = 0.0079/sm_EJ_2_TWa;

--- a/core/input/files
+++ b/core/input/files
@@ -21,6 +21,7 @@ p_adj_deltacapoffset.cs4r
 p_boundCapCCSindicator.cs4r
 p_boundEmi.cs4r
 p_emiFossilFuelExtr.cs4r
+p_emiFossilFuelExtr2020.cs4r
 f_nechem_emissionFactors.cs4r
 f_incinerationShares.cs4r
 p_emineg_econometric.cs3r

--- a/core/presolve.gms
+++ b/core/presolve.gms
@@ -69,10 +69,10 @@ display p_emineg_econometric;
 loop (emi2fuel(entyPe,enty),
   p_efFossilFuelExtrGlo(entyPe,enty)
   = sum(regi, p_emiFossilFuelExtr(regi,entyPe))
-  / sum((rlf,regi), vm_fuExtr.l("2005",regi,entyPe,rlf));
+  / sum((rlf,regi), vm_fuExtr.l("%cm_emifacs_baseyear%",regi,entyPe,rlf));
 
   loop (regi,
-    sm_tmp =  sum(rlf, vm_fuExtr.l("2005",regi,entyPe,rlf));
+    sm_tmp =  sum(rlf, vm_fuExtr.l("%cm_emifacs_baseyear%",regi,entyPe,rlf));
 
     p_efFossilFuelExtr(regi,entyPe,enty)$( sm_tmp )
       = p_emiFossilFuelExtr(regi,entyPe) / sm_tmp;

--- a/main.gms
+++ b/main.gms
@@ -1869,6 +1869,10 @@ $setglobal c_CES_calibration_industry_FE_target  1
 $setglobal c_testOneRegi_region  EUR       !! def = EUR  !! regexp = [A-Z]{3}
 *' cm_taxrc_RE     "switch to define whether tax on (CO2 content of) energy imports is recycled to additional direct investments in renewables (wind, solar and storage)"
 $setglobal cm_taxrc_RE  none   !! def = none   !! regexp = none|REdirect
+*' cm_emifacs_baseyear "base year for deriving nonCO2 emission factors"
+*' (2005): Uses EDGAR data with 2005 as base year
+*' (2020): Uses CEDS2024 data with 2020 as base year
+$setGlobal cm_emifacs_baseyear  2005          !! def = 2005
 *' cm_repeatNonOpt       "should nonoptimal regions be solved again?"
 *'
 *' *  (off): no, only infeasable regions are repeated, standard setting


### PR DESCRIPTION
## Purpose of this PR
Introduces an option to use updated values to calculate CH4 emission factors from fossil fuel extraction activities. This is controlled by a new flag:

```
*' cm_emifacs_baseyear "base year for deriving nonCO2 emission factors"
*' (2005): Uses EDGAR data with 2005 as base year
*' (2020): Uses CEDS2024 data with 2020 as base year
$setGlobal cm_emifacs_baseyear  2005          !! def = 2005

```

**Previous state:**
FF extraction EFs are calculated from EDGAR 2005 baseline emissions and REMIND's own 2005 activity levels, see presolve.gms:66. CH4 emissions from fuel extraction are read from p_emiFossilFuelExtr.cs4r , which is generated by running [calcEmiFossilFuelExtr](https://github.com/pik-piam/mrremind/blob/master/R/calcEmiFossilFuelExtr.R). 

**Update:**
The default is still unchanged. But setting `cm_emifacs_baseyear` to 2020 calibrates the emission factor that that year's REMIND activity levels and CEDS emission data instead.

This PR is part of what's needed to address https://github.com/remindmodel/development_issues/issues/442. As other changes will be introduced to nonCO2 emissions, I believe it's best to only fully switch over to the updated implementations after the other changes are introduced, and validate them as one.  


## Type of change

- [ ] New feature 
- [ ] Minor change (default scenarios show only small differences)


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Test runs are here: 
```
/p/projects/piam/abrahao/scratch/updatenonco2/remind/output/SSP2-NPi2025-CEDS2020_2025-01-15_15.06.44
/p/projects/piam/abrahao/scratch/updatenonco2/remind/output/SSP2-NPi2025-EDGAR2005_2025-01-15_15.06.31
```
PkBudg scenarios had INFES, but they seem unrelated and were experienced by others around the same time, so I believe this PR is not causing them.

* Comparison of results (what changes by this PR?): 

Overall, the derived emission factors lead to lower FF CH4 emissions than before. The ratios between fuels also change, but except for USA, all regions end up with lower emissions after mid-century in NPi.

![image](https://github.com/user-attachments/assets/fb32b7f7-d31b-41ec-8078-521e5aa76c05)
![image](https://github.com/user-attachments/assets/eb6c301b-a3e0-4c9b-bfd7-f36fabd52eb0)

