### PR TITLE
Turnkey premium now affects global floorcost

### DIFF
--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -348,12 +348,13 @@ $if not "%cm_techcosts%" == "GLO" + p_risk_premium_constr(regi)
 display p_tkpremused;
 
 *** modify regionalized cost data using cost premium during construction time
-pm_data(regi,"inco0",te)       = (1 + p_tkpremused(regi,te) ) * pm_data(regi,"inco0",te);
-pm_data(regi,"floorcost",te)   = (1 + p_tkpremused(regi,te) ) * pm_data(regi,"floorcost",te);
+pm_data(regi,"inco0",te)     = (1 + p_tkpremused(regi,te) ) * pm_data(regi,"inco0",te);
+pm_data(regi,"floorcost",te) = (1 + p_tkpremused(regi,te) ) * pm_data(regi,"floorcost",te);
 p_inco0(ttot,regi,teRegTechCosts)  = (1 + p_tkpremused(regi,teRegTechCosts) ) * p_inco0(ttot,regi,teRegTechCosts);
 
 *** take region average p_tkpremused for global convergence price
-fm_dataglob("inco0",te)       = (1 + sum(regi, p_tkpremused(regi,te)) / card(regi)) * fm_dataglob("inco0",te);
+fm_dataglob("inco0",te)      = (1 + sum(regi, p_tkpremused(regi,te)) / card(regi)) * fm_dataglob("inco0",te);
+fm_dataglob("floorcost",te)  = (1 + sum(regi, p_tkpremused(regi,te)) / card(regi)) * fm_dataglob("floorcost",te);
 
 *** ====================== floor cost scenarios ===========================
 *** report old floor costs pre manipulation in non-default scenario


### PR DESCRIPTION
## Purpose of this PR

Global floorcost of learning technologies is also multiplied by tkpremused (a matter of 3.4%), for consistency:
- global inco0  is multiplied
- regional inco0  is multiplied
- regional floorcost  is multiplied
- Before https://github.com/remindmodel/remind/pull/1985, global incolearn was not multiplied, which reduced VRE costs.


## Type of change

- [x] Bug fix of fm_dataglob("floorcost"
- [x] Refactoring of tkpremused calculation
- [x] Minor change (default scenarios show only small differences)


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] All automated model tests pass, executed after my final commit (`FAIL 0` in the output of `make test`)

## Further information (optional):

* Runs with these changes are here: `/p/tmp/fabricel/202503-remind-learningDoc/compScen-tkprem\*.pdf`
* Comparison of results (what changes by this PR?): `.1` are the **old** runs. A tiny bit more wind as [expected](https://github.com/remindmodel/remind/pull/1985#issuecomment-2711387466).

![image](https://github.com/user-attachments/assets/d93c1392-ba72-4ab7-b73d-ba440fbf3802)
