### PR TITLE
change coalftrec bound in SSP1 - follow-up to PR 2343

### DIFF
--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -451,10 +451,8 @@ vm_cap.lo(t,regi,"gash2",rlf) $ (t.val > 2030) = 0;
 *** strong reliance on coal-to-liquids is not consistent with SSP1 storyline, therefore limit their use in the SSP1 and SSP2 policy scenarios
 $ifthen %c_SSP_forcing_adjust% == "forcing_SSP1"
 *** ensure that no new capacity is built after 2005 / in the active model time (t only starts in cm_startyear)
-  vm_deltaCap.up(t,regi,"coalftrec","1")  $ (t.val > 2005) = 1e-7; 
-  vm_deltaCap.up(t,regi,"coalftcrec","1")  $ (t.val > 2005) = 1e-7; 
-*** and enforce the fastest possible phase-out in each region, starting in the larger of (cm_startyear, 2030), because most regions are fixed to zero earlyReti in 2030 
-  vm_capEarlyReti.lo(t,regi,"coalftrec") $ ( (t.val = 2030 + (1 / pm_regiEarlyRetiRate("2050",regi,"coalftrec") ) ) ) = 1 ;
+  vm_deltaCap.up(t,regi,"coalftrec","1")  $ (t.val > 2005) = 1e-6; 
+  vm_deltaCap.up(t,regi,"coalftcrec","1")  $ (t.val > 2005) = 1e-6; 
 
 *** fixing prodFE in 2005 to the value contained in pm_cesdata("2005",regi,in,"quantity"). This is done to ensure that the energy system will reproduce the 2005 calibration values.
 *** Fixing will produce clearly attributable errors (good for debugging) when using inconsistent data, as the GAMS accuracy when comparing fixed results is very high (< 1e-8).

--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -453,6 +453,8 @@ $ifthen %c_SSP_forcing_adjust% == "forcing_SSP1"
 *** ensure that no new capacity is built after 2005 / in the active model time (t only starts in cm_startyear)
   vm_deltaCap.up(t,regi,"coalftrec","1")  $ (t.val > 2005) = 1e-6; 
   vm_deltaCap.up(t,regi,"coalftcrec","1")  $ (t.val > 2005) = 1e-6; 
+  vm_cap.lo(t,regi,"coalftrec","1")  $ (t.val > 2005) = 0; !! also relax the lower bound on vm_cap to prevent infeasibilities when vm_capEarlyReti is already close to 1
+  vm_cap.lo(t,regi,"coalftcrec","1")  $ (t.val > 2005) = 0; !! also relax the lower bound on vm_cap to prevent infeasibilities when vm_capEarlyReti is already close to 1
 
 *** fixing prodFE in 2005 to the value contained in pm_cesdata("2005",regi,in,"quantity"). This is done to ensure that the energy system will reproduce the 2005 calibration values.
 *** Fixing will produce clearly attributable errors (good for debugging) when using inconsistent data, as the GAMS accuracy when comparing fixed results is very high (< 1e-8).
@@ -464,7 +466,8 @@ $endif
 $ifthen %c_SSP_forcing_adjust% == "forcing_SSP2"
 if(cm_emiscen > 1,
 *** as above: limit new additions after 2005 / in the active model time (t only starts in cm_startyear)
-  vm_deltaCap.up(t,regi,"coalftcrec","1")  $ ( (t.val > 2005) AND (t.val >= cm_startyear) ) = 1e-7; 
+  vm_deltaCap.up(t,regi,"coalftcrec","1")  $ (t.val > 2005)  = 1e-7; 
+  vm_cap.lo(t,regi,"coalftcrec","1")  $ (t.val > 2005) = 0; !! also relax the lower bound on vm_cap to prevent infeasibilities when vm_capEarlyReti is already close to 1
 );
 $endif
 


### PR DESCRIPTION
## Purpose of this PR

I merged the previous PR [2343](https://github.com/remindmodel/remind/pull/2343) too quickly - while make test passed correctly, there indeed was a problem left in SSP1. This PR removes the forced phase-out in SSP1, simply requiring that no new capacity is added. With a lifetime of 35 years, coalftrec use should still go down in SSP1. 

## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :ballot_box_with_check: GAMS Code
- :white_medium_square: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :ballot_box_with_check: Bug fix
- :white_medium_square: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

* Runs with these changes are here: /p/projects/remind/users/robertp/savePR/2026-05_coalftrecBound/new2withTNRS
* Comparison of results (what changes by this PR?): 
