### PR TITLE
set default max share of current cropland used for EW to 50%

### DIFF
--- a/main.gms
+++ b/main.gms
@@ -1373,7 +1373,7 @@ $setGlobal cm_CCSmaxBound    off  !! def = off
 *** cm_33_EW_maxShareOfCropland
 *** limit the share of cropland on which rocks can be spread. Affects the maximum total amount of rocks weathering on fields.
 *** example: "GLO 1, LAM 0.5" limits amount of rocks weathering on cropland in LAM to 50% of max value if all LAM cropland were used.
-$setglobal cm_33_EW_maxShareOfCropland GLO 1 !! def = GLO 1
+$setglobal cm_33_EW_maxShareOfCropland GLO 0.5 !! def = GLO 0.5
 *** cm_33_GDP_netNegCDR_maxShare
 *** limit the expenses for net negative emissions based on share in GDP. Default is GLO 1, i.e. limit = total GDP
 *** example: "GLO 1, LAM 0.1" limits spending on net negative emissions to 10% of GDP for LAM


### PR DESCRIPTION
## Purpose of this PR
This PR changes the default setting for the maximum share of current cropland that is used for enhanced weathering to 50%. 
Background: In highly ambitious scenarios, the maximum potential is reached for several regions, e.g. in end-of-century runs.  This means that **all** current cropland would be used for enhanced weathering. Given a range of uncertainties (e.g. soil effects, logistics etc.), we set the default more pessimistic at 50%. 
Note that the switch allows to make not only global but also regional adjustments (e.g. based on different agricultural systems that affect coordination efforts) for specific scenarios. 

## Type of change
- [x] Minor change (default scenarios show only small differences)

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] I checked the `log.txt` file of my runs for newly introduced summation, fixing or variable name errors
- [x] All automated model tests pass, executed after my final commit (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Runs with these changes are here:
* Comparison of results (what changes by this PR?): 

