### PR TITLE
Rework of REMIND climate assessment intergration - Reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### input data/calibration
 
 ### changed
--
+- Consolidated `MAGICC7_AR6.R` climate reporting script using the `remindClimateAssessment` and `piamenv` packages
 
 ### added
 -

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -61,6 +61,7 @@ Imports:
     readr,
     readxl,
     remind2 (>= 1.167.0),
+    remindClimateAssessment (== 0.0.2.9001),
     renv (>= 1.1.1),
     reshape2,
     reticulate,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -61,7 +61,7 @@ Imports:
     readr,
     readxl,
     remind2 (>= 1.167.0),
-    remindClimateAssessment (== 0.0.2.9001),
+    remindClimateAssessment (>= 0.0.3),
     renv (>= 1.1.1),
     reshape2,
     reticulate,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -61,7 +61,7 @@ Imports:
     readr,
     readxl,
     remind2 (>= 1.167.0),
-    remindClimateAssessment (>= 0.0.3),
+    remindClimateAssessment (>= 0.0.5),
     renv (>= 1.1.1),
     reshape2,
     reticulate,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -61,7 +61,7 @@ Imports:
     readr,
     readxl,
     remind2 (>= 1.167.0),
-    remindClimateAssessment (>= 0.0.5),
+    remindClimateAssessment (>= 0.0.6),
     renv (>= 1.1.1),
     reshape2,
     reticulate,

--- a/scripts/output/single/MAGICC7_AR6.R
+++ b/scripts/output/single/MAGICC7_AR6.R
@@ -42,9 +42,9 @@ if (!exists("source_include")) {
 runTimes <- c()
 runTimes <- c(runTimes, "set_up_assessment start" = Sys.time())
 # Normalize the output directory path, removing trailing slashes
-outputdir <- sub("/+$", "", normalizePath(outputdir, mustWork = TRUE))
+outputDir <- sub("/+$", "", normalizePath(outputdir, mustWork = TRUE))
 # cfg is a list containing all relevant paths and settings for the climate assessment
-cfg <- climateAssessmentConfig(outputdir, "report")
+cfg <- climateAssessmentConfig(outputDir, "report")
 # Keep track of runtimes of different parts of the script
 cat(date(), "MAGICC7_AR6.R:", reportClimateAssessmentConfig(cfg), file = cfg$logFile, append = TRUE)
 

--- a/tutorials/15_Using_Python.md
+++ b/tutorials/15_Using_Python.md
@@ -12,10 +12,10 @@ REMIND scripts do not alter the Python environment, ensuring that the environmen
 
 ### Environment Creation, Integrity, and Archiving
 
-REMIND supports using your system Python installation via `pip`, but also *virtual Python environments* like `conda` and `venv`. Among these, `conda` is the preferred option due to its ease of use and robust package management. For more details on installing `conda`, refer to the [Installing `conda`](#installing-conda) section.
+REMIND relies on the `conda run` subcommand to execute Python scripts. A recent `conda` installation is therefore required to make use of all REMIND capabilities. For more details on installing `conda`, refer to the [Installing `conda`](#installing-conda) section.
 
-The provided Makefile includes targets to create or clone a Python environment:
-- `make clone-conda`: Clones an existing `conda` environment. Note: Users of the PIK cluster should activate the default environment at `/p/projects/rd3mod/python/environments/scm_magicc7_hpc/`, then use `make conda-clone` to create their own version
+The `Makefile` provided by REMIND includes targets to create or clone a Python environment:
+- `make clone-conda`: Clones an existing `conda` environment. Note: Users of the PIK cluster should activate the default environment at ([see below](#conda-environment-for-remindmagicc7-operation-on-the-cluster) for more information) then use `make conda-clone` to create their own version
 - `make create-conda`: Creates a new `conda` environment based on the `py_requirements.txt` file.
 
 ### Leveraging `reticulate`
@@ -32,27 +32,25 @@ When using REMIND, you might encounter warnings about the inability to verify th
 
 ### `conda` Environment for REMIND/MAGICC7 Operation on the Cluster
 
-> **Note** This section assumes that you have access to the PIK HPC, have followed the instructions in the REMIND group-internal Wiki on [how to access the PIK HPC]((https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Cluster-Access)) and configure your [Python cluster environment](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Cluster#for-python-users).
+All necessary software is available on the cluster. Calling [`piamenv::condaInit(how = "pik-cluster")`](https://github.com/pik-piam/piamenv/blob/main/R/condaInit.R) in e.g. a coupling script ensures that modules are loaded at the appropriate time, [`piamenv::condaRun`](https://github.com/pik-piam/piamenv/blob/main/R/condaRun.R) will run a Python command in a specified `conda` environment.
 
-To ensure `climate-assessment` and `MAGICC7` are available when running REMIND on the PIK high performance cluster (HPC), follow these steps after logging in and before initiating a REMIND run that requires MAGICC7 (e.g., climate reporting). On the HPC (`foote.pik-potsdam.de`) activate the conda environment:
+You *can* load the PIK HPC `conda` module manually with 
 
 ```bash
-source activate /p/projects/rd3mod/python/environments/scm_magicc7_hpc
+module load anaconda/2025.10
 ```
 
-This setup ensures the correct Python versions are available. To deactivate the conda environment, type `conda deactivate`. **Please do not alter the conda environment as changes would affect all users.**
+and activate a `conda` environment with
 
-With the conda environment activated, you can start a climate assessment report from your REMIND folder with:
-
-```sh
-Rscript output.R
+```bash
+source activate path/to/env
 ```
 
-and navigate through the selection process as usual.
+before starting a run, but please note that as of REMIND version `3.5.0` *you don't have to*.
 
 ### Installing `conda`
 
-This is not necessary when running REMIND on the PIK cluster. If you are on a Desktop machine or are using another shared computing infrastructure, ask your local IT department if `conda` is available for your system. For Desktop users here's a brief overview of how to install `conda`. Follow these steps:
+> **Note** This is not applicable to REMIND users on the PIK HPC
 
 1. **Download the `conda` installer**:
     - *Recommended*: For Miniconda (a minimal installer for `conda`): [Miniconda Distribution](https://docs.conda.io/en/latest/miniconda.html)


### PR DESCRIPTION
## Purpose of this PR

First part of the reworking the REMIND climate assessment integration. Affects climate reporting via `MAGICC7_AR6.R`
    
- Script has been consolidated using the `remindClimateAssessment` and `piamenv` packages

- Python environment handling is done by `piamenv::condaInit` and `piamenv::condaRun`
  - Move towards `conda run`-based Python integration. This alleviates interference between R and Python environments
  - Init commands allow fine grained control of conda env activation
  - Only drawback so far in the new implementation is that logs are *not printed linewise* but dumped all at once
  - TODO (in a later PR): Archive Python run environment
  - TODO (in a later PR): Adapt `scripts/input/climate_assessment_*.R` to `piamenv`/`remindClimateAssessment` usage

- `remindClimateAssessment` handles all aspects of setting up runs of IIASA's [`climate-assessment` library](https://github.com/iiasa/climate-assessment)
  - Features a configuration concept that absorbs the previously tedious file name record keeping. List `climateAssessmentConfig` contains all directories and file names relevant to set up a climate assessment run
  - Run time reporting for various parts of the script was implemented by storing run times in a named vector. `reportRunTimes` generates a report and attaches it to the log file
  - Write climate assessment parameters to gdx via `remindClimateAssessment::dumpToGdx`
  - Relies on config files to associate climate assessment variables. gdx filenames and REMIND/GAMS variables names
  - `remindClimateAssessment::archiveClimateAssessmentData` stores climate assessment data of a particular run in a tar archive

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Refactoring
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I performed a self-review of my own code
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I checked the `log.txt` file of my runs for newly introduced summation, fixing or variable name errors
- [x] All automated model tests pass, executed after my final commit (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Runs with these changes are here:
* Comparison of results (what changes by this PR?): 

