### PR TITLE
Update release scripts: the release uses the renv snapshot, the develop does not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### added
 - [#2168](https://github.com/remindmodel/remind/pull/2168) Adds biochar as novel CDR option. Biochar can be produced via three established and one future pe2se technology.
+- [#2195](https://github.com/remindmodel/remind/pull/2195) Make it possible to provide a renv.lock to be used for a run (useful for the releases)
+- [#2196](https://github.com/remindmodel/remind/pull/2196) Update release scripts: the release uses the renv snapshot, the develop does not
 
 ### removed
 -

--- a/scripts/utils/postRelease.R
+++ b/scripts/utils/postRelease.R
@@ -5,9 +5,11 @@
 # in your fork switch to develop and execute this script in the main folder with Rscript scripts/utils/postRelease.R
 
 postRelease <- function() {
+  # pull (fetch+merge) the master into develop
   gert::git_fetch("upstream")
   gert::git_merge("upstream/master")
 
+  # add empty [Unreleased] section to CHANGELOG
   pattern <- "The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)."
   stopifnot(any(grepl(pattern, readLines("CHANGELOG.md"), fixed = TRUE)))
   textToAdd <- paste("",
@@ -33,6 +35,11 @@ postRelease <- function() {
   readLines("CHANGELOG.md") |>
     sub(pattern = pattern, replacement = paste0(pattern, textToAdd), fixed = TRUE) |>
     writeLines("CHANGELOG.md")
+  
+  # Unlike the release version, the development branch should not use a Renv snapshot.
+  readLines("config/default.cfg") |>
+    sub(pattern = 'cfg\\$UseThisRenvLock <- .*$', replacement = paste0('cfg$UseThisRenvLock <- NULL')) |>
+    writeLines("config/default.cfg")  
 
   message("Please perform the following step manually in another terminal:\n",
           "git add -p\n",

--- a/scripts/utils/release.R
+++ b/scripts/utils/release.R
@@ -76,7 +76,13 @@ release <- function(newVersion) {
   archivePath <- file.path(normalizePath(renv::project()), "renv", "archive", paste0(newVersion, "_renv.lock"))
   renv::snapshot(lockfile = archivePath)
   system(paste0("git add -f renv/archive/", newVersion, "_renv.lock"))
+  
+  # make the release run with the renv snapshot from above
+  readLines("config/default.cfg") |>
+    sub(pattern = 'cfg\\$UseThisRenvLock <- .*$', replacement = paste0('cfg$UseThisRenvLock <- "renv/archive/', newVersion, '_renv.lock"')) |>
+    writeLines("config/default.cfg")  
 
+  # commit all changes made so far
   message("Please only continue if you already cleaned CHANGELOG.md:\n",
           "In another terminal:\n",
           "1. git add -p\n",


### PR DESCRIPTION
## Purpose of this PR

See heading

## Type of change

### Parts concerned
- :white_medium_square: GAMS Code
- :ballot_box_with_check: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :white_medium_square: Bug fix
- :white_medium_square: Refactoring
- :ballot_box_with_check: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)
