### PR TITLE
Start debug runs also when ALL regions are INFES

### DIFF
--- a/modules/80_optimization/nash/postsolve.gms
+++ b/modules/80_optimization/nash/postsolve.gms
@@ -779,15 +779,10 @@ if (cm_abortOnConsecFail gt 0,
   );
 
   if (smax(regi, p80_trackConsecFail(regi)) >= cm_abortOnConsecFail,
-    if ((s80_runInDebug eq 0) AND (cm_nash_mode ne 1), !! auto-start debug only if not already in debug mode
-      if (sum(regi, pm_SolNonInfes(regi) ne 0) eq 0, !! if all regions are infeasible debug makes no sense
-        execute_unload "abort.gdx";
-        abort "Run was aborted because the maximum number of consecutive failures was reached in at least one region! No debug started since all regions are infeasible.";
-      else !! start debug mode only if at leat one region was feasible
+    if ( (s80_runInDebug eq 0) AND (cm_nash_mode ne 1), !! auto-start debug only if not already in debug mode
         s80_runInDebug = 1;
         cm_nash_mode = 1;
         display "Starting nash in debug mode after maximum number of consecutive failures was reached in at least one region.";
-      );
     else !! s80_runInDebug eq 1 AND/OR cm_nash_mode eq 1
       execute_unload "abort.gdx";
       abort "After debug mode run was aborted because the maximum number of consecutive failures was still reached in at least one region!";


### PR DESCRIPTION
## Purpose of this PR

Until now, debug runs were only started when not all regions were infeasible. This is now changed, so that a debug run also starts if all regions are infeasible, as also in that situation it is helpful to have the additional information from a serial debug run.

## Type of change

### Parts concerned
- :ballot_box_with_check: GAMS Code
- :white_medium_square: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :white_medium_square: Bug fix
- :white_medium_square: Refactoring
- :ballot_box_with_check: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :ballot_box_with_check: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

* Runs with these changes are here:
* Comparison of results (what changes by this PR?): Nothing - only more information when runs go infeasible.
