### PR TITLE
don't confuse checkSummations with more than 1 model

### DIFF
--- a/output.R
+++ b/output.R
@@ -163,7 +163,8 @@ if (! exists("output")) {
 if (! exists("outputdir")) {
   modulesNeedingMif <- c("compareScenarios2", "xlsx_IIASA", "policyCosts", "Ariadne_output",
                          "plot_compare_iterations", "varListHtml", "fixOnRef", "MAGICC7_AR6",
-                         "validateScenarios", "checkClimatePercentiles", "selectPlots")
+                         "validateScenarios", "checkClimatePercentiles", "selectPlots",
+                         "checkProjectSummations")
   needingMif <- any(modulesNeedingMif %in% output) && ! "reporting" %in% output[[1]]
   if (exists("remind_dir")) {
     dir_folder <- c(file.path(remind_dir, "output"), remind_dir)

--- a/scripts/output/single/checkProjectSummations.R
+++ b/scripts/output/single/checkProjectSummations.R
@@ -31,6 +31,7 @@ relDiff <- 0.01
 sources <- paste0("R",
                   if (isTRUE(envi$cfg$gms$CES_parameters == "load")) "T",
                   if (any(grepl("^MAgPIE", levels(mifdata$model)))) "M")
+mifdata <- mutate(mifdata, model = factor(paste(levels(mifdata$model), collapse = "-"))) # checkSummations need one single model
 message("\n### Check existence of variables in mappings.")
 missingVariables <- checkMissingVars(mifdata, setdiff(names(mappingNames()), c("AgMIP", "AR6_MAgPIE")), sources)
 if (length(missingVariables) > 0) message("Check piamInterfaces::variableInfo('variablename') etc.")


### PR DESCRIPTION
## Purpose of this PR

- if not, it tries to calculate summation checks independently for REMIND and MAgPIE which makes no sense.

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I checked the `log.txt` file of my runs for newly introduced summation, fixing or variable name errors
- [x] All automated model tests pass, executed after my final commit (`FAIL 0` in the output of `make test`)
- [x] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)
