### PR TITLE
Cleanup, removing unnecessary commented lines in reportExtraEmissions.R

### DIFF
--- a/scripts/output/single/reportExtraEmissions.R
+++ b/scripts/output/single/reportExtraEmissions.R
@@ -8,10 +8,6 @@ require(magrittr)
 
 readArgs("outputdir")
 
-# TESTING
-# outputdir <- "./output/SSP2-NPi2025-AMT_2025-03-21_22.16.32"
-# TESTING
-
 message("### reportExtraEmissions: started adding extra emission variable at ", round(Sys.time()))
 
 scenario <- getScenNames(outputdir)
@@ -139,6 +135,3 @@ fullmif <- rbind(inmif, outmif)
 write.mif(fullmif, remind_reporting_file, append = FALSE)
 piamutils::deletePlus(remind_reporting_file, writemif = TRUE)
 
-
-# TODO: overwrite existing Extra Variables in case reporrtinng has been run before
-# TODO: write Extra Variable to both the plus and without_plus mif


### PR DESCRIPTION
## Purpose of this PR


## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [ ] Bug fix 
- [ ] Refactoring
- [ ] New feature 
- [ ] Minor change (default scenarios show only small differences)
- [ ] Fundamental change
- [ ] This change requires a documentation update


## Checklist:

- [ ] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [ ] I explained my changes within the PR, particularly in hard-to-understand areas
- [ ] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] I checked the `log.txt` file of my runs for newly introduced summation, fixing or variable name errors
- [ ] All automated model tests pass, executed after my final commit (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Runs with these changes are here:
* Comparison of results (what changes by this PR?): 

