### PR TITLE
Fix landuse MAC costs to the reference run

### DIFF
--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -1551,6 +1551,7 @@ $include "./core/input/f_fedemand_build.cs4r"
 $offdelim
 /;
 
+
 pm_fedemand(t,regi,cal_ppf_buildings_dyn36) = f_fedemand_build(t,regi,"%cm_demScen%","%cm_rcp_scen_build%",cal_ppf_buildings_dyn36);
 $endif.cm_rcp_scen_build
 
@@ -1567,12 +1568,15 @@ $endif.scaleDemand
 *** initialize global target deviation scalar
 sm_globalBudget_dev = 1;
 
-*' load production values from reference gdx to allow penalizing changes vs reference run in the first time step via q_changeProdStartyearCost/q21_taxrevChProdStartYear
+
 if (cm_startyear gt 2005,
+*' load production values from reference gdx to allow penalizing changes vs reference run in the first time step via q_changeProdStartyearCost/q21_taxrevChProdStartYear
 execute_load "input_ref.gdx", p_prodSeReference = vm_prodSe.l;
 execute_load "input_ref.gdx", pm_prodFEReference = vm_prodFe.l;
 execute_load "input_ref.gdx", p_prodUeReference = v_prodUe.l;
 execute_load "input_ref.gdx", p_co2CCSReference = vm_co2CCS.l;
+*' load MAC costs from reference gdx. Values for t (i.e. after cm_start_year) will be overwritten in core/presolve.gms 
+execute_load "input_ref.gdx" pm_macCost;
 );
 
 p_prodAllReference(t,regi,te) =

--- a/core/presolve.gms
+++ b/core/presolve.gms
@@ -282,23 +282,23 @@ Display "computed abatement levels at carbon price", pm_macAbatLev;
 *** Integral under MAC cost curve
 *** costs = baseline emissions * price step * sum [over i to n] (q_n - q_i)
 *** q_i = abatement [fraction] at step i
-pm_macCost(ttot,regi,emiMacSector(enty))
+pm_macCost(t,regi,emiMacSector(enty))
   = 1e-3
   * p_macCostSwitch(enty)
   * p_emi_quan_conv_ar4(enty)
-  * v_macBase.l(ttot,regi,enty)
+  * v_macBase.l(t,regi,enty)
   * sm_dmac
   * ( ( sum(emiMac2mac(enty,enty2),
-          pm_macStep(ttot,regi,enty2)
+          pm_macStep(t,regi,enty2)
         )
       * sum(steps$( ord(steps) eq sum(emiMac2mac(enty,enty2),
-                                    pm_macStep(ttot,regi,enty2)) ),
-          sum(emiMac2mac(enty,enty2), pm_macAbat(ttot,regi,enty2,steps))
+                                    pm_macStep(t,regi,enty2)) ),
+          sum(emiMac2mac(enty,enty2), pm_macAbat(t,regi,enty2,steps))
         )
       )
     - sum(steps$( ord(steps) le sum(emiMac2mac(enty,enty2),
-                                  pm_macStep(ttot,regi,enty2)) ),
-        sum(emiMac2mac(enty,enty2), pm_macAbat(ttot,regi,enty2,steps))
+                                  pm_macStep(t,regi,enty2)) ),
+        sum(emiMac2mac(enty,enty2), pm_macAbat(t,regi,enty2,steps))
       )
     );
 


### PR DESCRIPTION
## Purpose of this PR

As pointed out [here](https://github.com/remindmodel/development_issues/issues/220#issuecomment-2595707969) the MAC costs for landuse emissions were not fixed to the reference run for t < cm_startyear. Now they are.

Test runs are here:

/p/tmp/dklein/remind-fixmaccosts/output/SSP2-PkBudg650_2025-01-22_18.11.29

```
$ dumpgdx fulldata.gdx pm_macCost 20[12].,CAZ,ch4rice
2020  CAZ  ch4rice  5.88012740405786E-8
2025  CAZ  ch4rice  7.408846270267E-8

$ dumpgdx input_ref.gdx pm_macCost 20[12].,CAZ,ch4rice
2020  CAZ  ch4rice  5.88012740405786E-8
2025  CAZ  ch4rice  7.408846270267E-8
```