### PR TITLE
CH4 abatement before 2025: Delete exception for EUR

### DIFF
--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -1415,10 +1415,8 @@ $if %cm_MAgPIE_coupling% == "off"  pm_macSwitch(ttot,regi,"co2luc") = 0;
 *** The tiny fraction n2ofertsom of total land use n2o can get slightly negative in some cases. Ignore MAC for n2ofertsom by default.
 $if %cm_MAgPIE_coupling% == "off"  pm_macSwitch(ttot,regi,"n2ofertsom") = 0;
 
-* GA: Deactivate MAC abatement for historical periods, assuming no abatement 
-* happens until 2030, except in Europe
+* GA: Deactivate MAC abatement for historical periods, assuming no abatement happens until 2030
 pm_macSwitch(ttot,regi,emiMacSector)$(ttot.val le 2025) = 0;
-pm_macSwitch(ttot,regi,emiMacSector)$(regi_group("EUR_regi",regi) and (ttot.val le 2025) and (ttot.val ge 2005))  = 1;
 
 * GA: Use long term (2050) pm_macSwitch to set p_macCostSwitch, as some MACCs
 * are turned off in the short term 


### PR DESCRIPTION
## Purpose of this PR

Remove exceptional MACC-based abatement for EUR in 2005-2025. Details here: https://github.com/remindmodel/development_issues/issues/612#issuecomment-3051804833

## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :ballot_box_with_check: GAMS Code
- :white_medium_square: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :ballot_box_with_check: Bug fix
- :white_medium_square: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [ ] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [ ] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [ ] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [ ] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I explained my changes within the PR, particularly in hard-to-understand areas
- [ ] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

* Runs with these changes are here:
* Comparison of results (what changes by this PR?): 
