### PR TITLE
New implementation of net-negative emissions tax

### DIFF
--- a/modules/21_tax/off/not_used.txt
+++ b/modules/21_tax/off/not_used.txt
@@ -72,3 +72,4 @@ pm_cf,input,only needed if tax is on
 vm_shDemSeel,input,only needed if tax is on
 pm_teAnnuity,input,only needed if tax is on
 sm_D2005_2_D2017,input,no conversion needed
+vm_emiCdrAll,input,only needed if tax is on

--- a/modules/21_tax/on/declarations.gms
+++ b/modules/21_tax/on/declarations.gms
@@ -65,6 +65,8 @@ p21_tau_CO2_tax_gdx_bau(ttot,all_regi)       "tax path from gdx, may overwrite d
 
 p21_implicitDiscRateMarg(ttot,all_regi,all_in)  "Difference between the normal discount rate and the implicit discount rate"
 
+p21_grossEmi0(ttot,all_regi)                       "Gross emissions from previous iteration"
+
 p21_tau_SE_tax_rampup(ttot,all_regi,all_te,teSeTax_coeff)  "Parameters of logistic function to describe relationship between SE electricity tax rate and share of technology in total electricity demand"
 $ifThen.SEtaxRampUpParam not "%cm_SEtaxRampUpParam%" == "off" 
   p21_SEtaxRampUpParameters(ext_regi,all_te,teSeTax_coeff)   "config values for SE electricity tax rate tech specific ramp up logistic function parameters" / %cm_SEtaxRampUpParam% /

--- a/modules/21_tax/on/equations.gms
+++ b/modules/21_tax/on/equations.gms
@@ -110,11 +110,13 @@ v21_taxrevNetNegEmi(t,regi) =e= cm_frac_NetNegEmi * pm_taxCO2eqSum(t,regi) * v21
 ***---------------------------------------------------------------------------
 *'  Auxiliary calculation of net-negative emissions: 
 *'  v21_emiAllco2neg and v21_emiAllco2neg_slack are defined as positive variables
-*'  so as long as vm_emiAll is positive, v21_emiAllco2neg_slack adjusts so that sum is zero
-*'  if vm_emiAll is negative, in order to minimize tax v21_emiAllco2neg_slack becomes zero
+*'  so as long as vm_emiCdrAll is smaller than p21_grossEmi0, v21_emiAllco2neg_slack adjusts so that sum is zero
+*'  if vm_emiCdrAll is larger than p21_grossEmi0, in order to minimize tax v21_emiAllco2neg_slack becomes zero
+*'  Note that (vm_emiCdrAll(t,regi) - p21_grossEmi0(t,regi)) - CDR in current iteration minus gross CO2 emissions in previous iteration - 
+*'  is used instead of (-vm_emiAll(t,regi,"co2")) - minus net CO2 emissions - to avoid incentivizing higher gross emissions
 ***---------------------------------------------------------------------------
 q21_emiAllco2neg(t,regi)..
-v21_emiALLco2neg(t,regi) =e= -vm_emiAll(t,regi,"co2") + v21_emiALLco2neg_slack(t,regi);
+v21_emiALLco2neg(t,regi) =e= (vm_emiCdrAll(t,regi) - p21_grossEmi0(t,regi)) + v21_emiALLco2neg_slack(t,regi);
 
 ***---------------------------------------------------------------------------
 *'  Calculation of PE tax: tax rate times primary energy

--- a/modules/21_tax/on/postsolve.gms
+++ b/modules/21_tax/on/postsolve.gms
@@ -25,6 +25,10 @@ p21_taxrevCCS0(ttot,regi) = cm_frac_CCS * pm_data(regi,"omf","ccsinje") * pm_inc
                             * ( sum(teCCS2rlf(te,rlf), sum(ccs2te(ccsCo2(enty),enty2,te), vm_co2CCS.l(ttot,regi,enty,enty2,te,rlf) ) ) )
                             * (1/pm_ccsinjecrate(regi)) * sum(teCCS2rlf(te,rlf), sum(ccs2te(ccsCo2(enty),enty2,te), vm_co2CCS.l(ttot,regi,enty,enty2,te,rlf) ) ) / pm_dataccs(regi,"quan","1");
 pm_taxrevNetNegEmi0(ttot,regi) = cm_frac_NetNegEmi * pm_taxCO2eqSum(ttot,regi) * v21_emiALLco2neg.l(ttot,regi);
+
+*** Display for debugging
+display pm_taxrevNetNegEmi0, v21_emiALLco2neg.l, v21_emiALLco2neg_slack.l;
+
 p21_taxrevFE0(ttot,regi) = sum((entyFe,sector)$entyFe2Sector(entyFe,sector),
     ( p21_tau_fe_tax(ttot,regi,sector,entyFe) + p21_tau_fe_sub(ttot,regi,sector,entyFe) ) 
     * 
@@ -78,6 +82,15 @@ p21_taxrevFlex_iter(iteration+1,ttot,regi) = v21_taxrevFlex.l(ttot,regi);
 p21_taxrevImport_iter(iteration+1,ttot,regi,tradePe) = v21_taxrevImport.l(ttot,regi,tradePe);
 p21_taxrevChProdStartYear_iter(iteration+1,t,regi) = v21_taxrevChProdStartYear.l(t,regi);
 p21_taxrevSE_iter(iteration+1,t,regi) = v21_taxrevSE.l(t,regi);
+
+*** Compute gross emissions in current iteration - will be used to compute net-negative emissions tax in next iteration
+*** vm_emiCdrAll is a positive variable. Therefore, gross emissions are computed as net emissions plus CDR
+*** Taking the max should not be necessary, and could be removed if we are sure that vm_emiCdrAll contains all CDR
+p21_grossEmi0(t,regi) = max(vm_emiAll.l(t,regi,"co2") + vm_emiCdrAll.l(t,regi),0);
+
+*** Disply for debugging
+display p21_residualEmissions0, vm_emiCdrAll.l, vm_emiAll.l;
+
 
 display p21_taxrevFE_iter;
 

--- a/modules/21_tax/on/postsolve.gms
+++ b/modules/21_tax/on/postsolve.gms
@@ -89,7 +89,7 @@ p21_taxrevSE_iter(iteration+1,t,regi) = v21_taxrevSE.l(t,regi);
 p21_grossEmi0(t,regi) = max(vm_emiAll.l(t,regi,"co2") + vm_emiCdrAll.l(t,regi),0);
 
 *** Disply for debugging
-display p21_residualEmissions0, vm_emiCdrAll.l, vm_emiAll.l;
+display p21_grossEmi0, vm_emiCdrAll.l, vm_emiAll.l;
 
 
 display p21_taxrevFE_iter;

--- a/modules/21_tax/on/preloop.gms
+++ b/modules/21_tax/on/preloop.gms
@@ -166,6 +166,12 @@ vm_emiMac.l(ttot,regi,enty) = 0;
 *LB* initialization of v21_emiALLco2neg
 v21_emiALLco2neg.l(ttot,regi) =0;
 
+*** Initializations of p21_grossEmi0 
+* TODO: It would probably be better for the convergence to introduce the tax only from iteration 2 
+* instead of charging the tax for all CDR in the first iteration which is what happens with p21_grossEmi0 equal to 0
+p21_grossEmi0(ttot,regi) = 0;
+
+
 *DK initialize bioenergy tax
 v21_tau_bio.l(ttot) = 0;
 


### PR DESCRIPTION
## Purpose of this PR

Compute net-negative emissions across iterations to break REMIND foresight, thereby removing incentive for higher gross emissions.

[Issue ](https://github.com/remindmodel/development_issues/issues/493) incl. path to runs

## Type of change

- [ ] Fundamental change


## Checklist:

- [ ] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [ ] I explained my changes within the PR, particularly in hard-to-understand areas
- [ ] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] I checked the `log.txt` file of my runs for newly introduced summation, fixing or variable name errors
- [ ] All automated model tests pass, executed after my final commit (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Runs with these changes are here:
* Comparison of results (what changes by this PR?): 

