### PR TITLE
new CES parameter for SSP2, SSP2-EU21, SSP1, SSP3, SSP5, SSP2_lowEn

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -31,7 +31,7 @@ cfg$extramappings_historic <- ""
 cfg$inputRevision <- "7.22"
 
 #### Current CES parameter and GDX revision (commit hash) ####
-cfg$CESandGDXversion <- "6ae8dd43a7707867df312d16f7e1b6b784cf6614"
+cfg$CESandGDXversion <- "3548a995c2dc21531fa51e71a4662a83936555d2"
 
 #### Force the model to download new input data ####
 cfg$force_download <- FALSE


### PR DESCRIPTION
## Purpose of this PR
* new CES parameter and gdx files for input data rev7.22 for SSP2, SSP2-EU21, SSP1, SSP3, SSP5, SSP2_lowEn, 
* calibration uns: /p/tmp/lavinia/REMIND/REMIND_calibration_2025_01_24/remind


## Type of change

- [x] Minor change (default scenarios show only small differences)


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code


## Further information (optional):

* Runs with these changes are here:
* Comparison of results (what changes by this PR?): 

