### PR TITLE
Check documentation-only PRs differently

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,7 +27,7 @@
 ## Checklist
 
 *Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
-In the end all checkboxes must be ticked before you can merge*.
+In the end all checkboxes must be ticked before you can merge*. (You may skip this list if only .md files are changed.)
 
 - [ ] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
 - [ ] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**

--- a/.github/workflows/check-pr-description-code.yaml
+++ b/.github/workflows/check-pr-description-code.yaml
@@ -1,0 +1,34 @@
+on:
+  pull_request:
+    types: [opened, reopened, edited, ready_for_review]
+    branches-ignore:
+      - 'master'
+    paths-ignore:
+      - '**.md'
+
+name: check-pr-checklist
+
+jobs:
+  check-pr-checklist:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR Checklist
+        env:
+          PR_DESCRIPTION: ${{ github.event.pull_request.body }}
+        run: |
+          ERROR_FOUND=0
+          
+          # Check 1: All checkboxes in "Checklist" must be checked
+          CHECKLIST_SECTION=$(echo "$PR_DESCRIPTION" | sed -n '/## Checklist/,/## Further information (optional)/p')
+          if echo "$CHECKLIST_SECTION" | grep -q "\[ \]"; then
+            echo "ERROR: Unchecked checkboxes found in 'Checklist' section."
+            echo "All checklist items must be checked before merging."
+            ERROR_FOUND=1
+          fi
+          
+          if [ $ERROR_FOUND -eq 1 ]; then
+            exit 1
+          fi
+          
+          echo "Success: All PR template requirements are fulfilled."

--- a/.github/workflows/check-pr-description.yaml
+++ b/.github/workflows/check-pr-description.yaml
@@ -3,13 +3,17 @@ on:
     types: [opened, reopened, edited, ready_for_review]
     branches-ignore:
       - 'master'
+    paths-ignore:
+      - '**.md'
+
+name: check-pr-description
 
 jobs:
-  check-pr-template:
+  check-pr-code-tasks:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-      - name: Check PR description
+      - name: Check PR Description
         env:
           PR_DESCRIPTION: ${{ github.event.pull_request.body }}
         run: |
@@ -28,14 +32,6 @@ jobs:
           if ! echo "$IMPACT_SECTION" | grep -q ":ballot_box_with_check:"; then
             echo "ERROR: No items selected in 'Impact' section."
             echo "Please select at least one item by replacing :white_medium_square: with :ballot_box_with_check:"
-            ERROR_FOUND=1
-          fi
-          
-          # Check 3: All checkboxes in "Checklist" must be checked
-          CHECKLIST_SECTION=$(echo "$PR_DESCRIPTION" | sed -n '/## Checklist/,/## Further information (optional)/p')
-          if echo "$CHECKLIST_SECTION" | grep -q "\[ \]"; then
-            echo "ERROR: Unchecked checkboxes found in 'Checklist' section."
-            echo "All checklist items must be checked before merging."
             ERROR_FOUND=1
           fi
           


### PR DESCRIPTION
## Purpose of this PR

To lower the hurdle of changing documentation and tutorials, I added a second checklist for documentation only that doesn't include `make test`. The Github action now automatically checks the right checklist.

I tested the github action with [act](https://github.com/nektos/act) but there might be differences to the actual github runners.

Points for discussion:
- more checkboxes?
- should the definition of documentation include more filetypes except .md

## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :white_medium_square: GAMS Code
- :white_medium_square: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :ballot_box_with_check: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :white_medium_square: Bug fix
- :white_medium_square: Refactoring
- :ballot_box_with_check: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [ ] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [ ] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)
