### PR TITLE
Fix odd behaviours in reportExtraEmissions

### DIFF
--- a/scripts/output/single/reportExtraEmissions.R
+++ b/scripts/output/single/reportExtraEmissions.R
@@ -86,16 +86,16 @@ out <- mbind(
     "Emi|N2O|Extra|Transport|Pass|Aviation (kt N2O/yr)"
   )
 )
-# CH4 from residential+commercial, assume most of it is from gas use. Requires CEDS detail
+# CH4 from residential+commercial, assume most of it is from incomplete biomass/solids burning. Requires CEDS detail
 ef <- setYears(
   dimReduce(cedsceds[, 2020, "1A4a_Commercial-institutional.ch4"] + cedsceds[, 2020, "1A4b_Residential.ch4"]) /
-    inreport[, 2020, "FE|Buildings|Gases|Fossil"], NULL
+    inreport[, 2020, "FE|Buildings|Solids"], NULL
 )
 out <- mbind(
   out,
   setNames(
-    inreport[, , "FE|Buildings|Gases|Fossil"] * ef,
-    "Emi|CH4|Extra|Buildings|Gases|Fossil (Mt CH4/yr)"
+    inreport[, , "FE|Buildings|Solids"] * ef,
+    "Emi|CH4|Extra|Buildings|Solids (Mt CH4/yr)"
   )
 )
 # N2O from residential+commercial. Requires CEDS detail, assume it's all from fuel burning byproducts.
@@ -111,7 +111,7 @@ out <- mbind(
   out,
   setNames(
     tmp * ef,
-    "Emi|N2O|Extra|Buildings|Gases|Fossil (kt N2O/yr)"
+    "Emi|N2O|Extra|Buildings (kt N2O/yr)"
   )
 )
 
@@ -134,4 +134,3 @@ fullmif <- rbind(inmif, outmif)
 
 write.mif(fullmif, remind_reporting_file, append = FALSE)
 piamutils::deletePlus(remind_reporting_file, writemif = TRUE)
-

--- a/scripts/output/single/reportExtraEmissions.R
+++ b/scripts/output/single/reportExtraEmissions.R
@@ -125,8 +125,8 @@ out <- mbind(out, setItems(dimSums(out, dim = 1), dim = 1, value = "GLO"))
 outmif <- as.quitte(out)
 outmif$region <- as.character(outmif$region)
 outmif[outmif$region == "GLO", "region"] <- "World"
-outmif$model <- levels(report$model)
-outmif$scenario <- levels(report$scenario)
+outmif$model <- unique(report$model)[str_detect(unique(report$model),"REMIND")][1] # Deals with REMIND-MAgPIE mifs
+outmif$scenario <- unique(report$scenario)[1] # Works on only one scenario at a time
 
 # Append to the original mif in-memory. We have do this to avoid duplicates.
 inmif <- filter(inmif, !(variable %in% as.character(unique(outmif$variable))))


### PR DESCRIPTION
## Purpose of this PR

Several changes to `reportExtraEmissions`:

`reportExtraEmissions` initially used gas demand as an activity level for CH4 emissions in the buildings sector, leading to massive increases in SSA. As the [CH4 emission factors](https://www.epa.gov/sites/default/files/2015-07/documents/emission-factors_2014.pdf) are generally much higher for incomplete combustion of solids than for leakage of gaseous fuels, we switched the activity variable to `FE|Buildings|Solids`.

Renamed several of the `|Extra|` emission variables for simplicity's sake.

Fixed an issue with using the script on coupled MIFs.


## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :white_medium_square: GAMS Code
- :ballot_box_with_check: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Other (please give a description)

### Impact
- :ballot_box_with_check: Bug fix
- :white_medium_square: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

* Runs with these changes are here:
 
`/p/projects/piam/abrahao/scratch/updatenonco2/remind_extra/output/SSP2-NPi2025-AMT_2025-03-21_22.16.32`

* Comparison of results (what changes by this PR?): 

The new `|Extra|` emissions now look like this for a standard NPi scenario:

![image](https://github.com/user-attachments/assets/fdce7788-d350-4aac-940a-827f564c2f43)

The 14x increase in `Emi|N2O|Extra|Transport|Pass|Aviation` does look concerning. However, they simply reflect the massive increase in passenger aviation activity levels (`ES|Transport|Pass|Aviation`), especially in developing regions (53x SSA, 18x IND). @robertpietzcker would you say these numbers are reasonable? The derived emission factor for SSA is 20x higher than the global average (see below). Assuming some sort of convergence towards global mean EFs sounds plausible, but also feels like a scenario-dependent assumption.


Aviation emission factors [kt N2O / billion pk/yr], global: 1.8e-6
```
  LAM 6.816027e-06
  OAS 3.973317e-06
  SSA 2.071165e-05
  EUR 1.380309e-06
  NEU 5.952423e-06
  MEA 1.510731e-06
  REF 2.182199e-06
  CAZ 6.710042e-07
  CHA 1.827399e-07
  IND 1.926228e-07
  JPN 2.425072e-07
  USA 3.988960e-08
```



