### PR TITLE
new input data (7.27), new CES parameter for SSP2, SSP2-EU21, SSP1, SSP3, SSP5

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -28,10 +28,10 @@ cfg$regionmapping <- "config/regionmappingH12.csv"
 cfg$extramappings_historic <- ""
 
 #### Current input data revision (<mainrevision>.<subrevision>) ####
-cfg$inputRevision <- "7.24"
+cfg$inputRevision <- "7.27"
 
 #### Current CES parameter and GDX revision (commit hash) ####
-cfg$CESandGDXversion <- "67560965b42b8b31449a9eb12ed87afcc421f1ca"
+cfg$CESandGDXversion <- "0c218725d0d002b6528287a53911a7c964aa32ce"
 
 #### Force the model to download new input data ####
 cfg$force_download <- FALSE

--- a/config/gdx-files/files
+++ b/config/gdx-files/files
@@ -5,4 +5,5 @@ indu_subsectors-buil_simple-tran_edge_esm-GDPpop_SSP3-En_SSP3-Kap_debt_limit-Reg
 indu_subsectors-buil_simple-tran_edge_esm-GDPpop_SSP3-En_SSP3-Kap_imperfect-Reg_62eff8f7.gdx
 indu_subsectors-buil_simple-tran_edge_esm-GDPpop_SSP5-En_SSP5-Kap_debt_limit-Reg_62eff8f7.gdx
 indu_subsectors-buil_simple-tran_edge_esm-GDPpop_SSP2-En_SSP2_lowEn-Kap_debt_limit-Reg_62eff8f7.gdx
+indu_subsectors-buil_simple-tran_edge_esm-GDPpop_SSP2IndiaHigh-En_SSP2IndiaHigh-Kap_debt_limit-Reg_62eff8f7.gdx
 

--- a/modules/29_CES_parameters/load/input/files
+++ b/modules/29_CES_parameters/load/input/files
@@ -5,5 +5,5 @@ indu_subsectors-buil_simple-tran_edge_esm-GDPpop_SSP3-En_SSP3-Kap_debt_limit-Reg
 indu_subsectors-buil_simple-tran_edge_esm-GDPpop_SSP3-En_SSP3-Kap_imperfect-Reg_62eff8f7.inc
 indu_subsectors-buil_simple-tran_edge_esm-GDPpop_SSP5-En_SSP5-Kap_debt_limit-Reg_62eff8f7.inc
 indu_subsectors-buil_simple-tran_edge_esm-GDPpop_SSP2-En_SSP2_lowEn-Kap_debt_limit-Reg_62eff8f7.inc
-
+indu_subsectors-buil_simple-tran_edge_esm-GDPpop_SSP2IndiaHigh-En_SSP2IndiaHigh-Kap_debt_limit-Reg_62eff8f7.inc
 


### PR DESCRIPTION
## Purpose of this PR
* new input data (7.27)
* new CES parameter and gdx files for SSP2, SSP2-EU21, SSP1, SSP3, SSP5, 
* calibration runs: /p/tmp/lavinia/REMIND/REMIND_calibration_2025_03_03/remind/output
* add SSP2IndiaHigh to gdx-files/files and modules/29_CES_parameters/load/input/files

## Type of change

- [x] Minor change (default scenarios show only small differences)


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [ ] All automated model tests pass, executed after my final commit (`FAIL 0` in the output of `make test`)


## Further information (optional):

* Runs with these changes are here:
* Comparison of results (what changes by this PR?): 

