### PR TITLE
Update wind costs, and how fast learning tech regional cost differentiation converges

### DIFF
--- a/core/equations.gms
+++ b/core/equations.gms
@@ -482,27 +482,27 @@ q_costTeCapital(t,regi,teLearn)$(NOT (pm_data(regi,"tech_stat",teLearn) eq 4 AND
     )$( (t.val gt 2005) AND (t.val le 2020) )
 
 $ifthen.floorscen %cm_floorCostScen% == "default"
-*** from 2020 to cm_LearnTeConvStartYear: use regional values
+*** from 2020 to c_LearnTeConvStartYear: use regional values
     + ( pm_data(regi,"learnMult_wFC",teLearn)
       * ( sum(regi2, vm_capCum(t,regi2,teLearn))
         + pm_capCumForeign(t,regi,teLearn)
         )
         ** pm_data(regi,"learnExp_wFC",teLearn)
-    )$( (t.val gt 2020) AND (t.val lt cm_LearnTeConvStartYear) )
+    )$( (t.val gt 2020) AND (t.val lt c_LearnTeConvStartYear) )
 
-*** cm_LearnConvergenceStartYear to cm_LearnTeConvEndYear: assuming linear convergence of regional learning curves to global values
-  + ( (pm_ttot_val(t) - cm_LearnTeConvStartYear) / (cm_LearnTeConvEndYear-cm_LearnTeConvStartYear) * fm_dataglob("learnMult_wFC",teLearn)
+*** c_LearnTeConvStartYear to c_LearnTeConvEndYear: assuming linear convergence of regional learning curves to global values
+  + ( (pm_ttot_val(t) - c_LearnTeConvStartYear) / (c_LearnTeConvEndYear-c_LearnTeConvStartYear) * fm_dataglob("learnMult_wFC",teLearn)
     * ( sum(regi2, vm_capCum(t,regi2,teLearn))
       + pm_capCumForeign(t,regi,teLearn)
       )
       ** fm_dataglob("learnExp_wFC",teLearn)
 
-    + (cm_LearnTeConvEndYear - pm_ttot_val(t)) / (cm_LearnTeConvEndYear-cm_LearnTeConvStartYear) * pm_data(regi,"learnMult_wFC",teLearn)
+    + (c_LearnTeConvEndYear - pm_ttot_val(t)) / (c_LearnTeConvEndYear-c_LearnTeConvStartYear) * pm_data(regi,"learnMult_wFC",teLearn)
     * ( sum(regi2, vm_capCum(t,regi2,teLearn))
       + pm_capCumForeign(t,regi,teLearn)
       )
       ** pm_data(regi,"learnExp_wFC",teLearn)
-    )$( t.val ge cm_LearnTeConvStartYear AND t.val le cm_LearnTeConvEndYear )
+    )$( t.val ge c_LearnTeConvStartYear AND t.val le c_LearnTeConvEndYear )
 $endif.floorscen
 
 $ifthen.floorscen %cm_floorCostScen% == "pricestruc"
@@ -524,11 +524,11 @@ $ifthen.floorscen %cm_floorCostScen% == "techtrans"
 $endif.floorscen
 
 $ifthen.floorscen %cm_floorCostScen% == "default"
-*** after cm_LearnTeConvEndYear: globally harmonized costs
+*** after c_LearnTeConvEndYear: globally harmonized costs
   + ( fm_dataglob("learnMult_wFC",teLearn)
      * (sum(regi2, vm_capCum(t,regi2,teLearn)) + pm_capCumForeign(t,regi,teLearn) )
        **(fm_dataglob("learnExp_wFC",teLearn))
-    )$(t.val gt cm_LearnTeConvEndYear)
+    )$(t.val gt c_LearnTeConvEndYear)
 $endif.floorscen
 ;
 *' @stop

--- a/core/equations.gms
+++ b/core/equations.gms
@@ -465,6 +465,7 @@ q_costTeCapital(t,regi,teLearn)$(NOT (pm_data(regi,"tech_stat",teLearn) eq 4 AND
         ** fm_dataglob("learnExp_wFC",teLearn)
       )
     )$( t.val le 2005 )
+    
 *** 2005 to 2020: linear transition from global 2005 to regional 2020
 *** to phase-in the observed 2020 regional variation from input-data
   + ( (2020 - t.val) / (2020-2005) * fm_dataglob("learnMult_wFC",teLearn)
@@ -477,23 +478,31 @@ q_costTeCapital(t,regi,teLearn)$(NOT (pm_data(regi,"tech_stat",teLearn) eq 4 AND
       * ( sum(regi2, vm_capCum(t,regi2,teLearn))
         + pm_capCumForeign(t,regi,teLearn)
         )
-  	  ** pm_data(regi,"learnExp_wFC",teLearn)
-    )$( (t.val gt 2005) AND (t.val lt 2020) )
+        ** pm_data(regi,"learnExp_wFC",teLearn)
+    )$( (t.val gt 2005) AND (t.val le 2020) )
 
 $ifthen.floorscen %cm_floorCostScen% == "default"
-*** 2020 to 2050: assuming linear convergence of regional learning curves to global values
-  + ( (pm_ttot_val(t) - 2020) / (2050-2020) * fm_dataglob("learnMult_wFC",teLearn)
+*** from 2020 to cm_LearnTeConvStartYear: use regional values
+    + ( pm_data(regi,"learnMult_wFC",teLearn)
+      * ( sum(regi2, vm_capCum(t,regi2,teLearn))
+        + pm_capCumForeign(t,regi,teLearn)
+        )
+        ** pm_data(regi,"learnExp_wFC",teLearn)
+    )$( (t.val gt 2020) AND (t.val lt cm_LearnTeConvStartYear) )
+
+*** cm_LearnConvergenceStartYear to cm_LearnTeConvEndYear: assuming linear convergence of regional learning curves to global values
+  + ( (pm_ttot_val(t) - cm_LearnTeConvStartYear) / (cm_LearnTeConvEndYear-cm_LearnTeConvStartYear) * fm_dataglob("learnMult_wFC",teLearn)
     * ( sum(regi2, vm_capCum(t,regi2,teLearn))
       + pm_capCumForeign(t,regi,teLearn)
       )
       ** fm_dataglob("learnExp_wFC",teLearn)
 
-    + (2050 - pm_ttot_val(t)) / (2050-2020) * pm_data(regi,"learnMult_wFC",teLearn)
+    + (cm_LearnTeConvEndYear - pm_ttot_val(t)) / (cm_LearnTeConvEndYear-cm_LearnTeConvStartYear) * pm_data(regi,"learnMult_wFC",teLearn)
     * ( sum(regi2, vm_capCum(t,regi2,teLearn))
       + pm_capCumForeign(t,regi,teLearn)
       )
-	  ** pm_data(regi,"learnExp_wFC",teLearn)
-    )$( t.val ge 2020 AND t.val le 2050 )
+      ** pm_data(regi,"learnExp_wFC",teLearn)
+    )$( t.val ge cm_LearnTeConvStartYear AND t.val le cm_LearnTeConvEndYear )
 $endif.floorscen
 
 $ifthen.floorscen %cm_floorCostScen% == "pricestruc"
@@ -515,11 +524,11 @@ $ifthen.floorscen %cm_floorCostScen% == "techtrans"
 $endif.floorscen
 
 $ifthen.floorscen %cm_floorCostScen% == "default"
-*** after 2050: globally harmonized costs
+*** after cm_LearnTeConvEndYear: globally harmonized costs
   + ( fm_dataglob("learnMult_wFC",teLearn)
      * (sum(regi2, vm_capCum(t,regi2,teLearn)) + pm_capCumForeign(t,regi,teLearn) )
        **(fm_dataglob("learnExp_wFC",teLearn))
-	)$(t.val gt 2050)
+    )$(t.val gt cm_LearnTeConvEndYear)
 $endif.floorscen
 ;
 *' @stop

--- a/core/input/generisdata_tech.prn
+++ b/core/input/generisdata_tech.prn
@@ -85,13 +85,13 @@ flexibility                     16                       16
 *** variable relewable energy
 +                windon      windoff         spv        csp
 inco0              2400         5000        5160       7224
-floorcost           200         1000          50       1092
+floorcost           500          750          50       1092
 constrTme             1            4           1          3
 eta                1.00         1.00        1.00       1.00
 omf                0.02         0.03        0.02      0.025
 lifetime             25           25          30         30
 ccap0              0.06       0.0007       0.005     0.0002
-learn              0.12         0.12        0.25      0.103
+learn              0.17         0.16        0.25      0.103
 luse                                        0.09      0.021
 flexibility          -1           -1         -1          -1
 

--- a/main.gms
+++ b/main.gms
@@ -1052,6 +1052,16 @@ parameter
   c_teNoLearngConvEndYr  = 2070;   !! def = 2070
 *'
 parameter
+  cm_LearnTeConvStartYear  "start year of cost convergence of learning technologies"
+;
+cm_LearnTeConvStartYear = 2025; !! def = 2025
+*'
+parameter
+  cm_LearnTeConvEndYear "end year of cost convergence of learning technologies"
+;
+cm_LearnTeConvEndYear = 2080;   !! def = 2080
+*'
+parameter
   c_earlyRetiValidYr         "Year before which the early retirement rate designated by c_tech_earlyreti_rate holds"
 ;
   c_earlyRetiValidYr  = 2035;   !! def = 2035

--- a/main.gms
+++ b/main.gms
@@ -1052,14 +1052,14 @@ parameter
   c_teNoLearngConvEndYr  = 2070;   !! def = 2070
 *'
 parameter
-  cm_LearnTeConvStartYear  "start year of cost convergence of learning technologies"
+  c_LearnTeConvStartYear  "start year of cost convergence of learning technologies"
 ;
-cm_LearnTeConvStartYear = 2025; !! def = 2025
+c_LearnTeConvStartYear = 2025; !! def = 2025
 *'
 parameter
-  cm_LearnTeConvEndYear "end year of cost convergence of learning technologies"
+  c_LearnTeConvEndYear "end year of cost convergence of learning technologies"
 ;
-cm_LearnTeConvEndYear = 2080;   !! def = 2080
+c_LearnTeConvEndYear = 2080;   !! def = 2080
 *'
 parameter
   c_earlyRetiValidYr         "Year before which the early retirement rate designated by c_tech_earlyreti_rate holds"


### PR DESCRIPTION
## Purpose of this PR

- bring wind costs more in line with recent data
- make the convergence of regionally differentiated costs less abrupt

## Type of change

### Parts concerned
- :ballot_box_with_check: GAMS Code
- :white_medium_square: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :ballot_box_with_check: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :white_medium_square: Bug fix
- :white_medium_square: Refactoring
- :ballot_box_with_check: New feature
- :ballot_box_with_check: Change of parameter values or input data (including CES parameters)
- :ballot_box_with_check: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

* Runs with these changes are here: /p/tmp/robertp/REMIND_3px/REMIND_2025_06_10/output
SSP2-NPi2025_windOnsh4_UScoal_2025-06-12_21.49.07 (new)
vs 
SSP2-NPi2025_2025-06-10_15.45.11 (old)
* Comparison of results (what changes by this PR?): 

1. wind onshore costs are lower in the 2020-2080 period, and there is no cost increase in CHA in the short-term anymore
 (green (or blue if green is not visible) is the new version, red the old one)
![image](https://github.com/user-attachments/assets/26629537-afd3-4aab-81d6-3b61ac9f8ee0)
(the CHA line is also reduced in 2020/2025 by an input data change that is currently being merged - will add the link to the PR once its done)

2. wind offshore costs are lower throughout the whole period
![image](https://github.com/user-attachments/assets/cb6897ae-217c-421e-8d60-5ce78c5dbd2c)

3. wind electricity increases by ~30% in 2050 and 2100
![image](https://github.com/user-attachments/assets/a7b34f5c-d9e7-4452-b45e-b9aa48d1bfbd)

onshore by 20%
![image](https://github.com/user-attachments/assets/fcec01a7-f3b7-4de1-8204-a0cb7d5e91c2)

offshore by 50%:
![image](https://github.com/user-attachments/assets/063e5ef9-9667-4085-864d-910356a60e1b)


this brings down the other sources, mostly solar, down a bit: 
![image](https://github.com/user-attachments/assets/1982f4c6-af52-475c-9657-794e7cc3cd70)

![image](https://github.com/user-attachments/assets/24be020e-d2ce-44b8-b5a3-3cc717bb2b51)



The update of learning rates is based on the 2023 IRENA costs of renewables report, and comparing the values therein with the REMIND curves.
for wind onshore, we currently have a learn rate of 0.12 in the model. looking at IRENA investment costs, we get 0.12 if we take 2005 and 2023 as the end points. if we instead take 2008 and 2023, we'd be at ~0.2, if we take 2014 and 2023, we'd be at 0.25 learn rate.
if we take LCOE, we'd be >0.2

this update increases the learning rate from 0.12 to 0.17, which is somewhat in the middle of the range that we can get from historic price/capacity data