### PR TITLE
Feature: buildings and industry FE demand can be pulled up/down by table with multipliers (project justMIP)

### DIFF
--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -1617,6 +1617,7 @@ $offdelim
 
 pm_scaleDemandBuildTable(t,regi) = f_scaleDemandBuildTable(t,regi);
 pm_scaleDemandBuildTable(t,regi) $ (t.val < 2030 ) = 1;  !! ensure that historic data is not changed
+pm_scaleDemandBuildTable(t,regi) $ ( pm_scaleDemandBuildTable(t,regi) le 0) = 1;  !! If no multiplier was entered or a negative value was entered, override by 1. (FE values <0 are not possible)
 pm_scaleDemandBuildTable(t,regi) $ (t.val > 2100 ) = pm_scaleDemandBuildTable("2100",regi); !! continue 2100 multiplier until end of time
 
   loop( (t,regi,in) $ in_buildings_dyn36(in) ,
@@ -1625,7 +1626,7 @@ pm_scaleDemandBuildTable(t,regi) $ (t.val > 2100 ) = pm_scaleDemandBuildTable("2
 $endif.scaleDemandBuildTable
 
 *** Scale FE demand in industry sectors
-$ifthen.scaleDemandIndTable not "%cm_scaleDemandIndTable%" == "off"
+$ifthen.scaleDemandIndTable not "%c_scaleDemandIndTable%" == "off"
 
 Parameter f_scaleDemandIndTable(ttot,all_regi) "Rescaling factor on industry final energy and usable energy demand, read-in from a table"
 /
@@ -1634,12 +1635,13 @@ $include "./core/input/f_fedemand_ind_scaleDemand.cs4r"
 $offdelim
 /;
 
-pm_scaleDemandIndTable(t,regi) $ (t.val > 2025 ) = f_scaleDemandIndTable(t,regi);
-pm_scaleDemandIndTable(t,regi) $ (t.val < 2030 ) = 1;  !! ensure that historic data is not changed
-pm_scaleDemandIndTable(t,regi) $ (t.val > 2100 ) = pm_scaleDemandIndTable("2100",regi); !! continue 2100 multiplier until end of time
+p_scaleDemandIndTable(t,regi) $ (t.val > 2025 ) = f_scaleDemandIndTable(t,regi);
+p_scaleDemandIndTable(t,regi) $ (t.val < 2030 ) = 1;  !! ensure that historic data is not changed
+p_scaleDemandIndTable(t,regi) $ ( p_scaleDemandIndTable(t,regi) le 0) = 1;  !! If no multiplier was entered or a negative value was entered, override by 1. (FE values <0 are not possible)
+p_scaleDemandIndTable(t,regi) $ (t.val > 2100 ) = p_scaleDemandIndTable("2100",regi); !! continue 2100 multiplier until end of time
 
   loop( (t,regi,in) $ in_industry_dyn37(in) ,
-    pm_fedemand(t,regi,in) = pm_fedemand(t,regi,in) * pm_scaleDemandIndTable(t,regi)
+    pm_fedemand(t,regi,in) = pm_fedemand(t,regi,in) * p_scaleDemandIndTable(t,regi)
   );
 $endif.scaleDemandIndTable
 

--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -1615,8 +1615,9 @@ $include "./core/input/f_fedemand_build_scaleDemand.cs4r"
 $offdelim
 /;
 
-pm_scaleDemandBuildTable(t,regi) $ (t.val > 2025 ) = f_scaleDemandBuildTable(t,regi);
-pm_scaleDemandBuildTable(t,regi) $ (t.val > 2100 ) = pm_scaleDemandBuildTable("2100",regi);
+pm_scaleDemandBuildTable(t,regi) = f_scaleDemandBuildTable(t,regi);
+pm_scaleDemandBuildTable(t,regi) $ (t.val < 2030 ) = 1;  !! ensure that historic data is not changed
+pm_scaleDemandBuildTable(t,regi) $ (t.val > 2100 ) = pm_scaleDemandBuildTable("2100",regi); !! continue 2100 multiplier until end of time
 
   loop( (t,regi,in) $ in_buildings_dyn36(in) ,
     pm_fedemand(t,regi,in) = pm_fedemand(t,regi,in) * pm_scaleDemandBuildTable(t,regi)
@@ -1634,7 +1635,8 @@ $offdelim
 /;
 
 pm_scaleDemandIndTable(t,regi) $ (t.val > 2025 ) = f_scaleDemandIndTable(t,regi);
-pm_scaleDemandIndTable(t,regi) $ (t.val > 2100 ) = pm_scaleDemandIndTable("2100",regi);
+pm_scaleDemandIndTable(t,regi) $ (t.val < 2030 ) = 1;  !! ensure that historic data is not changed
+pm_scaleDemandIndTable(t,regi) $ (t.val > 2100 ) = pm_scaleDemandIndTable("2100",regi); !! continue 2100 multiplier until end of time
 
   loop( (t,regi,in) $ in_industry_dyn37(in) ,
     pm_fedemand(t,regi,in) = pm_fedemand(t,regi,in) * pm_scaleDemandIndTable(t,regi)

--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -1616,6 +1616,7 @@ $offdelim
 /;
 
 pm_scaleDemandBuildTable(t,regi) = f_scaleDemandBuildTable(t,regi);
+pm_scaleDemandBuildTable(t,regi) $ (t.val > 2100 ) = pm_scaleDemandBuildTable("2100",regi);
 
   loop( (t,regi,in) $ in_buildings_dyn36(in) ,
     pm_fedemand(t,regi,in) = pm_fedemand(t,regi,in) * pm_scaleDemandBuildTable(t,regi)
@@ -1633,6 +1634,7 @@ $offdelim
 /;
 
 pm_scaleDemandIndTable(t,regi) = f_scaleDemandIndTable(t,regi);
+pm_scaleDemandIndTable(t,regi) $ (t.val > 2100 ) = pm_scaleDemandIndTable("2100",regi);
 
   loop( (t,regi,in) $ in_industry_dyn37(in) ,
     pm_fedemand(t,regi,in) = pm_fedemand(t,regi,in) * pm_scaleDemandIndTable(t,regi)

--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -1615,7 +1615,7 @@ $include "./core/input/f_fedemand_build_scaleDemand.cs4r"
 $offdelim
 /;
 
-pm_scaleDemandBuildTable(t,regi) = f_scaleDemandBuildTable;
+pm_scaleDemandBuildTable(t,regi) = f_scaleDemandBuildTable(t,regi);
 
   loop( (t,regi,in) $ in_buildings_dyn36(in) ,
     pm_fedemand(t,regi,in) = pm_fedemand(t,regi,in) * pm_scaleDemandBuildTable(t,regi)
@@ -1632,7 +1632,7 @@ $include "./core/input/f_fedemand_ind_scaleDemand.cs4r"
 $offdelim
 /;
 
-pm_scaleDemandIndTable(t,regi) = f_scaleDemandIndTable;
+pm_scaleDemandIndTable(t,regi) = f_scaleDemandIndTable(t,regi);
 
   loop( (t,regi,in) $ in_industry_dyn37(in) ,
     pm_fedemand(t,regi,in) = pm_fedemand(t,regi,in) * pm_scaleDemandIndTable(t,regi)

--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -1615,7 +1615,7 @@ $include "./core/input/f_fedemand_build_scaleDemand.cs4r"
 $offdelim
 /;
 
-pm_scaleDemandBuildTable(t,regi) = f_scaleDemandBuildTable(t,regi);
+pm_scaleDemandBuildTable(t,regi) $ (t.val > 2025 ) = f_scaleDemandBuildTable(t,regi);
 pm_scaleDemandBuildTable(t,regi) $ (t.val > 2100 ) = pm_scaleDemandBuildTable("2100",regi);
 
   loop( (t,regi,in) $ in_buildings_dyn36(in) ,
@@ -1633,7 +1633,7 @@ $include "./core/input/f_fedemand_ind_scaleDemand.cs4r"
 $offdelim
 /;
 
-pm_scaleDemandIndTable(t,regi) = f_scaleDemandIndTable(t,regi);
+pm_scaleDemandIndTable(t,regi) $ (t.val > 2025 ) = f_scaleDemandIndTable(t,regi);
 pm_scaleDemandIndTable(t,regi) $ (t.val > 2100 ) = pm_scaleDemandIndTable("2100",regi);
 
   loop( (t,regi,in) $ in_industry_dyn37(in) ,

--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -1608,10 +1608,16 @@ $endif.scaleDemand
 *** Scale FE demand in building sectors
 $ifthen.scaleDemandBuildTable not "%cm_scaleDemandBuildTable%" == "off"
 
+*** File should have the following format:
+*** 2025,USA,1.00
+*** 2030,USA,0.9
+*** 2035,USA,0.8
+
+
 Parameter f_scaleDemandBuildTable(ttot,all_regi) "Rescaling factor on industry final energy and usable energy demand, read-in from a table"
 /
 $ondelim
-$include "./core/input/f_fedemand_build_scaleDemand.cs4r"
+$include "./core/input/%cm_scaleDemandBuildTable%.cs4r"
 $offdelim
 /;
 
@@ -1628,10 +1634,15 @@ $endif.scaleDemandBuildTable
 *** Scale FE demand in industry sectors
 $ifthen.scaleDemandIndTable not "%c_scaleDemandIndTable%" == "off"
 
+*** File should have the following format:
+*** 2025,USA,1.00
+*** 2030,USA,0.9
+*** 2035,USA,0.8
+
 Parameter f_scaleDemandIndTable(ttot,all_regi) "Rescaling factor on industry final energy and usable energy demand, read-in from a table"
 /
 $ondelim
-$include "./core/input/f_fedemand_ind_scaleDemand.cs4r"
+$include "./core/input/%c_scaleDemandIndTable%.cs4r"
 $offdelim
 /;
 

--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -1605,6 +1605,39 @@ $ifthen.scaleDemand not "%cm_scaleDemand%" == "off"
   );
 $endif.scaleDemand
 
+*** Scale FE demand in building sectors
+$ifthen.scaleDemandBuildTable not "%cm_scaleDemandBuildTable%" == "off"
+
+Parameter f_scaleDemandBuildTable(ttot,all_regi) "Rescaling factor on industry final energy and usable energy demand, read-in from a table"
+/
+$ondelim
+$include "./core/input/f_fedemand_build_scaleDemand.cs4r"
+$offdelim
+/;
+
+pm_scaleDemandBuildTable(t,regi) = f_scaleDemandBuildTable;
+
+  loop( (t,regi,in) $ in_buildings_dyn36(in) ,
+    pm_fedemand(t,regi,in) = pm_fedemand(t,regi,in) * pm_scaleDemandBuildTable(t,regi)
+  );
+$endif.scaleDemandBuildTable
+
+*** Scale FE demand in industry sectors
+$ifthen.scaleDemandIndTable not "%cm_scaleDemandIndTable%" == "off"
+
+Parameter f_scaleDemandIndTable(ttot,all_regi) "Rescaling factor on industry final energy and usable energy demand, read-in from a table"
+/
+$ondelim
+$include "./core/input/f_fedemand_ind_scaleDemand.cs4r"
+$offdelim
+/;
+
+pm_scaleDemandIndTable(t,regi) = f_scaleDemandIndTable;
+
+  loop( (t,regi,in) $ in_industry_dyn37(in) ,
+    pm_fedemand(t,regi,in) = pm_fedemand(t,regi,in) * pm_scaleDemandIndTable(t,regi)
+  );
+$endif.scaleDemandIndTable
 
 *** initialize absolute deviation of global cumulated CO2 emissions budget from target budget
 sm_globalBudget_absDev = 0;

--- a/core/declarations.gms
+++ b/core/declarations.gms
@@ -322,9 +322,9 @@ $ifthen.scaleDemandBuildTable not "%cm_scaleDemandBuildTable%" == "off"
   pm_scaleDemandBuildTable(ttot, all_regi)                 "Rescaling factor on buildings final energy and usable energy demand, read-in from a table" 
 $endif.scaleDemandBuildTable
 
-$ifthen.scaleDemandIndTable not "%cm_scaleDemandIndTable%" == "off"
+$ifthen.scaleDemandIndTable not "%c_scaleDemandIndTable%" == "off"
 *** FE demand rescaling parameters
-  pm_scaleDemandIndTable(ttot, all_regi)                 "Rescaling factor on industry final energy and usable energy demand, read-in from a table" 
+  p_scaleDemandIndTable(ttot, all_regi)                 "Rescaling factor on industry final energy and usable energy demand, read-in from a table" 
 $endif.scaleDemandIndTable
 
 *** energy prices

--- a/core/declarations.gms
+++ b/core/declarations.gms
@@ -317,6 +317,16 @@ $ifthen.scaleDemand not "%cm_scaleDemand%" == "off"
   pm_scaleDemand(tall,tall,all_regi)                 "Rescaling factor on final energy and usable energy demand, for selected regions and over a phase-in window." / %cm_scaleDemand% /
 $endif.scaleDemand
 
+$ifthen.scaleDemandBuildTable not "%cm_scaleDemandBuildTable%" == "off"
+*** FE demand rescaling parameters
+  pm_scaleDemandBuildTable(ttot, all_regi)                 "Rescaling factor on buildings final energy and usable energy demand, read-in from a table" 
+$endif.scaleDemandBuildTable
+
+$ifthen.scaleDemandIndTable not "%cm_scaleDemandIndTable%" == "off"
+*** FE demand rescaling parameters
+  pm_scaleDemandIndTable(ttot, all_regi)                 "Rescaling factor on industry final energy and usable energy demand, read-in from a table" 
+$endif.scaleDemandIndTable
+
 *** energy prices
 pm_FEPrice(ttot,all_regi,all_enty,sector,emiMkt)     "parameter to capture all FE prices across sectors and markets [tr$2005/TWa]"
 pm_FEPrice_iter(iteration,ttot,all_regi,all_enty,sector,emiMkt) "parameter to capture all FE prices across sectors and markets [tr$2005/TWa] across iterations"

--- a/main.gms
+++ b/main.gms
@@ -1485,10 +1485,10 @@ $setGlobal cm_scaleDemand  off    !! def = off
 *** Requires re-calibration in order to work.
 *** When turned to "on", requires an input table f_fedemand_build_scaleDemand.cs4r to be added to core/input
 $setGlobal cm_scaleDemandBuildTable  off    !! def = off
-*** cm_scaleDemandIndTable - Rescaling factor on industry final energy and usable energy demand, with values coming from an input table.
+*** c_scaleDemandIndTable - Rescaling factor on industry final energy and usable energy demand, with values coming from an input table.
 *** Requires re-calibration in order to work.
 *** When turned to "on", requires an input table f_fedemand_ind_scaleDemand.cs4r to be added to core/input
-$setGlobal cm_scaleDemandIndTable  off    !! def = off
+$setGlobal c_scaleDemandIndTable  off    !! def = off
 *** cm_quantity_regiCO2target "emissions quantity upper bound from specific year for region group."
 ***   Example on how to use:
 ***     '2050.EUR_regi.netGHG 0.000001, obliges European GHG emissions to be approximately zero from 2050 onward"

--- a/main.gms
+++ b/main.gms
@@ -1481,6 +1481,14 @@ $setGlobal cm_emiMktTarget_tolerance  GLO 0.01    !! def = GLO 0.01
 ***   Example on how to use:
 ***     cm_scaleDemand = '2020.2040.(EUR,NEU,USA,JPN,CAZ) 0.75' applies a 25% demand reduction on those regions progressively between 2020 (100% demand) and 2040 (75% demand).
 $setGlobal cm_scaleDemand  off    !! def = off
+*** cm_scaleDemandBuildTable - Rescaling factor on buildings final energy and usable energy demand, with values coming from an input table.
+*** Requires re-calibration in order to work.
+*** When turned to "on", requires an input table f_fedemand_build_scaleDemand.cs4r to be added to core/input
+$setGlobal cm_scaleDemandBuildTable  off    !! def = off
+*** cm_scaleDemandIndTable - Rescaling factor on industry final energy and usable energy demand, with values coming from an input table.
+*** Requires re-calibration in order to work.
+*** When turned to "on", requires an input table f_fedemand_ind_scaleDemand.cs4r to be added to core/input
+$setGlobal cm_scaleDemandIndTable  off    !! def = off
 *** cm_quantity_regiCO2target "emissions quantity upper bound from specific year for region group."
 ***   Example on how to use:
 ***     '2050.EUR_regi.netGHG 0.000001, obliges European GHG emissions to be approximately zero from 2050 onward"

--- a/main.gms
+++ b/main.gms
@@ -1505,11 +1505,11 @@ $setGlobal cm_emiMktTarget_tolerance  GLO 0.01    !! def = GLO 0.01
 $setGlobal cm_scaleDemand  off    !! def = off
 *** cm_scaleDemandBuildTable - Rescaling factor on buildings final energy and usable energy demand, with values coming from an input table.
 *** Requires re-calibration in order to work.
-*** When turned to "on", requires an input table f_fedemand_build_scaleDemand.cs4r to be added to core/input
+*** One needs to name the cs4r-file with the multipliers in the scenario_config, and the file needs to be copied by hand to core/input
 $setGlobal cm_scaleDemandBuildTable  off    !! def = off
 *** c_scaleDemandIndTable - Rescaling factor on industry final energy and usable energy demand, with values coming from an input table.
 *** Requires re-calibration in order to work.
-*** When turned to "on", requires an input table f_fedemand_ind_scaleDemand.cs4r to be added to core/input
+*** One needs to name the cs4r-file with the multipliers in the scenario_config, and the file needs to be copied by hand to core/input
 $setGlobal c_scaleDemandIndTable  off    !! def = off
 *** cm_quantity_regiCO2target "emissions quantity upper bound from specific year for region group."
 ***   Example on how to use:

--- a/modules/36_buildings/simple/datainput.gms
+++ b/modules/36_buildings/simple/datainput.gms
@@ -78,9 +78,9 @@ $endif.scaleDemand
 *** Scale UE demand and floor space in the building sector
 $ifthen.scaleDemandBuildTable not "%cm_scaleDemandBuildTable%" == "off"
   loop( (t,regi),
-      p36_uedemand_build(t,regi,in)     = p36_uedemand_build(t,regi,in)     * pm_scaleDemandBuildTable(t,regi) );
+      p36_uedemand_build(t,regi,in)     = p36_uedemand_build(t,regi,in)     * pm_scaleDemandBuildTable(t,regi) ;
 *RH*  We assume that the reduction in final energy demand is only partially driven by floor space reduction (exponent 0.3).
-      p36_floorspace(t,regi,secBuild36) = p36_floorspace(t,regi,secBuild36) * pm_scaleDemandBuildTable(t,regi)**0.3 );
+      p36_floorspace(t,regi,secBuild36) = p36_floorspace(t,regi,secBuild36) * pm_scaleDemandBuildTable(t,regi)**0.3 ;
   );
 $endif.scaleDemandBuildTable
 

--- a/modules/36_buildings/simple/datainput.gms
+++ b/modules/36_buildings/simple/datainput.gms
@@ -75,6 +75,15 @@ $ifthen.scaleDemand not "%cm_scaleDemand%" == "off"
   );
 $endif.scaleDemand
 
+*** Scale UE demand and floor space in the building sector
+$ifthen.scaleDemandBuildTable not "%cm_scaleDemandBuildTable%" == "off"
+  loop( (t,regi),
+      p36_uedemand_build(t,regi,in)     = p36_uedemand_build(t,regi,in)     * pm_scaleDemandBuildTable(t,regi) );
+*RH*  We assume that the reduction in final energy demand is only partially driven by floor space reduction (exponent 0.3).
+      p36_floorspace(t,regi,secBuild36) = p36_floorspace(t,regi,secBuild36) * pm_scaleDemandBuildTable(t,regi)**0.3 );
+  );
+$endif.scaleDemandBuildTable
+
 
 ***-----------------------------------------------------------------------------
 * FE Share Bounds


### PR DESCRIPTION
## Purpose of this PR

Added the possibility to read in two external files (with file names specified in `c_scaleDemandIndTable` and `cm_scaleDemandBuildTable`) to multiplicatively scale up/down FE demands in buildings and industry for each region.

It follows the idea of the previously developed flag `cm_scaleDemand`, but lets the user have different rescalings in buildings and industry, and does not do interpolation by itself, but requires a full table of factors for all time steps between 2030 and 2100. 

## Type of change

### Parts concerned
- :ballot_box_with_check: GAMS Code
- :white_medium_square: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :ballot_box_with_check: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :ballot_box_with_check: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :white_medium_square: Bug fix
- :white_medium_square: Refactoring
- :ballot_box_with_check: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

* Runs with these changes are here:
* Comparison of results (what changes by this PR?): 
