### PR TITLE
turn on inconvPenalties on fossil solids in buildings

### DIFF
--- a/modules/02_welfare/ineqLognormal/datainput.gms
+++ b/modules/02_welfare/ineqLognormal/datainput.gms
@@ -11,7 +11,10 @@ $if %cm_less_TS% == "on"  pm_welf("2060") = 0.9;
 
 *RP* 2012-03-06: Inconvenience costs on seprod
 $IFTHEN.INCONV %cm_INCONV_PENALTY% == "on"
-p02_inconvpen_lap(ttot,regi,"coaltr")$(ttot.val ge 2005)      = sm_D2005_2_D2017 * 0;    !! for the moment, set InconvPen for fesos to ezero to make calibrations more stable
+p02_inconvpen_lap(ttot,regi,"coaltr")$(ttot.val ge 2005)      = sm_D2005_2_D2017 * 0;    !! In dollar per GJ seprod at 1.000$/cap GDP, or 10$/GJ at 10.000$_GDP/cap
+p02_inconvpen_lap(ttot,regi,"coaltr")$( (ttot.val ge 2005) AND (ttot.val le 2025) ) = 0.33 * p02_inconvpen_lap("2050",regi,"coaltr");  !! phase-in to decrease jump from historic 2020 fesob|foss to model 2025 results
+p02_inconvpen_lap("2030",regi,"coaltr") = 0.66 * p02_inconvpen_lap("2050",regi,"coaltr");  !! phase-in to decrease jump from historic 2020 fesob|foss to model 2025 results
+
 p02_inconvpen_lap(ttot,regi,"biotr")$(ttot.val ge 2005)       = sm_D2005_2_D2017 * 1.0;   
 p02_inconvpen_lap(ttot,regi,"biotrmod")$(ttot.val ge 2005)    = sm_D2005_2_D2017 * 0;    !! for the moment, set InconvPen for fesos to ezero to make calibrations more stable
 *' Transformation of coal to liquids/gases/H2 brings local pollution, which is less accepted at higher incomes -> use the inconvenience cost channel

--- a/modules/02_welfare/ineqLognormal/equations.gms
+++ b/modules/02_welfare/ineqLognormal/equations.gms
@@ -50,10 +50,19 @@ q02_welfare(regi) ..
         )$( pm_ies(regi) eq 1 )
           )
         )
-$ifthen %cm_INCONV_PENALTY% == "on"
+        
+$ifthen.inconvPen %cm_INCONV_PENALTY% == "on"
       - v02_inconvPen(ttot,regi)
+
+*RP Only turn on the inconv costs for fossil solids in buildings when the run is NOT a calibration run - in calibration runs, this inconv cost resulted in strong fluctuations.
+*RP Turning them on only shifts fossil solids from buildings to industry, so makes results more realistic, but overall FE use is not changed much - so this difference between 
+*RP calibration and normal model runs shouldn't be a problem
+$ifthen.notCalibration NOT "%CES_parameters%" == "calibrate"     
       - v02_inconvPenSolidsBuild(ttot,regi)
-$endif
+$endif.notCalibration      
+
+$endif.inconvPen
+
 $ifthen.INCONV_bioSwitch not "%cm_INCONV_PENALTY_FESwitch%" == "off"
       - sum((entySe,entyFe,te,sector,emiMkt)$(
                                     se2fe(entySe,entyFe,te)

--- a/modules/02_welfare/utilitarian/datainput.gms
+++ b/modules/02_welfare/utilitarian/datainput.gms
@@ -11,7 +11,10 @@ pm_welf("2060") = 0.9;
 
 *RP* 2012-03-06: Inconvenience costs on seprod
 $IFTHEN.INCONV %cm_INCONV_PENALTY% == "on"
-p02_inconvpen_lap(ttot,regi,"coaltr")$(ttot.val ge 2005)      = sm_D2005_2_D2017 * 0;   !! In dollar per GJ seprod at 1.000$/cap GDP, or 10$/GJ at 10.000$_GDP/cap
+p02_inconvpen_lap(ttot,regi,"coaltr")$(ttot.val ge 2005)      = sm_D2005_2_D2017 * 0;    !! In dollar per GJ seprod at 1.000$/cap GDP, or 10$/GJ at 10.000$_GDP/cap
+p02_inconvpen_lap(ttot,regi,"coaltr")$( (ttot.val ge 2005) AND (ttot.val le 2025) ) = 0.33 * p02_inconvpen_lap("2050",regi,"coaltr");  !! phase-in to decrease jump from historic 2020 fesob|foss to model 2025 results
+p02_inconvpen_lap("2030",regi,"coaltr") = 0.66 * p02_inconvpen_lap("2050",regi,"coaltr");  !! phase-in to decrease jump from historic 2020 fesob|foss to model 2025 results
+
 p02_inconvpen_lap(ttot,regi,"biotr")$(ttot.val ge 2005)       = sm_D2005_2_D2017 * 1.0;   !! In dollar per GJ seprod
 p02_inconvpen_lap(ttot,regi,"biotrmod")$(ttot.val ge 2005)    = sm_D2005_2_D2017 * 0;    !! In dollar per GJ seprod. Biotrmod is a mix of wood stoves and automated wood pellets for heating, which has lower air pollution and other discomfort effects
 *' Transformation of coal to liquids/gases/H2 brings local pollution, which is less accepted at higher incomes -> use the inconvenience cost channel

--- a/modules/02_welfare/utilitarian/equations.gms
+++ b/modules/02_welfare/utilitarian/equations.gms
@@ -42,10 +42,19 @@ q02_welfare(regi) ..
       + log(vm_cons(ttot,regi) / pm_pop(ttot,regi))$( pm_ies(regi) eq 1 )
           )
         )
-$ifthen %cm_INCONV_PENALTY% == "on"
+
+$ifthen.inconvPen %cm_INCONV_PENALTY% == "on"
       - v02_inconvPen(ttot,regi)
+
+*RP Only turn on the inconv costs for fossil solids in buildings when the run is NOT a calibration run - in calibration runs, this inconv cost resulted in strong fluctuations.
+*RP Turning them on only shifts fossil solids from buildings to industry, so makes results more realistic, but overall FE use is not changed much - so this difference between 
+*RP calibration and normal model runs shouldn't be a problem
+$ifthen.notCalibration NOT "%CES_parameters%" == "calibrate"     
       - v02_inconvPenSolidsBuild(ttot,regi)
-$endif
+$endif.notCalibration      
+
+$endif.inconvPen
+
 $ifthen.INCONV_bioSwitch not "%cm_INCONV_PENALTY_FESwitch%" == "off"
         !! inconvenience cost for fuel switching in FE between fossil,
         !! biogenic, synthetic solids, liquids and gases across sectors and


### PR DESCRIPTION
## Purpose of this PR

Turn on inconvenience penalties on fossil solids use in buildings. These inconvenience costs directly (linearly) enter the welfare equation, thus their relative strength increases with GDP/cap because consumption only enters via a logarithm-like function. 

They represent the observed behavior that heating with coal is very inconvenient, and the richer one gets the less one wants to go down to the coal cellar and carry up coal to a stinking burner in one's home. 

It is ONLY turned on in non-calibration runs, as these inconvenience penalties make the calibration somewhat unstable. This should not be a problem to the validity of the calibration, as the main effect is to shift fossil solids from buildings to industry. This makes results more realistic, but overall FE use is not changed much - so the overall difference between calibration and normal model run is small. 

## Type of change

- [x] New feature 
- [x] Minor change (default scenarios show only small differences)

## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] All automated model tests pass, executed after my final commit (`FAIL 0` in the output of `make test`)


## Further information (optional):

* Runs with these changes are here:
/p/projects/remind/users/robertp/REMIND_3px/2025-03-26-InconvPen/inconvPenPhasein

* Comparison of results (what changes by this PR?): 

blue = new, red = old, (green: intermediate version with full inconv costs from 2005 onwards)

more biosolids in buildings: 
![image](https://github.com/user-attachments/assets/49173636-8085-4aca-bf35-419411201418)


less fossil solids in buildings: 

![image](https://github.com/user-attachments/assets/9fc907a5-d540-45ec-9352-2aa372e132cc)


overall final energy solids use has relatively little change: 

![image](https://github.com/user-attachments/assets/b5b48b61-2425-42d4-865e-e60aa834be4d)

overall solids mix also has limited change: 

![image](https://github.com/user-attachments/assets/7a4dde16-dce3-4f79-84d9-0c9408a685c9)

