### PR TITLE
Adapt global budget convergence criterion for runs with interalized damages

### DIFF
--- a/modules/80_optimization/nash/postsolve.gms
+++ b/modules/80_optimization/nash/postsolve.gms
@@ -398,14 +398,25 @@ loop((t,regi,entyPe)$pm_implicitPePriceTarget(t,regi,entyPe),
 );  
 $endIf.cm_implicitPePriceTarget
 
-*** check global budget target from core/postsolve, must be within cm_budgetCO2_absDevTol (default 2 Gt) of target value
-p80_globalBudget_absDev_iter(iteration) = sm_globalBudget_absDev;
-if ( abs(p80_globalBudget_absDev_iter(iteration)) gt cm_budgetCO2_absDevTol , !! check if CO2 budget met in tolerance range,
-  s80_bool = 0;
-  p80_messageShow("globalbudget") = YES;
-);
-
 $ifthen.carbonprice %carbonprice% == "functionalForm"
+*** check global budget target from 45_carbonprice/functionalForm/postsolve
+*** convergence criterion defined via cm_budgetCO2_absDevTol [default = 2 Gt CO2]
+*** positive values of sm_globalBudget_absDev mean that target budget is exceeded (sm_globalBudget_absDev = s45_actualbudgetco2 - cm_budgetCO2from2020)
+*** if damages are not internalized, check positive and negative deviation from target budget
+*** if damages are internalized, only check positive deviation from target budget
+p80_globalBudget_absDev_iter(iteration) = sm_globalBudget_absDev;
+$ifthen.globalBudget "%internalizeDamages%" == "off"
+  if (abs(p80_globalBudget_absDev_iter(iteration)) gt cm_budgetCO2_absDevTol,
+    s80_bool = 0;
+    p80_messageShow("globalbudget") = YES;
+  );
+$else.globalBudget
+  if (p80_globalBudget_absDev_iter(iteration) gt cm_budgetCO2_absDevTol,
+    s80_bool = 0;
+    p80_messageShow("globalbudget") = YES;
+  );
+$endIf.globalBudget
+
 *** check whether cm_peakBudgYr corresponds to year of maximum cumulative CO2 emissions
 if (  (     cm_iterative_target_adj eq 9
         AND cm_peakBudgYr ne sm_peakBudgYr_check  ),


### PR DESCRIPTION
_This PR implements https://github.com/remindmodel/remind/pull/1988._

## Purpose of this PR

1. Adapt global budget convergence criterion for runs with internalized damages. If damages are internalized, it is only checked that the target budget is **not exceeded**. For example, if the target budget is 1000 Gt CO2 and the SCC is sufficiently high to imply that the carbon budget never exceeds 900 Gt CO2, the run should still converge. 

2. Move the global budget convergence criterion into the `$ifthen.carbonprice %carbonprice% == "functionalForm"` condition. This does not change anything since `%carbonprice% != "functionalForm"` implies `sm_globalBudget_absDev = 0` which implies that the criterion is anyway met. So it is only an aesthetic change to make it easier to understand the code by seeing that this convergence criterion is only relevant for the functionalForm realization.

Requesting review from @fpiontek to check that this interacts with the damage module as intended, from @LaviniaBaumstark for general check, and from @tabeado to check that 2 does not create problems for functionalFormRegi. Thanks!

## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :ballot_box_with_check: GAMS Code
- :white_medium_square: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :ballot_box_with_check: Bug fix
- :white_medium_square: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

* Runs with these changes are here:
* Comparison of results (what changes by this PR?): 
