### PR TITLE
CES paremeter for SSP2, SSP2-EU21, SSP1, SSP1-EU21, SSP3 and SSP5

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -31,7 +31,7 @@ cfg$extramappings_historic <- ""
 cfg$inputRevision <- "7.54"
 
 #### Current CES parameter and GDX revision (commit hash) ####
-cfg$CESandGDXversion <- "673fd2d4d75ce2b178f645ca1458287e44d7461b"
+cfg$CESandGDXversion <- "85399046f4a00fdd1dfd4dee32daa0a2912da6ee"
 
 #### Force the model to download new input data ####
 cfg$force_download <- FALSE


### PR DESCRIPTION
## Purpose of this PR

* new CES paremeter and gdx files for SSP2, SSP2-EU21, SSP1, SSP1-EU21, SSP3 and SSP5, 
* calibration runs: /p/projects/remind/calibration/REMIND_calibration_2025_07_03/remind

## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :white_medium_square: GAMS Code
- :white_medium_square: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :ballot_box_with_check: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :white_medium_square: Bug fix
- :white_medium_square: Refactoring
- :white_medium_square: New feature
- :ballot_box_with_check: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

* Runs with these changes are here:
* Comparison of results (what changes by this PR?): 
