### PR TITLE
Save p80_repy_thisSolitr instead of (wrong) p80_repy

### DIFF
--- a/modules/80_optimization/nash/solve.gms
+++ b/modules/80_optimization/nash/solve.gms
@@ -58,7 +58,7 @@ $endif.repeatNonOpt
     p80_repy_thisSolitr(all_regi,"resusd")    = hybrid.resusd;
     p80_repy_thisSolitr(all_regi,"objval")    = hybrid.objval;
     if (p80_repy_thisSolitr(all_regi,"modelstat") eq 2,
-      p80_repyLastOptim(all_regi,"objval") = p80_repy(all_regi,"objval");
+      p80_repyLastOptim(all_regi,"objval") = p80_repy_thisSolitr(all_regi,"objval");
     );
   );
 
@@ -86,10 +86,6 @@ until card(p80_handle) = 0;
 );
 
 regi(all_regi) = YES;
-
-
-display p80_repy_thisSolitr;
-display p80_repy;
 
 *** internal nash helper paramter:
 pm_SolNonInfes(regi) = 0;


### PR DESCRIPTION
## Purpose of this PR

Save `p80_repy_thisSolitr` instead of (wrong) `p80_repy`.
Remove `display` statements, since they are called twice.

## Type of change

### Parts concerned
- :ballot_box_with_check: GAMS Code
- :white_medium_square: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Other (please give a description)

### Impact
- :ballot_box_with_check: Bug fix
- :white_medium_square: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)
