### PR TITLE
Bugfix c_ccscapratescen for coalh2c 

### DIFF
--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -564,8 +564,8 @@ $endif.tech_CO2capturerate
 if (c_ccscapratescen eq 2,
   fm_dataemiglob("pecoal","seel","igccc","co2")    = 0.2;
   fm_dataemiglob("pecoal","seel","igccc","cco2")   = 25.9;
-  fm_dataemiglob("pecoal","seel","coalh2c","co2")  = 0.2;
-  fm_dataemiglob("pecoal","seel","coalh2c","cco2") = 25.9;
+  fm_dataemiglob("pecoal","seh2","coalh2c","co2")  = 0.2;
+  fm_dataemiglob("pecoal","seh2","coalh2c","cco2") = 25.9;
 $ifthen "%c_SSP_forcing_adjust%" == "forcing_SSP5"
    fm_dataemiglob("pegas","seel","ngccc","co2")  = 0.1;
    fm_dataemiglob("pegas","seel","ngccc","cco2") = 15.2;


### PR DESCRIPTION
## Purpose of this PR
The switch `c_ccscapratescen` is able to change capture rate from 90% to 99%.
There was a bug: it did not apply on coalh2c because seel instead of seh2, as seen here:
https://github.com/remindmodel/remind/blob/26abb7eaa130e6e1957b17f7298af553427e5e85/core/datainput.gms#L563-L575



## Type of change

- [x] Bug fix  https://github.com/remindmodel/development_issues/issues/505
- [x] Minor change (default scenarios show only small differences)

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] All automated model tests pass, executed after my final commit (`FAIL 0` in the output of `make test`)
