### PR TITLE
Global EOC budget with peaking carbon price

### DIFF
--- a/main.gms
+++ b/main.gms
@@ -919,11 +919,11 @@ parameter
 *' * (7): [requires 45_carbonprice = functionalForm and emiscen = 9] iterative adjustment of CO2 tax based on economy-wide CO2 cumulative emission peak budget, for runs with emission budget or CO2 tax constraints. Features: results in a peak budget with zero net CO2 emissions after peak budget is reached. See core/postsolve.gms for direct algorithms [see 45_carbonprice/functionalForm/postsolve.gms for direct algorithm]
 *' * (9): [requires 45_carbonprice = functionalForm and emiscen = 9] global: iterative adjustment of CO2 tax based on economy-wide CO2 cumulative emission peak budget, for runs with emission budget or CO2 tax constraints. Features: 1) after the year when budget peaks, CO2 tax has an annual increase by cm_taxCO2_IncAfterPeakBudgYr, 2) automatically shifts cm_peakBudgYr to find the correct year of budget peaking for a given budget. [see 45_carbonprice/functionalForm/postsolve.gms for direct algorithm]
 parameter
-  cm_taxCO2_Shape             "Only used with [functionalFormRegi], determines whether the carbon price increases until 2100 or is constant as of the exogenously set cm_peakYear"
+  cm_taxCO2_Shape             "Only used with [functionalFormRegi and functionalForm if EOC budget], determines whether the carbon price increases until 2100 or is constant as of the exogenously set cm_peakYear"
 ;
   cm_taxCO2_Shape = 1;            !! def = 1    !! regexp = 1|2
-*' * (1): EOC -  pm_taxCO2eq increases until 2100 according to cm_taxCO2_functionalForm for regional budget targets
-*' * (2): Peak - pm_taxCO2eq increases until an exogenously set "peak year" (via cm_peakBudgYear). Note: this does not necessarily correspond to the year in which the budget actually peaks.
+*' * (1): EOC -  pm_taxCO2eq increases until 2100 according to cm_taxCO2_functionalForm for EOC budget targets
+*' * (2): Peak - pm_taxCO2eq increases until an exogenously set "peak year" (via cm_peakBudgYear). Note: this does not necessarily correspond to the year in which the global or regional budget actually peaks.
 *'
 parameter 
   cm_CPslopeAdjustment        "Only used with [functionalFormRegi], determines whether the entire path is shifted up and down or the slope of is adjusted endogenously"

--- a/main.gms
+++ b/main.gms
@@ -919,7 +919,7 @@ parameter
 *' * (7): [requires 45_carbonprice = functionalForm and emiscen = 9] iterative adjustment of CO2 tax based on economy-wide CO2 cumulative emission peak budget, for runs with emission budget or CO2 tax constraints. Features: results in a peak budget with zero net CO2 emissions after peak budget is reached. See core/postsolve.gms for direct algorithms [see 45_carbonprice/functionalForm/postsolve.gms for direct algorithm]
 *' * (9): [requires 45_carbonprice = functionalForm and emiscen = 9] global: iterative adjustment of CO2 tax based on economy-wide CO2 cumulative emission peak budget, for runs with emission budget or CO2 tax constraints. Features: 1) after the year when budget peaks, CO2 tax has an annual increase by cm_taxCO2_IncAfterPeakBudgYr, 2) automatically shifts cm_peakBudgYr to find the correct year of budget peaking for a given budget. [see 45_carbonprice/functionalForm/postsolve.gms for direct algorithm]
 parameter
-  cm_taxCO2_Shape             "Only used with [functionalFormRegi and functionalForm if EOC budget], determines whether the carbon price increases until 2100 or is constant as of the exogenously set cm_peakYear"
+  cm_taxCO2_Shape             "Only used with [functionalFormRegi, and functionalForm if cm_iterative_target_adj=5 (i.e. EOC budget)], determines whether the carbon price increases until 2100 or is constant as of the exogenously set cm_peakYear"
 ;
   cm_taxCO2_Shape = 1;            !! def = 1    !! regexp = 1|2
 *' * (1): EOC -  pm_taxCO2eq increases until 2100 according to cm_taxCO2_functionalForm for EOC budget targets

--- a/modules/45_carbonprice/functionalForm/datainput.gms
+++ b/modules/45_carbonprice/functionalForm/datainput.gms
@@ -121,7 +121,7 @@ $endIf.taxCO2globalAnchor
 p45_taxCO2eq_anchor_until2150(ttot) = p45_taxCO2eq_anchor(ttot);
 
 *** Adjust global anchor trajectory so that after cm_peakBudgYr, it increases linearly with fixed annual increase given by cm_taxCO2_IncAfterPeakBudgYr
-if((cm_iterative_target_adj = 0) or (cm_iterative_target_adj = 9),
+if((cm_iterative_target_adj = 0) or (cm_iterative_target_adj = 9) or ((cm_iterative_target_adj eq 5) AND (cm_taxCO2_Shape eq 2)),
   p45_taxCO2eq_anchor(t)$(t.val gt cm_peakBudgYr) = sum(t2$(t2.val eq cm_peakBudgYr), p45_taxCO2eq_anchor_until2150(t2)) !! CO2 tax in peak budget year
                                                   + (t.val - cm_peakBudgYr) * cm_taxCO2_IncAfterPeakBudgYr * sm_DptCO2_2_TDpGtC;  !! increase by cm_taxCO2inc_after_peakBudgYr per year 
 );

--- a/modules/45_carbonprice/functionalForm/not_used.txt
+++ b/modules/45_carbonprice/functionalForm/not_used.txt
@@ -25,7 +25,6 @@ pm_macSwitch,input,not needed because default MAC curve settings are used
 pm_NDCEmiTargetDeviation,input,not used
 pm_actualbudgetco2Regi,input,added by codeCheck
 pm_dt,input,added by codeCheck
-cm_taxCO2_Shape,input,added by codeCheck
 cm_CPslopeAdjustment,input,added by codeCheck
 cm_useInputGdxForCarbonPrice,input,added by codeCheck
 pm_factorRescale_taxCO2Regi_Funneled2,input,added by codeCheck

--- a/modules/45_carbonprice/functionalForm/postsolve.gms
+++ b/modules/45_carbonprice/functionalForm/postsolve.gms
@@ -109,7 +109,7 @@ $endIf.taxCO2functionalForm4
     !! Use rescaled p45_taxCO2eq_anchor_until2150 as starting point for re-defining p45_taxCO2eq_anchor
     p45_taxCO2eq_anchor(ttot)$(ttot.val ge 2005) = p45_taxCO2eq_anchor_until2150(ttot);
     
-    if(cm_iterative_target_adj = 9, !! After cm_peakBudgYr, the global anchor trajectory increases linearly with fixed annual increase given by cm_taxCO2_IncAfterPeakBudgYr
+    if(cm_iterative_target_adj = 9 OR ((cm_iterative_target_adj eq 5) AND (cm_taxCO2_Shape eq 2)), !! After cm_peakBudgYr, the global anchor trajectory increases linearly with fixed annual increase given by cm_taxCO2_IncAfterPeakBudgYr
       p45_taxCO2eq_anchor(t)$(t.val gt cm_peakBudgYr) = sum(t2$(t2.val eq cm_peakBudgYr), p45_taxCO2eq_anchor_until2150(t2)) !! CO2 tax in peak budget year
                                                   + (t.val - cm_peakBudgYr) * cm_taxCO2_IncAfterPeakBudgYr * sm_DptCO2_2_TDpGtC;  !! increase by cm_taxCO2inc_after_peakBudgYr per year 
     );  


### PR DESCRIPTION
## Purpose of this PR

This PR adds the option to have a global EOC budget with a carbon price peaking in the year specified by `cm_peakYear`.

Analogous to the `functionalFormRegi` realization, this can be achieved by setting `cm_taxCO2_Shape = 2` and `cm_peakYear = 20XX`. 

Note: the peaking year does **not** adjust endogenously

## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :ballot_box_with_check: GAMS Code
- :white_medium_square: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :white_medium_square: Bug fix
- :white_medium_square: Refactoring
- :ballot_box_with_check: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

* Runs with these changes are here:
* Comparison of results (what changes by this PR?): 
