### PR TITLE
Allow scenario aliases in compareScenarios2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **30_biomass** Quick-fix for `cm_maxProdBiolc`: allocate up to 25 EJ/yr of the global lignocellulosic biomass potential to regions by hardcoded 2020 crop-production shares (remainder still via marginal-cost inversion); scales down if the budget is smaller and works for both the H12 and EU21 region resolutions
     [[#2390](https://github.com/remindmodel/remind/pull/2390)]
 - **scripts** Add the possibility to give aliases to runs in the compareScenarios2 script
+    [[#2399](https://github.com/remindmodel/remind/pull/2399)]
 
 ### removed
 -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### added
 - **30_biomass** Quick-fix for `cm_maxProdBiolc`: allocate up to 25 EJ/yr of the global lignocellulosic biomass potential to regions by hardcoded 2020 crop-production shares (remainder still via marginal-cost inversion); scales down if the budget is smaller and works for both the H12 and EU21 region resolutions
     [[#2390](https://github.com/remindmodel/remind/pull/2390)]
+- **scripts** Add the possibility to give aliases to runs in the compareScenarios2 script
 
 ### removed
 -

--- a/output.R
+++ b/output.R
@@ -139,25 +139,12 @@ choose_filename_prefix <- function(modules, title = "") {
   return(filename_prefix)
 }
 
-mutateDuplicates <- function(strings, duplicate_vector) {
-  # adds suffixes to all strings marked as duplicates by the duplicate_vector
-  stopifnot(length(strings) == length(duplicate_vector))
-  counter <- 1
-  for (i in seq_along(strings)) {
-    if(duplicate_vector[i]) {
-      strings[i] <- paste0(strings[i], "-dup-", counter)
-      counter <- counter + 1
-    }
-  }
-  return(strings)
-}
-
 promptForAliases <- function(outputdirs, scenarios) {
-  message("\nDuplicate scenario titles detected, suggested aliases to be used in the output (e.g. PDF files):")
+  message("\nSuggested names to be used in the output (e.g. PDF files):")
   for (i in seq_along(outputdirs)) {
     message(sprintf("  [%d] %s -> \"%s\"", i, basename(outputdirs[i]), scenarios[i]))
   }
-  message("\nIf you want to change these, please choose unique aliases.")
+  message("\nIf you want to change these, please choose unique names")
   message("Names separated by , or leave empty to accept suggestions:")
   aliases_str <- gms::getLine()
   aliases_list <- trimws(unlist(strsplit(aliases_str, ",")))
@@ -238,16 +225,17 @@ if (! exists("outputdir")) {
 
 # aliases are names for scenarios (=outputdirs) that are prompted when the scenarios have duplicate names
 # currently only compareScenarios2 uses aliases, feel free to implement it for your comparison script
-if (! exists("aliases")) {
+modules_supporting_aliases <- c("compareScenarios2")
+if (!exists("aliases") && any(modules_supporting_aliases %in% output)) {
   scenarios <- unname(lucode2::getScenNames(outputdirs))
-  duplicate <- duplicated(scenarios)
-  aliases <- mutateDuplicates(scenarios, duplicate)
-  # For better scripting, only prompt for aliases if output dirs were selected manually
-  if (!exists("outputdir") || any(duplicate)) {
+  aliases <- make.unique(scenarios)
+  # For better scripting backwards compatibility, don't prompt for aliases if output dirs were selected with command line parameters
+  if (!exists("outputdir")) {
     aliases = promptForAliases(outputdirs, aliases)
   }
-} else {
-   stopifnot("Number of aliases and outputdirs must be equal" = length(aliases) == length(outputdirs))
+}
+if (exists("aliases")) {
+  stopifnot("Number of aliases and outputdirs must be equal" = length(aliases) == length(outputdirs))
 }
 
 if (comp %in% c("comparison", "export")) {

--- a/output.R
+++ b/output.R
@@ -38,7 +38,7 @@ helpText <- "
 #'                        comp=comparison means scripts to compare runs
 #'                        (e.g. compareScenarios2, ...)
 #'                        comp=export means scripts to export runs
-#'                        (e..g xlsx_IIASA, ...)
+#'                        (e.g. xlsx_IIASA, ...)
 #'
 #'   --filename_prefix=   string to be added to filenames by some output scripts
 #'                        (compareScenarios, xlsx_IIASA)
@@ -49,6 +49,10 @@ helpText <- "
 #'   --outputdir=         Directly specify the output directories, bypassing run
 #'                        selection, as a comma-separated list
 #'                        (e.g. outputdir=./output/SSP2-Base-rem-1,./output/NDC-rem-1)
+#'
+#'   --aliases=           Specify aliases for the runs given in outputdir,
+#'                        as a comma-separated list
+#'                        (e.g. aliases=default,modified)
 #'
 #'   --remind_dir=        path to remind or output directories where runs can be
 #'                        found.  Defaults to ./output but can also be used to
@@ -94,7 +98,7 @@ flags <- NULL
 if (!exists("source_include")) {
   # if this script is not being sourced by another script but called from the command line via Rscript read the command
   # line arguments and let the user choose the slurm options
-  flags <- readArgs("outputdir", "output", "comp", "remind_dir", "slurmConfig", "filename_prefix",
+  flags <- readArgs("outputdir", "output", "aliases", "comp", "remind_dir", "slurmConfig", "filename_prefix",
                     .flags = c(t = "--test", h = "--help"))
 }
 
@@ -134,6 +138,42 @@ choose_filename_prefix <- function(modules, title = "") {
   }
   return(filename_prefix)
 }
+
+mutateDuplicates <- function(strings, duplicate_vector) {
+  # adds suffixes to all strings marked as duplicates by the duplicate_vector
+  stopifnot(length(strings) == length(duplicate_vector))
+  counter <- 1
+  for (i in seq_along(strings)) {
+    if(duplicate_vector[i]) {
+      strings[i] <- paste0(strings[i], "-dup-", counter)
+      counter <- counter + 1
+    }
+  }
+  return(strings)
+}
+
+promptForAliases <- function(outputdirs, scenarios) {
+  message("\nDuplicate scenario titles detected, suggested aliases to be used in the output (e.g. PDF files):")
+  for (i in seq_along(outputdirs)) {
+    message(sprintf("  [%d] %s -> \"%s\"", i, basename(outputdirs[i]), scenarios[i]))
+  }
+  message("\nIf you want to change these, please choose unique aliases.")
+  message("Names separated by , or leave empty to accept suggestions:")
+  aliases_str <- gms::getLine()
+  aliases_list <- trimws(unlist(strsplit(aliases_str, ",")))
+
+  if (length(scenarios) > length(aliases_list)) {
+    warning("Not enough aliases supplied. Only renaming first scenarios.")
+  }
+  for (i in seq_along(aliases_list)) {
+    if (i > length(scenarios)) {
+      stop("Too many aliases supplied")
+    }
+    scenarios[i] <- aliases_list[i]
+  }
+  return(scenarios)
+}
+
 
 if (exists("source_include")) {
   comp <- "single"
@@ -194,6 +234,20 @@ if (! exists("outputdir")) {
   }
 } else {
   outputdirs <- outputdir
+}
+
+# aliases are names for scenarios (=outputdirs) that are prompted when the scenarios have duplicate names
+# currently only compareScenarios2 uses aliases, feel free to implement it for your comparison script
+if (! exists("aliases")) {
+  scenarios <- unname(lucode2::getScenNames(outputdirs))
+  duplicate <- duplicated(scenarios)
+  aliases <- mutateDuplicates(scenarios, duplicate)
+  # For better scripting, only prompt for aliases if output dirs were selected manually
+  if (!exists("outputdir") || any(duplicate)) {
+    aliases = promptForAliases(outputdirs, aliases)
+  }
+} else {
+   stopifnot("Number of aliases and outputdirs must be equal" = length(aliases) == length(outputdirs))
 }
 
 if (comp %in% c("comparison", "export")) {

--- a/scripts/cs2/run_compareScenarios2.R
+++ b/scripts/cs2/run_compareScenarios2.R
@@ -8,13 +8,14 @@
 library(piamPlotComparison)
 
 if (!exists("source_include")) {
-  lucode2::readArgs("outputDirs", "outFileName", "profileName")
+  lucode2::readArgs("outputDirs", "outFileName", "profileName", "aliases")
 }
 
 run_compareScenarios2 <- function(
   outputDirs,
   outFileName,
-  profileName
+  profileName,
+  aliases=NULL
 ) {
 
   stopifnot(length(profileName) == 1 && is.character(profileName) && !is.na(profileName))
@@ -50,7 +51,8 @@ run_compareScenarios2 <- function(
     cfgScen = scenConfigPath,
     outputDir = outDir,
     outputFile = outFileName,
-    outputFormat = "pdf"
+    outputFormat = "pdf",
+    mifScenNames = aliases
   )
 
   # Load cs2 profile and change args.
@@ -92,4 +94,4 @@ run_compareScenarios2 <- function(
   message("Done!\n")
 }
 
-run_compareScenarios2(outputDirs, outFileName, profileName)
+run_compareScenarios2(outputDirs, outFileName, profileName, aliases)

--- a/scripts/output/comparison/compareScenarios2.R
+++ b/scripts/output/comparison/compareScenarios2.R
@@ -40,7 +40,8 @@ determineDefaultProfiles <- function(outputDir) {
 startComp <- function(
   outputDirs,
   nameCore,
-  profileName
+  profileName,
+  aliases=NULL
 ) {
   if (!exists("slurmConfig")) {
     slurmConfig <- "--qos=standby"
@@ -66,6 +67,7 @@ startComp <- function(
       " outputDirs=", paste(outputDirs, collapse = ","),
       " profileName=", profileName,
       " outFileName=", outFileName,
+      " aliases=", paste(aliases, collapse = ","),
       "\"")
     cat(clcom, "\n")
     system(clcom)
@@ -115,5 +117,6 @@ for (profileName in profileNames) {
   startComp(
     outputDirs = outputdirs,
     nameCore = nameCore,
-    profileName = profileName)
+    profileName = profileName,
+    aliases = aliases)
 }


### PR DESCRIPTION
## Purpose of this PR

If compareScenarios2 is started with runs that are based on the same scenario (e.g. default), they will have almost the same name in the resulting pdf (default.1, default.2), which makes comparing difficult. Now users are prompted for aliases if there are identical scenario names. For scripting backwards compatibility this only happens if the runs are selected manually. piamPlotComparison already offers a corresponding feature so no change is necessary there.

Other comparison modules may also make use of these aliases, but I have neither implemented not tested them, because I don't know which modules are still in use.

Please give lots of feedback, also about R conventions and functions, I'm learning it at the moment.

## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :white_medium_square: GAMS Code
- :ballot_box_with_check: R-scripts
- :ballot_box_with_check: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :white_medium_square: Bug fix
- :white_medium_square: Refactoring
- :ballot_box_with_check: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)
