### PR TITLE
use local fast repositories over remote slow repositories for input data

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -44,8 +44,8 @@ cfg$force_replace <- FALSE
 
 #### list of repositories containing input data
 # defined in your local .Rprofile or on the cluster /p/projects/rd3mod/R/.Rprofile
-cfg$repositories <- append(list("https://rse.pik-potsdam.de/data/remind/public" = NULL),
-                           getOption("remind_repos"))
+cfg$repositories <- append(getOption("remind_repos"),
+                           list("https://rse.pik-potsdam.de/data/remind/public" = NULL))
 
 #### Folder run statistics should be submitted to
 cfg$runstatistics <- "/p/projects/rd3mod/models/statistics/remind"


### PR DESCRIPTION
## Purpose of this PR

Do not hit the slow remote repository for input data if users have the [input data stored locally](https://github.com/remindmodel/remind/blob/develop/tutorials/02a_RunningREMINDLocally.md#use-local-input-data).

## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :white_medium_square: GAMS Code
- :white_medium_square: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :ballot_box_with_check: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :white_medium_square: Bug fix
- :white_medium_square: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

* Runs with these changes are here:
* Comparison of results (what changes by this PR?): 
