### PR TITLE
first CES parameters for SSP3 with imperfect capital markets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### input data/calibration
 - new input data rev7.21 including new MAgPIE data [[#1956](https://github.com/remindmodel/remind/pull/1956)]
 - new input data rev7.24 including IEA update [[#1992](https://github.com/remindmodel/remind/pull/1992)]
+- add CES parameters for SSP3 with imperfect capital markets [[#1995](https://github.com/remindmodel/remind/pull/1995)] 
 
 ### changed
 - **scripts** for MAgPIE coupled runs, if the coupled config contains a `path_gdx_ref` column, it needs a `path_gdx_refpolicycost` column as well.

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -31,7 +31,7 @@ cfg$extramappings_historic <- ""
 cfg$inputRevision <- "7.24"
 
 #### Current CES parameter and GDX revision (commit hash) ####
-cfg$CESandGDXversion <- "d31cb83efd5107c93889c8b21d206d4235fa628c"
+cfg$CESandGDXversion <- "67560965b42b8b31449a9eb12ed87afcc421f1ca"
 
 #### Force the model to download new input data ####
 cfg$force_download <- FALSE

--- a/config/gdx-files/files
+++ b/config/gdx-files/files
@@ -2,6 +2,7 @@ indu_subsectors-buil_simple-tran_edge_esm-GDPpop_SSP2-En_SSP2-Kap_debt_limit-Reg
 indu_subsectors-buil_simple-tran_edge_esm-GDPpop_SSP2-En_SSP2-Kap_debt_limit-Reg_2b1450bc.gdx
 indu_subsectors-buil_simple-tran_edge_esm-GDPpop_SSP1-En_SSP1-Kap_debt_limit-Reg_62eff8f7.gdx
 indu_subsectors-buil_simple-tran_edge_esm-GDPpop_SSP3-En_SSP3-Kap_debt_limit-Reg_62eff8f7.gdx
+indu_subsectors-buil_simple-tran_edge_esm-GDPpop_SSP3-En_SSP3-Kap_imperfect-Reg_62eff8f7.gdx
 indu_subsectors-buil_simple-tran_edge_esm-GDPpop_SSP5-En_SSP5-Kap_debt_limit-Reg_62eff8f7.gdx
 indu_subsectors-buil_simple-tran_edge_esm-GDPpop_SSP2-En_SSP2_lowEn-Kap_debt_limit-Reg_62eff8f7.gdx
 

--- a/modules/29_CES_parameters/load/input/files
+++ b/modules/29_CES_parameters/load/input/files
@@ -2,6 +2,7 @@ indu_subsectors-buil_simple-tran_edge_esm-GDPpop_SSP2-En_SSP2-Kap_debt_limit-Reg
 indu_subsectors-buil_simple-tran_edge_esm-GDPpop_SSP2-En_SSP2-Kap_debt_limit-Reg_2b1450bc.inc
 indu_subsectors-buil_simple-tran_edge_esm-GDPpop_SSP1-En_SSP1-Kap_debt_limit-Reg_62eff8f7.inc
 indu_subsectors-buil_simple-tran_edge_esm-GDPpop_SSP3-En_SSP3-Kap_debt_limit-Reg_62eff8f7.inc
+indu_subsectors-buil_simple-tran_edge_esm-GDPpop_SSP3-En_SSP3-Kap_imperfect-Reg_62eff8f7.inc
 indu_subsectors-buil_simple-tran_edge_esm-GDPpop_SSP5-En_SSP5-Kap_debt_limit-Reg_62eff8f7.inc
 indu_subsectors-buil_simple-tran_edge_esm-GDPpop_SSP2-En_SSP2_lowEn-Kap_debt_limit-Reg_62eff8f7.inc
 


### PR DESCRIPTION
## Purpose of this PR
* first CES parameters and gdx files for SSP3 with imperfect capital markets 
* indu_subsectors-buil_simple-tran_edge_esm-GDPpop_SSP3-En_SSP3-Kap_imperfect-Reg_62eff8f7.inc/gdx, 
* calibration run: /p/projects/remind/users/nicolasb/tests/remind_3p4p0_tradBio/output/SSP3-NPi_impCM-calibrate_red1_2025-02-10_11.23.55

## Type of change

- [x] New feature 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] I checked the `log.txt` file of my runs for newly introduced summation, fixing or variable name errors
- [x] All automated model tests pass, executed after my final commit (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Runs with these changes are here:
* Comparison of results (what changes by this PR?): 

