### PR TITLE
Make it possible for the release to use a renv.lock

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -33,6 +33,9 @@ cfg$inputRevision <- "7.62"
 #### Current CES parameter and GDX revision (commit hash) ####
 cfg$CESandGDXversion <- "00013a4f0071f982a549e73748e50e45a02032e8"
 
+#### Path to a renv.lock file to restore a project's dependencies from. If NULL, all R packages in their currently installed version will be used.
+cfg$UseThisRenvLock <- NULL
+
 #### Force the model to download new input data ####
 cfg$force_download <- FALSE
 

--- a/scripts/start/checkFixCfg.R
+++ b/scripts/start/checkFixCfg.R
@@ -21,7 +21,7 @@ checkFixCfg <- function(cfg, remindPath = ".", testmode = FALSE) {
   refcfg <- gms::readDefaultConfig(remindPath)
   remindextras <- c("backup", "remind_folder", "pathToMagpieReport", "cm_nash_autoconverge_lastrun", "var_luc",
                                "gms$c_expname", "restart_subsequent_runs",
-                               "gms$cm_CES_configuration", "gms$c_description", "model", "renvLockFromPrecedingRun",
+                               "gms$cm_CES_configuration", "gms$c_description", "model", "UseThisRenvLock",
                                "gms$c_model_version", "gms$c_results_folder")
   fail <- tryCatch(gms::check_config(cfg, reference_file = refcfg, modulepath = file.path(remindPath, "modules"),
                      settings_config = file.path(remindPath, "config", "settings_config.csv"),

--- a/scripts/start/run.R
+++ b/scripts/start/run.R
@@ -194,7 +194,7 @@ run <- function() {
       cfg$files2export$start[needfulldatagdx] <- fulldatapath
       # let the subsequent run use the renv.lock of this run
       message("In ", RData_file, ", use current renv.lock for subsequent run ", run, ".")
-      cfg$renvLockFromPrecedingRun <- file.path(cfg_main$remind_folder, cfg_main$results_folder, "renv.lock")
+      cfg$UseThisRenvLock <- file.path(cfg_main$remind_folder, cfg_main$results_folder, "renv.lock")
 
       save(cfg, file = RData_file)
 

--- a/scripts/start/submit.R
+++ b/scripts/start/submit.R
@@ -47,9 +47,9 @@ submit <- function(cfg, restart = FALSE, stopOnFolderCreateError = TRUE) {
       warning("No active renv project found, not using renv.")
     } else {
       # we only want to run renv checks/updates in the first run in a cascade:
-      # cfg$renvLockFromPrecedingRun is only NULL for the first run in a cascade.
+      # cfg$UseThisRenvLock is only NULL for the first run in a cascade.
       # For a subsequent run it has been set by the parent run in run.R (standalone) or start_coupled.R (coupled).
-      firstRunInCascade <- is.null(cfg$renvLockFromPrecedingRun)
+      firstRunInCascade <- is.null(cfg$UseThisRenvLock)
       if (firstRunInCascade) {
         if (getOption("autoRenvUpdates", FALSE)) {
           installedUpdates <- piamenv::updateRenv()
@@ -76,8 +76,8 @@ submit <- function(cfg, restart = FALSE, stopOnFolderCreateError = TRUE) {
         message("done.")
       } else {
         # a run renv is loaded, we are presumably starting new run in a cascade
-        message("   Copying lockfile '",cfg$renvLockFromPrecedingRun,"' into '", cfg$results_folder, "'")
-        file.copy(cfg$renvLockFromPrecedingRun, file.path(cfg$results_folder, "_renv.lock"))
+        message("   Copying lockfile '",cfg$UseThisRenvLock,"' into '", cfg$results_folder, "'")
+        file.copy(cfg$UseThisRenvLock, file.path(cfg$results_folder, "_renv.lock"))
       }
 
 

--- a/start_coupled.R
+++ b/start_coupled.R
@@ -242,7 +242,7 @@ start_coupled <- function(path_remind, path_magpie, cfg_rem, cfg_mag, runname, m
       subseq.env$cfg_rem$files2export$start[needfulldatagdx] <- fulldatapath
       # let the subsequent run use the renv.lock of this run
       message("In ", RData_file, ", use current renv.lock for subsequent run ", run, ".")
-      subseq.env$cfg_rem$renvLockFromPrecedingRun <- file.path(path_remind, cfg_rem$results_folder, "renv.lock")
+      subseq.env$cfg_rem$UseThisRenvLock <- file.path(path_remind, cfg_rem$results_folder, "renv.lock")
 
       if (isTRUE(subseq.env$path_report == runname)) subseq.env$path_report <- report_mag
       save(list = ls(subseq.env), file = RData_file, envir = subseq.env)


### PR DESCRIPTION
## Purpose of this PR

Make it possible for the release (and any run) to use a renv.lock:
- the functionality was already there in form of the `cfg$renvLockFromPrecedingRun`
- to make it less specific rename `cfg$renvLockFromPrecedingRun` to `cfg$UseThisRenvLock`
- add `cfg$renvLockFromPrecedingRun` to the `default.cfg`

## Type of change

### Parts concerned
- :white_medium_square: GAMS Code
- :ballot_box_with_check: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :ballot_box_with_check: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :white_medium_square: Bug fix
- :white_medium_square: Refactoring
- :ballot_box_with_check: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)
