### PR TITLE
enable yearly timesteps for xlsx exprt

### DIFF
--- a/scripts/output/export/xlsx_IIASA.R
+++ b/scripts/output/export/xlsx_IIASA.R
@@ -55,7 +55,8 @@ projects <- list(
                      mapping = "ScenarioMIP",
                      iiasatemplate = "https://files.ece.iiasa.ac.at/ssp-submission/ssp-submission-template.xlsx",
                      renameScen = c("SMIPv03-M-SSP2-NPi-def" = "SSP2 - Medium Emissions", "SMIPv03-LOS-SSP2-EcBudg400-def" = "SSP2 - Low Overshoot", "SMIPv03-ML-SSP2-PkPrice200-fromL" = "SSP2 - Medium-Low Emissions","SMIPv03-L-SSP2-PkPrice265-inc6-def" = "SSP2 - Low Emissions", "SMIPv03-VL-SSP2_SDP_MC-PkPrice300-def" = "SSP2 - Very Low Emissions"),
-                     checkSummation = "NAVIGATE"),
+                     checkSummation = "ScenarioMIP",
+                     timesteps = seq(2005, 2100)),
   PRISMA = list(model = "REMIND-MAgPIE 3.4-4.8",
                 mapping = c("ScenarioMIP", "PRISMA"),
                 iiasatemplate = "https://files.ece.iiasa.ac.at/prisma/prisma-template.xlsx",  
@@ -79,14 +80,14 @@ if (! exists("project")) {
 projectdata <- projects[[project]]
 message("# Overwrite settings with project settings for '", project, "'.")
 varnames <- c("mapping", "iiasatemplate", "addToScen", "removeFromScen", "renameScen",
-              "model", "outputFilename", "logFile", "checkSummation")
+              "model", "outputFilename", "logFile", "checkSummation", "timesteps")
 for (p in intersect(varnames, names(projectdata))) {
   assign(p, projectdata[[p]])
 }
 
 # overwrite settings with those specified as command-line arguments
 lucode2::readArgs("outputdirs", "filename_prefix", "outputFilename", "model", "mapping",
-                  "summationFile", "logFile", "removeFromScen", "addToScen", "iiasatemplate")
+                  "summationFile", "logFile", "removeFromScen", "addToScen", "iiasatemplate", "timesteps")
 
 if (is.null(mapping)) {
   mapping <- gms::chooseFromList(names(piamInterfaces::mappingNames()), type = "mapping")


### PR DESCRIPTION
## Purpose of this PR

- in #2056, I set the usual export scripts such that only normal REMIND timesteps are exported, but forgot to undo it for scenarioMIP

## Type of change

- [x] Bug fix 

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass, executed after my final commit (`FAIL 0` in the output of `make test`). I ran multiple exports and it works
