### PR TITLE
Revert "Set rescaling factor for FE bio-fossil switch penalty to 1/1e4"

### DIFF
--- a/modules/02_welfare/ineqLognormal/equations.gms
+++ b/modules/02_welfare/ineqLognormal/equations.gms
@@ -63,7 +63,7 @@ $ifthen "%cm_INCONV_PENALTY_FESwitch%" == "on"
           v02_NegInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt)
           + v02_PosInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt)
           )
-          / 1e4	!! heuristically determined rescaling factor so the dampening doesn't dominate the transformation
+          / 1e3	!! heuristically determined rescaling factor so the dampening doesn't dominate the transformation
 $endif
 $ifthen not "%cm_seFeSectorShareDevMethod%" == "off"
         !! penalizing secondary energy share deviation in sectors  

--- a/modules/02_welfare/utilitarian/equations.gms
+++ b/modules/02_welfare/utilitarian/equations.gms
@@ -58,7 +58,7 @@ $ifthen "%cm_INCONV_PENALTY_FESwitch%" == "on"
           v02_NegInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt)
           + v02_PosInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt)
           )
-          / 1e4	!! heuristically determined rescaling factor so the dampening doesn't dominate the transformation
+          / 1e3	!! heuristically determined rescaling factor so the dampening doesn't dominate the transformation
 $endif
 $ifthen not "%cm_seFeSectorShareDevMethod%" == "off"
         !! penalizing secondary energy share deviation in sectors  


### PR DESCRIPTION
This reverts commit e5f6d21f0f1de1ff67f9b133d7f9f54b58e046fd:

Thus the scaling factor of the FE bio-fossil switch penalty is set to 1/1e3 again

## Purpose of this PR

Undo the changes of PR #2041 because these produced too strong side effects as discussed in the corresponding [issue](https://github.com/remindmodel/development_issues/issues/512).

This is only temporary; the FE bio-fossil switch penalty will be adjusted in the future.

## Type of change

- [x] Bug fix 


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] I checked the `log.txt` file of my runs for newly introduced summation, fixing or variable name errors
- [x] All automated model tests pass, executed after my final commit (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

