### PR TITLE
fix to avoid random infeasibilities from fesos demand in industry

### DIFF
--- a/modules/37_industry/subsectors/bounds.gms
+++ b/modules/37_industry/subsectors/bounds.gms
@@ -161,4 +161,7 @@ loop ((ue_industry_dyn37(in),regi_groupExt(regi_fxDem37(ext_regi),regi)),
 );
 $endif.fixedUE_scenario
 
+!! Fix to avoid reoccurring random infeasibilities. May need to be excluded if e.g. synfuels (or something else) are set to zero.
+vm_demFeSector_afterTax.lo(t,regi,entySe,"fesos","indst",emiMkt)$(NOT sameAs(emiMkt, "other")) = 1e-16;
+
 *** EOF ./modules/37_industry/subsectors/bounds.gms


### PR DESCRIPTION
## Purpose of this PR
This PR addresses [this issue](https://github.com/remindmodel/development_issues/issues/487) of randomly reoccurring infeasibilities from fesos demand in industry.

## Type of change
- [x] Bug fix 

## Checklist:
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] I checked the `log.txt` file of my runs for newly introduced summation, fixing or variable name errors
- [x] All automated model tests pass, executed after my final commit (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Runs with these changes are here:
* Comparison of results (what changes by this PR?): 

