### PR TITLE
Fix problems when appending EDGE-T variables to REMIND mif

### DIFF
--- a/scripts/output/single/MAGICC7_AR6.R
+++ b/scripts/output/single/MAGICC7_AR6.R
@@ -18,25 +18,20 @@
 #' @param outputdir Directory where REMIND MIF file is located. Output files generated in the process will be written
 #' to a subfolder "climate-assessment-data" in this directory. Defaults to "."
 
-library(dplyr)
-library(lucode2)
 library(magrittr)
-library(piamInterfaces)
+library(lucode2)
 library(piamenv)
 library(piamutils)
 library(quitte)
 library(readr)
-library(remind2)
 library(remindClimateAssessment)
-library(stringr)
-library(tidyverse)
 
 #################### BASIC CONFIGURATION ##########################################################
 
 if (!exists("source_include")) {
   # Define arguments that can be read from command line
   outputdir <- "."
-  readArgs("outputdir", "gdxName", "gdx_ref_name", "gdx_refpolicycost_name")
+  lucode2::readArgs("outputdir", "gdxName", "gdx_ref_name", "gdx_refpolicycost_name")
 }
 
 runTimes <- c()
@@ -59,7 +54,7 @@ magiccEnv <- c(
   "MAGICC_WORKER_NUMBER"   = 1
 )
 
-magiccInit <- condaInit(how = "pik-cluster", log = cfg$logFile, verbose = 1)
+magiccInit <- piamenv::condaInit(how = "pik-cluster", log = cfg$logFile, verbose = 1)
 
 runHarmoniseAndInfillCmd <- paste(
   "python", file.path(cfg$scriptsDir, "run_harm_inf.py"), cfg$remindEmissionsFile, cfg$climateDir,
@@ -86,7 +81,7 @@ runTimes <- c(runTimes, "preprocessing start" = Sys.time())
 
 climateAssessmentInputData <- as.quitte(remindReportingFile) %>%
   emissionDataForClimateAssessment(cfg$scenario, logFile = cfg$logFile) %>%
-  write_csv(cfg$remindEmissionsFile, quote = "none")
+  readr::write_csv(cfg$remindEmissionsFile, quote = "none")
 
 runTimes <- c(runTimes, "preprocessing end" = Sys.time())
 cat(

--- a/scripts/output/single/fixOnRef.R
+++ b/scripts/output/single/fixOnRef.R
@@ -32,6 +32,7 @@ findRefMif <- function(outputdir, envi) {
   }
   # find scenario name of reference run to be able to find mif file
   refdir <- dirname(inputref)
+
   if (! file.exists(file.path(refdir, "config.Rdata"))) {
     message("Config in reference directory '", refdir, "' not found.")
     return(NULL)
@@ -102,7 +103,8 @@ fixOnMif <- function(outputdir) {
   failfile <- file.path(outputdir[[1]], "log_fixOnRef.csv")
   # call piamInterfaces::fixOnRef. Returns either TRUE if everything is fine, or the corrected data
   # small relative differences of 0.002 % are considered acceptable
-  fixeddata <- piamInterfaces::fixOnRef(d, dref, ret = "TRUE_or_fixed", startyear = startyear, failfile = failfile, relDiff = 0.00002)
+  fixeddata <- piamInterfaces::fixOnRef(d, dref, ret = "TRUE_or_fixed", startyear = startyear,
+                                        failfile = failfile, relDiff = 0.00002)
 
   # if cfg$fixOnRefAuto = TRUE), fix the data automatically
   # else if in interactive mode (not within a REMIND run), ask

--- a/scripts/output/single/reportCEScalib.R
+++ b/scripts/output/single/reportCEScalib.R
@@ -10,7 +10,7 @@ require(lucode2)
 
 if (!exists("source_include")) {
   # Define arguments that can be read from command line
-  readArgs("outputdir")
+  lucode2::readArgs("outputdir")
 }
 
 scenario <- lucode2::getScenNames(outputdir)

--- a/scripts/output/single/reporting.R
+++ b/scripts/output/single/reporting.R
@@ -78,6 +78,19 @@ EDGEToutput <- EDGEToutput[!(variable %in% REMINDoutput$variable | grepl(".*edge
 message("The following variables will be dropped from the EDGE-Transport reporting because ",
         "they are in the REMIND reporting: ", paste(unique(sharedVariables$variable), collapse = ", "))
 
+# in order to append to the mif file, the periods 2005 and 2010 must be brought back
+# see also: https://github.com/pik-piam/reporttransport/pull/38
+
+if (!all(c(2005, 2010) %in% unique(EDGEToutput$period))) {
+  tmp <- filter(EDGEToutput, .data$period == 2015)
+  EDGEToutput <- rbind(
+    EDGEToutput,
+    mutate(tmp, "value" = NA, period = 2005),
+    mutate(tmp, "value" = NA, period = 2010)
+  )
+}
+
+
 quitte::write.mif(EDGEToutput, remind_reporting_file, append = TRUE)
 piamutils::deletePlus(remind_reporting_file, writemif = TRUE)
 

--- a/scripts/output/single/reporting.R
+++ b/scripts/output/single/reporting.R
@@ -10,6 +10,7 @@ library(edgeTransport)
 library(reporttransport)
 library(quitte)
 library(piamutils)
+library(lucode2)
 
 ############################# BASIC CONFIGURATION #############################
 
@@ -20,7 +21,7 @@ gdx_refpolicycost_name <- "input_refpolicycost.gdx"  # name of the reference gdx
 if (!exists("source_include")) {
   # Define arguments that can be read from command line
   outputdir <- "."
-  readArgs("outputdir", "gdx_name", "gdx_ref_name", "gdx_refpolicycost_name")
+  lucode2::readArgs("outputdir", "gdx_name", "gdx_ref_name", "gdx_refpolicycost_name")
 }
 
 gdx     <- file.path(outputdir, gdx_name)

--- a/scripts/output/single/reporting.R
+++ b/scripts/output/single/reporting.R
@@ -5,16 +5,11 @@
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
 
-library(magclass)
 library(remind2)
-library(lucode2)
-library(gms)
-library(methods)
 library(edgeTransport)
 library(reporttransport)
 library(quitte)
 library(piamutils)
-
 
 ############################# BASIC CONFIGURATION #############################
 
@@ -65,33 +60,34 @@ convGDX2MIF(gdx, gdx_refpolicycost = gdx_refpolicycost,
 
 edgetOutputDir <- file.path(outputdir, "EDGE-T")
 
-if (file.exists(edgetOutputDir)) {
-
-  message("### start generation of EDGE-T reporting")
-  EDGEToutput <- reporttransport::reportEdgeTransport(edgetOutputDir,
-                                                      isTransportExtendedReported = FALSE,
-                                                      modelName = "REMIND",
-                                                      scenarioName = scenario,
-                                                      gdxPath = file.path(outputdir, "fulldata.gdx"),
-                                                      isStored = FALSE)
-
-  REMINDoutput <- as.data.table(read.quitte(file.path(outputdir, paste0("REMIND_generic_", scenario, "_withoutPlus.mif"))))
-  sharedVariables <- EDGEToutput[variable %in% REMINDoutput$variable | grepl(".*edge", variable)]
-  EDGEToutput <- EDGEToutput[!(variable %in% REMINDoutput$variable | grepl(".*edge", variable))]
-  message("The following variables will be dropped from the EDGE-Transport reporting because
-                they are in the REMIND reporting: ", paste(unique(sharedVariables$variable), collapse = ", "))
-
-  quitte::write.mif(EDGEToutput, remind_reporting_file, append = TRUE)
-  piamutils::deletePlus(remind_reporting_file, writemif = TRUE)
-
-  # generate transport extended mif
-  reporttransport::reportEdgeTransport(edgetOutputDir,
-                                       isTransportExtendedReported = TRUE,
-                                       gdxPath = file.path(outputdir, "fulldata.gdx"),
-                                       isStored = TRUE)
-
-  message("end generation of EDGE-T reporting")
+if (!file.exists(edgetOutputDir)) {
+  stop("EDGE-T folder is missing")
 }
+
+message("### start generation of EDGE-T reporting")
+EDGEToutput <- reporttransport::reportEdgeTransport(edgetOutputDir,
+                                                    isTransportExtendedReported = FALSE,
+                                                    modelName = "REMIND",
+                                                    scenarioName = scenario,
+                                                    gdxPath = file.path(outputdir, "fulldata.gdx"),
+                                                    isStored = FALSE)
+
+REMINDoutput <- as.data.table(read.quitte(file.path(outputdir, paste0("REMIND_generic_", scenario, "_withoutPlus.mif"))))
+sharedVariables <- EDGEToutput[variable %in% REMINDoutput$variable | grepl(".*edge", variable)]
+EDGEToutput <- EDGEToutput[!(variable %in% REMINDoutput$variable | grepl(".*edge", variable))]
+message("The following variables will be dropped from the EDGE-Transport reporting because
+              they are in the REMIND reporting: ", paste(unique(sharedVariables$variable), collapse = ", "))
+
+quitte::write.mif(EDGEToutput, remind_reporting_file, append = TRUE)
+piamutils::deletePlus(remind_reporting_file, writemif = TRUE)
+
+# generate transport extended mif
+reporttransport::reportEdgeTransport(edgetOutputDir,
+                                     isTransportExtendedReported = TRUE,
+                                     gdxPath = file.path(outputdir, "fulldata.gdx"),
+                                     isStored = TRUE)
+
+message("### end generation of EDGE-T reporting")
 
 # extra emission reporting (depends on REMIND and EDGE-T variables) ----
 message("### report additional emission variables (reportExtraEmissions)")
@@ -128,15 +124,14 @@ if (!is.null(magpie_reporting_file) && file.exists(magpie_reporting_file)) {
 
 # warn if duplicates in mif and incorrect spelling of variables ----
 mifcontent <- read.quitte(sub("\\.mif$", "_withoutPlus.mif", remind_reporting_file), check.duplicates = FALSE)
-reportDuplicates(mifcontent)
-invisible(piamInterfaces::checkVarNames(mifcontent))
+quitte::reportDuplicates(mifcontent)
 
 message("### end generation of mif files at ", round(Sys.time()))
 
 # produce REMIND LCOE reporting *.csv based on gdx information ----
 
 message("### start generation of LCOE reporting at ", round(Sys.time()))
-tmp <- try(convGDX2CSV_LCOE(gdx, file = LCOE_reporting_file, scen = scenario))
+tmp <- try(remind2::convGDX2CSV_LCOE(gdx, file = LCOE_reporting_file, scen = scenario))
 message("### end generation of LCOE reporting at ", round(Sys.time()))
 
 message("### reporting finished.")

--- a/scripts/output/single/reporting.R
+++ b/scripts/output/single/reporting.R
@@ -6,7 +6,6 @@
 # |  Contact: remind@pik-potsdam.de
 
 library(remind2)
-library(edgeTransport)
 library(reporttransport)
 library(quitte)
 library(piamutils)
@@ -29,7 +28,7 @@ gdx_ref <- file.path(outputdir, gdx_ref_name)
 gdx_refpolicycost <- file.path(outputdir, gdx_refpolicycost_name)
 if (!file.exists(gdx_ref))           gdx_ref <- NULL
 if (!file.exists(gdx_refpolicycost)) gdx_refpolicycost <- NULL
-scenario <- getScenNames(outputdir)
+scenario <- lucode2::getScenNames(outputdir)
 
 ###############################################################################
 
@@ -73,11 +72,11 @@ EDGEToutput <- reporttransport::reportEdgeTransport(edgetOutputDir,
                                                     gdxPath = file.path(outputdir, "fulldata.gdx"),
                                                     isStored = FALSE)
 
-REMINDoutput <- as.data.table(read.quitte(file.path(outputdir, paste0("REMIND_generic_", scenario, "_withoutPlus.mif"))))
+REMINDoutput <- read.quitte(file.path(outputdir, paste0("REMIND_generic_", scenario, "_withoutPlus.mif")))
 sharedVariables <- EDGEToutput[variable %in% REMINDoutput$variable | grepl(".*edge", variable)]
 EDGEToutput <- EDGEToutput[!(variable %in% REMINDoutput$variable | grepl(".*edge", variable))]
-message("The following variables will be dropped from the EDGE-Transport reporting because
-              they are in the REMIND reporting: ", paste(unique(sharedVariables$variable), collapse = ", "))
+message("The following variables will be dropped from the EDGE-Transport reporting because ",
+        "they are in the REMIND reporting: ", paste(unique(sharedVariables$variable), collapse = ", "))
 
 quitte::write.mif(EDGEToutput, remind_reporting_file, append = TRUE)
 piamutils::deletePlus(remind_reporting_file, writemif = TRUE)
@@ -132,7 +131,7 @@ message("### end generation of mif files at ", round(Sys.time()))
 # produce REMIND LCOE reporting *.csv based on gdx information ----
 
 message("### start generation of LCOE reporting at ", round(Sys.time()))
-tmp <- try(remind2::convGDX2CSV_LCOE(gdx, file = LCOE_reporting_file, scen = scenario))
+remind2::convGDX2CSV_LCOE(gdx, file = LCOE_reporting_file, scen = scenario)
 message("### end generation of LCOE reporting at ", round(Sys.time()))
 
 message("### reporting finished.")


### PR DESCRIPTION
## Purpose of this PR

Fixes problems when appending EDGE-T variables to REMIND mif, introduced as a side-effect by removing 2005 and 2010 from EDGE-T reporting https://github.com/pik-piam/reporttransport/pull/38

This is a quickfix and must be removed, once EDGE-T reports 2005 and 2010 again!

Besides, this removes some unnecessary imports in output scripts and writes an additional file `projectSummations.rds` in `checkProjectSummations`

## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :white_medium_square: GAMS Code
- :ballot_box_with_check: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :ballot_box_with_check: Bug fix
- :white_medium_square: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

* Runs with these changes are here:
* Comparison of results (what changes by this PR?): 
