### PR TITLE
Adding literature reference for s37_clinker_process_CO2.

### DIFF
--- a/modules/37_industry/subsectors/datainput.gms
+++ b/modules/37_industry/subsectors/datainput.gms
@@ -280,7 +280,7 @@ emiMac2mac("co2otherInd","co2otherInd") = NO;
   / 0.9
   * 0.99;
 
-s37_clinker_process_CO2 = 0.5262;
+s37_clinker_process_CO2 = 0.5262;  !! see Kermeli et al. (2019), doi: 10.1016/j.apenergy.2019.01.252
 
 *** Clinker-to-cement ratio
 Parameter


### PR DESCRIPTION
## Purpose of this PR
Adding literature reference for s37_clinker_process_CO2.

## Type of change
- [x] Minor change (default scenarios show only small differences)


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I checked the `log.txt` file of my runs for newly introduced summation, fixing or variable name errors
- [x] All automated model tests pass, executed after my final commit (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Runs with these changes are here:
* Comparison of results (what changes by this PR?): 

