### PR TITLE
increase required remind2 version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -64,7 +64,7 @@ Imports:
     raster,
     readr,
     readxl,
-    remind2 (>= 1.164.0),
+    remind2 (>= 1.164.3),
     renv (>= 1.0.7),
     reshape2,
     reticulate,


### PR DESCRIPTION
## Purpose of this PR
increase required remind2 version

## Type of change

- [x] Bug fix 


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code


## Further information (optional):

* Runs with these changes are here:
* Comparison of results (what changes by this PR?): 

