### PR TITLE
Removing deprecated cm_transpGDPscale switch from code

### DIFF
--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -543,13 +543,6 @@ v_shGasLiq_fe.lo(t,regi,sector)$pm_shGasLiq_fe_lo(t,regi,sector) = pm_shGasLiq_f
 vm_demFeSector.up(t,regi,"seh2","feh2s","build",emiMkt)$(t.val le cm_H2InBuildOnlyAfter) = 1e-6;
 
 ***----------------------------------------------------------------------------
-***  Controlling if active, dampening factor to align edge-t non-energy transportation costs with historical GDP data
-***----------------------------------------------------------------------------
-$IFTHEN.transpGDPscale not "%cm_transpGDPscale%" == "on" 
-  vm_transpGDPscale.fx(t,regi) = 1;
-$ENDIF.transpGDPscale
-
-***----------------------------------------------------------------------------
 *'  Limit slack variable and uncontrolled variable values for adj costs that limit changes to reference in cm_startyear
 ***----------------------------------------------------------------------------
 

--- a/core/declarations.gms
+++ b/core/declarations.gms
@@ -427,7 +427,6 @@ vm_changeProdStartyearCost(ttot,all_regi,all_te)     "Costs for changing output 
 vm_demFeForEs(ttot,all_regi,all_enty,all_esty,all_teEs)     "Final energy which will be used in the ES layer."
 
 vm_prodEs(ttot,all_regi,all_enty,all_esty,all_teEs)          "Energy services (unit determined by conversion factor pm_fe2es)."
-vm_transpGDPscale(ttot,all_regi)                            "dampening factor to align edge-t non-energy transportation costs with historical GDP data"
 
 $ifthen.seFeSectorShareDev not "%cm_seFeSectorShareDevMethod%" == "off"
   v_penSeFeSectorShare(ttot,all_regi,all_enty,all_enty,emi_sectors,all_emiMkt) "penalty cost for secondary energy share deviation between sectors, for each sector/emiMarket combination"

--- a/core/declarations.gms
+++ b/core/declarations.gms
@@ -426,7 +426,7 @@ vm_changeProdStartyearCost(ttot,all_regi,all_te)     "Costs for changing output 
 *** ES layer variables
 vm_demFeForEs(ttot,all_regi,all_enty,all_esty,all_teEs)     "Final energy which will be used in the ES layer."
 
-vm_prodEs(ttot,all_regi,all_enty,all_esty,all_teEs)          "Energy services (unit determined by conversion factor pm_fe2es)."
+v_prodEs(ttot,all_regi,all_enty,all_esty,all_teEs)          "Energy services (unit determined by conversion factor pm_fe2es)."
 
 $ifthen.seFeSectorShareDev not "%cm_seFeSectorShareDevMethod%" == "off"
   v_penSeFeSectorShare(ttot,all_regi,all_enty,all_enty,emi_sectors,all_emiMkt) "penalty cost for secondary energy share deviation between sectors, for each sector/emiMarket combination"

--- a/core/equations.gms
+++ b/core/equations.gms
@@ -238,13 +238,13 @@ q_balFeAfterTax(t,regi,entySe,entyFe,sector,emiMkt)$(sefe(entySe,entyFe) AND ent
 q_transFe2Es(t,regi,fe2es(entyFe,esty,teEs))..
     pm_fe2es(t,regi,teEs) * vm_demFeForEs(t,regi,entyFe,esty,teEs)
     =e=
-    vm_prodEs(t,regi,entyFe,esty,teEs);
+    v_prodEs(t,regi,entyFe,esty,teEs);
 
 *' Hand-over to CES:
 q_es2ppfen(t,regi,in)$ppfenFromEs(in)..
     vm_cesIO(t,regi,in) + pm_cesdata(t,regi,in,"offset_quantity")
     =e=
-    sum(fe2es(entyFe,esty,teEs)$es2ppfen(esty,in), vm_prodEs(t,regi,entyFe,esty,teEs))
+    sum(fe2es(entyFe,esty,teEs)$es2ppfen(esty,in), v_prodEs(t,regi,entyFe,esty,teEs))
 ;
 
 *' Shares of FE carriers w.r.t. a CES node:
@@ -1037,10 +1037,10 @@ q_esCapInv(ttot,regi,teEs)$(pm_esCapCost(ttot,regi,teEs) AND ttot.val ge cm_star
   vm_esCapInv(ttot,regi,teEs)
   =e=
   sum (fe2es(entyFe,esty,teEs)$entyFeTrans(entyFe), !!edge transport
-    pm_esCapCost(ttot,regi,teEs) * vm_prodEs(ttot,regi,entyFe,esty,teEs)
+    pm_esCapCost(ttot,regi,teEs) * v_prodEs(ttot,regi,entyFe,esty,teEs)
   ) +
   sum (fe2es(entyFe,esty,teEs)$(not(entyFeTrans(entyFe))),
-    pm_esCapCost(ttot,regi,teEs) * vm_prodEs(ttot,regi,entyFe,esty,teEs)
+    pm_esCapCost(ttot,regi,teEs) * v_prodEs(ttot,regi,entyFe,esty,teEs)
   )
 ;
 

--- a/core/equations.gms
+++ b/core/equations.gms
@@ -1037,7 +1037,7 @@ q_esCapInv(ttot,regi,teEs)$(pm_esCapCost(ttot,regi,teEs) AND ttot.val ge cm_star
   vm_esCapInv(ttot,regi,teEs)
   =e=
   sum (fe2es(entyFe,esty,teEs)$entyFeTrans(entyFe), !!edge transport
-    vm_transpGDPscale(ttot,regi) * pm_esCapCost(ttot,regi,teEs) * vm_prodEs(ttot,regi,entyFe,esty,teEs)
+    pm_esCapCost(ttot,regi,teEs) * vm_prodEs(ttot,regi,entyFe,esty,teEs)
   ) +
   sum (fe2es(entyFe,esty,teEs)$(not(entyFeTrans(entyFe))),
     pm_esCapCost(ttot,regi,teEs) * vm_prodEs(ttot,regi,entyFe,esty,teEs)

--- a/main.gms
+++ b/main.gms
@@ -1844,8 +1844,6 @@ $setGlobal cm_TCssp  SSP2  !! def = SSP2  !! regexp = SSP2|SSP5
 $setGlobal cm_TCpers  8  !! def = 8  !! regexp = [0-9]
 *** cfg$gms$cm_TCspec <- "mean"  # def = mean; {mean,median,95,05,83,17}  the uncertainty estimate of the TC damage function
 $setGlobal cm_TCspec  mean  !! def = mean  !! regexp = mean|median|95|05|83|17
-*** #cm_transpGDPscale <- "on"  # def "on", activate dampening factor to align edge-t non-energy transportation costs with historical GDP data"
-$setglobal cm_transpGDPscale  off  !! def = off  !! regexp = off|on
 *** This flag turns off output production
 $setGlobal c_skip_output  off        !! def = off  !! regexp = off|on
 ***  cm_CO2TaxSectorMarkup     "CO2 tax markup in buildings or transport sector, a value of 0.5 means CO2 tax increased by 50%"

--- a/modules/35_transport/edge_esm/datainput.gms
+++ b/modules/35_transport/edge_esm/datainput.gms
@@ -23,13 +23,6 @@ $include "./modules/35_transport/edge_esm/input/f35_esCapCost.cs4r"
 $offdelim
 /
 
-p35_transportGDPshare(ttot,all_regi) "transportation share in GDP [percentage]"
-/
-$ondelim
-$include "./modules/35_transport/edge_esm/input/f35_transportGDPshare.cs4r"
-$offdelim
-/
-
 p35_fe2es(tall,all_regi,all_GDPpopScen,all_demScen,EDGE_scenario_all,all_teEs) "Aggregate energy efficiency of transport fuel technologies [trn pkm/Twa or trn tkm/Twa]"
 /
 $ondelim

--- a/modules/35_transport/edge_esm/declarations.gms
+++ b/modules/35_transport/edge_esm/declarations.gms
@@ -10,9 +10,6 @@ p35_fe2es_aux(tall,all_regi,all_GDPpopScen,all_demScen,EDGE_scenario_all,all_teE
 ;
 Equations
 q35_demFeTrans(ttot,all_regi,all_enty,all_emiMkt) "Transport final energy demand"
-$IFTHEN.transpGDPscale "%cm_transpGDPscale%" == "on" 
-q35_transGDPshare(ttot,all_regi)  "Calculating dampening factor to align edge-t non-energy transportation costs with historical GDP data"
-$ENDIF.transpGDPscale
 ;
 
 *** EOF ./modules/35_transport/edge_esm/declarations.gms

--- a/modules/35_transport/edge_esm/equations.gms
+++ b/modules/35_transport/edge_esm/equations.gms
@@ -17,16 +17,6 @@ q35_demFeTrans(ttot,regi,entyFe,emiMkt)$((ttot.val ge cm_startyear) AND (entyFe2
   sum(fe2es(entyFe,esty,teEs)$(NOT (es_lo35(esty))), vm_demFeForEs(ttot,regi,entyFe,esty,teEs))$(sameas(emiMkt,"ES"))+
   sum(fe2es(entyFe,esty,teEs)$es_lo35(esty), vm_demFeForEs(ttot,regi,entyFe,esty,teEs))$(sameas(emiMkt,"other"));
 
-
-$IFTHEN.transpGDPscale "%cm_transpGDPscale%" == "on" 
-*' Calculating dampening factor to align edge-t non-energy transportation costs with historical GDP data
-q35_transGDPshare(ttot,regi)$(ttot.val ge cm_startyear)..
-  vm_transpGDPscale(ttot,regi) * (sum(fe2es(entyFe,esty,teEs)$entyFeTrans(entyFe), pm_esCapCost("2005",regi,teEs) * vm_prodEs("2005",regi,entyFe,esty,teEs)))
-  =e=
-  (p35_transportGDPshare("2005",regi)*pm_gdp("2005",regi))
-;
-$ENDIF.transpGDPscale
-
 *' @stop
 
 *** EOF ./modules/35_transport/edge_esm/equations.gms

--- a/scripts/start/readCheckScenarioConfig.R
+++ b/scripts/start/readCheckScenarioConfig.R
@@ -199,6 +199,7 @@ readCheckScenarioConfig <- function(filename, remindPath = ".", testmode = FALSE
        "cm_GDPscen" = "Use cm_GDPpopScen instead, see https://github.com/remindmodel/remind/pull/1973",
        "cm_POPscen" = "Use cm_GDPpopScen instead, see https://github.com/remindmodel/remind/pull/1973",
        "cm_DiscRateScen" = "Deleted, not used anymore, see https://github.com/remindmodel/remind/pull/2001",
+       "cm_transpGDPscale" = "Deleted, not used anymore, see https://github.com/remindmodel/remind/pull/2092",
      NULL)
     for (i in intersect(names(forbiddenColumnNames), unknownColumnNames)) {
       msg <- paste0("Column name ", i, " in remind settings is outdated. ", forbiddenColumnNames[i])


### PR DESCRIPTION
## Purpose of this PR

- Removing switch used more than two years ago as a short-term fix for limiting disproportional edge-t investment costs to a maximum proportion of the region GDP.  

## Type of change

### Parts concerned
- :ballot_box_with_check: GAMS Code
- :ballot_box_with_check: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :ballot_box_with_check: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Other (please give a description)

### Impact
- :white_medium_square: Bug fix
- :ballot_box_with_check: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)


