### PR TITLE
fix LULUCF national accounting on path_gdx_ref, don't complain about scenConf comment cols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### changed
 - **scripts** for MAgPIE coupled runs, if the coupled config contains a `path_gdx_ref` column, it needs a `path_gdx_refpolicycost` column as well.
     [[#1940](https://github.com/remindmodel/remind/pull/1940)]
-  **core** merge cm_GDPscen and cm_POPscen into cm_GDPpopScen [[#1973] (https://github.com/remindmodel/remind/pull/1973) ]
+  **core** merge cm_GDPscen and cm_POPscen into cm_GDPpopScen [[#1973](https://github.com/remindmodel/remind/pull/1973)]
 
 ### added
 -

--- a/modules/47_regipol/regiCarbonPrice/datainput.gms
+++ b/modules/47_regipol/regiCarbonPrice/datainput.gms
@@ -287,9 +287,9 @@ $offdelim
 ;
 
 *** difference between 2020 land-use change emissions from Magpie and UNFCCC 2015 and 2020 moving average land-use change emissions
-p47_LULUCFEmi_GrassiShift(t,regi)$(p47_EmiLULUCFCountryAcc("2020",regi)) = 
-  pm_macBaseMagpie("2020",regi,"co2luc") 
-  - 
+p47_LULUCFEmi_GrassiShift(ttot,regi)$(p47_EmiLULUCFCountryAcc("2020",regi)) =
+  pm_macBaseMagpie("2020",regi,"co2luc")
+  -
   (
     (
       ((p47_EmiLULUCFCountryAcc("2013",regi) + p47_EmiLULUCFCountryAcc("2014",regi) + p47_EmiLULUCFCountryAcc("2015",regi) + p47_EmiLULUCFCountryAcc("2016",regi) + p47_EmiLULUCFCountryAcc("2017",regi))/5)

--- a/scripts/start/readCheckScenarioConfig.R
+++ b/scripts/start/readCheckScenarioConfig.R
@@ -208,17 +208,20 @@ readCheckScenarioConfig <- function(filename, remindPath = ".", testmode = FALSE
       errorsfound <- errorsfound + length(intersect(names(forbiddenColumnNames), unknownColumnNames))
     }
     # sort out known but forbidden names from unknown
-    unknownColumnNames <- setdiff(unknownColumnNames, names(forbiddenColumnNames))
+    commentColNames <- grep("^\\.", unknownColumnNames, value = TRUE)
+    if (length(commentColNames) > 0) {
+      message("readCheckScenarioConfig.R treats these columns starting with '.' as comments: ", paste(commentColNames, collapse = ", "))
+    }
+    unknownColumnNames <- setdiff(unknownColumnNames, c(commentColNames, names(forbiddenColumnNames)))
     if (length(unknownColumnNames) > 0) {
       message("\nAutomated checks did not understand these columns in ", basename(filename), ":")
       message("  ", paste(unknownColumnNames, collapse = ", "))
       if (isFALSE(coupling)) message("These are no cfg or cfg$gms switches found in main.gms and default.cfg.")
       if (coupling %in% "MAgPIE") message("Maybe you specified REMIND switches in coupled config, which does not work.")
       message("If you find false positives, add them to knownColumnNames in scripts/start/readCheckScenarioConfig.R.\n")
-      unknownColumnNamesNoComments <- unknownColumnNames[! grepl("^\\.", unknownColumnNames)]
-      if (length(unknownColumnNamesNoComments) > 0) {
+      if (length(unknownColumnNames) > 0) {
         if (testmode) {
-          warning("Unknown column names: ", paste(unknownColumnNamesNoComments, collapse = ", "))
+          warning("Unknown column names: ", paste(unknownColumnNames, collapse = ", "))
         } else if (errorsfound == 0) {
           message("Do you want to continue and simply ignore them? Y/n")
           userinput <- tolower(gms::getLine())


### PR DESCRIPTION
## Purpose of this PR

- part of https://github.com/remindmodel/development_issues/issues/220: `Emi|CO2|CDR|existing forest sink|LULUCF national accounting` was 0 before cm_startyear because `p47_LULUCFEmi_GrassiShift` was not set as used [here](https://github.com/pik-piam/remind2/blob/8a03e503826290a7ffab5ed011184c39dc86343d/R/reportEmi.R#L2870) in reportEmi()
- when reading scenario_config file, be more transparent about comment columns and don't tell people that it did not understand these columns, see RSE mattermost channel
 
## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I checked the `log.txt` file of my runs for newly introduced summation, fixing or variable name errors
- [x] All automated model tests pass, executed after my final commit (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
