### PR TITLE
 move "rds_report" after MAGICC7, add timestamp to log_output.txt 

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -121,7 +121,7 @@ cfg$logoption <- 2
 # List the name of output scripts from ./scripts/output/ to be used by output.R
 # You can adjust that via an 'output' column in your scenario_config.
 # To overwrite, enter 'reporting,whatever'. To add, enter 'cfg$output,additionalreporting'.
-cfg$output <- c("reporting","reportCEScalib","rds_report","MAGICC7_AR6","fixOnRef","checkProjectSummations")
+cfg$output <- c("reporting","reportCEScalib","MAGICC7_AR6","fixOnRef","rds_report","checkProjectSummations")
 
 # automatically fix remaining differences between run and path_ref
 cfg$fixOnRefAuto <- FALSE

--- a/output.R
+++ b/output.R
@@ -65,6 +65,7 @@ helpText <- "
 "
 
 argv <- get0("argv", ifnotfound = commandArgs(trailingOnly = TRUE))
+timestamp <- format(Sys.time(), "%Y-%m-%d_%H.%M.%S")
 
 if (any(c("-h", "--help") %in% argv)) {
   message(gsub("#' ?", '', helpText))
@@ -326,7 +327,7 @@ if (comp %in% c("comparison", "export")) {
           }
         } else {
           # send the output script to slurm
-          logfile <- file.path(outputdir, "log_output.txt")
+          logfile <- file.path(outputdir, paste0("log_output_", timestamp, ".txt"))
           Rscripts <- paste0("Rscript scripts/output/single/", name, " outputdir=", outputdir, collapse = "; ")
           slurmcmd <- paste0("sbatch ", slurmConfig, " --job-name=", logfile, " --output=", logfile,
                        " --mail-type=END,FAIL --comment=output.R --wrap='", Rscripts, "'")


### PR DESCRIPTION
## Purpose of this PR

- make sure `report.rds` also contains MAGICC variables
- add timestamp to log_output.txt which now is something like log_output_2025-02-27_13.55.08.txt such that it isn't overwritten each time a new output script is started. See discussion here: https://mattermost.pik-potsdam.de/rd3/pl/sjbshjzkgbds8gq197jp6d88wh

## Type of change

- [x] Bug fix

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I checked the `log.txt` file of my runs for newly introduced summation, fixing or variable name errors
- [x] All automated model tests pass, executed after my final commit (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

