### PR TITLE
update SSP1 SSP3 SSP5 wind costs

### DIFF
--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -274,8 +274,9 @@ vm_capCum.lo(ttot,regi,teLearn)$(ttot.val ge cm_startyear) = pm_data(regi,"ccap0
 *** exception for tech_stat 4 technologies whose ccap0 refers to 2025 as these technologies don't exist in 2005
 vm_capCum.lo(ttot,regi,teLearn)$(pm_data(regi,"tech_stat",teLearn) eq 4 AND ttot.val le 2020) = 0;
 
-*nr: floor costs represent the lower bound of learning technologies investment costs
-vm_costTeCapital.lo(t,regi,teLearn) = pm_data(regi,"floorcost",teLearn);
+*RP: theoretically, floor costs represent the lower bound of investment costs for learnTe. However, with regional 
+*** variations of 2015 costs and long-term costs being high in SSP3/SSP5, this can be different -> set lower bound to 0.2
+vm_costTeCapital.lo(t,regi,teLearn) = 0.2 * pm_data(regi,"floorcost",teLearn);
 
 *cb 20120319 avoid negative adjustment costs in 2005 (they would allow the model to artificially save money)
 v_adjFactor.fx("2005",regi,te)=0;

--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -173,8 +173,12 @@ $ifthen.c_techAssumptScen "%c_techAssumptScen%" == "SSP1"
     fm_dataglob("learn",teVRE) =         1.1 * fm_dataglob("learn",teVRE);
     fm_dataglob("floorcost","spv") =     0.1 * fm_dataglob("floorcost","spv");
     fm_dataglob("floorcost","csp") =     0.8 * fm_dataglob("floorcost","csp");
-    fm_dataglob("floorcost","windon") =  0.5 * fm_dataglob("floorcost","windon");
-    fm_dataglob("floorcost","windoff") = 0.6 * fm_dataglob("floorcost","windoff");
+*** RP: because of the interaction of learn rates with floor costs, it is not possible to simply apply multiplicative factors. These 
+*** values need to be set by hand!
+    fm_dataglob("learn","windon")     =  0.18;  !! these values make 2100 wind onshore costs ~0.8 times those seen in SSP2 at the same cumCap
+    fm_dataglob("floorcost","windon") =  1;
+    fm_dataglob("learn","windoff")    =  0.145; !! these values make 2100 wind offshore costs ~0.8 times those seen in SSP2 at the same cumCap
+    fm_dataglob("floorcost","windoff") = 150; 
     fm_dataglob("inco0",teStor) =        0.7 * fm_dataglob("inco0",teStor); 
     fm_dataglob("floorcost",teStor) =    0.7 * fm_dataglob("floorcost",teStor);
 
@@ -196,8 +200,13 @@ $elseif.c_techAssumptScen "%c_techAssumptScen%" == "SSP3"
     fm_dataglob("learn","spv") =         0.8 * fm_dataglob("learn","spv");
     fm_dataglob("floorcost","spv") =     8   * fm_dataglob("floorcost","spv");
     fm_dataglob("floorcost","csp") =     1.6 * fm_dataglob("floorcost","csp");
-    fm_dataglob("floorcost","windon") =  4.5 * fm_dataglob("floorcost","windon");
-    fm_dataglob("floorcost","windoff") = 1.8 * fm_dataglob("floorcost","windoff");
+*** RP: because of the interaction of learn rates with floor costs, it is not possible to simply apply multiplicative factors. These 
+*** values need to be set by hand!
+    fm_dataglob("learn","windon")     =  0.20;  !! these values make 2100 wind onshore costs ~1.7 times those seen in SSP2 at the same cumCap
+    fm_dataglob("floorcost","windon") =  1600;
+    fm_dataglob("learn","windoff")    =  0.32; !! these values make 2100 wind offshore costs ~1.8 times those seen in SSP2 at the same cumCap
+    fm_dataglob("floorcost","windoff") = 1900; 
+
     fm_dataglob("inco0",teStor) =        2   * fm_dataglob("inco0",teStor); 
     fm_dataglob("floorcost",teStor) =    2   * fm_dataglob("floorcost",teStor); 
 
@@ -213,8 +222,12 @@ $elseif.c_techAssumptScen "%c_techAssumptScen%" == "SSP5"
     fm_dataglob("learn",teVRE) =         0.8 * fm_dataglob("learn",teVRE);
     fm_dataglob("floorcost","spv") =     3   * fm_dataglob("floorcost","spv");
     fm_dataglob("floorcost","csp") =     1.3 * fm_dataglob("floorcost","csp");
-    fm_dataglob("floorcost","windon") =  2.5 * fm_dataglob("floorcost","windon");
-    fm_dataglob("floorcost","windoff") = 1.4 * fm_dataglob("floorcost","windoff");
+*** RP: because of the interaction of learn rates with floor costs, it is not possible to simply apply multiplicative factors. These 
+*** values need to be set by hand!
+    fm_dataglob("learn","windon")     =  0.22;  !! these values make 2100 wind onshore costs ~1.3 times those seen in SSP2 at the same cumCap
+    fm_dataglob("floorcost","windon") =  1070;
+    fm_dataglob("learn","windoff")    =  0.18; !! these values make 2100 wind offshore costs ~1.3 times those seen in SSP2 at the same cumCap
+    fm_dataglob("floorcost","windoff") = 1200; 
     fm_dataglob("inco0",teStor) =        2   * fm_dataglob("inco0",teStor); 
     fm_dataglob("floorcost",teStor) =    2   * fm_dataglob("floorcost",teStor); 
 


### PR DESCRIPTION
## Purpose of this PR

update the learning curve parameterization for SSP1/3/5 so that the resulting wind costs are again in a reasonable ratio to the updated SSP2 wind costs. The update of costs in SSP2 in combination with the multiplicative factors for SSP1-5 led to floor costs being higher than initial costs, causing the model to crash. 

Because of the floor cost/ learning rate interaction, this should be done by hand and cannot be done via the automatic multiplicative factors used for the other techs, otherwise it is challenging to get 2025 and 2100 costs reasonable.

## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
-  :ballot_box_with_check: GAMS Code
- :white_medium_square: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
-  :ballot_box_with_check: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :ballot_box_with_check: Bug fix
- :white_medium_square: Refactoring
- :white_medium_square: New feature
- :ballot_box_with_check: Change of parameter values or input data (including CES parameters)
- :ballot_box_with_check: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

* Runs with these changes are here:
* Comparison of results (what changes by this PR?): 
