### PR TITLE
Remove unused set fe_tax_sub36

### DIFF
--- a/modules/36_buildings/simple/sets.gms
+++ b/modules/36_buildings/simple/sets.gms
@@ -63,16 +63,6 @@ Sets
     feels . (feelcb,feelhpb,feelrhb)
   /
   
-  fe_tax_sub36(all_in,all_in)  "correspondence between tax and subsidy input data resolution and model sectoral resolution"
-  /
-    fesob . fesob
-    fehob . fehob
-    fegab . fegab
-    feh2b . feh2b
-    feheb . feheb
-    feelb . (feelcb,feelhpb,feelrhb)
-  /
-  
   ue_dyn36(all_in)  "useful energy items"
   //
 
@@ -99,7 +89,6 @@ in(in_buildings_dyn36)               = YES;
 ppfEn(ppfen_buildings_dyn36)         = YES;
 cesOut2cesIn(ces_buildings_dyn36)    = YES;
 fe2ppfEn(fe2ppfEn36)                 = YES;
-fe_tax_sub_sbi(fe_tax_sub36)         = YES;
 ppfen_CESMkup(ppfen_buildings_dyn36) = YES;
 
 *** EOF ./modules/36_buildings/simple/sets.gms


### PR DESCRIPTION
## Purpose of this PR

Remove the set `fe_tax_sub36` from the buildings module as it is no longer used: All entries in this set are written to `fe_tax_sub_sbi`. But this set is only called with `fe_tax_sub_sbi("fehos", <input>)` whereas `fe_tax_sub36` contains no elements with "fehos" as the first entry.

Moreover, no other set elements are ever added to `fe_tax_sub_sbi`, meaning that `fe_tax_sub_sbi("fehos", <input>)` is empty. This issue should be addressed separately by cleaning up the `11_aerosols` module, where `fe_tax_sub_sbi` is called, and will not directly be addressed in this PR. @laurinks @gunnar-pik 

## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :ballot_box_with_check: GAMS Code
- :white_medium_square: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :white_medium_square: Bug fix
- :ballot_box_with_check: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

* Runs with these changes are here: `/p/tmp/ricardar/remind/remind/output/SSP2-NPi2025_2026-05-04_14.03.20/`
* Comparison of results (what changes by this PR?): This PR shouldn't change anything. Comparison with most recent AMT (`/p/tmp/ricardar/remind/remind/compScen-checkRemoveSet-2026-05-11_17.06.57-H12.pdf`) shows that indeed there are barely any changes; I would assume that the few changes that exist are due to one of the few PRs that have been merged between my test run and the most recent AMTs.
