### PR TITLE
Handle outdated config switch `var_luc` differently

### DIFF
--- a/scripts/start/readCheckScenarioConfig.R
+++ b/scripts/start/readCheckScenarioConfig.R
@@ -202,6 +202,7 @@ readCheckScenarioConfig <- function(filename, remindPath = ".", testmode = FALSE
        "cm_POPscen" = "Use cm_GDPpopScen instead, see https://github.com/remindmodel/remind/pull/1973",
        "cm_DiscRateScen" = "Deleted, not used anymore, see https://github.com/remindmodel/remind/pull/2001",
        "cm_transpGDPscale" = "Deleted, not used anymore, see https://github.com/remindmodel/remind/pull/2092",
+       "var_luc" = "Deleted, not used anymore. Land-use CO2 emissions are always RAW now. See https://github.com/remindmodel/remind/pull/2255",
      NULL)
     for (i in intersect(names(forbiddenColumnNames), unknownColumnNames)) {
       msg <- paste0("Column name ", i, " in remind settings is outdated. ", forbiddenColumnNames[i])

--- a/start.R
+++ b/start.R
@@ -470,15 +470,6 @@ if (any(c("--reprepare", "--restart") %in% flags)) {
       # GHG prices will be set to zero (in MAgPIE) until and including the year specified here
       cfg_mag$gms$c56_mute_ghgprices_until <- scenarios_magpie[scen, "no_ghgprices_land_until"]
 
-
-      # The distinction between 'raw' and 'smoothed' land use CO2 emissions is no longer supported,
-      # as the MAgPIE reporting now only includes raw and no longer includes smoothed. Accordingly,
-      # 'raw' has been removed from MAgPIE's variable names.
-      if ("var_luc" %in% names(scenarios_magpie)) {
-        message(red, "Error", NC, ": Unkown column 'var_luc' in coupled config file. Land-use CO2 emissions are always RAW now")
-        errorsfound <- errorsfound + 1
-      }
-
       # if provided use ghg prices for land (MAgPIE) from a different REMIND run than the one MAgPIE runs coupled to
       path_mif_ghgprice_land <- NULL
       if ("path_mif_ghgprice_land" %in% names(scenarios_magpie)) {


### PR DESCRIPTION
## Purpose of this PR

Add 'var_luc' to forbiddenColumnNames in readCheckScenarioConfig.R and remove check for 'var_luc' from start.R

## Type of change

### Parts concerned
- :white_medium_square: GAMS Code
- :ballot_box_with_check: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :ballot_box_with_check: Bug fix
- :white_medium_square: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)
