### PR TITLE
New cs2 profile for reporting air pollution emissions

### DIFF
--- a/scripts/cs2/AirPollutantsDetailed.Rmd
+++ b/scripts/cs2/AirPollutantsDetailed.Rmd
@@ -50,256 +50,324 @@ showLinePlots(data, "Emi|BC", histVars = "Emi|BC", vlines = 2020)
 showLinePlots(data, "Emi|BC|Energy Demand|Buildings", histVars = "Emi|BC|Energy|Demand|Buildings", vlines = 2020)
 ```
 
+### Emi|BC|Energy Demand|Industry
 ```{r Black Carbon Emissions - Industry}
 showLinePlots(data, "Emi|BC|Energy Demand|Industry", histVars = "Emi|BC|Energy|Demand|Industry", vlines = 2020)
 ```
 
+### Emi|BC|Energy Demand|Transport
 ```{r Black Carbon Emissions - Transport}
 showLinePlots(data, "Emi|BC|Energy Demand|Transport", histVars = "Emi|BC|Energy|Demand|Transport", vlines = 2020)
 ```
 
+### Emi|BC|Energy Demand|Transport|Aviation
 ```{r BC Emissions - Total}
 showLinePlots(data, "Emi|BC|Energy Demand|Transport|Aviation", histVars = "Emi|BC|Transport|Pass|Aviation|International|Demand", vlines = 2020)
 ```
 
+### Emi|BC|Energy Demand|Transport|International Shipping
 ```{r BC Emissions - Total}
 showLinePlots(data, "Emi|BC|Energy Demand|Transport|International Shipping", histVars = "Emi|BC|International Shipping", vlines = 2020)
 ```
 
+### Emi|BC|Energy Supply
 ```{r Black Carbon Emissions - Energy Supply}
 showLinePlots(data, "Emi|BC|Energy Supply", histVars = "Emi|BC|Energy|Supply", vlines = 2020)
 ```
 
+### Emi|BC|Land Use
 ```{r Black Carbon Emissions - Land use}
 showLinePlots(data, "Emi|BC|Land Use", histVars = "Emissions|BC|Land|", vlines = 2020)
 ```
 
+### Emi|BC|Solvents
 ```{r Black Carbon Emissions - Solvents}
 showLinePlots(data, "Emi|BC|Solvents", histVars = "Emi|BC|Solvents Production and Application", vlines = 2020)
 ```
 
+### Emi|BC|Waste
 ```{r Black Carbon Emissions - Waste}
 showLinePlots(data, "Emi|BC|Waste", histVars = "Emi|BC|Waste", vlines = 2020)
 ```
 
 ## SO2 
+
+### Emi|SO2|Energy Supply
 ```{r SO2 Emissions - Total}
 showLinePlots(data, "Emi|SO2|Energy Supply", histVars = "Emi|Sulfur|Energy|Supply", vlines = 2020)
 ```
 
+### Emi|SO2|Energy Demand|Buildings
 ```{r SO2 Emissions - Total}
 showLinePlots(data, "Emi|SO2|Energy Demand|Buildings", histVars = "Emi|Sulfur|Energy|Demand|Buildings", vlines = 2020)
 ```
 
+### Emi|SO2|Energy Demand|Industry
 ```{r SO2 Emissions - Total}
 showLinePlots(data, "Emi|SO2|Energy Demand|Industry", histVars = "Emi|Sulfur|Energy|Demand|Industry", vlines = 2020)
 ```
 
+### Emi|SO2|Energy Demand|Transport
 ```{r SO2 Emissions - Total}
 showLinePlots(data, "Emi|SO2|Energy Demand|Transport", histVars = "Emi|Sulfur|Energy|Demand|Transport", vlines = 2020)
 ```
 
+### Emi|SO2|Energy Demand|Transport|Aviation
 ```{r SO2 Emissions - Total}
 showLinePlots(data, "Emi|SO2|Energy Demand|Transport|Aviation", histVars = "Emi|Sulfur|Transport|Pass|Aviation|International|Demand", vlines = 2020)
 ```
 
+### Emi|SO2|Energy Demand|Transport|International Shipping
 ```{r SO2 Emissions - Total}
 showLinePlots(data, "Emi|SO2|Energy Demand|Transport|International Shipping", histVars = "Emi|Sulfur|International Shipping", vlines = 2020)
 ```
 
+### Emi|SO2|Land Use
 ```{r SO2 Emissions - Total}
 showLinePlots(data, "Emi|SO2|Land Use", histVars = "Emissions|SO2|Land|", vlines = 2020)
 ```
 
+### Emi|SO2|Solvents
 ```{r SO2 Emissions - Total}
 showLinePlots(data, "Emi|SO2|Solvents", histVars = "Emi|Sulfur|Solvents Production and Application", vlines = 2020)
 ```
 
+### Emi|SO2|Waste
 ```{r SO2 Emissions - Total}
 showLinePlots(data, "Emi|SO2|Waste", histVars = "Emi|Sulfur|Waste", vlines = 2020)
 ```
 
 ## VOC 
+
+### Emi|VOC|Energy Supply
 ```{r VOC Emissions - Total}
 showLinePlots(data, "Emi|VOC|Energy Supply", histVars = "Emi|VOC|Energy|Supply", vlines = 2020)
 ```
 
+### Emi|VOC|Energy Demand|Buildings
 ```{r VOC Emissions - Total}
 showLinePlots(data, "Emi|VOC|Energy Demand|Buildings", histVars = "Emi|VOC|Energy|Demand|Buildings", vlines = 2020)
 ```
 
+### Emi|VOC|Energy Demand|Industry
 ```{r VOC Emissions - Total}
 showLinePlots(data, "Emi|VOC|Energy Demand|Industry", histVars = "Emi|VOC|Energy|Demand|Industry", vlines = 2020)
 ```
 
+### Emi|VOC|Energy Demand|Transport
 ```{r VOC Emissions - Total}
 showLinePlots(data, "Emi|VOC|Energy Demand|Transport", histVars = "Emi|VOC|Energy|Demand|Transport", vlines = 2020)
 ```
 
+### Emi|VOC|Energy Demand|Transport|Aviation
 ```{r VOC Emissions - Total}
 showLinePlots(data, "Emi|VOC|Energy Demand|Transport|Aviation", histVars = "Emi|VOC|Transport|Pass|Aviation|International|Demand", vlines = 2020)
 ```
 
+### Emi|VOC|Energy Demand|Transport|International Shipping
 ```{r VOC Emissions - Total}
 showLinePlots(data, "Emi|VOC|Energy Demand|Transport|International Shipping", histVars = "Emi|VOC|International Shipping", vlines = 2020)
 ```
 
+### Emi|VOC|Land Use
 ```{r VOC Emissions - Total}
 showLinePlots(data, "Emi|VOC|Land Use", vlines = 2020)
 ```
 
+### Emi|VOC|Solvents
 ```{r VOC Emissions - Total}
 showLinePlots(data, "Emi|VOC|Solvents", histVars = "Emi|VOC|Solvents Production and Application", vlines = 2020)
 ```
 
+### Emi|VOC|Waste
 ```{r VOC Emissions - Total}
 showLinePlots(data, "Emi|VOC|Waste", histVars = "Emi|VOC|Waste", vlines = 2020)
 ```
 
 ## OC 
+
+### Emi|OC|Energy Supply
 ```{r OC Emissions - Total}
 showLinePlots(data, "Emi|OC|Energy Supply", histVars = "Emi|OC|Energy|Supply", vlines = 2020)
 ```
 
+### Emi|OC|Energy Demand|Buildings
 ```{r OC Emissions - Total}
 showLinePlots(data, "Emi|OC|Energy Demand|Buildings", histVars = "Emi|OC|Energy|Demand|Buildings", vlines = 2020)
 ```
 
+### Emi|OC|Energy Demand|Industry
 ```{r OC Emissions - Total}
 showLinePlots(data, "Emi|OC|Energy Demand|Industry", histVars = "Emi|OC|Energy|Demand|Industry", vlines = 2020)
 ```
 
+### Emi|OC|Energy Demand|Transport
 ```{r OC Emissions - Total}
 showLinePlots(data, "Emi|OC|Energy Demand|Transport", histVars = "Emi|OC|Energy|Demand|Transport", vlines = 2020)
 ```
 
+### Emi|OC|Energy Demand|Transport|Aviation
 ```{r OC Emissions - Total}
 showLinePlots(data, "Emi|OC|Energy Demand|Transport|Aviation", histVars = "Emi|OC|Transport|Pass|Aviation|International|Demand", vlines = 2020)
 ```
 
+### Emi|OC|Energy Demand|Transport|International Shipping
 ```{r OC Emissions - Total}
 showLinePlots(data, "Emi|OC|Energy Demand|Transport|International Shipping", histVars = "Emi|OC|International Shipping", vlines = 2020)
 ```
 
+### Emi|OC|Land Use
 ```{r OC Emissions - Total}
 showLinePlots(data, "Emi|OC|Land Use", vlines = 2020)
 ```
 
+### Emi|OC|Solvents
 ```{r OC Emissions - Total}
 showLinePlots(data, "Emi|OC|Solvents", histVars = "Emi|OC|Solvents Production and Application", vlines = 2020)
 ```
 
+### Emi|OC|Waste
 ```{r OC Emissions - Total}
 showLinePlots(data, "Emi|OC|Waste", histVars = "Emi|OC|Waste", vlines = 2020)
 ```
 
 ## NOX 
+
+### Emi|NOX|Energy Supply
 ```{r NOX Emissions - Total}
 showLinePlots(data, "Emi|NOX|Energy Supply", histVars = "Emi|NOX|Energy|Supply", vlines = 2020)
 ```
 
+### Emi|NOX|Energy Demand|Buildings
 ```{r NOX Emissions - Total}
 showLinePlots(data, "Emi|NOX|Energy Demand|Buildings", histVars = "Emi|NOX|Energy|Demand|Buildings", vlines = 2020)
 ```
 
+### Emi|NOX|Energy Demand|Industry
 ```{r NOX Emissions - Total}
 showLinePlots(data, "Emi|NOX|Energy Demand|Industry", histVars = "Emi|NOX|Energy|Demand|Industry", vlines = 2020)
 ```
 
+### Emi|NOX|Energy Demand|Transport
 ```{r NOX Emissions - Total}
 showLinePlots(data, "Emi|NOX|Energy Demand|Transport", histVars = "Emi|NOX|Energy|Demand|Transport", vlines = 2020)
 ```
 
+### Emi|NOX|Energy Demand|Transport|Aviation
 ```{r NOX Emissions - Total}
 showLinePlots(data, "Emi|NOX|Energy Demand|Transport|Aviation", histVars = "Emi|NOX|Transport|Pass|Aviation|International|Demand", vlines = 2020)
 ```
 
+### Emi|NOX|Energy Demand|Transport|International Shipping
 ```{r NOX Emissions - Total}
 showLinePlots(data, "Emi|NOX|Energy Demand|Transport|International Shipping", histVars = "Emi|NOX|International Shipping", vlines = 2020)
 ```
 
+### Emi|NOX|Land Use
 ```{r NOX Emissions - Total}
 showLinePlots(data, "Emi|NOX|Land Use", vlines = 2020)
 ```
 
+### Emi|NOX|Solvents
 ```{r NOX Emissions - Total}
 showLinePlots(data, "Emi|NOX|Solvents", histVars = "Emi|NOX|Solvents Production and Application", vlines = 2020)
 ```
 
+### Emi|NOX|Waste
 ```{r NOX Emissions - Total}
 showLinePlots(data, "Emi|NOX|Waste", histVars = "Emi|NOX|Waste", vlines = 2020)
 ```
 
 ## NH3 
+
+### Emi|NH3|Energy Supply
 ```{r NH3 Emissions - Total}
 showLinePlots(data, "Emi|NH3|Energy Supply", histVars = "Emi|NH3|Energy|Supply", vlines = 2020)
 ```
 
+### Emi|NH3|Energy Demand|Buildings
 ```{r NH3 Emissions - Total}
 showLinePlots(data, "Emi|NH3|Energy Demand|Buildings", histVars = "Emi|NH3|Energy|Demand|Buildings", vlines = 2020)
 ```
 
+### Emi|NH3|Energy Demand|Industry
 ```{r NH3 Emissions - Total}
 showLinePlots(data, "Emi|NH3|Energy Demand|Industry", histVars = "Emi|NH3|Energy|Demand|Industry", vlines = 2020)
 ```
 
+### Emi|NH3|Energy Demand|Transport
 ```{r NH3 Emissions - Total}
 showLinePlots(data, "Emi|NH3|Energy Demand|Transport", histVars = "Emi|NH3|Energy|Demand|Transport", vlines = 2020)
 ```
 
+### Emi|NH3|Energy Demand|Transport|Aviation
 ```{r NH3 Emissions - Total}
 showLinePlots(data, "Emi|NH3|Energy Demand|Transport|Aviation", histVars = "Emi|NH3|Transport|Pass|Aviation|International|Demand", vlines = 2020)
 ```
 
+### Emi|NH3|Energy Demand|Transport|International Shipping
 ```{r NH3 Emissions - Total}
 showLinePlots(data, "Emi|NH3|Energy Demand|Transport|International Shipping", histVars = "Emi|NH3|International Shipping", vlines = 2020)
 ```
 
+### Emi|NH3|Land Use
 ```{r NH3 Emissions - Total}
 showLinePlots(data, "Emi|NH3|Land Use", vlines = 2020)
 ```
 
+### Emi|NH3|Solvents
 ```{r NH3 Emissions - Total}
 showLinePlots(data, "Emi|NH3|Solvents", histVars = "Emi|NH3|Solvents Production and Application", vlines = 2020)
 ```
 
+### Emi|NH3|Waste
 ```{r NH3 Emissions - Total}
 showLinePlots(data, "Emi|NH3|Waste", histVars = "Emi|NH3|Waste", vlines = 2020)
 ```
 
 ## CO 
+
+### Emi|CO|Energy Supply
 ```{r CO Emissions - Total}
 showLinePlots(data, "Emi|CO|Energy Supply", histVars = "Emi|CO|Energy|Supply", vlines = 2020)
 ```
 
+### Emi|CO|Energy Demand|Buildings
 ```{r CO Emissions - Total}
 showLinePlots(data, "Emi|CO|Energy Demand|Buildings", histVars = "Emi|CO|Energy|Demand|Buildings", vlines = 2020)
 ```
 
+### Emi|CO|Energy Demand|Industry
 ```{r CO Emissions - Total}
 showLinePlots(data, "Emi|CO|Energy Demand|Industry", histVars = "Emi|CO|Energy|Demand|Industry", vlines = 2020)
 ```
 
+### Emi|CO|Energy Demand|Transport
 ```{r CO Emissions - Total}
 showLinePlots(data, "Emi|CO|Energy Demand|Transport", histVars = "Emi|CO|Energy|Demand|Transport", vlines = 2020)
 ```
 
+### Emi|CO|Energy Demand|Transport|Aviation
 ```{r CO Emissions - Total}
 showLinePlots(data, "Emi|CO|Energy Demand|Transport|Aviation", histVars = "Emi|CO|Transport|Pass|Aviation|International|Demand", vlines = 2020)
 ```
 
+### Emi|CO|Energy Demand|Transport|International Shipping
 ```{r CO Emissions - Total}
 showLinePlots(data, "Emi|CO|Energy Demand|Transport|International Shipping", histVars = "Emi|CO|International Shipping", vlines = 2020)
 ```
 
+### Emi|CO|Land Use
 ```{r CO Emissions - Total}
 showLinePlots(data, "Emi|CO|Land Use", vlines = 2020)
 ```
 
+### Emi|CO|Solvents
 ```{r CO Emissions - Total}
 showLinePlots(data, "Emi|CO|Solvents", histVars = "Emi|CO|Solvents Production and Application", vlines = 2020)
 ```
 
+### Emi|CO|Waste
 ```{r CO Emissions - Total}
 showLinePlots(data, "Emi|CO|Waste", histVars = "Emi|CO|Waste", vlines = 2020)
 ```

--- a/scripts/cs2/AirPollutantsDetailed.Rmd
+++ b/scripts/cs2/AirPollutantsDetailed.Rmd
@@ -8,34 +8,52 @@
 -->
 # Air Pollutants detailed
 
-```{r, echo = TRUE, results = 'show'}
-# Create some total variables that are not directly available in the historical data
-data <- data %>%
-  filter(model == "CEDS IAMC sectors") %>%
-  calc_addVariable(
-    `Emi|BC` = 
-    "`Emi|BC|Agriculture` +
-    `Emi|BC|Aircraft` +
-    `Emi|BC|Energy Sector` +
-    `Emi|BC|Industrial Sector` +
-    `Emi|BC|International Shipping` +
-    `Emi|BC|Residential Commercial Other` +
-    `Emi|BC|Solvents Production and Application` +
-    `Emi|BC|Transportation Sector` +
-    `Emi|BC|Waste`",
-    unit = "Mt BC/yr"
-  ) %>%
-  bind_rows(data, .)
+```{r, echo = FALSE, results = 'hide'}
+# Adds a new variable as the sum of a list of variables
+addSumVariables <- function(
+  fdata, sumvars, outvarname, outunit = NULL, convmult = 1, convoffset = 0, only.new = FALSE
+  ) {
+  if (is.null(outunit)) {
+    outunit <- fdata %>%
+      filter(variable == sumvars[1]) %>%
+      slice(1) %>%
+      select(unit) %>% unlist %>% as.character
+  }
 
-data %>%
-  filter(scenario == "historical") %>%
-  filter(variable == "Emi|BC")
+  newdata <- fdata %>%
+    filter(variable %in% sumvars) %>%
+    select(-varplus) %>%
+    distinct %>%
+    pivot_wider(names_from = variable, values_from = value) %>%
+    mutate(value = rowSums(across(sumvars))) %>%
+    select(-c(sumvars)) %>%
+    mutate(variable = outvarname, varplus = outvarname, unit = outunit)
+  if(!only.new) {
+    return(rbind(fdata, newdata))
+  } else {
+    return(newdata)
+  }
+}
 ```
 
-```{r, echo = TRUE, results = 'show'}
-data %>%
-  filter(scenario == "historical") %>%
-  filter(variable == "Emi|BC")
+```{r, echo = FALSE, results = 'hide'}
+# Create some total variables that are not directly available in the historical data
+sumvars <- c(
+    "Emi|BC|Agriculture",
+    "Emi|BC|Aircraft",
+    "Emi|BC|Energy Sector",
+    "Emi|BC|Industrial Sector",
+    "Emi|BC|International Shipping",
+    "Emi|BC|Residential Commercial Other",
+    "Emi|BC|Solvents Production and Application",
+    "Emi|BC|Transportation Sector",
+    "Emi|BC|Waste"
+  )
+
+data <- data %>% 
+  filter(model == "CEDS IAMC sectors") %>%
+  addSumVariables(sumvars, "Emi|BC", only.new = TRUE) %>%
+  bind_rows(data)
 ```
 
 ## BC

--- a/scripts/cs2/AirPollutantsDetailed.Rmd
+++ b/scripts/cs2/AirPollutantsDetailed.Rmd
@@ -1,0 +1,305 @@
+<!--
+|  (C) 2006-2024 Potsdam Institute for Climate Impact Research (PIK)
+|  authors, and contributors see CITATION.cff file. This file is part
+|  of REMIND and licensed under AGPL-3.0-or-later. Under Section 7 of
+|  AGPL-3.0, you are granted additional permissions described in the
+|  REMIND License Exception, version 1.0 (see LICENSE file).
+|  Contact: remind@pik-potsdam.de
+-->
+# Air Pollutants detailed
+
+```{r, echo = TRUE, results = 'show'}
+# Create some total variables that are not directly available in the historical data
+data <- data %>%
+  filter(model == "CEDS IAMC sectors") %>%
+  calc_addVariable(
+    `Emi|BC` = 
+    "`Emi|BC|Agriculture` +
+    `Emi|BC|Aircraft` +
+    `Emi|BC|Energy Sector` +
+    `Emi|BC|Industrial Sector` +
+    `Emi|BC|International Shipping` +
+    `Emi|BC|Residential Commercial Other` +
+    `Emi|BC|Solvents Production and Application` +
+    `Emi|BC|Transportation Sector` +
+    `Emi|BC|Waste`",
+    unit = "Mt BC/yr"
+  ) %>%
+  bind_rows(data, .)
+
+data %>%
+  filter(scenario == "historical") %>%
+  filter(variable == "Emi|BC")
+```
+
+```{r, echo = TRUE, results = 'show'}
+data %>%
+  filter(scenario == "historical") %>%
+  filter(variable == "Emi|BC")
+```
+
+## BC
+
+### Emi|BC
+```{r Black Carbon Emissions - Total}
+showLinePlots(data, "Emi|BC", histVars = "Emi|BC", vlines = 2020)
+```
+
+### Emi|BC|Energy Demand|Buildings
+```{r Black Carbon Emissions - Buildings}
+showLinePlots(data, "Emi|BC|Energy Demand|Buildings", histVars = "Emi|BC|Energy|Demand|Buildings", vlines = 2020)
+```
+
+```{r Black Carbon Emissions - Industry}
+showLinePlots(data, "Emi|BC|Energy Demand|Industry", histVars = "Emi|BC|Energy|Demand|Industry", vlines = 2020)
+```
+
+```{r Black Carbon Emissions - Transport}
+showLinePlots(data, "Emi|BC|Energy Demand|Transport", histVars = "Emi|BC|Energy|Demand|Transport", vlines = 2020)
+```
+
+```{r BC Emissions - Total}
+showLinePlots(data, "Emi|BC|Energy Demand|Transport|Aviation", histVars = "Emi|BC|Transport|Pass|Aviation|International|Demand", vlines = 2020)
+```
+
+```{r BC Emissions - Total}
+showLinePlots(data, "Emi|BC|Energy Demand|Transport|International Shipping", histVars = "Emi|BC|International Shipping", vlines = 2020)
+```
+
+```{r Black Carbon Emissions - Energy Supply}
+showLinePlots(data, "Emi|BC|Energy Supply", histVars = "Emi|BC|Energy|Supply", vlines = 2020)
+```
+
+```{r Black Carbon Emissions - Land use}
+showLinePlots(data, "Emi|BC|Land Use", histVars = "Emissions|BC|Land|", vlines = 2020)
+```
+
+```{r Black Carbon Emissions - Solvents}
+showLinePlots(data, "Emi|BC|Solvents", histVars = "Emi|BC|Solvents Production and Application", vlines = 2020)
+```
+
+```{r Black Carbon Emissions - Waste}
+showLinePlots(data, "Emi|BC|Waste", histVars = "Emi|BC|Waste", vlines = 2020)
+```
+
+## SO2 
+```{r SO2 Emissions - Total}
+showLinePlots(data, "Emi|SO2|Energy Supply", histVars = "Emi|Sulfur|Energy|Supply", vlines = 2020)
+```
+
+```{r SO2 Emissions - Total}
+showLinePlots(data, "Emi|SO2|Energy Demand|Buildings", histVars = "Emi|Sulfur|Energy|Demand|Buildings", vlines = 2020)
+```
+
+```{r SO2 Emissions - Total}
+showLinePlots(data, "Emi|SO2|Energy Demand|Industry", histVars = "Emi|Sulfur|Energy|Demand|Industry", vlines = 2020)
+```
+
+```{r SO2 Emissions - Total}
+showLinePlots(data, "Emi|SO2|Energy Demand|Transport", histVars = "Emi|Sulfur|Energy|Demand|Transport", vlines = 2020)
+```
+
+```{r SO2 Emissions - Total}
+showLinePlots(data, "Emi|SO2|Energy Demand|Transport|Aviation", histVars = "Emi|Sulfur|Transport|Pass|Aviation|International|Demand", vlines = 2020)
+```
+
+```{r SO2 Emissions - Total}
+showLinePlots(data, "Emi|SO2|Energy Demand|Transport|International Shipping", histVars = "Emi|Sulfur|International Shipping", vlines = 2020)
+```
+
+```{r SO2 Emissions - Total}
+showLinePlots(data, "Emi|SO2|Land Use", histVars = "Emissions|SO2|Land|", vlines = 2020)
+```
+
+```{r SO2 Emissions - Total}
+showLinePlots(data, "Emi|SO2|Solvents", histVars = "Emi|Sulfur|Solvents Production and Application", vlines = 2020)
+```
+
+```{r SO2 Emissions - Total}
+showLinePlots(data, "Emi|SO2|Waste", histVars = "Emi|Sulfur|Waste", vlines = 2020)
+```
+
+## VOC 
+```{r VOC Emissions - Total}
+showLinePlots(data, "Emi|VOC|Energy Supply", histVars = "Emi|VOC|Energy|Supply", vlines = 2020)
+```
+
+```{r VOC Emissions - Total}
+showLinePlots(data, "Emi|VOC|Energy Demand|Buildings", histVars = "Emi|VOC|Energy|Demand|Buildings", vlines = 2020)
+```
+
+```{r VOC Emissions - Total}
+showLinePlots(data, "Emi|VOC|Energy Demand|Industry", histVars = "Emi|VOC|Energy|Demand|Industry", vlines = 2020)
+```
+
+```{r VOC Emissions - Total}
+showLinePlots(data, "Emi|VOC|Energy Demand|Transport", histVars = "Emi|VOC|Energy|Demand|Transport", vlines = 2020)
+```
+
+```{r VOC Emissions - Total}
+showLinePlots(data, "Emi|VOC|Energy Demand|Transport|Aviation", histVars = "Emi|VOC|Transport|Pass|Aviation|International|Demand", vlines = 2020)
+```
+
+```{r VOC Emissions - Total}
+showLinePlots(data, "Emi|VOC|Energy Demand|Transport|International Shipping", histVars = "Emi|VOC|International Shipping", vlines = 2020)
+```
+
+```{r VOC Emissions - Total}
+showLinePlots(data, "Emi|VOC|Land Use", vlines = 2020)
+```
+
+```{r VOC Emissions - Total}
+showLinePlots(data, "Emi|VOC|Solvents", histVars = "Emi|VOC|Solvents Production and Application", vlines = 2020)
+```
+
+```{r VOC Emissions - Total}
+showLinePlots(data, "Emi|VOC|Waste", histVars = "Emi|VOC|Waste", vlines = 2020)
+```
+
+## OC 
+```{r OC Emissions - Total}
+showLinePlots(data, "Emi|OC|Energy Supply", histVars = "Emi|OC|Energy|Supply", vlines = 2020)
+```
+
+```{r OC Emissions - Total}
+showLinePlots(data, "Emi|OC|Energy Demand|Buildings", histVars = "Emi|OC|Energy|Demand|Buildings", vlines = 2020)
+```
+
+```{r OC Emissions - Total}
+showLinePlots(data, "Emi|OC|Energy Demand|Industry", histVars = "Emi|OC|Energy|Demand|Industry", vlines = 2020)
+```
+
+```{r OC Emissions - Total}
+showLinePlots(data, "Emi|OC|Energy Demand|Transport", histVars = "Emi|OC|Energy|Demand|Transport", vlines = 2020)
+```
+
+```{r OC Emissions - Total}
+showLinePlots(data, "Emi|OC|Energy Demand|Transport|Aviation", histVars = "Emi|OC|Transport|Pass|Aviation|International|Demand", vlines = 2020)
+```
+
+```{r OC Emissions - Total}
+showLinePlots(data, "Emi|OC|Energy Demand|Transport|International Shipping", histVars = "Emi|OC|International Shipping", vlines = 2020)
+```
+
+```{r OC Emissions - Total}
+showLinePlots(data, "Emi|OC|Land Use", vlines = 2020)
+```
+
+```{r OC Emissions - Total}
+showLinePlots(data, "Emi|OC|Solvents", histVars = "Emi|OC|Solvents Production and Application", vlines = 2020)
+```
+
+```{r OC Emissions - Total}
+showLinePlots(data, "Emi|OC|Waste", histVars = "Emi|OC|Waste", vlines = 2020)
+```
+
+## NOX 
+```{r NOX Emissions - Total}
+showLinePlots(data, "Emi|NOX|Energy Supply", histVars = "Emi|NOX|Energy|Supply", vlines = 2020)
+```
+
+```{r NOX Emissions - Total}
+showLinePlots(data, "Emi|NOX|Energy Demand|Buildings", histVars = "Emi|NOX|Energy|Demand|Buildings", vlines = 2020)
+```
+
+```{r NOX Emissions - Total}
+showLinePlots(data, "Emi|NOX|Energy Demand|Industry", histVars = "Emi|NOX|Energy|Demand|Industry", vlines = 2020)
+```
+
+```{r NOX Emissions - Total}
+showLinePlots(data, "Emi|NOX|Energy Demand|Transport", histVars = "Emi|NOX|Energy|Demand|Transport", vlines = 2020)
+```
+
+```{r NOX Emissions - Total}
+showLinePlots(data, "Emi|NOX|Energy Demand|Transport|Aviation", histVars = "Emi|NOX|Transport|Pass|Aviation|International|Demand", vlines = 2020)
+```
+
+```{r NOX Emissions - Total}
+showLinePlots(data, "Emi|NOX|Energy Demand|Transport|International Shipping", histVars = "Emi|NOX|International Shipping", vlines = 2020)
+```
+
+```{r NOX Emissions - Total}
+showLinePlots(data, "Emi|NOX|Land Use", vlines = 2020)
+```
+
+```{r NOX Emissions - Total}
+showLinePlots(data, "Emi|NOX|Solvents", histVars = "Emi|NOX|Solvents Production and Application", vlines = 2020)
+```
+
+```{r NOX Emissions - Total}
+showLinePlots(data, "Emi|NOX|Waste", histVars = "Emi|NOX|Waste", vlines = 2020)
+```
+
+## NH3 
+```{r NH3 Emissions - Total}
+showLinePlots(data, "Emi|NH3|Energy Supply", histVars = "Emi|NH3|Energy|Supply", vlines = 2020)
+```
+
+```{r NH3 Emissions - Total}
+showLinePlots(data, "Emi|NH3|Energy Demand|Buildings", histVars = "Emi|NH3|Energy|Demand|Buildings", vlines = 2020)
+```
+
+```{r NH3 Emissions - Total}
+showLinePlots(data, "Emi|NH3|Energy Demand|Industry", histVars = "Emi|NH3|Energy|Demand|Industry", vlines = 2020)
+```
+
+```{r NH3 Emissions - Total}
+showLinePlots(data, "Emi|NH3|Energy Demand|Transport", histVars = "Emi|NH3|Energy|Demand|Transport", vlines = 2020)
+```
+
+```{r NH3 Emissions - Total}
+showLinePlots(data, "Emi|NH3|Energy Demand|Transport|Aviation", histVars = "Emi|NH3|Transport|Pass|Aviation|International|Demand", vlines = 2020)
+```
+
+```{r NH3 Emissions - Total}
+showLinePlots(data, "Emi|NH3|Energy Demand|Transport|International Shipping", histVars = "Emi|NH3|International Shipping", vlines = 2020)
+```
+
+```{r NH3 Emissions - Total}
+showLinePlots(data, "Emi|NH3|Land Use", vlines = 2020)
+```
+
+```{r NH3 Emissions - Total}
+showLinePlots(data, "Emi|NH3|Solvents", histVars = "Emi|NH3|Solvents Production and Application", vlines = 2020)
+```
+
+```{r NH3 Emissions - Total}
+showLinePlots(data, "Emi|NH3|Waste", histVars = "Emi|NH3|Waste", vlines = 2020)
+```
+
+## CO 
+```{r CO Emissions - Total}
+showLinePlots(data, "Emi|CO|Energy Supply", histVars = "Emi|CO|Energy|Supply", vlines = 2020)
+```
+
+```{r CO Emissions - Total}
+showLinePlots(data, "Emi|CO|Energy Demand|Buildings", histVars = "Emi|CO|Energy|Demand|Buildings", vlines = 2020)
+```
+
+```{r CO Emissions - Total}
+showLinePlots(data, "Emi|CO|Energy Demand|Industry", histVars = "Emi|CO|Energy|Demand|Industry", vlines = 2020)
+```
+
+```{r CO Emissions - Total}
+showLinePlots(data, "Emi|CO|Energy Demand|Transport", histVars = "Emi|CO|Energy|Demand|Transport", vlines = 2020)
+```
+
+```{r CO Emissions - Total}
+showLinePlots(data, "Emi|CO|Energy Demand|Transport|Aviation", histVars = "Emi|CO|Transport|Pass|Aviation|International|Demand", vlines = 2020)
+```
+
+```{r CO Emissions - Total}
+showLinePlots(data, "Emi|CO|Energy Demand|Transport|International Shipping", histVars = "Emi|CO|International Shipping", vlines = 2020)
+```
+
+```{r CO Emissions - Total}
+showLinePlots(data, "Emi|CO|Land Use", vlines = 2020)
+```
+
+```{r CO Emissions - Total}
+showLinePlots(data, "Emi|CO|Solvents", histVars = "Emi|CO|Solvents Production and Application", vlines = 2020)
+```
+
+```{r CO Emissions - Total}
+showLinePlots(data, "Emi|CO|Waste", histVars = "Emi|CO|Waste", vlines = 2020)
+```

--- a/scripts/cs2/profiles.json
+++ b/scripts/cs2/profiles.json
@@ -94,6 +94,11 @@
 		"sections": "c(0,1,2,3,4,5,99)",
 		"mainReg": "'World'"
 	},
+		"AirPollutantsDetailed": {
+		"sections": "0",
+		"yearsHist": "c(seq(1990, 2024, 1), seq(2025, 2050, 5))",
+		"userSectionPath": "normalizePath('./scripts/cs2/AirPollutantsDetailed.Rmd')"
+	},
 	"mySection": {
 		"sections": "0",
 		"userSectionPath": "normalizePath('./scripts/cs2/mySection.Rmd')"


### PR DESCRIPTION
## Purpose of this PR

This PR adds a new, optional, compareScenarios2 profile, `AirPollutantsDetailed`, that reports detailed air pollution emissions, including the closest equivalent historical variables. The mapping to specific historical variables is still a bit of a work in progress, as they weren't very thoroughly checked for equivalency, but I see no reason not to merge this already.

## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :white_medium_square: GAMS Code
- :ballot_box_with_check: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :white_medium_square: Bug fix
- :white_medium_square: Refactoring
- :ballot_box_with_check: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

Example of output:
[compScen-ap9-2025-08-12_22.43.14-AirPollutantsDetailed.pdf](https://github.com/user-attachments/files/21743604/compScen-ap9-2025-08-12_22.43.14-AirPollutantsDetailed.pdf)

