### PR TITLE
MAgPIE coupling: when comparing iterations use the same years for all plots and show years after 2100

### DIFF
--- a/scripts/output/comparison/plot_compare_iterations.R
+++ b/scripts/output/comparison/plot_compare_iterations.R
@@ -76,8 +76,7 @@ plot_iterations <- function(runname) {
   TWa2EJ <- 31.5576 # TWa to EJ (1 a = 365.25*24*3600 s = 31557600 s)
   txtsiz <- 10
   r      <- sort(c("SSA","CHA","EUR","NEU","IND","JPN","LAM","MEA","OAS","CAZ","REF","USA"))
-  y      <- paste0("y",2000+10*(1:10))
-  years  <- paste0("y",c(seq(2005,2060,5),seq(2070,2100,10)))
+  years  <- paste0("y",c(seq(2005,2060,5),seq(2070,2100,10), c(2110,2130,2150)))
   sm_tdptwyr2dpgj <- 31.71 # convert [TerraDollar per TWyear] to [Dollar per GJoule]
 
 
@@ -92,7 +91,7 @@ plot_iterations <- function(runname) {
 
   var <- "Emi|CO2|+|Land-Use Change (Mt CO2/yr)"
 
-  p_emi_mag <- myplot(reports[r, y, var], ylab = "Mt CO2/yr", title = paste(runname, var, sep = "\n"))
+  p_emi_mag <- myplot(reports[r, years, var], ylab = "Mt CO2/yr", title = paste(runname, var, sep = "\n"))
 
 
   # ---- Plot: REMIND Production of purpose grown bioenergy ----


### PR DESCRIPTION
## Purpose of this PR

Display coupling iterations: use the same years for all plots and show years after 2100

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I checked the `log.txt` file of my runs for newly introduced summation, fixing or variable name errors
- [x] All automated model tests pass, executed after my final commit (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

