### PR TITLE
Update cs2 profiles, renaming -short into -to2050

### DIFF
--- a/scripts/cs2/profiles.json
+++ b/scripts/cs2/profiles.json
@@ -12,26 +12,33 @@
 	"H12": {
 		"projectLibrary": "'remind2'",
 		"reg": "c('CAZ', 'CHA', 'EUR', 'IND', 'JPN', 'LAM', 'MEA', 'NEU', 'OAS', 'REF', 'SSA', 'USA', 'World')",
-		"yearsHist": "c(seq(1990, 2024, 1), seq(2025, 2050, 5))"
+		"yearsHist": "union(seq(1990, format(Sys.Date(), '%Y'), 1), seq(2030, 2050, 5))"
 	},
-	"H12-short": {
+	"H12-to2050": {
 		"projectLibrary": "'remind2'",
 		"reg": "c('CAZ', 'CHA', 'EUR', 'IND', 'JPN', 'LAM', 'MEA', 'NEU', 'OAS', 'REF', 'SSA', 'USA', 'World')",
 		"yearsScen": "seq(2005, 2050, 5)",
-		"yearsHist": "c(seq(2000, 2024, 1), seq(2025, 2050, 5))",
-		"yearsBarPlot": "c(2020, 2030, 2040, 2050)"
+		"yearsHist": "union(seq(2005, format(Sys.Date(), '%Y'), 1), seq(2030, 2050, 5))",
+		"yearsBarPlot": "c(2025, 2030, 2040, 2050)"
+	},
+	"H12-to2060": {
+		"projectLibrary": "'remind2'",
+		"reg": "c('CAZ', 'CHA', 'EUR', 'IND', 'JPN', 'LAM', 'MEA', 'NEU', 'OAS', 'REF', 'SSA', 'USA', 'World')",
+		"yearsScen": "seq(2005, 2060, 5)",
+		"yearsHist": "union(seq(2005, format(Sys.Date(), '%Y'), 1), seq(2030, 2060, 5))",
+		"yearsBarPlot": "c(2025, 2030, 2040, 2060)"
 	},
 	"IndiaH12": {
 		"projectLibrary": "'remind2'",
 		"reg": "c('CAZ', 'CHA', 'EUR', 'IND', 'JPN', 'LAM', 'MEA', 'NEU', 'OAS', 'REF', 'SSA', 'USA', 'World')",
-		"yearsHist": "c(seq(1990, 2024, 1), seq(2025, 2050, 5))",
+		"yearsHist": "union(seq(1990, format(Sys.Date(), '%Y'), 1), seq(2030, 2050, 5))",
 		"mainReg": "'IND'"
 	},
-	"IndiaH12-short": {
+	"IndiaH12-to2050": {
 		"projectLibrary": "'remind2'",
 		"reg": "c('CAZ', 'CHA', 'EUR', 'IND', 'JPN', 'LAM', 'MEA', 'NEU', 'OAS', 'REF', 'SSA', 'USA', 'World')",
 		"yearsScen": "seq(2005, 2050, 5)",
-		"yearsHist": "c(seq(2000, 2024, 1), seq(2025, 2050, 5))",
+		"yearsHist": "union(seq(2005, format(Sys.Date(), '%Y'), 1), seq(2030, 2050, 5))",
 		"yearsBarPlot": "c(2020, 2030, 2040, 2050)",
 		"mainReg": "'IND'"
 	},
@@ -39,13 +46,13 @@
 		"projectLibrary": "'remind2'",
 		"reg": "c('DEU', 'ECE', 'ECS', 'ENC', 'ESC', 'ESW', 'EU27', 'EWN', 'FRA')",
 		"mainReg": "'EU27'",
-		"yearsHist": "c(seq(1990, 2024, 1), seq(2025, 2050, 5))"
+		"yearsHist": "union(seq(1990, format(Sys.Date(), '%Y'), 1), seq(2030, 2050, 5))"
 	},
-	"EU27-short": {
+	"EU27-to2050": {
 		"projectLibrary": "'remind2'",
 		"reg": "c('DEU', 'ECE', 'ECS', 'ENC', 'ESC', 'ESW', 'EU27', 'EWN', 'FRA')",
 		"yearsScen": "seq(2005, 2050, 5)",
-		"yearsHist": "c(seq(2000, 2024, 1), seq(2025, 2050, 5))",
+		"yearsHist": "union(seq(2005, format(Sys.Date(), '%Y'), 1), seq(2030, 2050, 5))",
 		"yearsBarPlot": "c(2020, 2030, 2040, 2050)",
 		"mainReg": "'EU27'"
 	},
@@ -53,13 +60,13 @@
 		"projectLibrary": "'remind2'",
 		"reg": "c('DEU', 'ECE', 'ECS', 'ENC', 'ESC', 'ESW', 'EU27', 'EWN', 'FRA', 'UKI', 'NES', 'NEN', 'EUR')",
 		"mainReg": "'EUR'",
-		"yearsHist": "c(seq(1990, 2024, 1), seq(2025, 2050, 5))"
+		"yearsHist": "union(seq(1990, format(Sys.Date(), '%Y'), 1), seq(2030, 2050, 5))"
 	},
-	"EUR-short": {
+	"EUR-to2050": {
 		"projectLibrary": "'remind2'",
 		"reg": "c('DEU', 'ECE', 'ECS', 'ENC', 'ESC', 'ESW', 'EU27', 'EWN', 'FRA', 'UKI', 'NES', 'NEN', 'EUR')",
 		"yearsScen": "seq(2005, 2050, 5)",
-		"yearsHist": "c(seq(2000, 2024, 1), seq(2025, 2050, 5))",
+		"yearsHist": "union(seq(2005, format(Sys.Date(), '%Y'), 1), seq(2030, 2050, 5))",
 		"yearsBarPlot": "c(2020, 2030, 2040, 2050)",
 		"mainReg": "'EUR'"
 	},
@@ -67,7 +74,7 @@
 		"projectLibrary": "'remind2'",
 		"reg": "c('DEU', 'ECE', 'ECS', 'ENC', 'ESC', 'ESW', 'EU27', 'EWN', 'FRA')",
 		"yearsScen": "seq(2005, 2050, 5)",
-		"yearsHist": "c(seq(2000, 2024, 1), seq(2025, 2050, 5))",
+		"yearsHist": "union(seq(2005, format(Sys.Date(), '%Y'), 1), seq(2030, 2050, 5))",
 		"yearsBarPlot": "c(2020, 2030, 2045)",
 		"modelsHistExclude": "c('IEA ETP B2DS', 'IEA ETP 2DS', 'IEA ETP RTS', 'EDGE_SSP1', 'EDGE_SSP2', 'CEDS', 'IRENA', 'IEA WEO 2021 APS', 'IEA WEO 2021 SDS', 'IEA WEO 2021 SPS')",
 		"mainReg": "'DEU'"
@@ -77,17 +84,17 @@
 		"sections": "c(0,1,99)"
 	},
 	"REMIND-MAgPIE": {
-  	"projectLibrary": "'remind2'",
-		"userSectionPath":  "c(normalizePath('./scripts/cs2/magpie.Rmd'), normalizePath('./scripts/cs2/planetaryboundaries.Rmd'))"
+		"projectLibrary": "'remind2'",
+		"userSectionPath": "c(normalizePath('./scripts/cs2/magpie.Rmd'), normalizePath('./scripts/cs2/planetaryboundaries.Rmd'))"
 	},
 	"MAgPIE": {
 		"sections": "0",
 		"userSectionPath": "normalizePath('./scripts/cs2/magpie.Rmd')"
 	},
-  "MAGICC7_AR6": {
-    "sections": "0",
-    "userSectionPath": "normalizePath('./scripts/cs2/MAGICC7_AR6.Rmd')"
-  },
+	"MAGICC7_AR6": {
+		"sections": "0",
+		"userSectionPath": "normalizePath('./scripts/cs2/MAGICC7_AR6.Rmd')"
+	},
 	"EDGE-Transport": {
 		"projectLibrary": "'reporttransport'",
 		"reg": "c('OAS', 'MEA', 'SSA', 'LAM', 'REF', 'CAZ', 'CHA', 'IND', 'JPN', 'USA', 'NEU', 'EUR', 'World')",
@@ -96,12 +103,12 @@
 	},
 	"AirPollutantsREMIND": {
 		"sections": "0",
-		"yearsHist": "c(seq(1990, 2024, 1), seq(2025, 2050, 5))",
+		"yearsHist": "union(seq(1990, format(Sys.Date(), '%Y'), 1), seq(2030, 2050, 5))",
 		"userSectionPath": "normalizePath('./scripts/cs2/AirPollutantsREMIND.Rmd')"
 	},
 	"AirPollutantsREMIND-MAgPIE": {
 		"sections": "0",
-		"yearsHist": "c(seq(1990, 2024, 1), seq(2025, 2050, 5))",
+		"yearsHist": "union(seq(1990, format(Sys.Date(), '%Y'), 1), seq(2030, 2050, 5))",
 		"userSectionPath": "normalizePath('./scripts/cs2/AirPollutantsREMIND-MAgPIE.Rmd')"
 	},
 	"PlanetaryBoundaries": {


### PR DESCRIPTION
## Purpose of this PR
Aesthetics changes in compareScenarios profiles:
* Rename all `*-short` profiles to `*-to2050`
* Add profile `H12-to2060`: I use it for fossil phase-out, other people may need it for net-zero targets etc
* `yearsHist` now goes until current year (2026 atm) in yearly steps, then 5-yearly. Maybe this could happen in piamPlotComparison instead.

## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :white_medium_square: GAMS Code
- :white_medium_square: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :ballot_box_with_check: Other (please give a description)

### Impact
- :white_medium_square: Bug fix
- :ballot_box_with_check: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :ballot_box_with_check: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)
