### PR TITLE
2026 07 add trade and PE tracking over iterations

### DIFF
--- a/modules/80_optimization/nash/declarations.gms
+++ b/modules/80_optimization/nash/declarations.gms
@@ -36,6 +36,11 @@ p80_defic_sum_rel(iteration)                "Surplus monetary value over all tim
 p80_etaLT_correct(all_enty,iteration)       "long term price correction factor in percent"
 p80_etaST_correct(tall,all_enty,iteration)  "short term price correction factor in percent"
 
+p80_Mport_iter(ttot,all_regi,all_enty,iteration)          "Imports over iterations"
+p80_Xport_iter(ttot,all_regi,all_enty,iteration)          "Exports over iterations"
+p80_prodPe_iter(ttot,all_regi,all_enty,iteration)         "PE production over iterations"
+p80_fuExtr_iter(ttot,all_regi,all_enty,rlf,iteration)     "Fuel extraction over iterations"
+
 p80_etaST_correct_safecopy(tall,all_enty,iteration)       "auxiliary parameter to remember short term price correction factor in percent, before new convergence adjustments"
 o80_counter_iteration_trade_ttot(ttot,all_enty,iteration) "auxiliary parameter to display in which iteration and for which item (ttot, trade) additional convergence measures were taken"
 o80_trackSurplusSign(ttot,all_enty,iteration)             "auxiliary parameter to track how long the surplus for an item (ttot, trade) had the same sign over iterations"

--- a/modules/80_optimization/nash/postsolve.gms
+++ b/modules/80_optimization/nash/postsolve.gms
@@ -26,8 +26,8 @@ p80_normalize0(ttot,regi,tradePe)$(ttot.val ge 2005) = max(0.5 * (sum(rlf, vm_fu
 loop(ttot$(ttot.val ge 2005),
   loop(regi,
     loop(trade,
-      p80_Mport_iter(ttot,trade,regi,iteration) = vm_Mport.l(ttot,regi,trade);
-      p80_Mport_iter(ttot,trade,regi,iteration) = vm_Xport.l(ttot,regi,trade);
+      p80_Mport_iter(ttot,regi,trade,iteration) = vm_Mport.l(ttot,regi,trade);
+      p80_Mport_iter(ttot,regi,trade,iteration) = vm_Xport.l(ttot,regi,trade);
     );
     loop(entyPe,
       p80_prodPe_iter(ttot,regi,entyPe,iteration)      = vm_prodPe.l(ttot,regi,entyPe);   

--- a/modules/80_optimization/nash/postsolve.gms
+++ b/modules/80_optimization/nash/postsolve.gms
@@ -22,12 +22,27 @@ p80_normalize0(ttot,regi,tradePe)$(ttot.val ge 2005) = max(0.5 * (sum(rlf, vm_fu
                                                         + p80_normalize0(ttot,regi,tradePe)$(pm_SolNonInfes(regi) eq 0) ,sm_eps);
 
 
+*** track exports and imports and fuel extraction and prodPe
+loop(ttot$(ttot.val ge 2005),
+  loop(regi,
+    loop(trade,
+      p80_Mport_iter(ttot,trade,regi,iteration) = vm_Mport.l(ttot,regi,trade);
+      p80_Mport_iter(ttot,trade,regi,iteration) = vm_Xport.l(ttot,regi,trade);
+    );
+    loop(entyPE,
+      p80_prodPe_iter(ttot,regi,entyPE,iteration)      = vm_prodPe.l(ttot,regi,entyPE);   
+      p80_fuExtr_iter(ttot,regi,entyPE,rlf,iteration)  = vm_fuExtr.l(ttot,regi,entyPE,rlf);
+    );
+  ); 
+); 
+
 ***calculate residual surplus on the markets
 loop(ttot$(ttot.val ge 2005),
   loop(trade$(NOT tradeSe(trade)),
-     p80_surplus(ttot,trade,iteration) = sum(regi, (vm_Xport.l(ttot,regi,trade) - vm_Mport.l(ttot,regi,trade))$(pm_SolNonInfes(regi) eq 1)
+    p80_surplus(ttot,trade,iteration) = sum(regi, (vm_Xport.l(ttot,regi,trade) - vm_Mport.l(ttot,regi,trade))$(pm_SolNonInfes(regi) eq 1)
                                                + (pm_Xport0(ttot,regi,trade) - p80_Mport0(ttot,regi,trade) )$(pm_SolNonInfes(regi) eq 0) );
-      ); 
+
+  ); 
 ); 
 
 *' calculate both the size of the price change due to the price change anticipation effect in percent, as well as  

--- a/modules/80_optimization/nash/postsolve.gms
+++ b/modules/80_optimization/nash/postsolve.gms
@@ -29,9 +29,9 @@ loop(ttot$(ttot.val ge 2005),
       p80_Mport_iter(ttot,trade,regi,iteration) = vm_Mport.l(ttot,regi,trade);
       p80_Mport_iter(ttot,trade,regi,iteration) = vm_Xport.l(ttot,regi,trade);
     );
-    loop(entyPE,
-      p80_prodPe_iter(ttot,regi,entyPE,iteration)      = vm_prodPe.l(ttot,regi,entyPE);   
-      p80_fuExtr_iter(ttot,regi,entyPE,rlf,iteration)  = vm_fuExtr.l(ttot,regi,entyPE,rlf);
+    loop(entyPe,
+      p80_prodPe_iter(ttot,regi,entyPe,iteration)      = vm_prodPe.l(ttot,regi,entyPe);   
+      p80_fuExtr_iter(ttot,regi,entyPe,rlf,iteration)  = vm_fuExtr.l(ttot,regi,entyPe,rlf);
     );
   ); 
 ); 


### PR DESCRIPTION
## Purpose of this PR

We currently do not track trade, fuel extraction and prodPe over iterations, which makes debugging some convergence issues problematic. I have now added parameters to do tihs

## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :ballot_box_with_check: GAMS Code
- :white_medium_square: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :white_medium_square: Bug fix
- :ballot_box_with_check: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

* Runs with these changes are here: `/p/projects/remind/users/robertp/savePR/2026-07_trackTrade/remind`
* Comparison of results (what changes by this PR?): nothing.
