### PR TITLE
Exclude renv.lock from file size check in github action

### DIFF
--- a/.github/workflows/size-check
+++ b/.github/workflows/size-check
@@ -16,4 +16,4 @@ maxfilesize <- function(max) {
   message("All files are smaller than ", max, "kB\n")
 }
 
-maxfilesize(200)
+maxfilesize(220)

--- a/.github/workflows/size-check
+++ b/.github/workflows/size-check
@@ -6,6 +6,8 @@ maxfilesize <- function(max) {
                  system("git diff --cached --name-only", intern = TRUE))
   out <- data.frame(files = files, size = round(file.size(files) / 1024, 2))
   out <- out[!is.na(out$size), ]
+  # Accept renv.lock files that exceed the maximum value by removing them before the check
+  out <- out[!grepl("renv.lock", out$files), ]
   out <- out[out$size > max, ]
   if (nrow(out) > 0) {
     stop(nrow(out), " files with size > ", max, "kB detected: \n",
@@ -14,4 +16,4 @@ maxfilesize <- function(max) {
   message("All files are smaller than ", max, "kB\n")
 }
 
-maxfilesize(550)
+maxfilesize(200)


### PR DESCRIPTION
## Purpose of this PR

The `renv.lock` files that are included with every release are by far bigger (~550 kB) than all other files (<200 kB). This required increasing the tolerable file size in the github action for *all* files. With this PR the maximum file size is reduced back to 200 kB since the gibthub action excludes the `renv.lock` from the check.

## Type of change

### Parts concerned
- :white_medium_square: GAMS Code
- :white_medium_square: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :ballot_box_with_check: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :white_medium_square: Bug fix
- :white_medium_square: Refactoring
- :ballot_box_with_check: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)