### PR TITLE
Set rescaling factor for FE bio-fossil switch penalty to 1/1e4

### DIFF
--- a/modules/02_welfare/ineqLognormal/equations.gms
+++ b/modules/02_welfare/ineqLognormal/equations.gms
@@ -63,7 +63,7 @@ $ifthen "%cm_INCONV_PENALTY_FESwitch%" == "on"
           v02_NegInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt)
           + v02_PosInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt)
           )
-          / 1e3	!! heuristically determined rescaling factor so the dampening doesn't dominate the transformation
+          / 1e4	!! heuristically determined rescaling factor so the dampening doesn't dominate the transformation
 $endif
 $ifthen not "%cm_seFeSectorShareDevMethod%" == "off"
         !! penalizing secondary energy share deviation in sectors  

--- a/modules/02_welfare/utilitarian/equations.gms
+++ b/modules/02_welfare/utilitarian/equations.gms
@@ -58,7 +58,7 @@ $ifthen "%cm_INCONV_PENALTY_FESwitch%" == "on"
           v02_NegInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt)
           + v02_PosInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt)
           )
-          / 1e3	!! heuristically determined rescaling factor so the dampening doesn't dominate the transformation
+          / 1e4	!! heuristically determined rescaling factor so the dampening doesn't dominate the transformation
 $endif
 $ifthen not "%cm_seFeSectorShareDevMethod%" == "off"
         !! penalizing secondary energy share deviation in sectors  


### PR DESCRIPTION
## Purpose of this PR
Reduce the penalty for FE demand changes in time, in order to address [issue 512](https://github.com/remindmodel/development_issues/issues/512#issuecomment-2732084127).

To this end, modify the rescaling factor of the utility penalty variables ```v02_NegInconvPenFeBioSwitch``` and ```v02_PosInconvPenFeBioSwitch```: So far this factor was ```1/1e3``` and is now ```1/1e4```.

Note: This is still to some extent experimental - test calibration is not through yet. But we don't expect any strong adverse effects, so due to time limitations, this should already be merged. May be modified or reverted in the future.

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I checked the `log.txt` file of my runs for newly introduced summation, fixing or variable name errors
- [x] All automated model tests pass, executed after my final commit (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Runs with these changes are here (still running): ```/p/tmp/ricardar/remind/calibrate_1e4_SwitchPen/remind/output/```

