### PR TITLE
Limit use of `execute_load`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   [[#788](https://github.com/pik-piam/mrremind/pull/788)]
 
 ### changed
-- **45_carbonprice** Use ScenarioMIP settings as new default for regional carbon price differentiation in 45_carbonprice/functionalForm 
+- **45_carbonprice** Use ScenarioMIP settings as new default for regional carbon price differentiation in `45_carbonprice/functionalForm` 
     [[#2229](https://github.com/remindmodel/remind/pull/2229)]
 - **11_aerosols** Move calculation of air pollutant emissions from REMIND module 11_aerosols to remind2.
     [[#2231](https://github.com/remindmodel/remind/pull/2231)]
@@ -22,6 +22,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     [[#2296](https://github.com/remindmodel/remind/pull/2296)]
 - **reporting** Distinguish between onshore and offshore transport and storage of captured CO2
     [[#777](https://github.com/pik-piam/remind2/pull/777)]
+- **core** replaced `execute_load` with `execute_loadpoint` in `core/preloop.gms` 
+    [[#2237](https://github.com/remindmodel/remind/pull/2207)]
+- **21_tax** replaced `execute_load` with `execute_loadpoint` in `21_tax/on/datainput.gms` 
+    [[#2237](https://github.com/remindmodel/remind/pull/2207)]
+- **24_trade** replaced `execute_load` with `execute_loadpoint` in `24_trade/se_trade/datainput.gms` 
+    [[#2237](https://github.com/remindmodel/remind/pull/2207)]
+- **29_CES_parameters** replaced `execute_load` with `execute_loadpoint` in `29_CES_parameters/calibrate/datainput.gms` and `29_CES_parameters/calibrate/preloop.gms` 
+    [[#2237](https://github.com/remindmodel/remind/pull/2207)]
+- **30_biomass** replaced `execute_load` with `execute_loadpoint` in `30_biomass/magpie_40/datainput.gms` 
+    [[#2237](https://github.com/remindmodel/remind/pull/2207)]
+- **36_buildings** replaced `execute_load` with `execute_loadpoint` in `36_buildings/simple/datainput.gms` 
+    [[#2237](https://github.com/remindmodel/remind/pull/2207)]
+- **37_industry** replaced `execute_load` with `execute_loadpoint` in `37_industry/subsectors/datainput.gms` 
+    [[#2237](https://github.com/remindmodel/remind/pull/2207)]
 
 ### added
 - **40_techpol** implement renewable energy share targets for NPi2025 realization based on NewClimate policy protocol

--- a/core/preloop.gms
+++ b/core/preloop.gms
@@ -88,7 +88,7 @@ $ENDIF.out
 
 *** load PE, SE, FE price parameters from reference gdx to have prices in time steps before cm_startyear
 if (cm_startyear gt 2005,
-execute_load "input_ref.gdx", pm_PEPrice, pm_SEPrice, pm_FEPrice;
+  Execute_Loadpoint "input_ref.gdx", pm_PEPrice, pm_SEPrice, pm_FEPrice;
 );
 
 *** load vm_capEarlyReti(ttot,regi,te) from reference gdx to have a reference point for q_smoothphaseoutCapEarlyReti and q_limitCapEarlyReti

--- a/modules/21_tax/on/datainput.gms
+++ b/modules/21_tax/on/datainput.gms
@@ -150,8 +150,8 @@ Execute_Loadpoint 'input_ref' p21_ref_costInvTeAdj_RE = vm_costInvTeAdj.l;
 $endif.importtaxrc
 
 if (cm_startyear gt 2005,
-execute_load "input_ref.gdx", pm_taxrevCO2LUC0;
-execute_load "input_ref.gdx", pm_taxrevGHG0;
+Execute_Loadpoint "input_ref.gdx", pm_taxrevCO2LUC0;
+Execute_Loadpoint "input_ref.gdx", pm_taxrevGHG0;
 );
 
 ***initialize co2 market taxes

--- a/modules/24_trade/se_trade/datainput.gms
+++ b/modules/24_trade/se_trade/datainput.gms
@@ -186,8 +186,8 @@ $endif.import_h2_EU
 p24_seAggReference(ttot,regi,seAgg) = sum(enty$seAgg2se(seAgg,enty), sum(se2fe(enty,enty2,te), pm_prodFEReference(ttot,regi,enty,enty2,te)));
 p24_FEregiShareInRegiGroup(ttot,ext_regi,regi,seAgg)$(regi_group(ext_regi,regi) and p24_seAggReference(ttot,regi,seAgg)) = p24_seAggReference(ttot,regi,seAgg) / sum(regi2$regi_group(ext_regi,regi2), p24_seAggReference(ttot,regi2,seAgg));
 
-execute_load "input_ref.gdx", p24_demFeForEsReference = vm_demFeForEs.l;
-execute_load "input_ref.gdx", p24_demFeIndSubReference = o37_demFeIndSub;
+Execute_Loadpoint "input_ref.gdx", p24_demFeForEsReference = vm_demFeForEs.l;
+Execute_Loadpoint "input_ref.gdx", p24_demFeIndSubReference = o37_demFeIndSub;
 
 *** calculate regional share of each region in the total of region group ext_regi with respect to FE demand, for chemicals + aviation liquids
 p24_aviationAndChemicalsFE(ttot,regi) = p24_demFeForEsReference(ttot,regi,"fedie","esdie_pass_lo","te_esdie_pass_lo") + !! aviation FE demand

--- a/modules/29_CES_parameters/calibrate/datainput.gms
+++ b/modules/29_CES_parameters/calibrate/datainput.gms
@@ -195,7 +195,7 @@ p29_capitalQuantity(tall,all_regi,"kap")
 *** Substract the end-use capital quantities from the aggregate capital
 
 *** Load CES parameters from the last run
-Execute_Load 'input'  p29_cesdata_load = pm_cesdata;
+Execute_Loadpoint 'input'  p29_cesdata_load = pm_cesdata;
 $ifthen.testOneRegi "%optimization%" == "testOneRegi"   !! optimization
   !! carry along CES parameters for other regions in testOneRegi runs
   pm_cesdata(t,regi,in,cesParameter)$( NOT regi_dyn29(regi) )

--- a/modules/29_CES_parameters/calibrate/preloop.gms
+++ b/modules/29_CES_parameters/calibrate/preloop.gms
@@ -26,7 +26,7 @@ display "check starting pm_cesdata", pm_cesdata;
 
 *** Abort if new structure flag is not set but should be
 $ifthen.old_structure %c_CES_calibration_new_structure% == "0"
-Execute_Load 'input'  ces2_29=cesOut2cesIn;
+Execute_Loadpoint 'input'  ces2_29=cesOut2cesIn;
 sm_tmp = 0;
 loop ( ces2_29(out,in)$( NOT cesOut2cesIn2(out,in) ), sm_tmp = 1);
 loop (cesOut2cesIn2(out,in)$( NOT  ces2_29(out,in) ), sm_tmp = 1);
@@ -35,7 +35,7 @@ if (sm_tmp,
   abort "CES structure does not match. Enable c_CES_calibration_new_structure";
 );
 
-Execute_Load 'input'  regi_29_load=regi;
+Execute_Loadpoint 'input'  regi_29_load=regi;
 sm_tmp = 0;
 loop ( regi_29_load(regi2)$( NOT regi(regi2) ), sm_tmp = 1);
 loop (regi(regi2)$( NOT  regi_29_load(regi2) ), sm_tmp = 1);

--- a/modules/30_biomass/magpie/datainput.gms
+++ b/modules/30_biomass/magpie/datainput.gms
@@ -62,7 +62,7 @@ $offdelim
 
 *** Why is this necessary? Isn't pm_pebiolc_costs_emu_preloop ALWAYS calculated in preloop, overwriting what has been loaded here?
 if (cm_startyear gt 2005,
-execute_load "input_ref.gdx", pm_pebiolc_costs_emu_preloop;
+Execute_Loadpoint "input_ref.gdx", pm_pebiolc_costs_emu_preloop;
 );
 
 *** Select bioenergy bioenergy supply curve according to SSP scenario

--- a/modules/36_buildings/simple/datainput.gms
+++ b/modules/36_buildings/simple/datainput.gms
@@ -60,7 +60,7 @@ $offdelim
 
 *** load UE demand for reporting from input_ref.gdx cm_startyear
 if (cm_startyear gt 2005,
-  execute_load "input_ref.gdx", p36_uedemand_build;
+  Execute_Loadpoint "input_ref.gdx", p36_uedemand_build;
 );
 
 p36_uedemand_build(t,regi,in) = f36_uedemand_build(t,regi,"%cm_demScen%","%cm_rcp_scen_build%",in);

--- a/modules/37_industry/subsectors/datainput.gms
+++ b/modules/37_industry/subsectors/datainput.gms
@@ -648,7 +648,7 @@ $offdelim
 
 *' load baseline industry ETS solids demand
 if (cm_startyear ne 2005,   !! not a BAU scenario
-execute_load "input_ref.gdx", vm_demFeSector_afterTax;
+Execute_Loadpoint "input_ref.gdx", vm_demFeSector_afterTax;
   p37_BAU_industry_ETS_solids(t,regi)
   = sum(se2fe(entySe,"fesos",te),
       vm_demFeSector_afterTax.l(t,regi,entySe,"fesos","indst","ETS")
@@ -869,7 +869,7 @@ if (cm_startyear gt 2005,
 );
 
 if (cm_startyear gt 2005,
-  execute_load "input_ref.gdx" v37_plasticWaste.l = v37_plasticWaste.l;
+  Execute_Loadpoint "input_ref.gdx" v37_plasticWaste.l = v37_plasticWaste.l;
 );
 
 *** EOF ./modules/37_industry/subsectors/datainput.gms


### PR DESCRIPTION
## Purpose of this PR

Using `execute_load` to load values from GDX risks replacing symbol data entirely. Use `execute_load` only iff you want a clean slate for all attributes of a variable. In all other cases use `execute_loadpoint` to merge new data from a GDX into existing symbols while preserving it's attributes (i.e. bounds, levels, ..). 

- Switch from `execute_load` to `execute_loadpoint` except for
- Usage in `core/datainput.gms` (lines 1627-1632) since there are no pre-existing values to preserve

Overview of the changes made:

| File Path | Lines | Action | Reason |
|-----------|-------|--------|--------|
| `core/datainput.gms` | [1627-1632](https://github.com/remindmodel/remind/blob/develop/core/datainput.gms#L1627-L1632) | Keep `execute_load` | Fresh initialization of reference parameters (`p_prodSeReference`, `pm_prodFEReference`, `p_prodUeReference`, `p_co2CCSReference`, `pm_macCost`) from scratch for comparison purposes. No pre-existing values to preserve. |
| `core/preloop.gms` | [170](https://github.com/remindmodel/remind/blob/develop/core/preloop.gms#L170) | Switch to `Execute_Loadpoint` | Loading historical prices (t < cm_startyear) for `pm_PEPrice`, `pm_SEPrice`, `pm_FEPrice`. Future prices may already exist and should be preserved. |
| `modules/21_tax/on/datainput.gms` | [153-154](https://github.com/remindmodel/remind/blob/develop/modules/21_tax/on/datainput.gms#L153-L154) | Switch to `Execute_Loadpoint` | Loading baseline tax revenue parameters (`pm_taxrevCO2LUC0`, `pm_taxrevGHG0`). Should merge with existing baseline data. |
| `modules/24_trade/se_trade/datainput.gms` | [189-190](https://github.com/remindmodel/remind/blob/develop/modules/24_trade/se_trade/datainput.gms#L189-L190) | Switch to `Execute_Loadpoint` | Loading reference demand values (`p24_demFeForEsReference`, `p24_demFeIndSubReference`). Should merge with existing reference data. |
| `modules/29_CES_parameters/calibrate/datainput.gms` | [198](https://github.com/remindmodel/remind/blob/develop/modules/29_CES_parameters/calibrate/datainput.gms#L198) | Switch to `Execute_Loadpoint` | Loading CES calibration data `p29_cesdata_load` from `input.gdx`. Should merge with existing calibration data. |
| `modules/29_CES_parameters/calibrate/preloop.gms` | [29](https://github.com/remindmodel/remind/blob/develop/modules/29_CES_parameters/calibrate/preloop.gms#L29), [38](https://github.com/remindmodel/remind/blob/develop/modules/29_CES_parameters/calibrate/preloop.gms#L38) | Switch to `Execute_Loadpoint` | Loading set mappings (`ces2_29`, `regi_29_load`) from `input.gdx`. Should merge with existing sets. |
| `modules/30_biomass/magpie_40/datainput.gms` | [79](https://github.com/remindmodel/remind/blob/develop/modules/30_biomass/magpie_40/datainput.gms#L79) | Switch to `Execute_Loadpoint` | Loading biomass cost data `pm_pebiolc_costs_emu_preloop`. Should merge with existing data. |
| `modules/36_buildings/simple/datainput.gms` | [61](https://github.com/remindmodel/remind/blob/develop/modules/36_buildings/simple/datainput.gms#L61) | Switch to `Execute_Loadpoint` | Loading reference building demand `p36_uedemand_build`. Likely partial data that should be merged with existing data. |
| `modules/37_industry/subsectors/datainput.gms` | [651](https://github.com/remindmodel/remind/blob/develop/modules/37_industry/subsectors/datainput.gms#L651) | Switch to `Execute_Loadpoint` | Loading variable `vm_demFeSector_afterTax`. Variable bounds (`.lo`, `.hi`) should be preserved. |
| `modules/37_industry/subsectors/datainput.gms` | [872](https://github.com/remindmodel/remind/blob/develop/modules/37_industry/subsectors/datainput.gms#L872) | Switch to `Execute_Loadpoint` | Loading only `.l` attribute of `v37_plasticWaste`. Variable bounds should be preserved. |

Please note that this might affect scenario results in unforeseen ways. Preliminary test runs:

- No changes, baseline run: `/p/tmp/tonnru/clean_remind/output/SMIPv08-M-SSP2-NPi2025-def_2025-11-04_14.37.55`
- Blanket replacement of `execute_load`, ✨ converged ✨: `/p/tmp/tonnru/clean_remind/output/SMIPv08-M-SSP2-NPi2025-def_2025-11-04_18.02.35`
- Partial replacement. *Converged, but had INFES*: `/p/tmp/tonnru/clean_remind/output/SMIPv08-M-SSP2-NPi2025-def_2025-11-05_17.57.57`
- Partial replacement, other scenario, ✨ converged ✨: `/p/tmp/tonnru/clean_remind/output/SMIPv08-ML-SSP2-EcPrice300-def_2025-11-05_22.51.01`

Please suggest further scenarios to be tested!

## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :ballot_box_with_check: GAMS Code
- :white_medium_square: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :white_medium_square: Bug fix
- :ballot_box_with_check: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

* Runs with these changes are here:
* Comparison of results (what changes by this PR?): 
