### PR TITLE
Remove distinction between 'raw' and 'smoothed' land use CO2 emissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     [[#2222](https://github.com/remindmodel/remind/pull/2222)]
 - **30_biomass** Replace realization magpie_40 with new coupling realization magpie that runs MAgPIE between the Nash iterations
     [#2249](https://github.com/remindmodel/remind/pull/2249)
-- **scripts** Add new coupling scriptexecuted between the Nash iterations to transfer data between REMIND and MAgPIE and run MAgPIE
+- **scripts** Add new coupling script executed between the Nash iterations to transfer data between REMIND and MAgPIE and run MAgPIE
     [#2249](https://github.com/remindmodel/remind/pull/2249)
 - **mapping** Add csv mapping MAgPIE to REMIND variables used by the coupling script
     [#2249](https://github.com/remindmodel/remind/pull/2249)
@@ -36,6 +36,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     [#2249](https://github.com/remindmodel/remind/pull/2249)
 - **scripts** Remove of coupling scripts
     [#2249](https://github.com/remindmodel/remind/pull/2249)
+- **scripts** The distinction between 'raw' and 'smoothed' land use CO2 emissions is no longer supported, as the MAgPIE reporting only includes raw emissions
+    [#2255](https://github.com/remindmodel/remind/pull/2255)
 
 
     

--- a/scripts/input/magpie.R
+++ b/scripts/input/magpie.R
@@ -107,7 +107,7 @@ runMAgPIE <- function(pathToRemindReport) {
 }
 
 # Transfer coupling variables from MAgPIE report to magpieData.gdx read by REMIND between the Nash iterations
-getMagpieData <- function(path_to_report = "report.mif", mapping = "mappingMAgPIE2REMIND.csv", var_luc = "raw") {
+getMagpieData <- function(path_to_report = "report.mif", mapping = "mappingMAgPIE2REMIND.csv") {
   
   require(gamstransfer, quietly = TRUE, warn.conflicts = FALSE)
   require(quitte,       quietly = TRUE, warn.conflicts = FALSE)
@@ -137,15 +137,6 @@ getMagpieData <- function(path_to_report = "report.mif", mapping = "mappingMAgPI
   # ---- Read and prepare MAgPIE data ----
   
   mag <- quitte::read.quitte(path_to_report, check.duplicates = FALSE)
-  
-  if (var_luc == "smooth") {
-    # do nothing and use variable names as defined above
-  } else if (var_luc == "raw") {
-    # add RAW to variable names
-    mapping$mag <- gsub("Emissions|CO2|Land","Emissions|CO2|Land RAW", mapping$mag, fixed = TRUE)
-  } else {
-    stop(paste0("Unkown setting for 'var_luc': `", var_luc, "`. Only `smooth` or `raw` are allowed."))
-  }
   
   # Stop if variables are missing
   variablesMissing <- ! mapping$mag %in% mag$variable
@@ -280,7 +271,7 @@ if (is.null(cfg$continueFromHere) || NashIteration > 1) {
 cfg$pathToMagpieReport <- pathToMagpieReport
 
 # In any case transfer MAgPIE data from report to magpieData.gdx
-getMagpieData(path_to_report = pathToMagpieReport, var_luc = cfg$var_luc)
+getMagpieData(path_to_report = pathToMagpieReport)
 
 # Save the same elements that were loaded (they may have been updated in the meantime)
 save(list = elementsLoaded, file = "config.Rdata")

--- a/scripts/start/checkFixCfg.R
+++ b/scripts/start/checkFixCfg.R
@@ -19,7 +19,7 @@ checkFixCfg <- function(cfg, remindPath = ".", testmode = FALSE) {
   NC    <- "\033[0m"   # No Color
 
   refcfg <- gms::readDefaultConfig(remindPath)
-  remindextras <- c("backup", "remind_folder", "cm_nash_autoconverge_lastrun", "var_luc",
+  remindextras <- c("backup", "remind_folder", "cm_nash_autoconverge_lastrun",
                                "gms$c_expname", "restart_subsequent_runs",
                                "gms$cm_CES_configuration", "gms$c_description", "model", "UseThisRenvLock",
                                "gms$c_model_version", "gms$c_results_folder", "path_magpie", "magpie_empty", "cfg_mag", "continueFromHere")

--- a/start.R
+++ b/start.R
@@ -470,15 +470,12 @@ if (any(c("--reprepare", "--restart") %in% flags)) {
       # GHG prices will be set to zero (in MAgPIE) until and including the year specified here
       cfg_mag$gms$c56_mute_ghgprices_until <- scenarios_magpie[scen, "no_ghgprices_land_until"]
 
-      # Write choice of land-use change variable to config. Use raw variable
-      # if not specified otherwise in coupled config, i.e. if the column is missing
-      # completely or if the row entry is empty.
-      if (! "var_luc" %in% names(scenarios_magpie) || is.na(scenarios_magpie[scen, "var_luc"])) {
-        cfg$var_luc <- "raw"
-      } else if (scenarios_magpie[scen, "var_luc"] %in% c("smooth", "raw")) {
-        cfg$var_luc <- scenarios_magpie[scen, "var_luc"]
-      } else {
-        message(red, "Error", NC, ": Unkown setting in coupled config file for 'var_luc': `", scenarios_magpie[scen, "var_luc"], "`. Please chose either `smooth` or `raw`")
+
+      # The distinction between 'raw' and 'smoothed' land use CO2 emissions is no longer supported,
+      # as the MAgPIE reporting now only includes raw and no longer includes smoothed. Accordingly,
+      # 'raw' has been removed from MAgPIE's variable names.
+      if ("var_luc" %in% names(scenarios_magpie)) {
+        message(red, "Error", NC, ": Unkown column 'var_luc' in coupled config file. Land-use CO2 emissions are always RAW now")
         errorsfound <- errorsfound + 1
       }
 


### PR DESCRIPTION
## Purpose of this PR

The distinction between 'raw' and 'smoothed' land use CO2 emissions is no longer supported, as the MAgPIE reporting now only includes raw and no longer includes smoothed. Accordingly, 'raw' has been removed from MAgPIE's variable names.

## Type of change

### Parts concerned
- :white_medium_square: GAMS Code
- :ballot_box_with_check: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :ballot_box_with_check: Bug fix
- :white_medium_square: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)