### PR TITLE
remove EUR from industry biosolids bounds

### DIFF
--- a/modules/37_industry/subsectors/bounds.gms
+++ b/modules/37_industry/subsectors/bounds.gms
@@ -156,6 +156,7 @@ vm_demFeSector_afterTax.lo(t,regi,entySe,"fesos","indst",emiMkt)$(NOT sameAs(emi
 
 !! Limit biosolids in industry to 0.3 of all solids used in industry (only for ETS - all sectors except otherInd)
 !! Solids biomass has limited substitution potential in both the steel and cement sector.
-v37_shSolidsIndst.fx(t,regi) = 0.3 ;
+!! Temporary: EUR excluded until cement and chemicals emissions are fixed 
+v37_shSolidsIndst.fx(t,regi)$(not regi_group("EUR_regi",regi)) = 0.3 ;
 
 *** EOF ./modules/37_industry/subsectors/bounds.gms


### PR DESCRIPTION
## Purpose of this PR

The new industry biosolids bounds were leading to increased EUR industry emissions in 2020-2030, due to some inconsistencies in the chemicals and cement sectors emissions. This will be fixed in the coming months, at which point we can remove this temporary fix. 

## Type of change

### Parts concerned
- :ballot_box_with_check: GAMS Code
- :white_medium_square: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :ballot_box_with_check: Bug fix
- :white_medium_square: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

### Runs with these changes are here:
`/p/tmp/claraba/remind/output/SSP2-NPi2025_2026-06-26_08.16.15`
compScen: `/p/tmp/claraba/remind/compScen-IndstFix_removeEURbound-2026-06-26_11.08.37-EUR.pdf`
### Comparison of results (what changes by this PR?): 
- withFix scenario is from a previous PR: https://github.com/remindmodel/remind/pull/2380
- removeEURbound is the previous PR + this PR combined
Both aim to adress this issue: https://github.com/remindmodel/development_issues/issues/770

#### Industry CO2 emisions:
<img width="786" height="1161" alt="image" src="https://github.com/user-attachments/assets/6c482d6e-1955-4544-bedc-ba385ce42a1b" />
