### PR TITLE
input data rev.7.21 and CES parameter for SSP2, SSP2-EU21, SSP1, SSP3, SSP5, SSP2_lowEn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### input data/calibration
+- new input data rev7.21 including new MAgPIE data
 
 ### changed
 - **scripts** for MAgPIE coupled runs, if the coupled config contains a `path_gdx_ref` column, it needs a `path_gdx_refpolicycost` column as well.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### input data/calibration
-- new input data rev7.21 including new MAgPIE data
+- new input data rev7.21 including new MAgPIE data [[#1956] (https://github.com/remindmodel/remind/pull/1956)]
 
 ### changed
 - **scripts** for MAgPIE coupled runs, if the coupled config contains a `path_gdx_ref` column, it needs a `path_gdx_refpolicycost` column as well.

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -28,10 +28,10 @@ cfg$regionmapping <- "config/regionmappingH12.csv"
 cfg$extramappings_historic <- ""
 
 #### Current input data revision (<mainrevision>.<subrevision>) ####
-cfg$inputRevision <- "7.19"
+cfg$inputRevision <- "7.21"
 
 #### Current CES parameter and GDX revision (commit hash) ####
-cfg$CESandGDXversion <- "cfe76b2cb670aee30490e8191a5498ff8b0b6421"
+cfg$CESandGDXversion <- "6ae8dd43a7707867df312d16f7e1b6b784cf6614"
 
 #### Force the model to download new input data ####
 cfg$force_download <- FALSE


### PR DESCRIPTION

## Purpose of this PR
- new input data rev.7.21 including updated MAgPIE data
- new CES parameter and gdx files for 7.21 for SSP2, SSP2-EU21, SSP1, SSP3, SSP5, SSP2_lowEn, 
- calibrtion runs: /p/tmp/lavinia/REMIND/REMIND_calibration_2025_01_20/remind

## Type of change

- [x] Minor change (default scenarios show only small differences)


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

