### PR TITLE
turn of q_limitSO2 because of unwanted strong side effects

### DIFF
--- a/core/declarations.gms
+++ b/core/declarations.gms
@@ -511,7 +511,11 @@ q_balcapture(ttot,all_regi,all_enty,all_enty,all_te)  "balance equation for carb
 q_balCCUvsCCS(ttot,all_regi)                          "balance equation for captured carbon to CCU or CCS or valve"
 q_ccsShare(ttot,all_regi)                             "calculate the share of captured CO2 that is stored geologically"
 
-q_limitSo2(ttot,all_regi)                             "prevent SO2 from rising again after 2050"
+* RP: this equation is turned off as of 2025-03-11, because it has strong negative side
+*     effects on coal use - eg SSA strongly increases coal use until 2050 only because 
+*     it wants coal solids in 2070 and needs to ramp it up until 2050 due to this limit
+*     this limit 
+* q_limitSo2(ttot,all_regi)                             "prevent SO2 from rising again after 2050"
 
 q_limitGeopot(ttot,all_regi,all_enty,rlf)             "constraint on annual renewable production due to competition for the same geographical potential"
 

--- a/core/equations.gms
+++ b/core/equations.gms
@@ -934,10 +934,14 @@ q_limitCCS(regi,ccs2te2(enty,"ico2",te),rlf)$teCCS2rlf(te,rlf)..
 ***---------------------------------------------------------------------------
 *' Emission constraint on SO2 after 2050:
 ***---------------------------------------------------------------------------
-q_limitSo2(ttot+1,regi) $((pm_ttot_val(ttot+1) ge max(cm_startyear,2055)) AND (cm_emiscen gt 1) AND (ord(ttot) lt card(ttot))) ..
-         vm_emiTe(ttot+1,regi,"so2")
-         =l=
-         vm_emiTe(ttot,regi,"so2");
+* RP: this equation is turned off as of 2025-03-11, because it has strong negative side
+*     effects on coal use - eg SSA strongly increases coal use until 2050 only because 
+*     it wants coal solids in 2070 and needs to ramp it up until 2050 due to this limit
+*     this limit 
+* q_limitSo2(ttot+1,regi) $((pm_ttot_val(ttot+1) ge max(cm_startyear,2055)) AND (cm_emiscen gt 1) AND (ord(ttot) lt card(ttot))) ..
+*         vm_emiTe(ttot+1,regi,"so2")
+*         =l=
+*         vm_emiTe(ttot,regi,"so2");
 
 
 ***---------------------------------------------------------------------------


### PR DESCRIPTION
## Purpose of this PR

Prevent unwanted side effects of the equation q_limitSO2 by turning it off, namely the large coal hump in SSA in 2050: https://github.com/remindmodel/development_issues/issues/421

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass, executed after my final commit (`FAIL 0` in the output of `make test`)

## Further information (optional):

* Runs with these changes are here: 
with the equation turned off: /p/projects/remind/users/robertp/REMIND_3px/2025-03-07_InconvPen/limSO2all/output/SSP2-NPi2025_qlimSO2all_reCalib_2025-03-11_10.14.00

same model version with the equation still turned on: /p/projects/remind/users/robertp/REMIND_3px/2025-03-07_InconvPen/default/output/SSP2-NPi2025_2025-03-07_11.43.48

compScen: `/p/projects/remind/users/robertp/REMIND_3px/2025-03-07_InconvPen/compSSA/compScen-NPi2025_Def-qlimSO2allrecalib-2025-03-11_12.49.34-H12.pdf`

* Comparison of results (what changes by this PR?): 

The coal hump in SSA goes away, but somehow SO2 emissions stay almost unchanged.

![image](https://github.com/user-attachments/assets/df1a88b3-217a-41a6-9ae2-978ab38e7f90)

![image](https://github.com/user-attachments/assets/b273cdd9-7e07-4b2b-a298-57d7c1ef6298)
