### PR TITLE
Extend subsidy max values to cm_fetaxscen eq 1 scenario

### DIFF
--- a/modules/21_tax/on/preloop.gms
+++ b/modules/21_tax/on/preloop.gms
@@ -52,12 +52,12 @@ if (cm_fetaxscen eq 0, !! no FE and ResEx sub
    	      = p21_tau_fe_sub("2025",regi,sector,entyFe) 
          + ( f21_sub_convergence_rollback("2035",regi,sector,entyFe) * 0.001 / sm_EJ_2_TWa - p21_tau_fe_sub("2025",regi,sector,entyFe) ) * ( (ttot.val - 2025) / (2035 - 2025) );
       p21_tau_fe_sub(ttot,regi,sector,entyFe)$(f21_sub_convergence_rollback("2035",regi,sector,entyFe) gt 0 AND ttot.val  gt 2035) = f21_sub_convergence_rollback("2035",regi,sector,entyFe) * 0.001 / sm_EJ_2_TWa;
-*** Limit subsidy feelt and feels maximum value at 2050 onward to 0.2 [$/TWa] to avoid negative electricity prices. Linearly reduce values from 2035.
-      p21_tau_fe_sub(ttot,regi,sector,entyFe)$((ttot.val gt 2035) AND (ttot.val le 2050) AND (p21_tau_fe_sub("2050",regi,sector,entyFe) lt -0.2) AND (sameas(entyFe,"feelt") OR sameas(entyFe,"feels"))) = 
-        p21_tau_fe_sub("2035",regi,sector,entyFe) - 
-        (p21_tau_fe_sub("2050",regi,sector,entyFe) - (-0.2)) * (ttot.val - 2035) / (2050 - 2035);
-      p21_tau_fe_sub(ttot,regi,sector,entyFe)$((ttot.val gt 2050)) = p21_tau_fe_sub("2050",regi,sector,entyFe);
     );
+*** Limit subsidy feelt and feels maximum value at 2050 onward to 0.2 [$/TWa] to avoid negative electricity prices. Linearly reduce values from 2035.
+    p21_tau_fe_sub(ttot,regi,sector,entyFe)$((ttot.val gt 2035) AND (ttot.val le 2050) AND (p21_tau_fe_sub("2050",regi,sector,entyFe) lt -0.2) AND (sameas(entyFe,"feelt") OR sameas(entyFe,"feels"))) = 
+      p21_tau_fe_sub("2035",regi,sector,entyFe) - 
+      (p21_tau_fe_sub("2050",regi,sector,entyFe) - (-0.2)) * (ttot.val - 2035) / (2050 - 2035);
+    p21_tau_fe_sub(ttot,regi,sector,entyFe)$((ttot.val gt 2050)) = p21_tau_fe_sub("2050",regi,sector,entyFe);
   elseif(cm_fetaxscen eq 2) or (cm_fetaxscen eq 3) or (cm_fetaxscen eq 4), 
     p21_tau_fe_sub(ttot,regi,sector,entyFe)$(ttot.val gt 2005)=p21_tau_fe_sub("2005",regi,sector,entyFe);
     p21_tau_fuEx_sub(ttot,regi,entyPe)$(ttot.val gt 2005)=p21_tau_fuEx_sub("2005",regi,entyPe);


### PR DESCRIPTION
## Purpose of this PR

- Extend solution proposed here: https://github.com/remindmodel/remind/pull/2119 and here:https://github.com/remindmodel/development_issues/issues/568 to cm_fetaxscen eq 1.

- Limits felt and feels subsidy levels at a maximum of 0.2 $/TWa starting from 2050 onward.

## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :ballot_box_with_check: GAMS Code
- :white_medium_square: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :ballot_box_with_check: Bug fix
- :white_medium_square: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

* Runs with these changes are here:
* Comparison of results (what changes by this PR?): 
