### PR TITLE
Dynamically calculate calibration_resuts path

### DIFF
--- a/scripts/utils/set-local-calibration.sh
+++ b/scripts/utils/set-local-calibration.sh
@@ -24,10 +24,7 @@ cp ../scripts/utils/set-local-calibration/pre-commit .git/hooks
 cp ../scripts/utils/set-local-calibration/post-commit .git/hooks
 chmod u+x .git/hooks/pre-commit .git/hooks/post-commit
 
-# create additional .Rprofile (sourced through default .Rprofile)
-echo -e "options(remind_repos = c(\n" \
-	"    getOption(\"remind_repos\"),\n" \
-	"    stats::setNames(list(x = NULL), \"$PWD\")))" \
-	> .Rprofile_calibration_results
+# add additional .Rprofile (sourced through default .Rprofile)
+cp ../scripts/utils/set-local-calibration/.Rprofile_calibration_results ./
 
 cd "$OLDPWD"

--- a/scripts/utils/set-local-calibration/.Rprofile_calibration_results
+++ b/scripts/utils/set-local-calibration/.Rprofile_calibration_results
@@ -1,0 +1,4 @@
+options(remind_repos = c(
+     getOption("remind_repos"),
+     stats::setNames(list(x = NULL),
+                     dirname(normalizePath(parent.frame(2)[['ofile']])))))


### PR DESCRIPTION
Change `calibration_results/.Rprofile_calibration_results` to use the current directory the file is located in for the `remind_repos` option to allow for moving project directories after the `calibration_results` directory has been set up.
See https://mattermost.pik-potsdam.de/rd3/pl/iiionod59bdquxpj6io7z87bur