### PR TITLE
fix bug due to new domain of p36_floorspace

### DIFF
--- a/modules/36_buildings/simple/datainput.gms
+++ b/modules/36_buildings/simple/datainput.gms
@@ -68,10 +68,10 @@ p36_uedemand_build(t,regi,in) = f36_uedemand_build(t,regi,"%cm_demScen%","%cm_rc
 *** Scale UE demand and floor space in the building sector
 $ifthen.scaleDemand not "%cm_scaleDemand%" == "off"
   loop((tall,tall2,regi) $ pm_scaleDemand(tall,tall2,regi),
-*FL*  rescaled demand               = normal demand                 * [ scaling factor                       + (1-scaling factor)                       * remaining phase-in, between zero and one               ]
-      p36_uedemand_build(t,regi,in) = p36_uedemand_build(t,regi,in) * ( pm_scaleDemand(tall,tall2,regi)      + (1-pm_scaleDemand(tall,tall2,regi))      * min(1, max(0, tall2.val-t.val) / (tall2.val-tall.val)) );
+*FL*  rescaled demand                   = normal demand                     * [ scaling factor                       + (1-scaling factor)                       * remaining phase-in, between zero and one               ]
+      p36_uedemand_build(t,regi,in)     = p36_uedemand_build(t,regi,in)     * ( pm_scaleDemand(tall,tall2,regi)      + (1-pm_scaleDemand(tall,tall2,regi))      * min(1, max(0, tall2.val-t.val) / (tall2.val-tall.val)) );
 *RH*  We assume that the reduction in final energy demand is only partially driven by floor space reduction (exponent 0.3).
-      p36_floorspace(t,regi)        = p36_floorspace(t,regi)        * ( pm_scaleDemand(tall,tall2,regi)**0.3 + (1-pm_scaleDemand(tall,tall2,regi)**0.3) * min(1, max(0, tall2.val-t.val) / (tall2.val-tall.val)) );
+      p36_floorspace(t,regi,secBuild36) = p36_floorspace(t,regi,secBuild36) * ( pm_scaleDemand(tall,tall2,regi)**0.3 + (1-pm_scaleDemand(tall,tall2,regi)**0.3) * min(1, max(0, tall2.val-t.val) / (tall2.val-tall.val)) );
   );
 $endif.scaleDemand
 


### PR DESCRIPTION
## Purpose of this PR

- `p36_floorspace` has a new "commercial or residential" domain since https://github.com/remindmodel/remind/pull/1197
- this was not yet adapted in codes part with scaleDemand used in IKEA configs.
- this lead to errors in automatic tests, see https://github.com/remindmodel/remind/pull/2268#issuecomment-3804363620

## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :ballot_box_with_check: GAMS Code
- :white_medium_square: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :ballot_box_with_check: Bug fix
- :white_medium_square: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :ballot_box_with_check: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

* Checking that compilation of non-standard scenarios work:
```
N-login03:/p/tmp/fabricel/remindScaleDem > Rscript start.R --gamscompile startgroup=* titletag=TESTTHAT-scenario_config_IKEA config/scenario_config_IKEA.csv
Global .Rprofile loaded! (R version 4.3.2 (2023-10-31))
Loading required package: gdx
Loading required package: gdxrrw
Loading required package: magclass

Attaching package: 'magclass'

The following object is masked from 'package:dplyr':

    where

The following objects are masked from 'package:base':

    pmax, pmin

Reading config file config/scenario_config_IKEA.csv

readCheckScenarioConfig.R treats these columns starting with '.' as comments: .cm_coalPhaseoutOECD

Trying to compile 16 selected runs...
2026-01-27 15:23:43: try to acquire model lock...
2026-01-27 15:23:43: acquired model lock in 0 secs.
 OK  ./output/gamscompile/main_SSP2-NPi-calibrate-TESTTHAT-scenario_config_IKEA.lst
 OK  ./output/gamscompile/main_SSP2-NPi-TESTTHAT-scenario_config_IKEA.lst
 OK  ./output/gamscompile/main_SSP2-NPi2025-TESTTHAT-scenario_config_IKEA.lst
 OK  ./output/gamscompile/main_SSP2-PkBudg650-TESTTHAT-scenario_config_IKEA.lst
 OK  ./output/gamscompile/main_SSP2-PkBudg1000-TESTTHAT-scenario_config_IKEA.lst
 OK  ./output/gamscompile/main_NPE-calibrate-TESTTHAT-scenario_config_IKEA.lst
 OK  ./output/gamscompile/main_NPE-calibrate-demandChanged-TESTTHAT-scenario_config_IKEA.lst
 OK  ./output/gamscompile/main_NPE-calibrate-demandStandard-TESTTHAT-scenario_config_IKEA.lst
 OK  ./output/gamscompile/main_NPE-NPi-demandChanged-TESTTHAT-scenario_config_IKEA.lst
 OK  ./output/gamscompile/main_NPE-NPi-demandStandard-TESTTHAT-scenario_config_IKEA.lst
 OK  ./output/gamscompile/main_NPE-core-TESTTHAT-scenario_config_IKEA.lst
 OK  ./output/gamscompile/main_NPE-convEarly-TESTTHAT-scenario_config_IKEA.lst
 OK  ./output/gamscompile/main_NPE-convLate-TESTTHAT-scenario_config_IKEA.lst
 OK  ./output/gamscompile/main_NPE-demandStandard-TESTTHAT-scenario_config_IKEA.lst
 OK  ./output/gamscompile/main_NPE-2C-demandChanged-TESTTHAT-scenario_config_IKEA.lst
 OK  ./output/gamscompile/main_NPE-2C-demandStandard-TESTTHAT-scenario_config_IKEA.lst

2026-01-27 15:27:15: unlocked model.

Finished: 8 runs started. 8 runs are waiting.
To investigate potential FAILs, run: less -j 4 --pattern='^\*\*\*\*' filename.lst
```