### PR TITLE
Adjust final energy carriers for CDR options

### DIFF
--- a/modules/33_CDR/portfolio/bounds.gms
+++ b/modules/33_CDR/portfolio/bounds.gms
@@ -37,9 +37,11 @@ v33_co2emi_non_atm_calcination.fx(t,regi,te_oae33)$(t.val lt 2025) = 0;
 *** vm_cap for dac is fixed for t<2025 in core/bounds.gms (tech_stat eq 4)
 vm_co2capture_cdr.fx(t,regi,enty,enty2,te,rlf)$(ccs2te(enty,enty2,te) AND t.val lt 2025) = 0;
 
-*** Set minimum DAC capacities (if available) to help the solver find the technology 
+*** Set minimum DAC capacities (if available) to help the solver find the technology and exclude fegas and feh2s for low-temperature dac
 if (te_used33("dac"),
     vm_cap.lo(t,regi,"dac",rlf)$(teNoTransform2rlf33("dac",rlf) AND (t.val ge 2030)) = sm_eps;
+    v33_FEdemand.fx(t,regi,"fegas","fehes","dac") = 0;
+    v33_FEdemand.fx(t,regi,"feh2s","fehes","dac") = 0;
 );
 
 *** Bounds for enhanced weathering
@@ -59,6 +61,9 @@ else
 if(card(te_oae33) ne 0,
     !! OAE starts in cm_33_OAE_startyear
     vm_cap.fx(t, regi, te_oae33, rlf)$(t.val lt cm_33_OAE_startyr) = 0;
+    !! exclude feh2s for oae_el
+    v33_FEdemand.fx(t,regi,"feh2s","feels","oae_el") = 0;
+    v33_FEdemand.fx(t,regi,"feh2s","fehes","oae_el") = 0;
 else
     v33_co2emi_non_atm_calcination.fx(t, regi, "oae_ng") = 0;
     v33_co2emi_non_atm_calcination.fx(t, regi, "oae_el") = 0;

--- a/modules/33_CDR/portfolio/sets.gms
+++ b/modules/33_CDR/portfolio/sets.gms
@@ -43,6 +43,7 @@ fe2cdr(all_enty,all_enty,all_te) "mapping of FE carriers supplying FE demand for
       feels.feels.oae_ng
       fedie.fedie.oae_ng
       fegas.fehes.oae_ng
+      feh2s.fehes.oae_ng
 
       feels.feels.oae_el
       fedie.fedie.oae_el


### PR DESCRIPTION
## Purpose of this PR
This PR changes the FE carriers that can be used by CDR technologies:
- dac: feh2s and fegas are fixed to 0 for plausibility reasons. 
- oae_el: feh2s supply is fixed to 0. for plausibility reasons.
- oae_ng: feh2s supply  is _added_ since this is a high-temperature heat process.

We chose to fix some carriers to 0 because removing the carriers proved difficult and the current structure might be needed at a later point when additional process parametrizations might be added.

## Type of change
- [x] Minor change (default scenarios show only small differences)

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] I checked the `log.txt` file of my runs for newly introduced summation, fixing or variable name errors
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)