### PR TITLE
bugfix path dependency outputdir

### DIFF
--- a/scripts/output/single/reporting.R
+++ b/scripts/output/single/reporting.R
@@ -10,6 +10,7 @@ library(quitte)
 library(piamutils)
 library(lucode2)
 library(dplyr)
+library(data.table)
 
 ############################# BASIC CONFIGURATION #############################
 

--- a/scripts/output/single/reporting.R
+++ b/scripts/output/single/reporting.R
@@ -65,7 +65,7 @@ if (!file.exists(edgetOutputDir)) {
 }
 
 message("### start generation of EDGE-T reporting")
-reporttransport::checkConvergence()
+reporttransport::checkConvergence(outputdir)
 EDGEToutput <- reporttransport::reportEdgeTransport(edgetOutputDir,
                                                      isTransportExtendedReported = FALSE,
                                                      modelName = "REMIND",
@@ -89,7 +89,8 @@ quitte::write.mif(EDGEToutput, remind_reporting_file, append = TRUE)
 piamutils::deletePlus(remind_reporting_file, writemif = TRUE)
 
 # generate transport extended mif
-EDGEToutputPriorHarmonization <-reporttransport::reportEdgeTransport(edgetOutputDir,
+EDGEToutputPriorHarmonization <- reporttransport::reportEdgeTransport(edgetOutputDir,
+                                                                     isREMINDinputReported = TRUE,
                                      isTransportExtendedReported = TRUE,
                                      gdxPath = file.path(outputdir, "fulldata.gdx"),
                                      isStored = TRUE)
@@ -97,7 +98,7 @@ EDGEToutputPriorHarmonization <-reporttransport::reportEdgeTransport(edgetOutput
 #Add ratio of "FE|Transport" (with bunkers) EDGE-T to REMIND before harmonization to the REMIND.mif as an indicator
 FEratioEDGE <- EDGEToutputPriorHarmonization[variable == "FE|Transport with bunkers"][, c("variable", "model", "scenario") := NULL]
 setnames(FEratioEDGE, "value", "EDGEfe")
-mifs <- list.files(".", recursive = FALSE, full.names = TRUE)
+mifs <- list.files(outputdir, recursive = FALSE, full.names = TRUE)
 mif <- mifs[grepl(".*withoutPlus\\.mif", mifs)]
 #Select matching variables
 REMINDvars <- as.data.table(read.quitte(mif))


### PR DESCRIPTION
## Purpose of this PR
This PR is a bugfix for the missing outputdir path dependency in [PR2320](https://github.com/remindmodel/remind/pull/2320). This PR is connected to the [respective PR](https://github.com/pik-piam/reporttransport/pull/47) in reporttransport 
*Please explain your PR here.*
Add outputdir path dependency
## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :white_medium_square: GAMS Code
- :ballot_box_with_check: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :ballot_box_with_check: Bug fix
- :white_medium_square: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x ] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

* Runs with these changes are here: 
* Comparison of results (what changes by this PR?): 
