### PR TITLE
write results_folder and model_version to gdx

### DIFF
--- a/core/sets.gms
+++ b/core/sets.gms
@@ -15,9 +15,11 @@ sets
 numberOrder     "set to assure that numeric values follow ascending order in the GAMS entry order (e.g. iterations and years used in loop statements)" / 1*2200 /
 
 *** Save select compiler flags as sets, to make them accessible from the final gdx
-c_expname       "c_expname as set for use in GDX"       /%c_expname%/
-c_description   "%c_description%"   /"for model description, see explanatory text"/
-cm_GDPpopScen   "cm_GDPpopScen as set for use in GDX"      /%cm_GDPpopScen%/
+c_expname        "c_expname as set for use in GDX"       /%c_expname%/
+c_description    "%c_description%"   /"for model description, see explanatory text"/
+c_results_folder "%c_results_folder%"  /"for cfg$results_folder, see explanatory text"/
+c_model_version  "model version" /%c_model_version%/
+cm_GDPpopScen    "cm_GDPpopScen as set for use in GDX"      /%cm_GDPpopScen%/
 
 
 all_GDPpopScen    "all possible GDP scenarios"

--- a/main.gms
+++ b/main.gms
@@ -232,6 +232,8 @@ foo_msg.nr = 1;   !! namely F-format (decimal) (and not E-format = scientific no
 ***---------------------    Run name and description    -------------------------
 $setGlobal c_expname  default
 $setGlobal c_description  REMIND run with default settings
+$setGlobal c_model_version  REMIND model version will be automatically added during prepare.R
+$setGlobal c_results_folder  REMIND results_folder will be automatically added during prepare.R
 
 ***------------------------------------------------------------------------------
 *' ####                      MODULES

--- a/scripts/start/checkFixCfg.R
+++ b/scripts/start/checkFixCfg.R
@@ -21,7 +21,8 @@ checkFixCfg <- function(cfg, remindPath = ".", testmode = FALSE) {
   refcfg <- gms::readDefaultConfig(remindPath)
   remindextras <- c("backup", "remind_folder", "pathToMagpieReport", "cm_nash_autoconverge_lastrun", "var_luc",
                                "gms$c_expname", "restart_subsequent_runs",
-                               "gms$cm_CES_configuration", "gms$c_description", "model", "renvLockFromPrecedingRun")
+                               "gms$cm_CES_configuration", "gms$c_description", "model", "renvLockFromPrecedingRun",
+                               "gms$c_model_version", "gms$c_results_folder")
   fail <- tryCatch(gms::check_config(cfg, reference_file = refcfg, modulepath = file.path(remindPath, "modules"),
                      settings_config = file.path(remindPath, "config", "settings_config.csv"),
                      extras = remindextras),

--- a/scripts/start/prepare.R
+++ b/scripts/start/prepare.R
@@ -123,6 +123,8 @@ prepare <- function() {
   # add info from cfg into cfg$gams so it ends up in gams.
   cfg$gms$c_expname <- cfg$title
   cfg$gms$c_description <- substr(cfg$description, 1, 255)
+  cfg$gms$c_results_folder <- substr(normalizePath(cfg$results_folder), 1, 255)
+  cfg$gms$c_model_version <- gsub("[^a-zA-Z0-9]", "-", substr(cfg$model_version, 1, 255))
   # create modified version
   tmpModelFile <- sub(".gms", paste0("_", cfg$title, ".gms"), cfg$model)
   file.copy(cfg$model, tmpModelFile, overwrite = TRUE)

--- a/start_coupled.R
+++ b/start_coupled.R
@@ -125,7 +125,7 @@ start_coupled <- function(path_remind, path_magpie, cfg_rem, cfg_mag, runname, m
         stop("### COUPLING ### REMIND didn't produce any gdx. Coupling iteration stopped!")
       }
 
-      # In the coupling, at the end of each REMIND run, report.R already automatically appends the MAgPIE
+      # In the coupling, at the end of each REMIND run, reporting.R already automatically appends the MAgPIE
       # report of the previous MAgPIE run to the normal REMIND_generic reporting.
       # After the last coupling iteration: read this combined report from the REMIND output folder, set the 
       # model name to 'REMIND-MAgPIE' and write the combined report directly to the 'output' folder.


### PR DESCRIPTION
## Purpose of this PR

- make results_folder and model_version available from gdx via:
```
as.character(gdx::readGDX("/p/tmp/oliverr/remindmagpie/output/testOneRegi/fulldata.gdx", "c_model_version"))
attributes(gdx::readGDX("/p/tmp/oliverr/remindmagpie/output/testOneRegi/fulldata.gdx", "c_results_folder"))$description
```
yields
```
"3-4-0-dev551"
"/p/tmp/oliverr/remindmagpie/output/testOneRegi"
```
You cannot put the folder directly as a set part because of the `/`, but I think reading it from the description (similar to `cfg$description`) is good enough. Also `.` is not supported, so I replaced it with `-`.

## Type of change

- [x] New feature 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I checked the `log.txt` file of my runs for newly introduced summation, fixing or variable name errors
- [x] All automated model tests pass, executed after my final commit (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
