### PR TITLE
Add ScenarioMIP summation checks and remove dummy parameter p21_implicitDiscRate0

### DIFF
--- a/modules/21_tax/on/declarations.gms
+++ b/modules/21_tax/on/declarations.gms
@@ -21,7 +21,6 @@ p21_taxrevSO20(ttot,all_regi)                                       "reference l
 p21_taxrevBioSust0(ttot,all_regi)                                   "reference level value of global sustainability tax on bioenergy"
 p21_taxrevBioEF0(ttot,all_regi)                                     "reference level value of emission-factor-based tax on bioenergy"
 p21_taxrevBio0(ttot,all_regi)                                       "reference level value of sum of emission-factor-based tax and global sustainability tax on bioenergy" !! TO BE DELETED ONCE REMIND2 REPORTING IS ADJUSTED
-p21_implicitDiscRate0(ttot,all_regi)                                "reference level value of implicit tax on energy efficient capital" !! TO BE DELETED ONCE REMIND2 REPORTING IS ADJUSTED
 p21_taxemiMkt0(ttot,all_regi,all_emiMkt)                            "reference level value of co2 emission taxes per emission market"
 p21_taxrevFlex0(ttot,all_regi)                                      "reference level value of flexibility tax"
 p21_taxrevImport0(ttot,all_regi,all_enty,tax_import_type_21)        "reference level value of energy import tax"

--- a/modules/21_tax/on/postsolve.gms
+++ b/modules/21_tax/on/postsolve.gms
@@ -43,7 +43,6 @@ p21_taxrevSO20(ttot,regi) = p21_tau_so2_tax(ttot,regi) * vm_emiTe.l(ttot,regi,"s
 p21_taxrevBioSust0(ttot,regi) = v21_tau_bio.l(ttot) * vm_pebiolc_price.l(ttot,regi) * vm_fuExtr.l(ttot,regi,"pebiolc","1");
 p21_taxrevBioEF0(ttot,regi) = p21_bio_EF(ttot,regi) * pm_taxCO2eq(ttot,regi) * (vm_fuExtr.l(ttot,regi,"pebiolc","1") - (vm_Xport.l(ttot,regi,"pebiolc")-vm_Mport.l(ttot,regi,"pebiolc")));
 p21_taxrevBio0(ttot,regi) = p21_taxrevBioSust0(ttot,regi) + p21_taxrevBioEF0(ttot,regi); !! TO BE DELETED ONCE REMIND2 REPORTING IS ADJUSTED
-p21_implicitDiscRate0(ttot,regi) = 0; !! TO BE DELETED ONCE REMIND2 REPORTING IS ADJUSTED
 p21_taxemiMkt0(ttot,regi,emiMkt) = pm_taxemiMkt(ttot,regi,emiMkt) * vm_co2eqMkt.l(ttot,regi,emiMkt);
 p21_taxrevFlex0(ttot,regi)   =  sum(en2en(enty,enty2,te)$(teFlexTax(te)),
                                         - vm_flexAdj.l(ttot,regi,te) * vm_demSe.l(ttot,regi,enty,enty2,te));

--- a/modules/21_tax/on/presolve.gms
+++ b/modules/21_tax/on/presolve.gms
@@ -42,7 +42,6 @@ p21_taxrevSO20(ttot,regi) = p21_tau_so2_tax(ttot,regi) * vm_emiTe.l(ttot,regi,"s
 p21_taxrevBioSust0(ttot,regi) = v21_tau_bio.l(ttot) * vm_pebiolc_price.l(ttot,regi) * vm_fuExtr.l(ttot,regi,"pebiolc","1");
 p21_taxrevBioEF0(ttot,regi) = p21_bio_EF(ttot,regi) * pm_taxCO2eq(ttot,regi) * (vm_fuExtr.l(ttot,regi,"pebiolc","1") - (vm_Xport.l(ttot,regi,"pebiolc")-vm_Mport.l(ttot,regi,"pebiolc")));
 p21_taxrevBio0(ttot,regi) = p21_taxrevBioSust0(ttot,regi) + p21_taxrevBioEF0(ttot,regi); !! TO BE DELETED ONCE REMIND2 REPORTING IS ADJUSTED
-p21_implicitDiscRate0(ttot,regi) = 0; !! TO BE DELETED ONCE REMIND2 REPORTING IS ADJUSTED
 p21_taxemiMkt0(ttot,regi,emiMkt) = pm_taxemiMkt(ttot,regi,emiMkt) * vm_co2eqMkt.l(ttot,regi,emiMkt);
 p21_taxrevFlex0(ttot,regi)   =  sum(en2en(enty,enty2,te)$(teFlexTax(te)),
                                         - vm_flexAdj.l(ttot,regi,te) * vm_demSe.l(ttot,regi,enty,enty2,te));

--- a/scripts/output/single/checkProjectSummations.R
+++ b/scripts/output/single/checkProjectSummations.R
@@ -37,7 +37,7 @@ if (length(missingVariables) > 0) message("Check piamInterfaces::variableInfo('v
 
 checkMappings <- list( # list(mappings, summationsFile, skipBunkers)
   list(c("NAVIGATE", "ELEVATE"), "NAVIGATE", FALSE),
-  list("ScenarioMIP", NULL, FALSE)
+  list("ScenarioMIP", "ScenarioMIP", FALSE)
 )
 
 for (i in seq_along(checkMappings)) {


### PR DESCRIPTION
## Purpose of this PR

- Add ScenarioMIP to `checkProjectSummations.R`
- Remove dummy parameter `p21_implicitDiscRate0` since remind2 has been updated https://github.com/pik-piam/remind2/pull/698

## Type of change

- [x] Clean-up

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] I checked the `log.txt` file of my runs for newly introduced summation, fixing or variable name errors
- [x] All automated model tests pass, executed after my final commit (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)


