### PR TITLE
Fix calibration problem for SSP2_lowEn

### DIFF
--- a/modules/29_CES_parameters/calibrate/datainput.gms
+++ b/modules/29_CES_parameters/calibrate/datainput.gms
@@ -152,14 +152,14 @@ $offdelim
 /
 
 parameter
-f29_capitalQuantity(tall,all_regi,all_demScen,all_in)          "capital quantities"
+f29_capitalQuantity(tall,all_regi,all_GDPpopScen,all_in)          "capital quantities"
 /
 $ondelim
 $include "./modules/29_CES_parameters/calibrate/input/f29_capitalQuantity.cs4r"
 $offdelim
 /
 ;
-p29_capitalQuantity(t,regi,ppfKap) = f29_capitalQuantity(t,regi,"%cm_demScen%",ppfKap);
+p29_capitalQuantity(t,regi,ppfKap) = f29_capitalQuantity(t,regi,"%cm_GDPpopScen%",ppfKap);
 
 *** fix industry energy efficiency capital for mrremind rounding
 loop ((ttot,regi,ppfKap_industry_dyn37(in))$( t(ttot-1) AND t(ttot+1) ),


### PR DESCRIPTION
## Purpose of this PR

SSP2_lowEn with standard config was not able to calibrate.
Reason is `modules/29_CES_parameters/calibrate/input/f29_capitalQuantity.cs4r` file is based on `cm_GDPpopScen` while REMIND expected `cm_demScen`.

This PR corrects that by reverting a previous commit a9449306eaed9f4e5729767687f8da3a0d171574. It does not affect other scenarios as they have the same value for both switches.



## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :ballot_box_with_check: GAMS Code
- :white_medium_square: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :ballot_box_with_check: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :ballot_box_with_check: Bug fix
- :white_medium_square: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :ballot_box_with_check: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

* Runs with these changes are here: Testing calibration after simply reverting commit `/p/tmp/fabricel/fossilPhaseout/07-remind351/output/SSP2_lowEn-NPi-calibrate_2025-12-10_10.11.21`
* Comparison of results (what changes by this PR?): 
