### PR TITLE
fix 'UE|Buildings*' on ref run, fix some warnings

### DIFF
--- a/modules/36_buildings/simple/datainput.gms
+++ b/modules/36_buildings/simple/datainput.gms
@@ -55,7 +55,13 @@ $include "./modules/36_buildings/simple/input/f36_uedemand_build.cs4r"
 $offdelim
 /
 ;
-p36_uedemand_build(ttot,regi,in) = f36_uedemand_build(ttot,regi,"%cm_demScen%","%cm_rcp_scen_build%",in);
+
+*** load UE demand for reporting from input_ref.gdx cm_startyear
+if (cm_startyear gt 2005,
+  execute_load "input_ref.gdx", p36_uedemand_build;
+);
+
+p36_uedemand_build(t,regi,in) = f36_uedemand_build(t,regi,"%cm_demScen%","%cm_rcp_scen_build%",in);
 
 *** Scale UE demand and floor space in the building sector
 $ifthen.scaleDemand not "%cm_scaleDemand%" == "off"

--- a/scripts/output/single/MAGICC7_AR6.R
+++ b/scripts/output/single/MAGICC7_AR6.R
@@ -242,6 +242,6 @@ if (dir.exists(workersFolder)) {
   }
 }
 
-logmsg <- paste0(logmsg, date(), "MAGICC7_AR6.R finished\n")
+logmsg <- paste0(logmsg, date(), "  MAGICC7_AR6.R finished\n")
 cat(logmsg)
 capture.output(cat(logmsg), file = logFile, append = TRUE)

--- a/scripts/output/single/checkProjectSummations.R
+++ b/scripts/output/single/checkProjectSummations.R
@@ -19,7 +19,7 @@ scen <- lucode2::getScenNames(outputdir)
 mif  <- file.path(outputdir, paste0("REMIND_generic_", scen, ".mif"))
 mifdata <- as.quitte(mif)
 envi <- new.env()
-load(file.path(outputdir, "config.Rdata"), env =  envi)
+load(file.path(outputdir, "config.Rdata"), envir = envi)
 
 stopmessage <- NULL
 

--- a/scripts/output/single/fixOnRef.R
+++ b/scripts/output/single/fixOnRef.R
@@ -78,7 +78,7 @@ fixOnMif <- function(outputdir) {
 
   # load config of first outputdir (the folder we are checking)
   envi <- new.env()
-  load(configs[[1]], env =  envi)
+  load(configs[[1]], envir = envi)
   title <- envi$cfg$title
   stopifnot(title == scens[[1]])
   startyear <- envi$cfg$gms$cm_startyear


### PR DESCRIPTION
## Purpose of this PR

- part of https://github.com/remindmodel/development_issues/issues/220
- fix partial matching warnings and unreadable logging

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I checked the `log.txt` file of my runs for newly introduced summation, fixing or variable name errors
- [x] All automated model tests pass, executed after my final commit (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
