### PR TITLE
Freedom of choice for fossil extractors

### DIFF
--- a/core/declarations.gms
+++ b/core/declarations.gms
@@ -404,8 +404,9 @@ v_changeProdStartyear(ttot,all_regi,all_te)          "absolute change of output 
 v_relChangeProdStartYear(ttot,all_regi,all_te)       "calculating the relative change of output with respect to the reference run for each te [Percent]"
 v_changeProdStartyearSlack(ttot,all_regi,all_te)     "slack variable to allow a minimum cost-free change with respect to the reference run [TWa] for all energy-conversion tech, [GtC] for the CCS chain in ccs2te (pipelines/injection)"
 
+v_costFu(ttot,all_regi)                              "costs of primary energy production/extraction (can be negative depending on vm_costFuBio) [T$]"
 *** move to biomass module?
-vm_costFuBio(ttot,all_regi)                          "fuel costs from bioenergy production [T$]"
+vm_costFuBio(ttot,all_regi)                          "fuel costs from bioenergy production (can be negative depending on total agricultural cost) [T$]"
 
 *** move to CDR module?
 vm_omcosts_cdr(tall,all_regi)                        "O&M costs for spreading grinded rocks on fields [T$]"
@@ -460,8 +461,7 @@ vm_demFeNonEnergySector(ttot,all_regi,all_enty,all_enty,emi_sectors,all_emiMkt) 
 
 *** energy system cost variables
 vm_costEnergySys(ttot,all_regi)                      "total energy system costs [T$]"
-v_costFu(ttot,all_regi)                              "costs of primary energy production (extraction) [T$]"
-vm_costFuEx(ttot,all_regi,all_enty)                  "costs of exhaustible primary energy production (extraction) of fossil fuels and uranium [T$]"
+vm_costFuEx(ttot,all_regi,all_enty)                  "costs of exhaustible primary energy production/extraction of fossil fuels and uranium [T$]"
 v_costOM(ttot,all_regi)                              "operation and maintenance costs of technologies [T$]"
 v_costInv(ttot,all_regi)                             "total technology investment costs (including adjustment costs) [T$]"
 


### PR DESCRIPTION
## Purpose of this PR

Some regions were forced to extract exhaustible PE (coal, gas, oil, uranium) even when the trade marktet price was extremely low.
This is due to  `v_costFu` being a "positive variable", while one of its terms (the Bio one) can be negative. It causes issues for trade convergence:
- https://github.com/remindmodel/development_issues/issues/627#issuecomment-3281558145

This PR simply puts `v_costFu` in the (positive or negative) variables instead of positive variables.

## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :ballot_box_with_check: GAMS Code
- :white_medium_square: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :ballot_box_with_check: Bug fix
- :white_medium_square: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :ballot_box_with_check: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

* Runs with these changes are here: `/p/tmp/fabricel/remind351/`, see results in [visualisation sheet](https://docs.google.com/spreadsheets/d/1EUtUhuxGa_gGDxaBXdnGOIrZKHRvqCQaiJV9iJ4W0Y8/edit?gid=168402579#gid=168402579&range=K218:Y231)
* Comparison of results (what changes by this PR?): generally no difference in standard Pk650, but some in more constrained runs (limited bio, ccs, nuc) `/p/tmp/fabricel/remind351/compScen-negativeCostFu-2025-09-12_11.45.40-H12.pdf`
**GHG**: small reduction, because we are not forcing fossil extraction anymore
<img width="1312" height="870" alt="image" src="https://github.com/user-attachments/assets/519ce99a-b673-497d-8bbe-a9db94920b2f" />

**Trade**: less random fluctuations, better convergence 
<img width="1312" height="873" alt="image" src="https://github.com/user-attachments/assets/23ffd8f8-e206-4e3c-b1d9-cb0aa273bbb1" />

**Fossil consumption**: less 
<img width="1319" height="658" alt="image" src="https://github.com/user-attachments/assets/0e8510d8-6684-4ff8-a820-48bf712bffcf" />

**Elec**: more in total, more renewables 
<img width="1307" height="893" alt="image" src="https://github.com/user-attachments/assets/4ad45ef2-ade8-4bc4-958d-60f7255c9f6d" />

