### PR TITLE
Enhance checkProjectSummations script to run an alternative ScenarioMIP check

### DIFF
--- a/scripts/output/single/checkProjectSummations.R
+++ b/scripts/output/single/checkProjectSummations.R
@@ -38,8 +38,14 @@ if (length(missingVariables) > 0) message("Check piamInterfaces::variableInfo('v
 
 # list(mappings, summationsFile, skipBunkers, dataDumpFile, generatePlots, timesteps)
 checkMappings <- list(
-  list(c("NAVIGATE", "ELEVATE"), "NAVIGATE", FALSE, NULL, FALSE, seq(2005, 2100, 1)),
-  list("ScenarioMIP", "ScenarioMIP", FALSE, NULL, FALSE, seq(2005, 2100, 1)),
+  list(
+    c("NAVIGATE", "ELEVATE"), "NAVIGATE", FALSE, NULL, FALSE,
+    c(seq(2005, 2060, 5), seq(2070, 2100, 10))
+  ),
+  list(
+    "ScenarioMIP", "ScenarioMIP", FALSE, NULL, FALSE,
+    c(seq(2005, 2060, 5), seq(2070, 2100, 10))
+  ),
   # temporary check until EDGE-T reports 2005 and 2010 again
   list(
     "ScenarioMIP", "ScenarioMIP", FALSE, "projectSummationsScenarioMIP.csv", TRUE,


### PR DESCRIPTION
## Purpose of this PR

Create an additional ScenarioMIP check that excludes the years 2005 and 2010 to drop summation checks failing because of omitted EDGE-T variables. 

In addition, this restricts summation checks to REMIND years to avoid summation errors due to interpolation of only some of the variables which are part of a summation check. This should reduce the number of false positives in the summation checks. 

## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :white_medium_square: GAMS Code
- :ballot_box_with_check: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :white_medium_square: Bug fix
- :white_medium_square: Refactoring
- :ballot_box_with_check: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :ballot_box_with_check: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

* Runs with these changes are here:
* Comparison of results (what changes by this PR?): 
