### PR TITLE
Update MAgPIE variable name in REMIND-MAgPIE coupling interface

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,7 @@ Imports:
     luscale,
     lusweave,
     magclass,
-    magpie4 (>= 2.3.10),
+    magpie4 (>= 2.35.1),
     magpiesets,
     mip (>= 0.150.0),
     modelstats,

--- a/scripts/start/getReportData.R
+++ b/scripts/start/getReportData.R
@@ -142,7 +142,7 @@ getReportData <- function(path_to_report,inputpath_mag="magpie_40",inputpath_acc
 
   mag2rem <- tribble(
     ~mag,                      ~factorMag2Rem,
-    "Costs Without Incentives", 1/1000/1000) # 10E6 US$2017 to 10E12 US$2017
+    "Costs Accounting|Costs without incentives", 1/1000/1000) # 10E6 US$2017 to 10E12 US$2017
 
   cost <- .convertAndWrite(magData, mag2rem, file = paste0("./modules/26_agCosts/",inputpath_acc,"/input/p26_totLUcost_coupling.csv"), path_to_report)
   


### PR DESCRIPTION
## Purpose of this PR

Update coupling interface such that it works with the latest MAgPIE reporting files: adapt coupling variable name to new name used in magpie4 (R package) from version 2.35.1 onwards.

## Type of change

### Parts concerned
- :white_medium_square: GAMS Code
- :ballot_box_with_check: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :ballot_box_with_check: Bug fix
- :white_medium_square: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)