### PR TITLE
adjust readcoupledgdx, always show if job in slurm

### DIFF
--- a/core/input/files
+++ b/core/input/files
@@ -33,7 +33,7 @@ p_macBase1990.cs4r
 p_macBase2005.cs4r
 p_macBaseCEDS2020.cs4r
 p_macBaseCEDS2005.cs4r
-*p_macBaseHarmsen2022.cs4r
+p_macBaseHarmsen2022.cs4r
 p_macBaseVanv.cs4r
 p_macPolCO2luc.cs4r
 p_boundCapCCS.cs4r

--- a/scripts/output/single/checkProjectSummations.R
+++ b/scripts/output/single/checkProjectSummations.R
@@ -32,7 +32,7 @@ sources <- paste0("R",
                   if (isTRUE(envi$cfg$gms$CES_parameters == "load")) "T",
                   if (any(grepl("^MAgPIE", levels(mifdata$model)))) "M")
 message("\n### Check existence of variables in mappings.")
-missingVariables <- checkMissingVars(mifdata, TRUE, sources)
+missingVariables <- checkMissingVars(mifdata, setdiff(names(mappingNames()), c("AgMIP", "AR6_MAgPIE")), sources)
 if (length(missingVariables) > 0) message("Check piamInterfaces::variableInfo('variablename') etc.")
 
 checkMappings <- list( # list(mappings, summationsFile, skipBunkers)

--- a/scripts/utils/readcoupledgdx.R
+++ b/scripts/utils/readcoupledgdx.R
@@ -6,12 +6,12 @@ vars <- c("pm_gmt_conv", "pm_sccConvergenceMaxDeviation")
 argv <- commandArgs(trailingOnly = TRUE)
 if (length(argv) > 0 && ! isTRUE(argv == "")) vars <- strsplit(argv, ",")[[1]]
 folder <- if (sum(file.exists(c("output", "output.R", "start.R", "main.gms"))) == 4) "output" else "."
-dirs <- grep("^C_.*-rem-[0-9]+$", dir(folder), value = TRUE)
+dirs <- grep(".*-rem-[0-9]+$", dir(folder), value = TRUE)
 if (length(dirs) == 0) {
   message("No run found in ", normalizePath(folder))
   q()
 }
-maxrem <- max(as.numeric(gsub("^C_.*-rem-", "", dirs)))
+maxrem <- max(as.numeric(gsub(".*-rem-", "", dirs)))
 runs <- unique(gsub("-rem-[0-9]+$", "", dirs))
 message("\nNumbers in parentheses indicate runs currently in slurm.")
 message("A minus sign indicates that run does not exist.")
@@ -25,18 +25,18 @@ for (v in vars) {
     for (m in seq(maxrem)) {
       rfolder <- file.path(folder, paste0(runs[r], "-rem-", m))
       gdx <- file.path(rfolder, "fulldata.gdx")
+      data <- NA
       if (file.exists(gdx)) {
-        data <- NULL
         data <- try(gdx::readGDX(gdx, v, react = "silent"), silent = TRUE)
         if (inherits(data, "try-error")) data <- "-"
         if (is.null(data)) data <- "null"
         if (is.numeric(data)) data <- if (data < 10) signif(data, 2) else round(data, 2)
         data <- paste(data, collapse = ",")
-        if (! modelstats::foundInSlurm(rfolder) == "no" && data != "null") {
-          data <- paste0("(", data, ")")
-        }
-        results[[r, paste0("rem", m)]] <- data
       }
+      if (! modelstats::foundInSlurm(rfolder) == "no") {
+        data <- paste0("(", data, ")")
+      }
+      results[[r, paste0("rem", m)]] <- data
     }
   }
   results[is.na(results)] <- "-"

--- a/tests/testthat/test_20-coupled.R
+++ b/tests/testthat/test_20-coupled.R
@@ -269,5 +269,9 @@ for (csvfile in csvfiles) {
 test_that("delete files to leave clean state", {
   # leave clean state
   skipIfPreviousFailed()
-  expect_true(0 == unlink(deleteallfiles, recursive = TRUE))
+  if (! all(file.exists(deleteallfiles))) {
+    skip("Not cleaning up coupled tests as not all required files exist.")
+  } else {
+    expect_true(0 == unlink(deleteallfiles, recursive = TRUE))
+  }
 })


### PR DESCRIPTION
## Purpose of this PR

- follow-up of #1977
- always show if job in slurm, even if no fulldata.gdx has been written yet
- no need to restrict coupled runs to `C_` prefix
- uncomment file that was missing in input data until #1973 was merged.
- skip MAgPIE only mappings to avoid that numerous MAgPIE special variables are claimed to be missing in coupled runs.
- don't delete all relevant files if coupled tests have actually failed. Impossible to debug.

## Type of change

- [x] Minor change (default scenarios show only small differences)

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I checked the `log.txt` file of my runs for newly introduced summation, fixing or variable name errors
- [x] All automated model tests pass, executed after my final commit (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
