### PR TITLE
extend historic nuclear bounds into the future, based on historic data from 2025

### DIFF
--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -189,16 +189,33 @@ if(cm_startyear <= 2015,
   vm_cap.up("2015",regi,"tnrs","1") = 1.1 * p_CapFixFromRWfix("2015",regi,"tnrs");
 );
 
+if(cm_startyear <= 2020,
+  p_CapFixFromRWfix("2020",regi,"tnrs") = max( pm_aux_capLowerLimit("tnrs",regi,"2020") , pm_NuclearConstraint("2020",regi,"tnrs") );
+  p_deltaCapFromRWfix("2020",regi,"tnrs") = ( p_CapFixFromRWfix("2020",regi,"tnrs") - pm_aux_capLowerLimit("tnrs",regi,"2020") )
+                                    / 7.5;  !! this parameter is currently only for display and not further used to fix anything
+*** keep nuclear power capacity in +-10% range of historic data for 2020, choose range to allow for some flexibility for the model
+  vm_cap.lo("2020",regi,"tnrs","1") = 0.9 * p_CapFixFromRWfix("2020",regi,"tnrs");
+  vm_cap.up("2020",regi,"tnrs","1") = 1.1 * p_CapFixFromRWfix("2020",regi,"tnrs");
+);
 
-if(cm_startyear <= 2020, !! require the realization of at least 70% of the plants that are currently under construction and thus might be finished until 2020 - should be updated with real-world 2020 numbers
-   vm_deltaCap.lo("2020",regi,"tnrs","1") = 0.70 * pm_NuclearConstraint("2020",regi,"tnrs") / 5;
-   vm_deltaCap.up("2020",regi,"tnrs","1") = pm_NuclearConstraint("2020",regi,"tnrs") / 5;
+if(cm_startyear <= 2025,
+  p_CapFixFromRWfix("2025",regi,"tnrs") = max( pm_aux_capLowerLimit("tnrs",regi,"2025") , pm_NuclearConstraint("2025",regi,"tnrs") );
+  p_deltaCapFromRWfix("2025",regi,"tnrs") = ( p_CapFixFromRWfix("2025",regi,"tnrs") - pm_aux_capLowerLimit("tnrs",regi,"2025") )
+                                    / 7.5;  !! this parameter is currently only for display and not further used to fix anything
+*** keep nuclear power capacity in +-10% range of historic data for 2025, choose range to allow for some flexibility for the model
+  vm_cap.lo("2025",regi,"tnrs","1") = 0.9 * p_CapFixFromRWfix("2025",regi,"tnrs");
+  vm_cap.up("2025",regi,"tnrs","1") = 1.1 * p_CapFixFromRWfix("2025",regi,"tnrs");
 );
-if(cm_startyear <= 2025, !! upper bound calculated in mrremind/R/calcCapacityNuclear.R: 50% of planned and 30% of proposed plants, plus extra for lifetime extension and newcomers
-   vm_deltaCap.up("2025",regi,"tnrs","1") = pm_NuclearConstraint("2025",regi,"tnrs") / 5;
-);
-if(cm_startyear <= 2030, !! upper bound calculated in mrremind/R/calcCapacityNuclear.R: 50% of planned and 70% of proposed plants, plus extra for lifetime extension and newcomers
+
+if(cm_startyear <= 2030, !! require the realization of at least 50% of the max additions until 2030 (estimated at 80% of plants currently under construction) 
+   vm_deltaCap.lo("2030",regi,"tnrs","1") = 0.50 * pm_NuclearConstraint("2030",regi,"tnrs") / 5;
    vm_deltaCap.up("2030",regi,"tnrs","1") = pm_NuclearConstraint("2030",regi,"tnrs") / 5;
+);
+if(cm_startyear <= 2035, !! upper bound calculated in mrremind/R/calcCapacityNuclear.R: 50% of planned and 30% of proposed plants, plus extra for lifetime extension and newcomers
+   vm_deltaCap.up("2035",regi,"tnrs","1") = pm_NuclearConstraint("2035",regi,"tnrs") / 5;
+);
+if(cm_startyear <= 2040, !! upper bound calculated in mrremind/R/calcCapacityNuclear.R: 50% of planned and 70% of proposed plants, plus extra for lifetime extension and newcomers
+   vm_deltaCap.up("2040",regi,"tnrs","1") = pm_NuclearConstraint("2040",regi,"tnrs") / 5;
 );
 
 display p_CapFixFromRWfix, p_deltaCapFromRWfix;

--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -207,7 +207,7 @@ display p_CapFixFromRWfix, p_deltaCapFromRWfix;
 *' switch to prevent new nuclear capacities after 2025, until then all currently planned plants are built
 if(cm_nucscen = 5,
   vm_deltaCap.up(t,regi_nucscen,"tnrs",rlf) $ (t.val > 2025) = 1e-6;
-  vm_cap.lo(t,regi_nucscen,"tnrs",rlf) $ (t.val > 2015) = 0;
+  vm_cap.lo(t,regi_nucscen,"tnrs",rlf) $ (t.val > 2025) = 0;
 );
 
 

--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -181,7 +181,10 @@ vm_deltaCap.fx(t,regi,te,rlf) $ (t.val <= 2025 and pm_data(regi,"tech_stat",te) 
 
 loop(t,
   if( ( t.val > 2010 ) AND ( t.val < 2030 ) AND ( cm_startyear <= t.val ),
-    p_CapFixFromRWfix(t,regi,"tnrs") = max( pm_aux_capLowerLimit("tnrs",regi,t) , pm_NuclearConstraint(t,regi,"tnrs") );
+*' The spin-up capacity from initialcap2 may be larger than historic capacities. For all regions but DEU, we don't want to enforce early retirement, so we calculate the standing capacities 
+*' resulting from 2005 capacities and normal technical depreciation. For DEU, the explicit nuclear phaseout means that capacities are phased down faster than the normal techincal lifetime
+    p_CapFixFromRWfix(t,regi,"tnrs") $ (NOT sameas(regi,"DEU") ) = max( pm_aux_capLowerLimit("tnrs",regi,t) , pm_NuclearConstraint(t,regi,"tnrs") );
+    p_CapFixFromRWfix(t,regi,"tnrs") $ ( sameas(regi,"DEU") ) = pm_NuclearConstraint(t,regi,"tnrs") ;  
     p_deltaCapFromRWfix(t,regi,"tnrs") = ( p_CapFixFromRWfix(t,regi,"tnrs") - pm_aux_capLowerLimit("tnrs",regi,t) )
                                     / 7.5;  !! this parameter is currently only for display and not further used to fix anything
 *** keep nuclear power capacity in +-10% range of historic data, choose range to allow for some flexibility for the model

--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -209,7 +209,7 @@ if(cm_startyear <= 2025,
 
 if(cm_startyear <= 2030, !! require the realization of at least 50% of the max additions until 2030 (estimated at 80% of plants currently under construction) 
    vm_deltaCap.lo("2030",regi,"tnrs","1") = 0.50 * pm_NuclearConstraint("2030",regi,"tnrs") / 5;
-   vm_deltaCap.up("2030",regi,"tnrs","1") = pm_NuclearConstraint("2030",regi,"tnrs") / 5;
+   vm_deltaCap.up("2030",regi,"tnrs","1") = pm_NuclearConstraint("2030",regi,"tnrs") / 5; 
 );
 if(cm_startyear <= 2035, !! upper bound calculated in mrremind/R/calcCapacityNuclear.R: 50% of planned and 30% of proposed plants, plus extra for lifetime extension and newcomers
    vm_deltaCap.up("2035",regi,"tnrs","1") = pm_NuclearConstraint("2035",regi,"tnrs") / 5;
@@ -221,9 +221,9 @@ if(cm_startyear <= 2040, !! upper bound calculated in mrremind/R/calcCapacityNuc
 display p_CapFixFromRWfix, p_deltaCapFromRWfix;
 
 
-*' switch to prevent new nuclear capacities after 2020, until then all currently planned plants are built
+*' switch to prevent new nuclear capacities after 2025, until then all currently planned plants are built
 if(cm_nucscen = 5,
-  vm_deltaCap.up(t,regi_nucscen,"tnrs",rlf) $ (t.val > 2020) = 1e-6;
+  vm_deltaCap.up(t,regi_nucscen,"tnrs",rlf) $ (t.val > 2025) = 1e-6;
   vm_cap.lo(t,regi_nucscen,"tnrs",rlf) $ (t.val > 2015) = 0;
 );
 

--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -178,33 +178,16 @@ vm_deltaCap.fx(t,regi,te,rlf) $ (t.val <= 2025 and pm_data(regi,"tech_stat",te) 
 *** ------------------------------------------------------------------
 *' ##### Capacity for nuclear energy
 *** TODO: data update ------------------------------------------------
-if(cm_startyear <= 2015,
-  p_CapFixFromRWfix("2015",regi,"tnrs") = max( pm_aux_capLowerLimit("tnrs",regi,"2015") , pm_NuclearConstraint("2015",regi,"tnrs") );
-  p_deltaCapFromRWfix("2015",regi,"tnrs") = ( p_CapFixFromRWfix("2015",regi,"tnrs") - pm_aux_capLowerLimit("tnrs",regi,"2015") )
-                                    / 7.5;  !! this parameter is currently only for display and not further used to fix anything
-  p_deltaCapFromRWfix("2010",regi,"tnrs") = ( p_CapFixFromRWfix("2015",regi,"tnrs") - pm_aux_capLowerLimit("tnrs",regi,"2015") )
-                                    / 7.5; !! this parameter is currently only for display and not further used to fix anything
-*** keep nuclear power capacity in +-10% range of historic data for 2015, choose range to allow for some flexibility for the model
-  vm_cap.lo("2015",regi,"tnrs","1") = 0.9 * p_CapFixFromRWfix("2015",regi,"tnrs");
-  vm_cap.up("2015",regi,"tnrs","1") = 1.1 * p_CapFixFromRWfix("2015",regi,"tnrs");
-);
 
-if(cm_startyear <= 2020,
-  p_CapFixFromRWfix("2020",regi,"tnrs") = max( pm_aux_capLowerLimit("tnrs",regi,"2020") , pm_NuclearConstraint("2020",regi,"tnrs") );
-  p_deltaCapFromRWfix("2020",regi,"tnrs") = ( p_CapFixFromRWfix("2020",regi,"tnrs") - pm_aux_capLowerLimit("tnrs",regi,"2020") )
+loop(t,
+  if( ( t.val > 2010 ) AND ( t.val < 2030 ) AND ( cm_startyear <= t.val ),
+    p_CapFixFromRWfix(t,regi,"tnrs") = max( pm_aux_capLowerLimit("tnrs",regi,t) , pm_NuclearConstraint(t,regi,"tnrs") );
+    p_deltaCapFromRWfix(t,regi,"tnrs") = ( p_CapFixFromRWfix(t,regi,"tnrs") - pm_aux_capLowerLimit("tnrs",regi,t) )
                                     / 7.5;  !! this parameter is currently only for display and not further used to fix anything
-*** keep nuclear power capacity in +-10% range of historic data for 2020, choose range to allow for some flexibility for the model
-  vm_cap.lo("2020",regi,"tnrs","1") = 0.9 * p_CapFixFromRWfix("2020",regi,"tnrs");
-  vm_cap.up("2020",regi,"tnrs","1") = 1.1 * p_CapFixFromRWfix("2020",regi,"tnrs");
-);
-
-if(cm_startyear <= 2025,
-  p_CapFixFromRWfix("2025",regi,"tnrs") = max( pm_aux_capLowerLimit("tnrs",regi,"2025") , pm_NuclearConstraint("2025",regi,"tnrs") );
-  p_deltaCapFromRWfix("2025",regi,"tnrs") = ( p_CapFixFromRWfix("2025",regi,"tnrs") - pm_aux_capLowerLimit("tnrs",regi,"2025") )
-                                    / 7.5;  !! this parameter is currently only for display and not further used to fix anything
-*** keep nuclear power capacity in +-10% range of historic data for 2025, choose range to allow for some flexibility for the model
-  vm_cap.lo("2025",regi,"tnrs","1") = 0.9 * p_CapFixFromRWfix("2025",regi,"tnrs");
-  vm_cap.up("2025",regi,"tnrs","1") = 1.1 * p_CapFixFromRWfix("2025",regi,"tnrs");
+*** keep nuclear power capacity in +-10% range of historic data, choose range to allow for some flexibility for the model
+    vm_cap.lo(t,regi,"tnrs","1") = 0.9 * p_CapFixFromRWfix(t,regi,"tnrs");
+    vm_cap.up(t,regi,"tnrs","1") = 1.1 * p_CapFixFromRWfix(t,regi,"tnrs");
+  );
 );
 
 if(cm_startyear <= 2030, !! require the realization of at least 50% of the max additions until 2030 (estimated at 80% of plants currently under construction) 

--- a/modules/40_techpol/NDC/bounds.gms
+++ b/modules/40_techpol/NDC/bounds.gms
@@ -9,8 +9,8 @@
 ***AM the lowbound of solar and pv for 2030 to be taken from the NDCs (in GW), therefore multiplying by 0.001 for TW*
 *** FS: activate capacity tarets only from 2025 on to be better in line with current trends
 vm_cap.lo(t,regi,"spv","1")$(t.val ge 2025) = p40_TechBound(t,regi,"spv")*0.001;
-vm_cap.lo(t,regi,"tnrs","1")$(t.val ge 2025) = p40_TechBound(t,regi,"tnrs")*0.001;
-vm_cap.lo(t,regi_nucscen,"tnrs",rlf)$((t.val ge 2025) and (cm_nucscen eq 5)) = 0; !! we assume: Nucscen (limiting nuclear deployment) overrides NDC targets -> resetting lower bound to value defined at cm_nucscen switch
+vm_cap.lo(t,regi,"tnrs","1")$(t.val ge 2030) = p40_TechBound(t,regi,"tnrs")*0.001; !! for 2025, we now have actual capacity values as bounds, so the techbounds should not overwrite them
+vm_cap.lo(t,regi_nucscen,"tnrs",rlf)$((t.val ge 2030) and (cm_nucscen eq 5)) = 0; !! we assume: Nucscen (limiting nuclear deployment) overrides NDC targets -> resetting lower bound to value defined at cm_nucscen switch
 vm_cap.lo(t,regi,"hydro","1")$(t.val ge 2035) = p40_TechBound(t,regi,"hydro")*0.001;
 vm_cap.lo(t,regi,"windon","1")$(t.val gt 2025) = p40_TechBound(t,regi,"windon")*0.001; 
 vm_cap.lo(t,regi,"windoff","1")$(t.val gt 2025) = p40_TechBound(t,regi,"windoff")*0.001; 

--- a/modules/40_techpol/NDCplus/bounds.gms
+++ b/modules/40_techpol/NDCplus/bounds.gms
@@ -8,8 +8,8 @@
 
 ***AM the lowbound of solar and pv for 2025 and 2030 to be taken from the NDCs (in GW), therefore multiplying by 0.001 for TW*
 vm_cap.lo(t,regi,"spv","1")$(t.val lt 2031 AND t.val gt 2024) = p40_TechBound(t,regi,"spv")*0.001; 
-vm_cap.lo(t,regi,"tnrs","1")$(t.val ge 2025) = p40_TechBound(t,regi,"tnrs")*0.001;
-vm_cap.lo(t,regi_nucscen,"tnrs",rlf)$((t.val ge 2025) and (cm_nucscen eq 5)) = 0; !! we assume: Nucscen (limiting nuclear deployment) overrides NDC targets -> resetting lower bound to value defined at cm_nucscen switch
+vm_cap.lo(t,regi,"tnrs","1")$(t.val ge 2030) = p40_TechBound(t,regi,"tnrs")*0.001; !! for 2025, we now have actual capacity values as bounds, so the techbounds should not overwrite them
+vm_cap.lo(t,regi_nucscen,"tnrs",rlf)$((t.val ge 2030) and (cm_nucscen eq 5)) = 0; !! we assume: Nucscen (limiting nuclear deployment) overrides NDC targets -> resetting lower bound to value defined at cm_nucscen switch
 vm_cap.lo(t,regi,"hydro","1")$(t.val lt 2031 AND t.val gt 2024) = p40_TechBound(t,regi,"hydro")*0.001;
 vm_cap.lo(t,regi,"windon","1")$(t.val gt 2025) = p40_TechBound(t,regi,"windon")*0.001; 
 vm_cap.lo(t,regi,"windoff","1")$(t.val gt 2025) = p40_TechBound(t,regi,"windoff")*0.001; 

--- a/modules/40_techpol/NPi2018/bounds.gms
+++ b/modules/40_techpol/NPi2018/bounds.gms
@@ -9,8 +9,8 @@
 *** AM the lowbound of solar and pv for 2030 to be taken from the NDCs (in GW), therefore multiplying by 0.001 for TW*
 *** NPi bounds are only applied after 2020, as NPi scenarios should always have cm_startyear higher than 2020.
 vm_cap.lo(t,regi,"spv","1")$(t.val gt 2020) = p40_TechBound(t,regi,"spv")*0.001; 
-vm_cap.lo(t,regi,"tnrs","1")$(t.val ge 2025) = p40_TechBound(t,regi,"tnrs")*0.001;
-vm_cap.lo(t,regi_nucscen,"tnrs",rlf)$((t.val ge 2025) and (cm_nucscen eq 5)) = 0; !! we assume: Nucscen (limiting nuclear deployment) overrides NDC targets -> resetting lower bound to value defined at cm_nucscen switch
+vm_cap.lo(t,regi,"tnrs","1")$(t.val ge 2030) = p40_TechBound(t,regi,"tnrs")*0.001; !! for 2025, we now have actual capacity values as bounds, so the techbounds should not overwrite them
+vm_cap.lo(t,regi_nucscen,"tnrs",rlf)$((t.val ge 2030) and (cm_nucscen eq 5)) = 0; !! we assume: Nucscen (limiting nuclear deployment) overrides NDC targets -> resetting lower bound to value defined at cm_nucscen switch
 vm_cap.lo(t,regi,"windon","1")$(t.val gt 2025) = p40_TechBound(t,regi,"windon")*0.001; 
 vm_cap.lo(t,regi,"windoff","1")$(t.val gt 2025) = p40_TechBound(t,regi,"windoff")*0.001; 
 *** Bound only applies from 2030 onward when technologies have historical values in 2025

--- a/modules/40_techpol/NPi2025/bounds.gms
+++ b/modules/40_techpol/NPi2025/bounds.gms
@@ -22,8 +22,8 @@
 *** NPi bounds are only applied after 2020, as NPi scenarios should always have cm_startyear higher than 2020.
 vm_cap.lo(t,regi,"spv","1")$(t.val gt 2025) = p40_TechBound(t,regi,"spv")*0.001;
 vm_cap.lo(t,regi,"csp","1")$(t.val gt 2025) = p40_TechBound(t,regi,"csp")*0.001;   
-vm_cap.lo(t,regi,"tnrs","1")$(t.val ge 2025) = p40_TechBound(t,regi,"tnrs")*0.001;
-vm_cap.lo(t,regi_nucscen,"tnrs",rlf)$((t.val ge 2025) and (cm_nucscen eq 5)) = 0; !! we assume: Nucscen (limiting nuclear deployment) overrides NDC targets -> resetting lower bound to value defined at cm_nucscen switch
+vm_cap.lo(t,regi,"tnrs","1")$(t.val ge 2030) = p40_TechBound(t,regi,"tnrs")*0.001; !! for 2025, we now have actual capacity values as bounds, so the techbounds should not overwrite them
+vm_cap.lo(t,regi_nucscen,"tnrs",rlf)$((t.val ge 2030) and (cm_nucscen eq 5)) = 0; !! we assume: Nucscen (limiting nuclear deployment) overrides NDC targets -> resetting lower bound to value defined at cm_nucscen switch
 vm_cap.lo(t,regi,"hydro","1")$(t.val gt 2025) = p40_TechBound(t,regi,"hydro")*0.001;
 vm_cap.lo(t,regi,"windon","1")$(t.val gt 2025) = p40_TechBound(t,regi,"windon")*0.001; 
 vm_cap.lo(t,regi,"windoff","1")$(t.val gt 2025) = p40_TechBound(t,regi,"windoff")*0.001;

--- a/modules/47_regipol/regiCarbonPrice/bounds.gms
+++ b/modules/47_regipol/regiCarbonPrice/bounds.gms
@@ -202,6 +202,13 @@ $IFTHEN.NucRegiPol not "%cm_NucRegiPol%" == "off"
     vm_cap.lo(t,regi,"tnrs","1")$((t.val ge 2025) and (t.val ge cm_startyear) and (sameas(regi,"DEU"))) = 0;
 *' ESC -> no new Nuclear capacity (Italy had a plebiscite for this and Greece should not have any new capacity)
     vm_deltaCap.up(t,regi,"tnrs","1")$((t.val ge 2020) and (t.val ge cm_startyear) and (sameas(regi,"ESC"))) = 0;
+*' Neither France, ENC, NEN, ECS, ESW or ECE currently plan to early-retire any of their current fleet until 2050
+    vm_capEarlyReti.up(t,regi,"tnrs") $ ( (t.val ge cm_startyear) AND (t.val le 2050) AND (sameas(regi,"FRA")) ) = 0;
+    vm_capEarlyReti.up(t,regi,"tnrs") $ ( (t.val ge cm_startyear) AND (t.val le 2050) AND (sameas(regi,"ENC")) ) = 0;
+    vm_capEarlyReti.up(t,regi,"tnrs") $ ( (t.val ge cm_startyear) AND (t.val le 2050) AND (sameas(regi,"NEN")) ) = 0;
+    vm_capEarlyReti.up(t,regi,"tnrs") $ ( (t.val ge cm_startyear) AND (t.val le 2050) AND (sameas(regi,"ECS")) ) = 0;
+    vm_capEarlyReti.up(t,regi,"tnrs") $ ( (t.val ge cm_startyear) AND (t.val le 2050) AND (sameas(regi,"ESW")) ) = 0;
+    vm_capEarlyReti.up(t,regi,"tnrs") $ ( (t.val ge cm_startyear) AND (t.val le 2050) AND (sameas(regi,"ECE")) ) = 0;
 $ENDIF.NucRegiPol  
 
 *' Extended nuclear policies:

--- a/modules/47_regipol/regiCarbonPrice/bounds.gms
+++ b/modules/47_regipol/regiCarbonPrice/bounds.gms
@@ -203,12 +203,12 @@ $IFTHEN.NucRegiPol not "%cm_NucRegiPol%" == "off"
 *' ESC -> no new Nuclear capacity (Italy had a plebiscite for this and Greece should not have any new capacity)
     vm_deltaCap.up(t,regi,"tnrs","1")$((t.val ge 2020) and (t.val ge cm_startyear) and (sameas(regi,"ESC"))) = 0;
 *' Neither France, ENC, NEN, ECS, ESW or ECE currently plan to early-retire any of their current fleet until 2050
-    vm_capEarlyReti.up(t,regi,"tnrs") $ ( (t.val ge cm_startyear) AND (t.val le 2050) AND (sameas(regi,"FRA")) ) = 0;
-    vm_capEarlyReti.up(t,regi,"tnrs") $ ( (t.val ge cm_startyear) AND (t.val le 2050) AND (sameas(regi,"ENC")) ) = 0;
-    vm_capEarlyReti.up(t,regi,"tnrs") $ ( (t.val ge cm_startyear) AND (t.val le 2050) AND (sameas(regi,"NEN")) ) = 0;
-    vm_capEarlyReti.up(t,regi,"tnrs") $ ( (t.val ge cm_startyear) AND (t.val le 2050) AND (sameas(regi,"ECS")) ) = 0;
-    vm_capEarlyReti.up(t,regi,"tnrs") $ ( (t.val ge cm_startyear) AND (t.val le 2050) AND (sameas(regi,"ESW")) ) = 0;
-    vm_capEarlyReti.up(t,regi,"tnrs") $ ( (t.val ge cm_startyear) AND (t.val le 2050) AND (sameas(regi,"ECE")) ) = 0;
+    vm_capEarlyReti.up(t,regi,"tnrs") $ ( (t.val ge cm_startyear) AND (t.val le 2050) AND (sameas(regi,"FRA")) ) = 1e-3;
+    vm_capEarlyReti.up(t,regi,"tnrs") $ ( (t.val ge cm_startyear) AND (t.val le 2050) AND (sameas(regi,"ENC")) ) = 1e-3;
+    vm_capEarlyReti.up(t,regi,"tnrs") $ ( (t.val ge cm_startyear) AND (t.val le 2050) AND (sameas(regi,"NEN")) ) = 1e-3;
+    vm_capEarlyReti.up(t,regi,"tnrs") $ ( (t.val ge cm_startyear) AND (t.val le 2050) AND (sameas(regi,"ECS")) ) = 1e-3;
+    vm_capEarlyReti.up(t,regi,"tnrs") $ ( (t.val ge cm_startyear) AND (t.val le 2050) AND (sameas(regi,"ESW")) ) = 1e-3;
+    vm_capEarlyReti.up(t,regi,"tnrs") $ ( (t.val ge cm_startyear) AND (t.val le 2050) AND (sameas(regi,"ECE")) ) = 1e-3;
 $ENDIF.NucRegiPol  
 
 *' Extended nuclear policies:

--- a/modules/47_regipol/regiCarbonPrice/bounds.gms
+++ b/modules/47_regipol/regiCarbonPrice/bounds.gms
@@ -199,7 +199,7 @@ vm_cap.up("2020",regi,"pc","1")$((cm_startyear le 2020) and (sameas(regi,"UKI"))
 $IFTHEN.NucRegiPol not "%cm_NucRegiPol%" == "off" 
 *' Germany Nuclear phase-out
     vm_cap.up(t,regi,"tnrs","1")$((t.val ge 2025) and (t.val ge cm_startyear) and (sameas(regi,"DEU"))) = 1E-6;
-    vm_cap.lo(t,regi,"tnrs","1")$((t.val ge 2025) and (t.val ge cm_startyear) and (sameas(regi,"DEU"))) = 1E-6;
+    vm_cap.lo(t,regi,"tnrs","1")$((t.val ge 2025) and (t.val ge cm_startyear) and (sameas(regi,"DEU"))) = 0;
 *' ESC -> no new Nuclear capacity (Italy had a plebiscite for this and Greece should not have any new capacity)
     vm_deltaCap.up(t,regi,"tnrs","1")$((t.val ge 2020) and (t.val ge cm_startyear) and (sameas(regi,"ESC"))) = 0;
 $ENDIF.NucRegiPol  

--- a/modules/47_regipol/regiCarbonPrice/bounds.gms
+++ b/modules/47_regipol/regiCarbonPrice/bounds.gms
@@ -199,6 +199,7 @@ vm_cap.up("2020",regi,"pc","1")$((cm_startyear le 2020) and (sameas(regi,"UKI"))
 $IFTHEN.NucRegiPol not "%cm_NucRegiPol%" == "off" 
 *' Germany Nuclear phase-out
     vm_cap.up(t,regi,"tnrs","1")$((t.val ge 2025) and (t.val ge cm_startyear) and (sameas(regi,"DEU"))) = 1E-6;
+    vm_cap.lo(t,regi,"tnrs","1")$((t.val ge 2025) and (t.val ge cm_startyear) and (sameas(regi,"DEU"))) = 1E-6;
 *' ESC -> no new Nuclear capacity (Italy had a plebiscite for this and Greece should not have any new capacity)
     vm_deltaCap.up(t,regi,"tnrs","1")$((t.val ge 2020) and (t.val ge cm_startyear) and (sameas(regi,"ESC"))) = 0;
 $ENDIF.NucRegiPol  
@@ -207,13 +208,13 @@ $ENDIF.NucRegiPol
 $IFTHEN.proNucRegiPol not "%cm_proNucRegiPol%" == "off" 
 *' Pro nuclear countries tend to keep nuclear production by political decision
 *' assuming France would keep at least 80% of its 2015 nuclear capacity in the future.
-vm_cap.lo(t,regi,"tnrs","1")$((t.val ge cm_startyear) and (sameas(regi,"FRA"))) = 0.8*pm_histCap("2015",regi,"tnrs");
+vm_cap.lo(t,regi,"tnrs","1")$((t.val ge cm_startyear) AND (t.val ge 2030) AND (sameas(regi,"FRA"))) = 0.8*pm_histCap("2015",regi,"tnrs");
 *' Assuming Czech Republic would keep at least its 2015 nuclear capacity in the future (CZE corresponds to 61.8% of nuclear capacity of ECE in 2015)
-vm_cap.lo(t,regi,"tnrs","1")$((t.val ge cm_startyear) and (sameas(regi,"ECE"))) = 0.618*pm_histCap("2015",regi,"tnrs");
+vm_cap.lo(t,regi,"tnrs","1")$((t.val ge cm_startyear) AND (t.val ge 2030) AND (sameas(regi,"ECE"))) = 0.618*pm_histCap("2015",regi,"tnrs");
 *' Assuming Finland would keep at least its 2015 nuclear capacity in the future (FIN corresponds to 21.6% of nuclear capacity of ENC in 2015)
-vm_cap.lo(t,regi,"tnrs","1")$((t.val ge cm_startyear) and (sameas(regi,"ENC"))) = 0.216*pm_histCap("2015",regi,"tnrs");
+vm_cap.lo(t,regi,"tnrs","1")$((t.val ge cm_startyear) AND (t.val ge 2030) AND (sameas(regi,"ENC"))) = 0.216*pm_histCap("2015",regi,"tnrs");
 *' Assuming Romania would keep at least its 2015 nuclear capacity in the future (ROU corresponds to 22.1% of nuclear capacity of ECS in 2015)
-vm_cap.lo(t,regi,"tnrs","1")$((t.val ge cm_startyear) and (sameas(regi,"ECS"))) = 0.221*pm_histCap("2015",regi,"tnrs");
+vm_cap.lo(t,regi,"tnrs","1")$((t.val ge cm_startyear) AND (t.val ge 2030) AND (sameas(regi,"ECS"))) = 0.221*pm_histCap("2015",regi,"tnrs");
 $ENDIF.proNucRegiPol 
 
 *' This accounts for different CCS policies that can be chosen for the EU subregions.


### PR DESCRIPTION
## Purpose of this PR

With the new nuclear input data from https://github.com/pik-piam/mrremind/pull/786 , we can now extend the bounds on nuclear capacity

This also required shifting the nuclear techbounds back to only be effective from 2030 onwards - targets shouldn't trump actual values for 2025. 

I then noticed that `cm_nucscen = 5` (no new nuclear capacity additions) still started in 2025, so I also shifted that to 2030 - when we want to make such a "no nuclear" run, it shouldn't change 2025 values by default. 

also, the German nuclear phaseout did not include an overwrite of the 2025 lower capacity bound, so I added that. 

## Type of change

### Parts concerned
- :ballot_box_with_check: GAMS Code
- :white_medium_square: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :ballot_box_with_check: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :white_medium_square: Bug fix
- :white_medium_square: Refactoring
- :white_medium_square: New feature
- :ballot_box_with_check: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

* Runs with these changes are here: `/p/projects/remind/users/robertp/savePR/2026-03_extendNuclearCapacityBounds/new2`
* Comparison of results (what changes by this PR?): 
Nuclear capacities now better follow the historical trend. 
In EUR, they are not anymore phased out as fast as previously (FRA, ESW, ENC):
<img width="1244" height="876" alt="image" src="https://github.com/user-attachments/assets/538fd6fb-a146-40ef-9f33-5c8f34129804" />

<img width="1478" height="887" alt="image" src="https://github.com/user-attachments/assets/5059cc3f-743e-4d8f-853c-f9cf6e6e3cb4" />

