### PR TITLE
Tutorial updates: Running REMIND & Python config on HPC

### DIFF
--- a/tutorials/02_RunningREMIND.md
+++ b/tutorials/02_RunningREMIND.md
@@ -1,13 +1,9 @@
 Start running REMIND with default settings
 ================
-Felix Schreyer (<felix.schreyeru@pik-potsdam.de>), Lavinia Baumstark (<baumstark@pik-potsdam.de>), David Klein (<dklein@pik-potsdam.de>), Tonn Rüter (<tonn.rueter@pik-potsdam.de>)
-30 April, 2019
 
 - [Start running REMIND with default settings](#start-running-remind-with-default-settings)
 - [Your first run](#your-first-run)
   - [Default Configurations](#default-configurations)
-  - [Accessing the HPC](#accessing-the-hpc)
-  - [HPC terminal configuration: Adjust `.profile` and `.bashrc`](#hpc-terminal-configuration-adjust-profile-and-bashrc)
   - [Starting the run](#starting-the-run)
   - [Restarting runs](#restarting-runs)
 - [What happens during a REMIND run?](#what-happens-during-a-remind-run)
@@ -17,8 +13,9 @@ Felix Schreyer (<felix.schreyeru@pik-potsdam.de>), Lavinia Baumstark (<baumstark
   - [Optimization](#optimization)
   - [Output Processing](#output-processing)
 
-
 # Your first run
+
+> **Note** This tutorial assumes that you have access to the PIK HPC, have followed the instructions [in the REMIND group-internal Wiki](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Cluster-Access) on how to access the PIK HPC and configure your cluster environment.
 
 This section will explain how you start your first REMIND run on the Potsdam Institute for Climate Impact Research (PIK) High Performance Cluster (HPC). Running REMIND on other hosts is theoretically possible but works slightly different depending on input data availability and operating system configuration.
 
@@ -38,46 +35,6 @@ b. The SWITCHES section contains setting parameters to control, for e.g., how ma
 c. The FLAGS section contains compilation flags (setGlobals) for further configuration, for e.g., which SSP to use.
 
 d. The last part includes all model parts from the core and modules.
-
-## Accessing the HPC
-
-Follow the instructions [in the PIK-internal Wiki](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Cluster-Access) on how to access the HPC.
-
-## HPC terminal configuration: Adjust `.profile` and `.bashrc`
-
-In order to ready your HPC session for REMIND operation, you'll need to have a properly configured `.profile` file in your HPC home folder. Log into the HPC, then type
-
-```bash
-nano ~/.profile
-```
-
-Add these lines in the text editor:
-
-```bash
-umask 0002
-
-source /p/system/modulefiles/defaults/piam/module_load_piam
-module load anaconda/2024.10
-```
-
-Save the file and exit the editor by pressing <kbd>Ctrl</kbd> + <kbd>X</kbd> and confirm with <kbd>Enter</kbd>. Please note that `umask 0002` needs to be the first line in the `.profile`! This lines makes sure the files you create on the HPC will be writable by your coworkers. The subsequent lines load the `piam` environment, ensuring that all system libraries necessary to run REMIND are available. 
-
-For compatibility reasons you'll also need to add a `.bashrc` file in your home folder. It's the same procedure as with `.profile`: Open the file
-
-```bash
-nano ~/.bashrc
-```
-
-and add `umask 0002` as the first line. A typical `.bashrc` file might look like
-
-```bash
-umask 0002 # Must be the first line
-
-# Additional typical .bashrc configurations like aliases must come after
-alias ll="ls -la"
-```
-
-Again save the file by pressing <kbd>Ctrl</kbd> + <kbd>X</kbd> and confirm with <kbd>Enter</kbd>.
 
 ## Starting the run
 

--- a/tutorials/15_Using_Python.md
+++ b/tutorials/15_Using_Python.md
@@ -1,6 +1,6 @@
 # Python support in REMIND
-Mika Pflüger (mika.pflueger@pik-potsdam.de)
-Tonn Rüter (tonn.rueter@pik-potsdam.de)
+
+For support contact [Tonn Rüter](mailto:tonn.rueter@pik-potsdam.de)
 
 Python is a high-level, interpreted programming language known for its readability and versatility. In REMIND, Python is essential for coupling to specialized models, such as those used for climate assessment reporting. These models often require advanced data processing and integration with other tools, which Python in conjecture with R `reticulate` facilitates efficiently.
 
@@ -32,24 +32,14 @@ When using REMIND, you might encounter warnings about the inability to verify th
 
 ### `conda` Environment for REMIND/MAGICC7 Operation on the Cluster
 
-To ensure `climate-assessment` and `MAGICC7` are available when running REMIND on the clusters, follow these steps after logging in and before initiating a REMIND run that requires MAGICC7 (e.g., climate reporting). On the new cluster (`foote.pik-potsdam.de`) do:
+> **Note** This section assumes that you have access to the PIK HPC, have followed the instructions in the REMIND group-internal Wiki on [how to access the PIK HPC]((https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Cluster-Access)) and configure your [Python cluster environment](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Cluster#for-python-users).
 
-1. Load the necessary `module`s:
-    ```sh
-    # Make sure module_load_piam is already active, otherwise run
-    # source /p/system/modulefiles/defaults/piam/module_load_piam
-    module load anaconda/2023.09
-    ```
+To ensure `climate-assessment` and `MAGICC7` are available when running REMIND on the PIK high performance cluster (HPC), follow these steps after logging in and before initiating a REMIND run that requires MAGICC7 (e.g., climate reporting). On the HPC (`foote.pik-potsdam.de`) activate the conda environment:
 
-2. *Optional:* Configure the terminal prompt to avoid unnecessary length. This only has to run once!
-    ```sh
-    conda config --set env_prompt '({name})'
-    ```
+```bash
+source activate /p/projects/rd3mod/python/environments/scm_magicc7_hpc
+```
 
-3. Activate the conda environment:
-    ```sh
-    source activate /p/projects/rd3mod/python/environments/scm_magicc7_hpc
-    ```
 This setup ensures the correct Python versions are available. To deactivate the conda environment, type `conda deactivate`. **Please do not alter the conda environment as changes would affect all users.**
 
 With the conda environment activated, you can start a climate assessment report from your REMIND folder with:


### PR DESCRIPTION
In `02_RunningREMIND.md`:

- Added a note refering to the cluster access tutorial from the PIK internal RSE wiki
- Rm'd section on Cluster Access since this is PIK and not REMIND specific
- Rm'd author section, since the whole concept seems outdated (git keeps track of authorship)

In `15_Using_Python.md`:
- Rm'd section specific to PIK HPC environment configuration
- Added links to proper tutorials in RSE wiki
- Rm'd deprecated author info

## Purpose of this PR

Continued tutorial consolidation

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Refactoring

## Checklist:

- [ ] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [ ] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] I checked the `log.txt` file of my runs for newly introduced summation, fixing or variable name errors
- [ ] All automated model tests pass, executed after my final commit (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):


