### PR TITLE
input data (7.28) and new CES parameters for SSP2, SSP2-EU21, SSP1, SSP3, SSP5, SSP2IndiaHigh

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -28,10 +28,10 @@ cfg$regionmapping <- "config/regionmappingH12.csv"
 cfg$extramappings_historic <- ""
 
 #### Current input data revision (<mainrevision>.<subrevision>) ####
-cfg$inputRevision <- "7.27"
+cfg$inputRevision <- "7.28"
 
 #### Current CES parameter and GDX revision (commit hash) ####
-cfg$CESandGDXversion <- "5a3b7d202eb6a328e868ab4b838c253179dbdbc2"
+cfg$CESandGDXversion <- "5cf438b0a21da16e9fb54097054fb1f1653842ac"
 
 #### Force the model to download new input data ####
 cfg$force_download <- FALSE


### PR DESCRIPTION
## Purpose of this PR
* new input data (7.28) and 
* new CES parameters and gdx files for SSP2, SSP2-EU21, SSP1, SSP3, SSP5, SSP2IndiaHigh, 
* calibration runs: /p/tmp/lavinia/REMIND/REMIND_calibration_2025_03_11/remind/output

## Type of change

- [x] Minor change (default scenarios show only small differences)


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass, executed after my final commit (`FAIL 0` in the output of `make test`)


## Further information (optional):

* Runs with these changes are here:
* Comparison of results (what changes by this PR?): 

