### PR TITLE
Shift reference iteration for carbon price adjustment, and relax bounds on slope

### DIFF
--- a/modules/47_regipol/regiCarbonPrice/postsolve.gms
+++ b/modules/47_regipol/regiCarbonPrice/postsolve.gms
@@ -251,6 +251,8 @@ loop((ext_regi,ttot)$regiANDperiodEmiMktTarget_47(ttot,ext_regi),
     p47_slopeReferenceIteration_iter(iteration,ttot,ext_regi) = 1;
   elseif(NOT(p47_currentConvergence_iter(iteration,ttot,ext_regi) eq p47_currentConvergence_iter(iteration-1,ttot,ext_regi))), !! reset the iteration reference for slope calculation if the target that is being analyzed changes
     p47_slopeReferenceIteration_iter(iteration,ttot,ext_regi) = ord(iteration);
+  elseif ( iteration.val - p47_slopeReferenceIteration_iter(iteration-1,ttot,ext_regi) > 5 ) !! make sure the reference point is updated regularly, so the comparison point is not stuck in some very different past.
+    p47_slopeReferenceIteration_iter(iteration,ttot,ext_regi) = iteration.val - 5 ;
   else
     p47_slopeReferenceIteration_iter(iteration,ttot,ext_regi) = p47_slopeReferenceIteration_iter(iteration-1,ttot,ext_regi);
   );
@@ -329,10 +331,10 @@ loop(ext_regi$regiEmiMktTarget(ext_regi),
 ***               if we are still using the slope
                   if(NOT(regiEmiMktRescaleType(iteration,ttot,ttot2,ext_regi,emiMktExt,"squareDev_noNonPositiveSlope")),
 ***                 clamp slopes values to avoid extreme changes (or no change) on a single iteration (avoid corner cases where other parts of the model changes causing undesirable fluctuations on the calculated slope)
-                    if((p47_factorRescaleSlope(ttot,ttot2,ext_regi,emiMktExt) gt -0.3) OR (p47_factorRescaleSlope(ttot,ttot2,ext_regi,emiMktExt) lt -5),
+                    if((p47_factorRescaleSlope(ttot,ttot2,ext_regi,emiMktExt) gt -0.05) OR (p47_factorRescaleSlope(ttot,ttot2,ext_regi,emiMktExt) lt -5),
                       p47_clampedRescaleSlope_iter(iteration,ttot,ttot2,ext_regi,emiMktExt) = p47_factorRescaleSlope(ttot,ttot2,ext_regi,emiMktExt);
                     );
-                    p47_factorRescaleSlope(ttot,ttot2,ext_regi,emiMktExt) = max(-5,min(-0.3, p47_factorRescaleSlope(ttot,ttot2,ext_regi,emiMktExt)));               
+                    p47_factorRescaleSlope(ttot,ttot2,ext_regi,emiMktExt) = max(-5,min(-0.05, p47_factorRescaleSlope(ttot,ttot2,ext_regi,emiMktExt)));               
 ***                 calculate the tax rescale factor using the above calculated slope
                     pm_factorRescaleemiMktCO2Tax(ttot,ttot2,ext_regi,emiMktExt) = 
                       (

--- a/modules/47_regipol/regiCarbonPrice/postsolve.gms
+++ b/modules/47_regipol/regiCarbonPrice/postsolve.gms
@@ -251,8 +251,8 @@ loop((ext_regi,ttot)$regiANDperiodEmiMktTarget_47(ttot,ext_regi),
     p47_slopeReferenceIteration_iter(iteration,ttot,ext_regi) = 1;
   elseif(NOT(p47_currentConvergence_iter(iteration,ttot,ext_regi) eq p47_currentConvergence_iter(iteration-1,ttot,ext_regi))), !! reset the iteration reference for slope calculation if the target that is being analyzed changes
     p47_slopeReferenceIteration_iter(iteration,ttot,ext_regi) = ord(iteration);
-  elseif ( iteration.val - p47_slopeReferenceIteration_iter(iteration-1,ttot,ext_regi) > 5 ) !! make sure the reference point is updated regularly, so the comparison point is not stuck in some very different past.
-    p47_slopeReferenceIteration_iter(iteration,ttot,ext_regi) = iteration.val - 5 ;
+  elseif ( iteration.val - p47_slopeReferenceIteration_iter(iteration-1,ttot,ext_regi) > 8 ) !! make sure the reference point is updated regularly, so the comparison point is not stuck in some very different past.
+    p47_slopeReferenceIteration_iter(iteration,ttot,ext_regi) = iteration.val - 8 ;
   else
     p47_slopeReferenceIteration_iter(iteration,ttot,ext_regi) = p47_slopeReferenceIteration_iter(iteration-1,ttot,ext_regi);
   );


### PR DESCRIPTION
## Purpose of this PR

Try to accelerate convergance of regional carbon prices in module 47

## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :ballot_box_with_check: GAMS Code
- :white_medium_square: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :white_medium_square: Bug fix
- :white_medium_square: Refactoring
- :ballot_box_with_check: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

* Runs with these changes are here:
* Comparison of results (what changes by this PR?): 
