### PR TITLE
Bugfix EOC budgets

### DIFF
--- a/modules/45_carbonprice/functionalFormRegi/datainput.gms
+++ b/modules/45_carbonprice/functionalFormRegi/datainput.gms
@@ -174,7 +174,8 @@ if(p45_taxCO2eq_anchorRegi("2100",regi) le 0,
 );
 ); !! If carbon price information from input.gdx should be used
 
-$endif.taxCO2GeneralShape !! exponential and linear shape specification
+$endif.taxCO2GeneralShape 
+!! exponential and linear shape specification
 
 ***-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 *** Part II (Post-peak behaviour): The global anchor trajectory can be adjusted after reaching the peak of global CO2 emissions in cm_peakBudgYr.

--- a/modules/45_carbonprice/functionalFormRegi/postsolve.gms
+++ b/modules/45_carbonprice/functionalFormRegi/postsolve.gms
@@ -13,7 +13,7 @@ if(cm_iterative_target_adj eq 5,
 *** 1. Get the relevant information from this iteration
   !! Update the actual budget by region and save across iterations for debugging
   p45_actualbudgetco2Regi_2100(regi) = sum(t$(t.val eq 2100), pm_actualbudgetco2Regi(t,regi)); 
-  p45_actualbudgetco2Regi_2100_iter(iteration, regi) = pm_actualbudgetco2Regi(regi);
+  p45_actualbudgetco2Regi_2100_iter(iteration, regi) = p45_actualbudgetco2Regi_2100(regi);
 
   !! Save pm_taxCO2eq over iterations
   pm_taxCO2eq_iter(iteration,ttot,regi) = pm_taxCO2eq(ttot,regi);


### PR DESCRIPTION
## Purpose of this PR

Minor bugfix to correct the `p45_actualbudgetco2Regi_2100_iter(iteration, regi) `calculation.

## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :ballot_box_with_check: GAMS Code
- :white_medium_square: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :ballot_box_with_check: Bug fix
- :white_medium_square: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

* Runs with these changes are here: `/p/tmp/rahelma/Committed/Equity/trading`
* Comparison of results (what changes by this PR?): 
