### PR TITLE
Postpone NPi2018 hydro bound to 2030 in order to avoid calibration infes

### DIFF
--- a/modules/40_techpol/NPi2018/bounds.gms
+++ b/modules/40_techpol/NPi2018/bounds.gms
@@ -6,14 +6,15 @@
 *** |  Contact: remind@pik-potsdam.de
 *** SOF ./modules/40_techpol/NPi2018/bounds.gms
 
-*AM the lowbound of solar and pv for 2030 to be taken from the NDCs (in GW), therefore multiplying by 0.001 for TW*
-*NPi bounds are only applied after 2020, as NPi scenarios should always have cm_startyear higher than 2020.
+*** AM the lowbound of solar and pv for 2030 to be taken from the NDCs (in GW), therefore multiplying by 0.001 for TW*
+*** NPi bounds are only applied after 2020, as NPi scenarios should always have cm_startyear higher than 2020.
 vm_cap.lo(t,regi,"spv","1")$(t.val gt 2020) = p40_TechBound(t,regi,"spv")*0.001; 
 vm_cap.lo(t,regi,"tnrs","1")$(t.val ge 2025) = p40_TechBound(t,regi,"tnrs")*0.001;
 vm_cap.lo(t,regi_nucscen,"tnrs",rlf)$((t.val ge 2025) and (cm_nucscen eq 5)) = 0; !! we assume: Nucscen (limiting nuclear deployment) overrides NDC targets -> resetting lower bound to value defined at cm_nucscen switch
-vm_cap.lo(t,regi,"hydro","1")$(t.val gt 2020) = p40_TechBound(t,regi,"hydro")*0.001;
 vm_cap.lo(t,regi,"windon","1")$(t.val gt 2025) = p40_TechBound(t,regi,"windon")*0.001; 
 vm_cap.lo(t,regi,"windoff","1")$(t.val gt 2025) = p40_TechBound(t,regi,"windoff")*0.001; 
+*** Bound only applies from 2030 onward when technologies have historical values in 2025
+vm_cap.lo(t,regi,"hydro","1")$(t.val >= 2030) = p40_TechBound(t,regi,"hydro")*0.001;
 
 display vm_cap.lo;
 


### PR DESCRIPTION
## Purpose of this PR

- Following update of hydro historical bounds in https://github.com/remindmodel/remind/pull/2080, runs that use techpol NDC or NPi2025 work fine, but calibration using techpol NPi2018 fails:
```
**** Matrix error - lower bound > upper bound
vm_cap(2025,USA,hydro,1)   (.LO, .L, .UP = 0.1062418, 0.11077563111263, 0.1033396)

/p/tmp/lavinia/REMIND/REMIND_calibration_2025_05_01/remind/output/SSP2-NPi-calibrate_2025-05-01_14.05.17
```
This PR pushes the application date of NPi2018 hydro from 2025 to 2030.

## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :ballot_box_with_check: GAMS Code
- :white_medium_square: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :ballot_box_with_check: Bug fix
- :white_medium_square: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :ballot_box_with_check: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [ ] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

* Runs with these changes are here:
* Comparison of results (what changes by this PR?): 
