### PR TITLE
new input data 7.46, new CES parameter for SSP2, SSP2-EU21, SSP1, SSP3

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -28,10 +28,10 @@ cfg$regionmapping <- "config/regionmappingH12.csv"
 cfg$extramappings_historic <- ""
 
 #### Current input data revision (<mainrevision>.<subrevision>) ####
-cfg$inputRevision <- "7.45airpol"
+cfg$inputRevision <- "7.46"
 
 #### Current CES parameter and GDX revision (commit hash) ####
-cfg$CESandGDXversion <- "bc6fb003877631b062025dc328c178d09de9bda0"
+cfg$CESandGDXversion <- "355e779020a8a89c803b4ab8562b17fcf58d5abb"
 
 #### Force the model to download new input data ####
 cfg$force_download <- FALSE

--- a/core/sets.gms
+++ b/core/sets.gms
@@ -91,6 +91,7 @@ all_APssp     "all air pollutant SSPs. GAINSlegacy means the SSP is picked with 
     SSP4
     SSP5
     GAINSlegacy
+    SSP2IndiaHigh
 /
 
 all_APscen     "all air pollutant scenarios"


### PR DESCRIPTION

## Purpose of this PR

* new input data 7.46, 
* new CES parameter and gdx files for input data 7.46 for SSP2, SSP2-EU21, SSP1, SSP3, 
* calibration runs: /p/tmp/lavinia/REMIND/REMIND_calibration_2025_06_01/remind/output;
* add missing set SSP2IndiaHigh

## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :white_medium_square: GAMS Code
- :white_medium_square: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :ballot_box_with_check: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :white_medium_square: Bug fix
- :white_medium_square: Refactoring
- :white_medium_square: New feature
- :ballot_box_with_check: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

* Runs with these changes are here:
* Comparison of results (what changes by this PR?): 
