### PR TITLE
Modify scaling of FE switch penalty

### DIFF
--- a/core/declarations.gms
+++ b/core/declarations.gms
@@ -151,6 +151,9 @@ p_shSeFeSector(ttot,all_regi,all_enty,all_enty,emi_sectors,all_emiMkt) "Initial 
 pm_shGasLiq_fe_up(ttot,all_regi,emi_sectors)         "Final energy gases plus liquids shares exogenous upper bounds per sector"
 pm_shGasLiq_fe_lo(ttot,all_regi,emi_sectors)         "Final energy gases plus liquids shares exogenous lower bounds per sector"
 
+p_demFeSector0(ttot,all_regi,all_enty,all_enty,emi_sectors,all_emiMkt) "Final Energy demand in the previous iteration"
+pm_demFeTotal0(ttot,all_regi)                        "Total Final Energy demand in the previous iteration"
+
 p_adj_coeff_Orig(ttot,all_regi,all_te)               "initial value of p_adj_coeff"
 p_adj_seed_te_Orig(ttot,all_regi,all_te)             "initial value of p_adj_seed_te"
 $ifthen not "%cm_adj_seed_cont%" == "off"

--- a/core/presolve.gms
+++ b/core/presolve.gms
@@ -51,6 +51,15 @@ $endif
 
 display p_emineg_econometric;
 
+*** Calculate total FE demand of previous iteration or input gdx.
+*** Required as a weight for penalty terms
+p_demFeSector0(ttot,regi,entySe,entyFe,sector,emiMkt) = vm_demFeSector.l(ttot,regi,entySe,entyFe,sector,emiMkt);
+
+pm_demFeTotal0(ttot, regi)
+  = sum((entySe,entyFe,sector,emiMkt)$( sefe(entySe,entyFe) AND entyFe2Sector(entyFe,sector) AND sector2emiMkt(sector,emiMkt) ),
+  p_demFeSector0(ttot,regi,entySe,entyFe,sector,emiMkt))
+;
+
 ***--------------------------------------
 *** calculate some emission factors
 ***--------------------------------------

--- a/main.gms
+++ b/main.gms
@@ -1782,9 +1782,17 @@ $setGLobal c_agricult_base_shift off !! def off
 ***  cm_INCONV_PENALTY  on     !! def = on
 *** *RP* 2012-03-06 Flag to turn on inconvenience penalties, e.g. for air pollution
 $setglobal cm_INCONV_PENALTY  on         !! def = on  !! regexp = off|on
-*** cm_INCONV_PENALTY_FESwitch  off     !! def = off
-*** flag to trun on inconvenience penalty to avoid switching shares on buildings, transport and industry biomass use if costs are relatively close (seLiqbio, sesobio, segabio)
-$setglobal cm_INCONV_PENALTY_FESwitch  on !! def = on  !! regexp = off|on
+*** cm_INCONV_PENALTY_FESwitch  linear     !! def = linear
+*** flag to run on inconvenience penalty to avoid switching shares on buildings, transport and industry biomass use if costs are relatively close (seLiqbio, sesobio, segabio)
+*** The penalty acts on changes in FE demand for each sector and SE-FE combination.
+*** (off): No inconvenience penalty
+*** (linear): Inconvenience penalty favors linear FE development
+*** (constant): Inconvenience penalty favors constant FE development
+$setglobal cm_INCONV_PENALTY_FESwitch  constant !! def = linear  !! regexp = off|linear|constant
+*** cm_INCONV_PENALTY_FESwitchRegi
+*** Switch to determine the reference region for the scaling of the FE switch penalty.
+*** Needs to be a valid Remind region and should be a region with average total FE demand compared to other regions.
+$setglobal cm_INCONV_PENALTY_FESwitchRegi  USA !! def = USA  !! regexp = [A-Z]{3}
 *** cm_seFeSectorShareDevMethod "Switch to enable an optimization incentive for sectors to have similar shares of secondary energy fuels and determine the method used for the incentive."
 *** Possible values: off or the method name (sqSectorShare, sqSectorAvrgShare, or minMaxAvrgShare)
 ***  off               "The model can freely allocate bio/syn/fossil fuels between sectors. If not off, a penalization term is added so sectors are incentivized to apply similar shares of bio-fuels, synfuels, and fossils in each sector."

--- a/modules/02_welfare/ineqLognormal/declarations.gms
+++ b/modules/02_welfare/ineqLognormal/declarations.gms
@@ -33,7 +33,7 @@ $ifthen.inconv %cm_INCONV_PENALTY% == "on"
 p02_inconvpen_lap(ttot,all_regi,all_te)           "Parameter for inconvenience penalty for local air pollution. [T$/TWa at Consumption of 1000$/cap]"
 $endif.inconv
 
-$IFTHEN.INCONV_bioSwitch "%cm_INCONV_PENALTY_FESwitch%" == "on"
+$IFTHEN.INCONV_bioSwitch not "%cm_INCONV_PENALTY_FESwitch%" == "off"
 p02_inconvPen_Switch_Track(ttot,all_regi)                       "Parameter to track magnitude of inconvenience penalty for bio/synfuel share switching [share of consumption]"
 $ENDIF.INCONV_bioSwitch
 ;
@@ -67,7 +67,7 @@ v02_inconvPen(ttot,all_regi)                      "Inconvenience penalty on pe2s
 v02_inconvPenSolidsBuild(ttot,all_regi)             "Inconvenience penalty in the welfare function, e.g. for air pollution or inconvenience, for solids used in Buildings. Unit: ?Utils?"
 $endif.inconv
 
-$IFTHEN.INCONV_bioSwitch "%cm_INCONV_PENALTY_FESwitch%" == "on"
+$IFTHEN.INCONV_bioSwitch not "%cm_INCONV_PENALTY_FESwitch%" == "off"
 v02_NegInconvPenFeBioSwitch(ttot,all_regi,all_enty,all_enty,emi_sectors,all_emiMkt) "Negative inconvenience penalty in the welfare function for bio/synfuel shares switch between sectors and emissions markets"
 v02_PosInconvPenFeBioSwitch(ttot,all_regi,all_enty,all_enty,emi_sectors,all_emiMkt) "Positive inconvenience penalty in the welfare function for bio/synfuel shares switch between sectors and emissions markets"
 $ENDIF.INCONV_bioSwitch
@@ -107,7 +107,7 @@ q02_inconvPen(ttot,all_regi)                      "Calculate the inconvenience p
 q02_inconvPenSolidsBuild(ttot,all_regi)      "Calculate the inconvenience penalty v02_inconvPenSolids for solids used in Buildings"
 $endif.inconv
 
-$IFTHEN.INCONV_bioSwitch "%cm_INCONV_PENALTY_FESwitch%" == "on"
+$IFTHEN.INCONV_bioSwitch not "%cm_INCONV_PENALTY_FESwitch%" == "off"
 q02_inconvPenFeBioSwitch(ttot,all_regi,all_enty,all_enty,all_te,emi_sectors,all_emiMkt)  "Calculate the inconvenience penalty to avoid switching biomass and synfuel shares in hydrocarbons in buildings, transport and industry and emissions markets if costs are relatively close"
 $ENDIF.INCONV_bioSwitch
 

--- a/modules/02_welfare/ineqLognormal/postsolve.gms
+++ b/modules/02_welfare/ineqLognormal/postsolve.gms
@@ -6,7 +6,7 @@
 *** |  Contact: remind@pik-potsdam.de
 *** SOF ./modules/02_welfare/ineqLognormal/postsolve.gms
 
-$IFTHEN.INCONV_bioSwitch "%cm_INCONV_PENALTY_FESwitch%" == "on"
+$IFTHEN.INCONV_bioSwitch not "%cm_INCONV_PENALTY_FESwitch%" == "off"
 *** track inconvenience penalty for bio/synfuel switching to check how large it
 *** is relative to consumption
 p02_inconvPen_Switch_Track(t,regi)
@@ -18,7 +18,9 @@ p02_inconvPen_Switch_Track(t,regi)
       v02_NegInconvPenFeBioSwitch.l(t,regi,entySe,entyFe,sector,emiMkt) 
     + v02_PosInconvPenFeBioSwitch.l(t,regi,entySe,entyFe,sector,emiMkt)
     )
-  / 1e3;
+  / 1e3
+  * pm_demFeTotal0(t,regi) / pm_demFeTotal0(t,"%cm_INCONV_PENALTY_FESwitchRegi%")
+;
 $ENDIF.INCONV_bioSwitch
 
 *for use in the SCC calculation

--- a/modules/02_welfare/utilitarian/declarations.gms
+++ b/modules/02_welfare/utilitarian/declarations.gms
@@ -20,7 +20,7 @@ $ifthen.inconv %cm_INCONV_PENALTY% == "on"
 p02_inconvpen_lap(ttot,all_regi,all_te)           "Parameter for inconvenience penalty for local air pollution. [T$/TWa at Consumption of 1000$/cap]"
 $endif.inconv
 
-$IFTHEN.INCONV_bioSwitch "%cm_INCONV_PENALTY_FESwitch%" == "on"
+$IFTHEN.INCONV_bioSwitch not "%cm_INCONV_PENALTY_FESwitch%" == "off"
 p02_inconvPen_Switch_Track(ttot,all_regi)                       "Parameter to track magnitude of inconvenience penalty for bio/synfuel share switching [share of consumption]"
 $ENDIF.INCONV_bioSwitch
 ;
@@ -41,7 +41,7 @@ v02_inconvPen(ttot,all_regi)                      "Inconvenience penalty on pe2s
 v02_inconvPenSolidsBuild(ttot,all_regi)             "Inconvenience penalty in the welfare function, e.g. for air pollution or inconvenience, for solids used in Buildings. Unit: ?Utils?"
 $endif.inconv
 
-$IFTHEN.INCONV_bioSwitch "%cm_INCONV_PENALTY_FESwitch%" == "on"
+$IFTHEN.INCONV_bioSwitch not "%cm_INCONV_PENALTY_FESwitch%" == "off"
 
 v02_NegInconvPenFeBioSwitch(ttot,all_regi,all_enty,all_enty,emi_sectors,all_emiMkt) "Negative inconvenience penalty in the welfare function for bio/synfuel shares switch between sectors and emissions markets"
 v02_PosInconvPenFeBioSwitch(ttot,all_regi,all_enty,all_enty,emi_sectors,all_emiMkt) "Positive inconvenience penalty in the welfare function for bio/synfuel shares switch between sectors and emissions markets"
@@ -61,7 +61,7 @@ q02_inconvPen(ttot,all_regi)                      "Calculate the inconvenience p
 q02_inconvPenSolidsBuild(ttot,all_regi)      "Calculate the inconvenience penalty v02_inconvPenSolids for solids used in Buildings"
 $endif.inconv
 
-$IFTHEN.INCONV_bioSwitch "%cm_INCONV_PENALTY_FESwitch%" == "on"
+$IFTHEN.INCONV_bioSwitch not "%cm_INCONV_PENALTY_FESwitch%" == "off"
 q02_inconvPenFeBioSwitch(ttot,all_regi,all_enty,all_enty,all_te,emi_sectors,all_emiMkt)  "Calculate the inconvenience penalty to avoid switching biomass and synfuel shares in hydrocarbons in buildings, transport and industry and emissions markets if costs are relatively close"
 $ENDIF.INCONV_bioSwitch
 

--- a/modules/02_welfare/utilitarian/equations.gms
+++ b/modules/02_welfare/utilitarian/equations.gms
@@ -46,7 +46,7 @@ $ifthen %cm_INCONV_PENALTY% == "on"
       - v02_inconvPen(ttot,regi)
       - v02_inconvPenSolidsBuild(ttot,regi)
 $endif
-$ifthen "%cm_INCONV_PENALTY_FESwitch%" == "on"
+$ifthen.INCONV_bioSwitch not "%cm_INCONV_PENALTY_FESwitch%" == "off"
         !! inconvenience cost for fuel switching in FE between fossil,
         !! biogenic, synthetic solids, liquids and gases across sectors and
         !! emissions markets
@@ -58,8 +58,9 @@ $ifthen "%cm_INCONV_PENALTY_FESwitch%" == "on"
           v02_NegInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt)
           + v02_PosInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt)
           )
-          / 1e3	!! heuristically determined rescaling factor so the dampening doesn't dominate the transformation
-$endif
+          / 1e3 !! heuristically determined rescaling factor so the dampening doesn't dominate the transformation
+          * pm_demFeTotal0(ttot,regi) / pm_demFeTotal0(ttot,"%cm_INCONV_PENALTY_FESwitchRegi%") !! scale by relative total FE demand
+$endif.INCONV_bioSwitch
 $ifthen not "%cm_seFeSectorShareDevMethod%" == "off"
         !! penalizing secondary energy share deviation in sectors  
         - vm_penSeFeSectorShareDevCost(ttot,regi)
@@ -97,7 +98,7 @@ $ENDIF.INCONV
 *** between two time steps in buildings and industry and emissison markets
 *** necessary to avoid switching behavior in sectors and emissions markets
 *** between time steps as those sectors and markets do not have se2fe capcities
-$IFTHEN.INCONV_bioSwitch "%cm_INCONV_PENALTY_FESwitch%" == "on"
+$IFTHEN.INCONV_bioSwitch "%cm_INCONV_PENALTY_FESwitch%" == "constant"
 q02_inconvPenFeBioSwitch(ttot,regi,entySe,entyFe,te,sector,emiMkt)$(
                                   ttot.val ge cm_startyear
                               AND se2fe(entySe,entyFe,te) 
@@ -106,6 +107,23 @@ q02_inconvPenFeBioSwitch(ttot,regi,entySe,entyFe,te,sector,emiMkt)$(
                               AND (entySeBio(entySe) OR  entySeFos(entySe)) ) ..
     vm_demFeSector(ttot,regi,entySe,entyFe,sector,emiMkt) 
   - vm_demFeSector(ttot-1,regi,entySe,entyFe,sector,emiMkt)
+  + v02_NegInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt)
+  - v02_PosInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt)
+  =e=
+  0
+;
+$ELSEIF.INCONV_bioSwitch "%cm_INCONV_PENALTY_FESwitch%" == "linear"
+q02_inconvPenFeBioSwitch(ttot,regi,entySe,entyFe,te,sector,emiMkt)$(
+                                  ttot.val ge cm_startyear
+                              AND ttot.val < 2150
+                              AND se2fe(entySe,entyFe,te) 
+                              AND entyFe2Sector(entyFe,sector) 
+                              AND sector2emiMkt(sector,emiMkt) 
+                              AND (entySeBio(entySe) OR  entySeFos(entySe)) ) ..
+  (vm_demFeSector(ttot+1,regi,entySe,entyFe,sector,emiMkt)
+  - vm_demFeSector(ttot,regi,entySe,entyFe,sector,emiMkt))
+  - (vm_demFeSector(ttot,regi,entySe,entyFe,sector,emiMkt) 
+  - vm_demFeSector(ttot-1,regi,entySe,entyFe,sector,emiMkt))
   + v02_NegInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt)
   - v02_PosInconvPenFeBioSwitch(ttot,regi,entySe,entyFe,sector,emiMkt)
   =e=

--- a/modules/02_welfare/utilitarian/postsolve.gms
+++ b/modules/02_welfare/utilitarian/postsolve.gms
@@ -6,7 +6,7 @@
 *** |  Contact: remind@pik-potsdam.de
 *** SOF ./modules/02_welfare/utilitarian/postsolve.gms
 
-$IFTHEN.INCONV_bioSwitch "%cm_INCONV_PENALTY_FESwitch%" == "on"
+$IFTHEN.INCONV_bioSwitch not "%cm_INCONV_PENALTY_FESwitch%" == "off"
 *** track inconvenience penalty for bio/synfuel switching to check how large it
 *** is relative to consumption
 p02_inconvPen_Switch_Track(t,regi)
@@ -18,7 +18,9 @@ p02_inconvPen_Switch_Track(t,regi)
       v02_NegInconvPenFeBioSwitch.l(t,regi,entySe,entyFe,sector,emiMkt) 
     + v02_PosInconvPenFeBioSwitch.l(t,regi,entySe,entyFe,sector,emiMkt)
     )
-  / 1e3;
+  / 1e3
+  * pm_demFeTotal0(t,regi) / pm_demFeTotal0(t,"%cm_INCONV_PENALTY_FESwitchRegi%")
+;
 $ENDIF.INCONV_bioSwitch
 
 


### PR DESCRIPTION
## Purpose of this PR
Reduce the stagnation behavior by modifying the FE switch penalty:
- This penalty now more generally favors a linear FE demand instead of constant FE demands as before. The old penalty formulation remains available as an option to the ```cm_INCONV_PENALTY_FESwitch``` flag.
- The penalty is rescaled according to total FE demand: The penalty is multiplied by the ratio of total FE demand of the current region and total FE demand of a reference region. This reference region is specified by the flag ```cm_INCONV_PENALTY_FESwitchRegi``` and set to USA by default.

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Bug fix 
- [x] Minor change (default scenarios show only small differences)


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I checked the `log.txt` file of my runs for newly introduced summation, fixing or variable name errors
- [x] All automated model tests pass, executed after my final commit (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Runs with these changes are here (but there are also other runs there): ```/p/tmp/ricardar/remind/calibrate_mod_seFeSecSh/remind/output```
* Comparison of results (what changes by this PR?):Changes in SSP2-EU21 runs can be found here: ```/p/tmp/ricardar/results/Stagnating-Quantities/modified_switchPenalty```; FE demands in buildings and industry change in mot cases only slightly, so the overall effect should be small.
* Comment on the log.txt file: I had to do the reporting separately and for some reason this lead to different summation checks than in the validation runs I compared to. I don't expect I introduced any new summation errors (especially not large ones), but I can't say for sure.
