### PR TITLE
Introduce climate impacts for buildings thermal end-use demands

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,6 +13,7 @@ Depends:
     R (>= 4.0.0)
 Imports:
     callr,
+    climbed (>= 1.2.0),
     colorspace,
     crayon,
     data.table,
@@ -54,6 +55,7 @@ Imports:
     piamPlotComparison (>= 0.0.10),
     piamutils,
     plotly,
+    pracma,
     purrr,
     quitte (>= 0.3149.0),
     R.utils,

--- a/core/declarations.gms
+++ b/core/declarations.gms
@@ -302,6 +302,7 @@ p_prodAllReference(ttot,all_regi,all_te)             "Sum of the above in the re
 *** CES calibration tarjectories industry and buildings
 pm_fedemandInd(tall,all_regi,all_in)                    "read-in parameter for final energy and production trajectories used for the CES parameter calibration in industry [EJ, ue_primary_steel, ue_secondary_steel: Gt, ue_otherInd: $tn]"
 pm_fedemandBuild(tall,all_regi,all_in)                  "read-in parameter for final energy and production trajectories used for the CES parameter calibration in buildings [EJ]"
+pm_climateCorrection(ttot,all_regi,all_in) "climate correction factors for building energy demand [unitless]"
 
 *** parameters for setting final energy shares
 pm_shfe_up(ttot,all_regi,all_enty,emi_sectors)       "Final energy shares exogenous upper bounds per sector [share]"

--- a/core/sets.gms
+++ b/core/sets.gms
@@ -80,7 +80,7 @@ all_SSP_forcing_adjust  "all possible forcing targets and budgets according to S
 /
 
 all_rcp_scen   "all possible RCP scenarios"
-/none,rcp20,rcp26,rcp37,rcp45,rcp60,rcp85/
+/none,rcp19,rcp20,rcp26,rcp37,rcp45,rcp60,rcp70,rcp85/
 
 all_delayPolicy   "all possible SPA policy choices"
 /

--- a/main.gms
+++ b/main.gms
@@ -1910,6 +1910,13 @@ $setGlobal cm_reducCostB  none  !! def = none
 *** cfg$gms$cm_effHP         <- 5 #def <- 5 , efficiency of heat pumps
 $setGlobal cm_effHP  5  !! def = 5
 
+*** cm_climateCorrection "enable or disable climate correction for buildings energy demand"
+*** def = "off", climate correction is disabled and pm_climateCorrection is set to 1.0 for all iterations
+*** (on): climate correction is enabled and correction factors are calculated iteratively using
+***        external R scripts (climateAssessmentInterimRun.R and calculateClimateCorrection.R)
+***        to adjust building energy demand based on climate conditions
+$setGlobal cm_climateCorrection  off  !! def = off
+
 *** Note on CES markup cost:
 *** They represent the sector-specific demand-side transformation cost, can also
 *** be used to influence efficiencies during calibration as higher markup-cost

--- a/modules/36_buildings/simple/equations.gms
+++ b/modules/36_buildings/simple/equations.gms
@@ -18,8 +18,9 @@ q36_demFeBuild(ttot,regi,entyFe,emiMkt)$(ttot.val ge cm_startyear
   =e=
   sum(in$(fe2ppfEn(entyFe,in)
           AND ppfen_buildings_dyn36(in)),
-      vm_cesIO(ttot,regi,in) * pm_climateCorrection(ttot,regi,in)
-      + pm_cesdata(ttot,regi,in,"offset_quantity") 
+      vm_cesIO(ttot,regi,in)
+      + (pm_climateCorrection(ttot,regi,in) - 1) * vm_cesIO.l(ttot,regi,in)
+      + pm_cesdata(ttot,regi,in,"offset_quantity")
   )$(sameas(emiMkt,"ES"))
 ;
 

--- a/modules/36_buildings/simple/equations.gms
+++ b/modules/36_buildings/simple/equations.gms
@@ -18,7 +18,7 @@ q36_demFeBuild(ttot,regi,entyFe,emiMkt)$(ttot.val ge cm_startyear
   =e=
   sum(in$(fe2ppfEn(entyFe,in)
           AND ppfen_buildings_dyn36(in)),
-      vm_cesIO(ttot,regi,in)
+      vm_cesIO(ttot,regi,in) * pm_climateCorrection(ttot,regi,in)
       + pm_cesdata(ttot,regi,in,"offset_quantity") 
   )$(sameas(emiMkt,"ES"))
 ;

--- a/modules/36_buildings/simple/postsolve.gms
+++ b/modules/36_buildings/simple/postsolve.gms
@@ -7,8 +7,28 @@
 *** SOF ./modules/36_buildings/simple/postsolve.gms
 
 *** calculation of FE Buildings Prices (useful for internal use and reporting purposes)
-pm_FEPrice(ttot,regi,entyFe,"build",emiMkt)$(abs(qm_budget.m(ttot,regi)) gt sm_eps) = 
+pm_FEPrice(ttot,regi,entyFe,"build",emiMkt)$(abs(qm_budget.m(ttot,regi)) gt sm_eps) =
   q36_demFeBuild.m(ttot,regi,entyFe,emiMkt)
   / qm_budget.m(ttot,regi);
+
+*** Climate correction handling
+*** Only run climate assessment from iteration 2 onwards to ensure all postsolve calculations are complete
+*** (reportEmiForClimateAssessment requires industry variables calculated in module 37)
+$ifthen.climateCorr not "%cm_climateCorrection%" == "off"
+if(iteration.val gt 1,
+
+Execute_Unload 'fulldata_postsolve';
+
+*** Execute climate assessment script
+Execute "Rscript climateAssessmentInterimRun.R";
+
+*** Call R script to calculate climate correction factors
+Execute "Rscript calculateClimateCorrection.R";
+
+*** Load climate correction factors
+execute_load "pm_ClimateCorrection.gdx", pm_climateCorrection;
+
+);
+$endif.climateCorr
 
 *** EOF ./modules/36_buildings/simple/postsolve.gms

--- a/modules/36_buildings/simple/presolve.gms
+++ b/modules/36_buildings/simple/presolve.gms
@@ -1,0 +1,6 @@
+*** Initialize climate correction factors to 1.0
+*** - Always if climate correction is off
+*** - In first iteration if climate correction is on
+if(iteration.val eq 1 OR sameas("%cm_climateCorrection%","off"),
+  pm_climateCorrection(ttot,all_regi,ppfen_buildings_dyn36) = 1.0;
+);

--- a/modules/36_buildings/simple/realization.gms
+++ b/modules/36_buildings/simple/realization.gms
@@ -27,6 +27,7 @@ $Ifi "%phase%" == "declarations" $include "./modules/36_buildings/simple/declara
 $Ifi "%phase%" == "datainput" $include "./modules/36_buildings/simple/datainput.gms"
 $Ifi "%phase%" == "equations" $include "./modules/36_buildings/simple/equations.gms"
 $Ifi "%phase%" == "bounds" $include "./modules/36_buildings/simple/bounds.gms"
+$Ifi "%phase%" == "presolve" $include "./modules/36_buildings/simple/presolve.gms"
 $Ifi "%phase%" == "postsolve" $include "./modules/36_buildings/simple/postsolve.gms"
 *######################## R SECTION END (PHASES) ###############################
 *** EOF ./modules/36_buildings/simple/realization.gms

--- a/scripts/input/calculateClimateCorrection.R
+++ b/scripts/input/calculateClimateCorrection.R
@@ -1,0 +1,12 @@
+# |  (C) 2006-2024 Potsdam Institute for Climate Impact Research (PIK)
+# |  authors, and contributors see CITATION.cff file. This file is part
+# |  of REMIND and licensed under AGPL-3.0-or-later. Under Section 7 of
+# |  AGPL-3.0, you are granted additional permissions described in the
+# |  REMIND License Exception, version 1.0 (see LICENSE file).
+# |  Contact: remind@pik-potsdam.de
+
+# Load the local climbed package for development
+devtools::load_all("/p/tmp/hagento/dev/climbed")
+
+# Calculate climate correction factors
+climbed::computeClimateCorrection()

--- a/scripts/input/climateAssessmentInterimRun.R
+++ b/scripts/input/climateAssessmentInterimRun.R
@@ -111,7 +111,8 @@ runTimes <- c(runTimes, "write_gdx start" = Sys.time())
 # Map climate assessment variables to REMIND/GAMS
 varmap <- c(
   'Surface Air Temperature Change'            = 'pm_globalMeanTemperature',
-  'Effective Radiative Forcing|Anthropogenic' = 'p15_forc_magicc'
+  'Effective Radiative Forcing|Anthropogenic' = 'p15_forc_magicc',
+  'Atmospheric Concentrations|CO2'            = 'p15_co2_conc'
 )
 
 # Postprocess by renaming IAMC-style `period` (year) column to REMIND compatible `tall` set & using this as sole index 


### PR DESCRIPTION
## Purpose of this PR

This PR introduces endogenous climate impacts to the thermal end-uses of the buildings sector.  When enabled, building energy demands now dynamically adjust based on the model's own GHG emissions and resulting atmospheric CO2 concentrations.

<img width="724" height="510" alt="Bildschirmfoto 2026-06-09 um 15 09 59" src="https://github.com/user-attachments/assets/27130de9-d703-48e9-8b4b-55f8c0b6b101" />

## Feature Overview

Currently, final energy demands for space heating and cooling do not react to altered climatic conditions caused by REMIND's GHG emissions. This PR introduces a climate correction mechanism that can be activated with `cm_climateCorrection = on` (default: `off`).

## How It Works

After every iteration (except the first):

1. **Climate assessment**: A `fulldata_postsolve.gdx` is dumped and `scripts/input/climateAssessmentInterimRun.R` calculates atmospheric CO2 concentrations (`Atmospheric Concentrations|CO2`) based on REMIND's current emissions, saved as `p15_co2_conc` in `p15_climate.gdx`

2. **Correction computation**: Upon successful completion, `climbed::computeClimateCorrection()` ([climbed PR #9](https://github.com/pik-piam/climbed/pull/9)) is executed:
   - Compares current CO2 concentrations to RCP-based reference trajectories to determine relative interpolation weights per time step
   - Interpolates FE demands from existing RCP baselines (from `f_fedemandBuild`, generated using climate data based on RCP reference concentrations)
   - Calculates ratios between interpolated demands and the no-climate-change scenario (calibration baseline with `cm_rcp_scen = none`)
   - Saves correction factors to `pm_climateCorrection.gdx`

3. **Application**: The correction factors from `pm_climateCorrection` are applied to `vm_cesIO` for variables in the set `ppfen_buildings_dyn36`

## Requirements

- Buildings input data `f_fedemandBuild` must contain multiple scenarios in `all_rcp_scen` for every `scenario` to enable interpolation across different RCPs
- A corresponding feature was introduced in `edgebuildings` to expand default scenarios to a range of RCP scenarios

## Type of change

### Parts concerned
- :ballot_box_with_check: GAMS Code
- :ballot_box_with_check: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :white_medium_square: Bug fix
- :white_medium_square: Refactoring
- :ballot_box_with_check: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [ ] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [ ] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [ ] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [ ] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I explained my changes within the PR, particularly in hard-to-understand areas
- [ ] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

* Runs with these changes are here: 
 - no correction: `/p/tmp/hagento/dev/REMIND/climateCorrection/remind/output/SSP2-NPi2025_2026-06-09_09.23.33`
 - with correction: `/p/tmp/hagento/dev/REMIND/climateCorrection/remind/output/SSP2-NPi2025-climCorr_2026-06-09_09.22.13`
* Comparison of results (what changes by this PR?): `/p/tmp/hagento/dev/REMIND/climateCorrection/remind/compScen-climateCorrection-2026-06-09_13.41.26-H12.pdf`

Additional information will follow. 



