### PR TITLE
Bugfix: remove leftovers of debugging

### DIFF
--- a/scripts/input/magpie.R
+++ b/scripts/input/magpie.R
@@ -124,7 +124,7 @@ runMAgPIE <- function(pathToRemindReport) {
 
     # Start MAgPIE
     message(round(Sys.time()), " Starting MAgPIE\n                    with  Report = ", pathToRemindReport, "\n                          Folder = ", cfg$cfg_mag$results_folder)
-    outfolder_mag <- cfg$cfg_mag$results_folder # start_run(cfg$cfg_mag, codeCheck = FALSE)
+    outfolder_mag <- start_run(cfg$cfg_mag, codeCheck = FALSE)
     pathToMagpieReport <- file.path(cfg$path_magpie, outfolder_mag, "report.mif")
     message(round(Sys.time()), " MAgPIE finished")
 


### PR DESCRIPTION
## Purpose of this PR

Remove lines that were forgotton to be deleted after debugging and blocked MAgPIE from running.

## Type of change

### Parts concerned
- :white_medium_square: GAMS Code
- :ballot_box_with_check: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :ballot_box_with_check: Bug fix
- :white_medium_square: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)