### PR TITLE
Bugfix: make compareScenarios2 work with new AND old coupling

### DIFF
--- a/scripts/output/comparison/compareScenarios2.R
+++ b/scripts/output/comparison/compareScenarios2.R
@@ -25,7 +25,7 @@ if (!exists("outputdirs")) {
 determineDefaultProfiles <- function(outputDir) {
   env <- new.env()
   load(file.path(outputDir, "config.Rdata"), envir = env)
-  if (env$cfg$gms$cm_MAgPIE_Nash == 1) return("REMIND-MAgPIE")
+  if (isTRUE(env$cfg$gms$cm_MAgPIE_Nash == 1) | isTRUE(env$cfg$gms$cm_MAgPIE_coupling == "on")) return("REMIND-MAgPIE")
   regionMappingFile <- basename(env$cfg$regionmapping)
   defaults <- switch(
     regionMappingFile,


### PR DESCRIPTION
## Purpose of this PR

The scripts checks if a run is a coupled REMIND-MAgPIE run. The criterion is the coupling switch. If you want to compare standalone runs from before and after the merge of the new MAgPIE-Nash coupling, the script must therefore check for both, the new and the old coupling switches.

## Type of change

### Parts concerned
- :white_medium_square: GAMS Code
- :ballot_box_with_check: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :ballot_box_with_check: Bug fix
- :white_medium_square: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)