### PR TITLE
More information when gdx not found upon startup

### DIFF
--- a/scripts/start/prepare.R
+++ b/scripts/start/prepare.R
@@ -183,10 +183,14 @@ prepare <- function() {
   ### ADD MODULE INFO IN SETS  ############# END #########
 
   # copy right gdx file to the output folder
-  gdx_name <- paste0("config/gdx-files/",cfg$gms$cm_CES_configuration,".gdx")
-  if (0 != system(paste('cp', gdx_name,
-			file.path(cfg$results_folder, 'input.gdx')))) {
-    stop('Could not copy gdx file ', gdx_name)
+  gdx_name <- paste0("config/gdx-files/", cfg$gms$cm_CES_configuration, ".gdx")
+  if (!file.copy(gdx_name, file.path(cfg$results_folder, 'input.gdx'))) {
+    errmsg <- 'Could not copy gdx file:\n   '
+    if (cfg$gms$CES_parameters == 'calibrate') {
+      errmsg <- paste0(errmsg,
+        'Calibration requires a start point, so copy the gdx file with the closest configuration and paste it to:\n   ')
+    }
+    stop(errmsg, gdx_name, '\n\n')
   } else {
     message('Copied ', gdx_name, ' to input.gdx')
   }


### PR DESCRIPTION
## Purpose of this PR

When using specific calibrations, the required gdx and inc is not necessarily available, which causes an error. This PR improves the error message in order to know where to put which filename.
Adapted from [this conversation](https://mattermost.pik-potsdam.de/rd3/pl/ys6noq9ta3r3x8gr38nsn9gata).

## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :white_medium_square: GAMS Code
- :ballot_box_with_check: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :white_medium_square: Bug fix
- :white_medium_square: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :ballot_box_with_check: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

* Folder with these changes `/p/tmp/fabricel/remindGDXfailure`