### PR TITLE
Adapt global budget convergence criterion for runs with interalized damages

### DIFF
--- a/modules/80_optimization/nash/postsolve.gms
+++ b/modules/80_optimization/nash/postsolve.gms
@@ -374,12 +374,23 @@ loop((t,regi,entyPe)$pm_implicitPePriceTarget(t,regi,entyPe),
 );  
 $endIf.cm_implicitPePriceTarget
 
-*** check global budget target from core/postsolve, must be within 2 Gt of target value
+*** check global budget target from 45_carbonprice/functionalForm/postsolve
+*** convergence criterion defined via cm_budgetCO2_absDevTol [default = 2 Gt CO2]
+*** positive values of sm_globalBudget_absDev mean that target budget is exceeded (sm_globalBudget_absDev = s45_actualbudgetco2 - cm_budgetCO2from2020)
+*** if damages are not internalized, check positive and negative deviation from target budget
+*** if damages are internalized, only check positive deviation from target budget
 p80_globalBudget_absDev_iter(iteration) = sm_globalBudget_absDev;
-if (abs(p80_globalBudget_absDev_iter(iteration)) gt cm_budgetCO2_absDevTol,
-  s80_bool = 0;
-  p80_messageShow("target") = YES;
-);
+$ifthen.globalBudget "%internalizeDamages%" == "off"
+  if (abs(p80_globalBudget_absDev_iter(iteration)) gt cm_budgetCO2_absDevTol,
+    s80_bool = 0;
+    p80_messageShow("target") = YES;
+  );
+$else.globalBudget
+  if (p80_globalBudget_absDev_iter(iteration) gt cm_budgetCO2_absDevTol,
+    s80_bool = 0;
+    p80_messageShow("target") = YES;
+  );
+$endIf.globalBudget
 
 *** additional criterion: if damage internalization is on, is damage iteration converged?
 p80_sccConvergenceMaxDeviation_iter(iteration) = pm_sccConvergenceMaxDeviation;


### PR DESCRIPTION
## Purpose of this PR


## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [ ] Bug fix 
- [ ] Refactoring
- [ ] New feature 
- [ ] Minor change (default scenarios show only small differences)
- [ ] Fundamental change
- [ ] This change requires a documentation update


## Checklist:

- [ ] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [ ] I explained my changes within the PR, particularly in hard-to-understand areas
- [ ] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] I checked the `log.txt` file of my runs for newly introduced summation, fixing or variable name errors
- [ ] All automated model tests pass, executed after my final commit (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Runs with these changes are here:
* Comparison of results (what changes by this PR?): 

