### PR TITLE
fix fixOnRef and checkProjectSummations bugs

### DIFF
--- a/core/input/files
+++ b/core/input/files
@@ -33,7 +33,7 @@ p_macBase1990.cs4r
 p_macBase2005.cs4r
 p_macBaseCEDS2020.cs4r
 p_macBaseCEDS2005.cs4r
-p_macBaseHarmsen2022.cs4r
+*p_macBaseHarmsen2022.cs4r
 p_macBaseVanv.cs4r
 p_macPolCO2luc.cs4r
 p_boundCapCCS.cs4r

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -22,7 +22,7 @@
 - [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
 - [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
 - [ ] I checked the `log.txt` file of my runs for newly introduced summation, fixing or variable name errors
-- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)
+- [ ] All automated model tests pass, executed after my final commit (`FAIL 0` in the output of `make test`)
 - [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
 
 ## Further information (optional):

--- a/scripts/output/single/checkProjectSummations.R
+++ b/scripts/output/single/checkProjectSummations.R
@@ -28,7 +28,9 @@ options(width = 160)
 absDiff <- 0.00001
 relDiff <- 0.01
 
-sources <- paste0("RT", if (any(grepl("^MAgPIE", levels(mifdata$model)))) "M")
+sources <- paste0("R",
+                  if (isTRUE(envi$cfg$gms$CES_parameters == "load")) "T",
+                  if (any(grepl("^MAgPIE", levels(mifdata$model)))) "M")
 message("\n### Check existence of variables in mappings.")
 missingVariables <- checkMissingVars(mifdata, TRUE, sources)
 if (length(missingVariables) > 0) message("Check piamInterfaces::variableInfo('variablename') etc.")

--- a/scripts/output/single/fixOnRef.R
+++ b/scripts/output/single/fixOnRef.R
@@ -6,7 +6,7 @@
 # |  Contact: remind@pik-potsdam.de
 
 # if you want to change the reference run for yourrun, you can run:
-# Rscript scripts/output/single/fixRefOn.R -i outputdir=yourrun,newreferencerun
+# Rscript scripts/output/single/fixOnRef.R -i outputdir=yourrun,newreferencerun
 
 suppressPackageStartupMessages(library(tidyverse))
 
@@ -56,7 +56,7 @@ fixOnMif <- function(outputdir) {
 
   gdxs    <- file.path(outputdir, "fulldata.gdx")
   configs <- file.path(outputdir, "config.Rdata")
-  message("### Checking if mif is correctly fixed on reference run for ", outputdir)
+  message("### Checking if mif is correctly fixed on reference run for ", outputdir[[1]])
   if (! all(file.exists(gdxs, configs))) stop("gdx or config.Rdata not found!")
   scens   <- lucode2::getScenNames(outputdir)
   mifs    <- file.path(outputdir, paste0("REMIND_generic_", scens, ".mif"))
@@ -77,14 +77,14 @@ fixOnMif <- function(outputdir) {
     stop("length(outputdir)=", length(outputdir), ", is bigger than 2.")
   }
   refname <- basename(dirname(refmif))
-  d <- quitte::as.quitte(mifs)
+  d <- quitte::as.quitte(mifs[[1]])
   dref <- quitte::as.quitte(refmif)
   d <- fixMAGICC(d, dref, startyear, title)
-  failfile <- file.path(outputdir, "log_fixOnRef.csv")
+  failfile <- file.path(outputdir[[1]], "log_fixOnRef.csv")
   fixeddata <- piamInterfaces::fixOnRef(d, dref, ret = "TRUE_or_fixed", startyear = startyear, failfile = failfile, relDiff = 0.00002)
 
   update <- paste0("MAGICC data. ", if (! isTRUE(fixeddata)) "Run output.R -> single -> fixOnRef to fix the rest.")
-  if (! isTRUE(fixeddata) && envi$cfg$fixOnRefAuto %in% c(TRUE, "TRUE")) {
+  if (! isTRUE(fixeddata) && isTRUE(envi$cfg$fixOnRefAuto %in% c(TRUE, "TRUE"))) {
     d <- fixeddata
     update <- "data from reference run because cfg$fixOnRefAuto=TRUE."
   } else if (! isTRUE(fixeddata) && exists("flags") && isTRUE("--interactive" %in% flags)) {

--- a/scripts/output/single/fixOnRef.R
+++ b/scripts/output/single/fixOnRef.R
@@ -5,24 +5,32 @@
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
 
-# if you want to change the reference run for yourrun, you can run:
+# Call this script via output.R -> single -> fixOnRef.
+# This script allows to check whether for ttot < cm_startyear, the run is identical
+# to path_gdx_ref by comparing the mif files. It can automatically find the required
+# data based on config.Rdata.
+
+# If you want to change the reference run for yourrun, you cannot use output.R, but run:
 # Rscript scripts/output/single/fixOnRef.R -i outputdir=yourrun,newreferencerun
 
 suppressPackageStartupMessages(library(tidyverse))
 
+# Define arguments that can be read from command line
 if(! exists("source_include")) {
-  # Define arguments that can be read from command line
   outputdir <- "."
   flags <- lucode2::readArgs("outputdir", .flags = c(i = "--interactive"))
 }
 
+# find the mif file of the reference run automatically by reading from cfg the output folder
 findRefMif <- function(outputdir, envi) {
   stopifnot(length(outputdir) == 1)
   inputref <- try(envi$cfg$files2export$start[["input_ref.gdx"]], silent = TRUE)
+  # if something goes wrong or no path_gdx_ref specified, return nothing
   if (inherits(inputref, "try-error") || is.na(inputref) || isTRUE(inputref == "NA") || length(inputref) == 0) {
     message("No input_ref.gdx found in config.")
     return(NULL)
   }
+  # find scenario name of reference run to be able to find mif file
   refdir <- dirname(inputref)
   if (! file.exists(file.path(refdir, "config.Rdata"))) {
     message("Config in reference directory '", refdir, "' not found.")
@@ -30,6 +38,7 @@ findRefMif <- function(outputdir, envi) {
   }
   refscen <- lucode2::getScenNames(refdir)
   refmif <- file.path(refdir, paste0("REMIND_generic_", refscen, ".mif"))
+  # mif file might not exist for whatever reason
   if (! file.exists(refmif)) {
     message("Reference mif '", refmif, "' not found, run reporting!")
     return(NULL)
@@ -37,9 +46,13 @@ findRefMif <- function(outputdir, envi) {
   return(refmif)
 }
 
+# always automatically fixes all MAGICC data that strangely is not correctly
+# fixed on the reference run, but we see no way to change that.
 fixMAGICC <- function(d, dref, startyear, scen) {
+  # grep of variables coming from MAGICC
   magiccgrep <- "^Forcing|^Temperature|^Concentration|^MAGICC7 AR6"
   message("Fixing MAGICC6 and 7 data before ", startyear)
+  # combine MAGICC dref data for t < startyear with the rest
   dnew <-
     rbind(
       filter(dref, grepl(magiccgrep, .data$variable),
@@ -52,8 +65,9 @@ fixMAGICC <- function(d, dref, startyear, scen) {
   return(dnew)
 }
 
+# does the actual fixing on the reference run
 fixOnMif <- function(outputdir) {
-
+  # first find gdx, config and mif files for all outputdir folder
   gdxs    <- file.path(outputdir, "fulldata.gdx")
   configs <- file.path(outputdir, "config.Rdata")
   message("### Checking if mif is correctly fixed on reference run for ", outputdir[[1]])
@@ -62,27 +76,37 @@ fixOnMif <- function(outputdir) {
   mifs    <- file.path(outputdir, paste0("REMIND_generic_", scens, ".mif"))
   if (! all(file.exists(mifs))) stop("mif file not found, run reporting!")
 
+  # load config of first outputdir (the folder we are checking)
   envi <- new.env()
   load(configs[[1]], env =  envi)
   title <- envi$cfg$title
   stopifnot(title == scens[[1]])
   startyear <- envi$cfg$gms$cm_startyear
 
-  if (length(outputdir) == 1) {
+  if (length(outputdir) == 1) { # search for mif of reference run based on config
     refmif <- findRefMif(outputdir, envi)
     if (is.null(refmif)) return(NULL)
-  } else if (length(outputdir) == 2) {
+  } else if (length(outputdir) == 2) { # use outputdir[2] as reference run
     refmif <- mifs[[2]]
-  } else {
+  } else { # something went wrong
     stop("length(outputdir)=", length(outputdir), ", is bigger than 2.")
   }
   refname <- basename(dirname(refmif))
+
+  # load data of run and reference run
   d <- quitte::as.quitte(mifs[[1]])
   dref <- quitte::as.quitte(refmif)
+  # always fix MAGICC automatically
   d <- fixMAGICC(d, dref, startyear, title)
+  # logfile to write errors to
   failfile <- file.path(outputdir[[1]], "log_fixOnRef.csv")
+  # call piamInterfaces::fixOnRef. Returns either TRUE if everything is fine, or the corrected data
+  # small relative differences of 0.002 % are considered acceptable
   fixeddata <- piamInterfaces::fixOnRef(d, dref, ret = "TRUE_or_fixed", startyear = startyear, failfile = failfile, relDiff = 0.00002)
 
+  # if cfg$fixOnRefAuto = TRUE), fix the data automatically
+  # else if in interactive mode (not within a REMIND run), ask
+  # else if in REMIND run, just print the problems
   update <- paste0("MAGICC data. ", if (! isTRUE(fixeddata)) "Run output.R -> single -> fixOnRef to fix the rest.")
   if (! isTRUE(fixeddata) && isTRUE(envi$cfg$fixOnRefAuto %in% c(TRUE, "TRUE"))) {
     d <- fixeddata
@@ -100,6 +124,7 @@ fixOnMif <- function(outputdir) {
   quitte::write.mif(d, tmpfile)
   file.rename(tmpfile, mifs[[1]])
   piamutils::deletePlus(mifs[[1]], writemif = TRUE)
+  # if you update a run, all other runs that use this run as input should be updated as well.
   message("Keep in mind to update the runs that use this as `path_gdx_ref` as well.")
   return(NULL)
 }


### PR DESCRIPTION
## Purpose of this PR

- fixOnRef: make sure fixing on a different run also works. Then, `outputdir` must have two values, and so we have to assign the second one to the reference, whereas always the first one has to be used for everything else. Fix fail if `cfg$fixOnRefAuto = NULL`.
- checkProjectSummations: For calibration runs where EDGE-T is not running, do not complain about missing Transport variables
- pull request template: highlight that you have to run `make test` on final commit
- comment a single file that is yet missing from input data as agreed with @gabriel-abrahao 

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I checked the `log.txt` file of my runs for newly introduced summation, fixing or variable name errors
- [x] All automated model tests pass (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
