### PR TITLE
update carbon price correction rules

### DIFF
--- a/modules/47_regipol/regiCarbonPrice/declarations.gms
+++ b/modules/47_regipol/regiCarbonPrice/declarations.gms
@@ -60,7 +60,7 @@ $endif.emiMktTargetType
   p47_slopeReferenceIteration_iter(iteration,ttot,ext_regi)    "auxiliary parameter to store reference iteration used for calculating slope of current mititgation cost [#]"
   pm_factorRescaleemiMktCO2Tax(ttot,ttot2,ext_regi,emiMktExt) "multiplicative tax rescale factor that rescales emiMkt carbon price from iteration to iteration to reach regipol targets [%]"
   p47_factorRescaleemiMktCO2Tax_iter(iteration,ttot,ttot2,ext_regi,emiMktExt) "parameter to save rescale factor across iterations for debugging purposes [%]"
-  p47_clampedRescaleSlope_iter(iteration,ttot,ttot2,ext_regi,emiMktExt) "auxiliary parameter to save the slope value before clamping. Useful for debugging purposes [#]"
+  p47_factorRescaleemiMktCO2TaxPreclamp_iter(iteration,ttot,ttot2,ext_regi,emiMktExt)   "auxiliary parameter to save the rescale factor before clamping over iterations. Useful for debugging purposes []"
   p47_dampedFactorRescaleemiMktCO2Tax_iter(iteration,ttot,ttot2,ext_regi,emiMktExt) "auxiliary parameter to save the rescale factor value before dampening. Useful for debugging purposes [#]"
 
 *** Parameters necessary to define the CO2 tax curve shape   

--- a/modules/47_regipol/regiCarbonPrice/postsolve.gms
+++ b/modules/47_regipol/regiCarbonPrice/postsolve.gms
@@ -339,10 +339,10 @@ loop(ext_regi$regiEmiMktTarget(ext_regi),
                 );
               );
 
-***           clamp tax rescale refactor to [0.3 .. 3] to avoid extreme changes (or no change) on a single iteration (avoid corner cases where other parts of the model changes causing undesirable fluctuations on the calculated slope)
-              if(  ( pm_factorRescaleemiMktCO2Tax(ttot,ttot2,ext_regi,emiMktExt) gt 3 ) OR ( pm_factorRescaleemiMktCO2Tax(ttot,ttot2,ext_regi,emiMktExt) lt 0.33 ) ,
+***           clamp tax rescale refactor to [0.5 .. 2] to avoid extreme changes (or no change) on a single iteration (avoid corner cases where other parts of the model changes causing undesirable fluctuations on the calculated slope)
+              if(  ( pm_factorRescaleemiMktCO2Tax(ttot,ttot2,ext_regi,emiMktExt) gt 2 ) OR ( pm_factorRescaleemiMktCO2Tax(ttot,ttot2,ext_regi,emiMktExt) lt 0.5 ) ,
                 p47_factorRescaleemiMktCO2TaxPreclamp_iter(ttot,ttot2,ext_regi,emiMktExt) = pm_factorRescaleemiMktCO2Tax(ttot,ttot2,ext_regi,emiMktExt); 
-                pm_factorRescaleemiMktCO2Tax(ttot,ttot2,ext_regi,emiMktExt) = min(3, max( 0.33, pm_factorRescaleemiMktCO2Tax(ttot,ttot2,ext_regi,emiMktExt) ) );  
+                pm_factorRescaleemiMktCO2Tax(ttot,ttot2,ext_regi,emiMktExt) = min(2, max( 0.5, pm_factorRescaleemiMktCO2Tax(ttot,ttot2,ext_regi,emiMktExt) ) );  
               );
             ); 
 ***         dampen if rescale oscillates

--- a/modules/47_regipol/regiCarbonPrice/postsolve.gms
+++ b/modules/47_regipol/regiCarbonPrice/postsolve.gms
@@ -329,10 +329,10 @@ loop(ext_regi$regiEmiMktTarget(ext_regi),
 ***               if we are still using the slope
                   if(NOT(regiEmiMktRescaleType(iteration,ttot,ttot2,ext_regi,emiMktExt,"squareDev_noNonPositiveSlope")),
 ***                 clamp slopes values to avoid extreme changes (or no change) on a single iteration (avoid corner cases where other parts of the model changes causing undesirable fluctuations on the calculated slope)
-                    if((p47_factorRescaleSlope(ttot,ttot2,ext_regi,emiMktExt) gt -0.3) OR (p47_factorRescaleSlope(ttot,ttot2,ext_regi,emiMktExt) lt -5),
+                    if((p47_factorRescaleSlope(ttot,ttot2,ext_regi,emiMktExt) gt -0.3) OR (p47_factorRescaleSlope(ttot,ttot2,ext_regi,emiMktExt) lt 5),
                       p47_clampedRescaleSlope_iter(iteration,ttot,ttot2,ext_regi,emiMktExt) = p47_factorRescaleSlope(ttot,ttot2,ext_regi,emiMktExt);
                     );
-                    p47_factorRescaleSlope(ttot,ttot2,ext_regi,emiMktExt) = max(-5,min(-0.3, p47_factorRescaleSlope(ttot,ttot2,ext_regi,emiMktExt)));               
+                    p47_factorRescaleSlope(ttot,ttot2,ext_regi,emiMktExt) = min(5,max(-0.3, p47_factorRescaleSlope(ttot,ttot2,ext_regi,emiMktExt)));               
 ***                 calculate the tax rescale factor using the above calculated slope
                     pm_factorRescaleemiMktCO2Tax(ttot,ttot2,ext_regi,emiMktExt) = 
                       (

--- a/modules/47_regipol/regiCarbonPrice/postsolve.gms
+++ b/modules/47_regipol/regiCarbonPrice/postsolve.gms
@@ -328,11 +328,6 @@ loop(ext_regi$regiEmiMktTarget(ext_regi),
                   );
 ***               if we are still using the slope
                   if(NOT(regiEmiMktRescaleType(iteration,ttot,ttot2,ext_regi,emiMktExt,"squareDev_noNonPositiveSlope")),
-***                 clamp slopes values to avoid extreme changes (or no change) on a single iteration (avoid corner cases where other parts of the model changes causing undesirable fluctuations on the calculated slope)
-                    if((p47_factorRescaleSlope(ttot,ttot2,ext_regi,emiMktExt) gt -0.3) OR (p47_factorRescaleSlope(ttot,ttot2,ext_regi,emiMktExt) lt 5),
-                      p47_clampedRescaleSlope_iter(iteration,ttot,ttot2,ext_regi,emiMktExt) = p47_factorRescaleSlope(ttot,ttot2,ext_regi,emiMktExt);
-                    );
-                    p47_factorRescaleSlope(ttot,ttot2,ext_regi,emiMktExt) = min(5,max(-0.3, p47_factorRescaleSlope(ttot,ttot2,ext_regi,emiMktExt)));               
 ***                 calculate the tax rescale factor using the above calculated slope
                     pm_factorRescaleemiMktCO2Tax(ttot,ttot2,ext_regi,emiMktExt) = 
                       (
@@ -343,7 +338,13 @@ loop(ext_regi$regiEmiMktTarget(ext_regi),
                   );
                 );
               );
-            );
+
+***           clamp tax rescale refactor to [0.3 .. 3] to avoid extreme changes (or no change) on a single iteration (avoid corner cases where other parts of the model changes causing undesirable fluctuations on the calculated slope)
+              if(  ( pm_factorRescaleemiMktCO2Tax(ttot,ttot2,ext_regi,emiMktExt) gt 3 ) OR ( pm_factorRescaleemiMktCO2Tax(ttot,ttot2,ext_regi,emiMktExt) lt 0.33 ) ,
+                p47_factorRescaleemiMktCO2TaxPreclamp_iter(ttot,ttot2,ext_regi,emiMktExt) = pm_factorRescaleemiMktCO2Tax(ttot,ttot2,ext_regi,emiMktExt); 
+                pm_factorRescaleemiMktCO2Tax(ttot,ttot2,ext_regi,emiMktExt) = min(3, max( 0.33, pm_factorRescaleemiMktCO2Tax(ttot,ttot2,ext_regi,emiMktExt) ) );  
+              );
+            ); 
 ***         dampen if rescale oscillates
             if( (iteration.val > 3) , 
               if ( ( 


### PR DESCRIPTION
## Purpose of this PR

The previous carbon price adjustment in module 47 had some algorithmic issues that made it likely it stuck to a (slow) corner solution.

## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :ballot_box_with_check: GAMS Code
- :white_medium_square: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :ballot_box_with_check: Bug fix
- :white_medium_square: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

* Runs with these changes are here:
* Comparison of results (what changes by this PR?): 
