### PR TITLE
Ensure that technology bounds are non decreasing

### DIFF
--- a/modules/40_techpol/NPi2025/datainput.gms
+++ b/modules/40_techpol/NPi2025/datainput.gms
@@ -14,16 +14,12 @@ $offdelim
 $onlisting
 ;
 
-p40_TechBound(ttot,all_regi,te) = f40_TechBound(ttot,all_regi,"%cm_NPi_version%",te);
+*** ensure that technology bounds are not decreasing
+p40_TechBound(ttot,all_regi,te) = smax(ttot2$(ttot2.val le ttot.val) , f40_TechBound(ttot2,all_regi,"%cm_NPi_version%",te));
 
 *** windoffshore-todo: separate NDC targets for windon and windoff
 p40_TechBound(ttot,all_regi,"wind") = f40_TechBound(ttot,all_regi,"%cm_NPi_version%","wind");
 p40_ElecBioBound("2030",regi) = p40_TechBound("2030",regi,"bioigcc");
-
-*** ensure that technology bounds are not decreasing
-loop(ttot$(ttot.val > 2025),
-    p40_TechBound(ttot, all_regi, te) = max(p40_TechBound(ttot, all_regi, te), p40_TechBound(ttot-1, all_regi, te));
-);
 
 *** In scenarios with 2nd generation bioenergy technology phaseout,
 *** switch-off biomass capacity targets of NDC

--- a/modules/40_techpol/NPi2025/datainput.gms
+++ b/modules/40_techpol/NPi2025/datainput.gms
@@ -14,7 +14,8 @@ $offdelim
 $onlisting
 ;
 
-*** ensure that technology bounds are not decreasing
+*** ensure that lower technology bounds are not decreasing
+*** this only refers to lower bounds and needs to be revised once upper bounds are introduced.
 p40_TechBound(ttot,all_regi,te) = smax(ttot2$(ttot2.val le ttot.val) , f40_TechBound(ttot2,all_regi,"%cm_NPi_version%",te));
 
 *** windoffshore-todo: separate NDC targets for windon and windoff

--- a/modules/40_techpol/NPi2025/datainput.gms
+++ b/modules/40_techpol/NPi2025/datainput.gms
@@ -18,8 +18,12 @@ p40_TechBound(ttot,all_regi,te) = f40_TechBound(ttot,all_regi,"%cm_NPi_version%"
 
 *** windoffshore-todo: separate NDC targets for windon and windoff
 p40_TechBound(ttot,all_regi,"wind") = f40_TechBound(ttot,all_regi,"%cm_NPi_version%","wind");
-
 p40_ElecBioBound("2030",regi) = p40_TechBound("2030",regi,"bioigcc");
+
+*** ensure that technology bounds are not decreasing
+loop(ttot$(ttot.val > 2025),
+    p40_TechBound(ttot, all_regi, te) = max(p40_TechBound(ttot, all_regi, te), p40_TechBound(ttot-1, all_regi, te));
+);
 
 *** In scenarios with 2nd generation bioenergy technology phaseout,
 *** switch-off biomass capacity targets of NDC


### PR DESCRIPTION
## Purpose of this PR
After technology targets are met, they should stay at least at the same level.
E.g., EU wind offshore target:

Before:
![image](https://github.com/user-attachments/assets/5bf9a3a2-c32f-498f-a3fa-c2fbf06476ec)

After:
![image](https://github.com/user-attachments/assets/c7eb76f1-2083-46c8-bdf2-24a6bdbf8862)

Still don't really understand the spike in 2060!

Overview on policy updates:
https://docs.google.com/document/d/1ZQrfXY6zuSqb9ieI6JhoO_AsCvH1oikk96kwPbAqVCM/edit?addon_store&tab=t.0

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix 
- [ ] Refactoring
- [ ] New feature 
- [ ] Minor change (default scenarios show only small differences)
- [ ] Fundamental change
- [ ] This change requires a documentation update


## Checklist:

- [ ] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [ ] I explained my changes within the PR, particularly in hard-to-understand areas
- [ ] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] I checked the `log.txt` file of my runs for newly introduced summation, fixing or variable name errors
- [ ] All automated model tests pass, executed after my final commit (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Runs with these changes are here:
* Comparison of results (what changes by this PR?): 

