### PR TITLE
Reduce elasticity of ue_industry 

### DIFF
--- a/modules/37_industry/subsectors/datainput.gms
+++ b/modules/37_industry/subsectors/datainput.gms
@@ -16,7 +16,7 @@ Parameters
 *** substitution elasticities
   p37_cesdata_sigma(all_in)  "industry substitution elasticities"
   /
-    ue_industry                      0.5   !! cement - chemicals - steel - other
+    ue_industry                      0.3   !! cement - chemicals - steel - other
 
       ue_cement                      1.7   !! energy, capital
         en_cement                    0.3   !! non-electric, electric


### PR DESCRIPTION
## Purpose of this PR

Reduce elasticity of ue_industry to avoid strong diminution of materials under stringent mitigation.
- https://github.com/remindmodel/development_issues/issues/445#issuecomment-2743353071

Note that this increases the "living standard" in terms of cement demand in SSA/IND Pk650, but does **not** bring more convergence across regions (because cement increases in every region).


## Type of change

- [x] Minor change (default scenarios show only small differences)


## Checklist:


- [x] All automated model tests pass, executed after my final commit (`FAIL 0` in the output of `make test`)

## Further information (optional):

* Runs with these changes are here:
* Comparison of results (what changes by this PR?): 

Tried setting ue_industry elasticity to 0.3 (`elast3`) instead of 0.5 (`elast5`). 
`/p/tmp/fabricel/industry-elasticity/elast5/compScen-elast3vs5-SSP1-2025-03-21_11.17.45-H12-short.pdf`
`/p/tmp/fabricel/industry-elasticity/elast5/compScen-elast3vs5-SSP2-2025-03-21_11.17.02-H12-short.pdf`

No significant changes in NPi.
In Peak budget 650, for SSP1 and 2, cement does not decrease as much with elast3 as with elast5. This makes the situation slightly better for near-term SSA/IND, but still not great. And other regions are affected in the same direction, which wasn't our wish.
Steel does not change, and other industry goes down a little, which seems fine.
The rest of the system is not affected much.

![Image](https://github.com/user-attachments/assets/df5ffd72-8795-45b1-b68a-d8325f99641d)
