### PR TITLE
add iteration tracking parameters

### DIFF
--- a/core/declarations.gms
+++ b/core/declarations.gms
@@ -620,6 +620,11 @@ o_vm_fuExtr_pebiolc(iteration,ttot,all_regi)         "track vm_fuExtr for pebiol
 o_vm_pebiolc_price(iteration,ttot,all_regi)          "track vm_pebiolc_price across Nash iterations"
 o_PEDem_Bio_ECrops(iteration,ttot,all_regi)          "track pebiolc demand across Nash iterations"
 o_vm_emiMacSector_co2luc(iteration,ttot,all_regi)    "track co2luc across Nash iterations"
+
+o_vm_cesIO_iter(ttot,all_regi,all_in,iteration)                              "Production factor over iterations" 
+o_vm_demFeForEs_iter(ttot,all_regi,all_enty,all_esty,all_teEs,iteration)     "Final energy which will be used in the energy service layer over iterations [TWa]"
+o_v_prodEs_iter(ttot,all_regi,all_enty,all_esty,all_teEs,iteration)          "Energy services over iterations [Tpkm for passenger transport, Ttkm for freight transport]"
+
 ;
 
 *** ------------- Scalars ----------------------------

--- a/core/declarations.gms
+++ b/core/declarations.gms
@@ -621,9 +621,15 @@ o_vm_pebiolc_price(iteration,ttot,all_regi)          "track vm_pebiolc_price acr
 o_PEDem_Bio_ECrops(iteration,ttot,all_regi)          "track pebiolc demand across Nash iterations"
 o_vm_emiMacSector_co2luc(iteration,ttot,all_regi)    "track co2luc across Nash iterations"
 
+*** CES tree and energy services
 o_vm_cesIO_iter(ttot,all_regi,all_in,iteration)                              "Production factor over iterations" 
 o_vm_demFeForEs_iter(ttot,all_regi,all_enty,all_esty,all_teEs,iteration)     "Final energy which will be used in the energy service layer over iterations [TWa]"
 o_v_prodEs_iter(ttot,all_regi,all_enty,all_esty,all_teEs,iteration)          "Energy services over iterations [Tpkm for passenger transport, Ttkm for freight transport]"
+
+*** edgeTransport
+o_pm_esCapCost_iter(ttot,all_regi,all_teEs,iteration)                 "Capital energy cost per unit of consumption for end-use capital (energy service layer) over iterations [T$/unit energy service]"
+o_pm_fe2es_iter(ttot,all_regi,all_teEs,iteration)                     "Conversion factor from final energies to transport energy services over iterations [Tpkm/TWa, Ttkm/TWa]"
+o_pm_shFeCes_iter(ttot,all_regi,all_enty,all_in,all_teEs,iteration)   "Shares of fuels by CES node over iterations"
 
 ;
 

--- a/core/declarations.gms
+++ b/core/declarations.gms
@@ -616,10 +616,10 @@ o_pm_pebiolc_demandmag(iteration,ttot,all_regi)      "track pm_pebiolc_demandmag
 o_pm_macBaseMagpie(iteration,ttot,all_regi,all_enty) "track pm_macBaseMagpie across Nash iterations"
 o_pm_macSwitch(iteration,ttot,all_regi,all_enty)     "track pm_macSwitch across Nash iterations"
 o_p_efFossilFuelExtr_n2obio(iteration,all_regi)      "track p_efFossilFuelExtr for n2obio across Nash iterations"
-o_vm_fuExtr_pebiolc(iteration,ttot,all_regi)         "track vm_fuExtr for pebiolc across Nash iterations"
-o_vm_pebiolc_price(iteration,ttot,all_regi)          "track vm_pebiolc_price across Nash iterations"
-o_PEDem_Bio_ECrops(iteration,ttot,all_regi)          "track pebiolc demand across Nash iterations"
-o_vm_emiMacSector_co2luc(iteration,ttot,all_regi)    "track co2luc across Nash iterations"
+o_vm_fuExtr_pebiolc_iter(iteration,ttot,all_regi)         "track vm_fuExtr for pebiolc across Nash iterations"
+o_vm_pebiolc_price_iter(iteration,ttot,all_regi)          "track vm_pebiolc_price across Nash iterations"
+o_PEDem_Bio_ECrops_iter(iteration,ttot,all_regi)          "track pebiolc demand across Nash iterations"
+o_vm_emiMacSector_co2luc_iter(iteration,ttot,all_regi)    "track co2luc across Nash iterations"
 
 *** CES tree and energy services
 o_vm_cesIO_iter(ttot,all_regi,all_in,iteration)                              "Production factor over iterations" 

--- a/core/postsolve.gms
+++ b/core/postsolve.gms
@@ -234,6 +234,14 @@ loop(ttot$(ttot.val ge 2005),
   );
 );
 
+*** track parameters read in from edgeTransport over iterations
+if(edgeTransportIter(iteration),
+  loop(ttot$(ttot.val ge 2005),
+    o_pm_esCapCost_iter(ttot,regi,teEs_dyn35,iteration)                  = pm_esCapCost(ttot,regi,teEs_dyn35);
+    o_pm_fe2es_iter(ttot,regi,teEs_dyn35,iteration)                      = pm_fe2es(ttot,regi,teEs_dyn35);
+    o_pm_shFeCes_iter(ttot,regi,entyFe,ppfen_dyn35,teEs_dyn35,iteration) = pm_shFeCes(ttot,regi,entyFe,ppfen_dyn35,teEs_dyn35);
+  );
+); 
 
 
 *** EOF ./core/postsolve.gms

--- a/core/postsolve.gms
+++ b/core/postsolve.gms
@@ -225,4 +225,15 @@ o_vm_fuExtr_pebiolc(iteration,ttot,regi) = vm_fuExtr.l(ttot,regi,"pebiolc","1");
 o_PEDem_Bio_ECrops(iteration,ttot,regi) = vm_fuExtr.l(ttot,regi,"pebiolc","1") + (1 - pm_costsPEtradeMp(regi,"pebiolc")) * vm_Mport.l(ttot,regi,"pebiolc") - vm_Xport.l(ttot,regi,"pebiolc");
 o_vm_emiMacSector_co2luc(iteration,ttot,regi) = vm_emiMacSector.l(ttot,regi,"co2luc");
 
+*** track CES tree and energy services over iterations
+loop(ttot$(ttot.val ge 2005),
+  o_vm_cesIO_iter(ttot,regi,in,iteration) = vm_cesIO.l(ttot,regi,in) ;
+  loop(entyFe2Sector(entyFe,"trans"),
+    o_vm_demFeForEs_iter(ttot,regi,entyFe,esty,teEs,iteration)$fe2es(entyFe,esty,teEs) = vm_demFeForEs.l(ttot,regi,entyFe,esty,teEs);
+    o_v_prodEs_iter(ttot,regi,entyFe,esty,teEs,iteration)$fe2es(entyFe,esty,teEs) = v_prodEs.l(ttot,regi,entyFe,esty,teEs);
+  );
+);
+
+
+
 *** EOF ./core/postsolve.gms

--- a/core/postsolve.gms
+++ b/core/postsolve.gms
@@ -220,10 +220,10 @@ p_FEPrice_by_EmiMkt_iter(iteration,t,regi,entyFe,emiMkt) = p_FEPrice_by_EmiMkt(t
 p_FEPrice_by_FE_iter(iteration,t,regi,entyFe) = p_FEPrice_by_FE(t,regi,entyFe);
 
 *** Track demand for purpose-grown ligno-cellulosic biomass across iterations
-o_vm_pebiolc_price(iteration,ttot,regi)  = vm_pebiolc_price.l(ttot,regi);
-o_vm_fuExtr_pebiolc(iteration,ttot,regi) = vm_fuExtr.l(ttot,regi,"pebiolc","1");
-o_PEDem_Bio_ECrops(iteration,ttot,regi) = vm_fuExtr.l(ttot,regi,"pebiolc","1") + (1 - pm_costsPEtradeMp(regi,"pebiolc")) * vm_Mport.l(ttot,regi,"pebiolc") - vm_Xport.l(ttot,regi,"pebiolc");
-o_vm_emiMacSector_co2luc(iteration,ttot,regi) = vm_emiMacSector.l(ttot,regi,"co2luc");
+o_vm_pebiolc_price_iter(iteration,ttot,regi)  = vm_pebiolc_price.l(ttot,regi);
+o_vm_fuExtr_pebiolc_iter(iteration,ttot,regi) = vm_fuExtr.l(ttot,regi,"pebiolc","1");
+o_PEDem_Bio_ECrops_iter(iteration,ttot,regi) = vm_fuExtr.l(ttot,regi,"pebiolc","1") + (1 - pm_costsPEtradeMp(regi,"pebiolc")) * vm_Mport.l(ttot,regi,"pebiolc") - vm_Xport.l(ttot,regi,"pebiolc");
+o_vm_emiMacSector_co2luc_iter(iteration,ttot,regi) = vm_emiMacSector.l(ttot,regi,"co2luc");
 
 *** track CES tree and energy services over iterations
 loop(ttot$(ttot.val ge 2005),

--- a/modules/80_optimization/nash/declarations.gms
+++ b/modules/80_optimization/nash/declarations.gms
@@ -48,10 +48,6 @@ p80_esCapCost_iter(ttot,all_regi,all_teEs,iteration)                 "Capital en
 p80_fe2es_iter(ttot,all_regi,all_teEs,iteration)                     "Conversion factor from final energies to transport energy services over iterations [Tpkm/TWa, Ttkm/TWa]"
 p80_shFeCes_iter(ttot,all_regi,all_enty,all_in,all_teEs,iteration)   "Shares of fuels by CES node over iterations"
 
-*** CES tree 
-p80_cesIO_iter(ttot,all_regi,all_in,iteration)                               "Production factor over iterations" 
-p80_demFeForEs_iter(ttot,all_regi,all_enty,all_esty,all_teEs,iteration)      "Final energy which will be used in the energy service layer over iterations [TWa]"
-p80_prodEs_iter(ttot,all_regi,all_enty,all_esty,all_teEs,iteration)          "Energy services over iterations [Tpkm for passenger transport, Ttkm for freight transport]"
 
 
 p80_etaST_correct_safecopy(tall,all_enty,iteration)       "auxiliary parameter to remember short term price correction factor in percent, before new convergence adjustments"

--- a/modules/80_optimization/nash/declarations.gms
+++ b/modules/80_optimization/nash/declarations.gms
@@ -36,10 +36,23 @@ p80_defic_sum_rel(iteration)                "Surplus monetary value over all tim
 p80_etaLT_correct(all_enty,iteration)       "long term price correction factor in percent"
 p80_etaST_correct(tall,all_enty,iteration)  "short term price correction factor in percent"
 
+*** RP parameters to track model results over iterations to help diagnose convergence problems
+*** Trade
 p80_Mport_iter(ttot,all_regi,all_enty,iteration)          "Imports over iterations"
 p80_Xport_iter(ttot,all_regi,all_enty,iteration)          "Exports over iterations"
 p80_prodPe_iter(ttot,all_regi,all_enty,iteration)         "PE production over iterations"
 p80_fuExtr_iter(ttot,all_regi,all_enty,rlf,iteration)     "Fuel extraction over iterations"
+
+*** edgeTransport
+p80_esCapCost_iter(ttot,all_regi,all_teEs,iteration)                 "Capital energy cost per unit of consumption for end-use capital (energy service layer) over iterations [T$/unit energy service]"
+p80_fe2es_iter(ttot,all_regi,all_teEs,iteration)                     "Conversion factor from final energies to transport energy services over iterations [Tpkm/TWa, Ttkm/TWa]"
+p80_shFeCes_iter(ttot,all_regi,all_enty,all_in,all_teEs,iteration)   "Shares of fuels by CES node over iterations"
+
+*** CES tree 
+p80_cesIO_iter(ttot,all_regi,all_in,iteration)                               "Production factor over iterations" 
+p80_demFeForEs_iter(ttot,all_regi,all_enty,all_esty,all_teEs,iteration)      "Final energy which will be used in the energy service layer over iterations [TWa]"
+p80_prodEs_iter(ttot,all_regi,all_enty,all_esty,all_teEs,iteration)          "Energy services over iterations [Tpkm for passenger transport, Ttkm for freight transport]"
+
 
 p80_etaST_correct_safecopy(tall,all_enty,iteration)       "auxiliary parameter to remember short term price correction factor in percent, before new convergence adjustments"
 o80_counter_iteration_trade_ttot(ttot,all_enty,iteration) "auxiliary parameter to display in which iteration and for which item (ttot, trade) additional convergence measures were taken"

--- a/modules/80_optimization/nash/declarations.gms
+++ b/modules/80_optimization/nash/declarations.gms
@@ -43,11 +43,6 @@ p80_Xport_iter(ttot,all_regi,all_enty,iteration)          "Exports over iteratio
 p80_prodPe_iter(ttot,all_regi,all_enty,iteration)         "PE production over iterations"
 p80_fuExtr_iter(ttot,all_regi,all_enty,rlf,iteration)     "Fuel extraction over iterations"
 
-*** edgeTransport
-p80_esCapCost_iter(ttot,all_regi,all_teEs,iteration)                 "Capital energy cost per unit of consumption for end-use capital (energy service layer) over iterations [T$/unit energy service]"
-p80_fe2es_iter(ttot,all_regi,all_teEs,iteration)                     "Conversion factor from final energies to transport energy services over iterations [Tpkm/TWa, Ttkm/TWa]"
-p80_shFeCes_iter(ttot,all_regi,all_enty,all_in,all_teEs,iteration)   "Shares of fuels by CES node over iterations"
-
 
 
 p80_etaST_correct_safecopy(tall,all_enty,iteration)       "auxiliary parameter to remember short term price correction factor in percent, before new convergence adjustments"

--- a/modules/80_optimization/nash/postsolve.gms
+++ b/modules/80_optimization/nash/postsolve.gms
@@ -36,6 +36,24 @@ loop(ttot$(ttot.val ge 2005),
   ); 
 ); 
 
+*** track parameters read in from edgeTransport over iterations
+if(edgeTransportIter(iteration),
+  loop(ttot$(ttot.val ge 2005),
+    p80_esCapCost_iter(ttot,regi,teEs_dyn35,iteration)                  = pm_esCapCost(ttot,regi,teEs_dyn35);
+    p80_fe2es_iter(ttot,regi,teEs_dyn35,iteration)                      = pm_fe2es(ttot,regi,teEs_dyn35);
+    p80_shFeCes_iter(ttot,regi,entyFe,ppfen_dyn35,teEs_dyn35,iteration) = pm_shFeCes(ttot,regi,entyFe,ppfen_dyn35,teEs_dyn35);
+  );
+); 
+
+*** track CES tree and energy services over iterations
+loop(ttot$(ttot.val ge 2005),
+  p80_cesIO_iter(ttot,regi,in,iteration) = vm_cesIO.l(ttot,regi,in) ;
+  loop(entyFe2Sector(entyFe,"trans"),
+    p80_demFeForEs_iter(ttot,regi,entyFe,esty,teEs,iteration)$fe2es(entyFe,esty,teEs) = vm_demFeForEs.l(ttot,regi,entyFe,esty,teEs);
+    p80_prodEs_iter(ttot,regi,entyFe,esty,teEs,iteration)$fe2es(entyFe,esty,teEs) = v_prodEs.l(ttot,regi,entyFe,esty,teEs);
+  );
+);
+
 ***calculate residual surplus on the markets
 loop(ttot$(ttot.val ge 2005),
   loop(trade$(NOT tradeSe(trade)),

--- a/modules/80_optimization/nash/postsolve.gms
+++ b/modules/80_optimization/nash/postsolve.gms
@@ -45,15 +45,6 @@ if(edgeTransportIter(iteration),
   );
 ); 
 
-*** track CES tree and energy services over iterations
-loop(ttot$(ttot.val ge 2005),
-  p80_cesIO_iter(ttot,regi,in,iteration) = vm_cesIO.l(ttot,regi,in) ;
-  loop(entyFe2Sector(entyFe,"trans"),
-    p80_demFeForEs_iter(ttot,regi,entyFe,esty,teEs,iteration)$fe2es(entyFe,esty,teEs) = vm_demFeForEs.l(ttot,regi,entyFe,esty,teEs);
-    p80_prodEs_iter(ttot,regi,entyFe,esty,teEs,iteration)$fe2es(entyFe,esty,teEs) = v_prodEs.l(ttot,regi,entyFe,esty,teEs);
-  );
-);
-
 ***calculate residual surplus on the markets
 loop(ttot$(ttot.val ge 2005),
   loop(trade$(NOT tradeSe(trade)),

--- a/modules/80_optimization/nash/postsolve.gms
+++ b/modules/80_optimization/nash/postsolve.gms
@@ -36,15 +36,6 @@ loop(ttot$(ttot.val ge 2005),
   ); 
 ); 
 
-*** track parameters read in from edgeTransport over iterations
-if(edgeTransportIter(iteration),
-  loop(ttot$(ttot.val ge 2005),
-    p80_esCapCost_iter(ttot,regi,teEs_dyn35,iteration)                  = pm_esCapCost(ttot,regi,teEs_dyn35);
-    p80_fe2es_iter(ttot,regi,teEs_dyn35,iteration)                      = pm_fe2es(ttot,regi,teEs_dyn35);
-    p80_shFeCes_iter(ttot,regi,entyFe,ppfen_dyn35,teEs_dyn35,iteration) = pm_shFeCes(ttot,regi,entyFe,ppfen_dyn35,teEs_dyn35);
-  );
-); 
-
 ***calculate residual surplus on the markets
 loop(ttot$(ttot.val ge 2005),
   loop(trade$(NOT tradeSe(trade)),

--- a/scripts/output/comparison/plotRemMagNash.R
+++ b/scripts/output/comparison/plotRemMagNash.R
@@ -78,23 +78,23 @@ plot_iterations <- function(dat, runname) {
 
   # ---- Plot: MAgPIE co2luc ----
   
-  p_emi_mag    <- myplot(dat, "o_vm_emiMacSector_co2luc", runname, ylab = "Mt CO2/yr")
-  p_emi_mag_it <- myplot(dat, "o_vm_emiMacSector_co2luc", xaxis = "iteration", color = "ttot", runname, ylab = "Mt CO2/yr")
+  p_emi_mag    <- myplot(dat, "o_vm_emiMacSector_co2luc_iter", runname, ylab = "Mt CO2/yr")
+  p_emi_mag_it <- myplot(dat, "o_vm_emiMacSector_co2luc_iter", xaxis = "iteration", color = "ttot", runname, ylab = "Mt CO2/yr")
   
   
   # ---- Plot: REMIND Production of purpose grown bioenergy ----
   
-  p_fuelex         <- myplot(dat, "o_vm_fuExtr_pebiolc", runname,                                      ylab = "EJ/yr")
-  p_fuelex_it      <- myplot(dat, "o_vm_fuExtr_pebiolc", runname, xaxis = "iteration", color = "ttot", ylab = "EJ/yr")
-  p_fuelex_it_fix  <- myplot(dat, "o_vm_fuExtr_pebiolc", runname, xaxis = "iteration", color = "ttot", ylab = "EJ/yr", scales = "fixed")
+  p_fuelex         <- myplot(dat, "o_vm_fuExtr_pebiolc_iter", runname,                                      ylab = "EJ/yr")
+  p_fuelex_it      <- myplot(dat, "o_vm_fuExtr_pebiolc_iter", runname, xaxis = "iteration", color = "ttot", ylab = "EJ/yr")
+  p_fuelex_it_fix  <- myplot(dat, "o_vm_fuExtr_pebiolc_iter", runname, xaxis = "iteration", color = "ttot", ylab = "EJ/yr", scales = "fixed")
   p_fuelex_it_2060 <- myplot(dat |> filter(ttot == 2060),
-                                  "o_vm_fuExtr_pebiolc", runname, type = "bar", 
+                                  "o_vm_fuExtr_pebiolc_iter", runname, type = "bar", 
                                                                   xaxis = "iteration", color = "ttot", ylab = "EJ/yr", scales = "fixed")
   
   # ---- Plot: REMIND Demand for purpose grown bioenergy ----
   
-  p_demPE    <- myplot(dat, "o_PEDem_Bio_ECrops", runname,                                      ylab = "EJ/yr")
-  p_demPE_it <- myplot(dat, "o_PEDem_Bio_ECrops", runname, xaxis = "iteration", color = "ttot", ylab = "EJ/yr")
+  p_demPE    <- myplot(dat, "o_PEDem_Bio_ECrops_iter", runname,                                      ylab = "EJ/yr")
+  p_demPE_it <- myplot(dat, "o_PEDem_Bio_ECrops_iter", runname, xaxis = "iteration", color = "ttot", ylab = "EJ/yr")
   
   # ---- Plot: REMIND Price scaling factor ----
   
@@ -151,9 +151,9 @@ readDataFromGdx <- function(runfolder, allIter = TRUE) {
   # "Emi|CO2|+|Land-Use Change (Mt CO2/yr)"
   # vm_emiMacSector <- readGDX(gdx, "vm_emiMacSector", field = "l", restore_zeros = FALSE)
   # dimSums(vm_emiMacSector[, , "co2luc"]                 , dim = 3) * GtC_2_MtCO2
-  # "o_vm_emiMacSector_co2luc"
+  # "o_vm_emiMacSector_co2luc_iter"
   # core/postsolve.gms:
-  # o_vm_emiMacSector_co2luc(iteration,ttot,regi) = vm_emiMacSector.l(ttot,regi,"co2luc");
+  # o_vm_emiMacSector_co2luc_iter(iteration,ttot,regi) = vm_emiMacSector.l(ttot,regi,"co2luc");
   
   # "Primary Energy Production|Biomass|Energy Crops (EJ/yr)"
   # remind2::reportExtraction.R
@@ -162,16 +162,16 @@ readDataFromGdx <- function(runfolder, allIter = TRUE) {
   # dimSums(fuelex_bio[, , "pebiolc.1"], dim = 3) * TWa_2_EJ
   #   -> "PE|Production|Biomass|+|Lignocellulosic (EJ/yr)"
   #   -> "Primary Energy Production|Biomass|Energy Crops (EJ/yr)" (used also in coupling interface in MAgPIE)
-  # "o_vm_fuExtr_pebiolc"
+  # "o_vm_fuExtr_pebiolc_iter"
   # core/postsolve.gms:
-  # o_vm_fuExtr_pebiolc = vm_fuExtr.l(ttot,regi,"pebiolc","1");
+  # o_vm_fuExtr_pebiolc_iter = vm_fuExtr.l(ttot,regi,"pebiolc","1");
   
   # "PE|Biomass|+++|Energy Crops (EJ/yr)"
   # remind2::reportPE.R
   # fuelex[,,"pebiolc.1"] + (1-p_costsPEtradeMp[,,"pebiolc"]) * Mport[,,"pebiolc"] - Xport[,,"pebiolc"] -> "PE|Biomass|+++|Energy Crops (EJ/yr)"
-  # "o_PEDem_Bio_ECrops"
+  # "o_PEDem_Bio_ECrops_iter"
   # core/postsolve.gms:
-  # o_PEDem_Bio_ECrops(iteration,ttot,regi) = vm_fuExtr.l(ttot,regi,"pebiolc","1") + (1 - pm_costsPEtradeMp(ttot,regi"pebiolc")) * vm_Mport.l(ttot,regi,"pebiolc") - vm_Xport.l(ttot,regi"pebiolc");
+  # o_PEDem_Bio_ECrops_iter(iteration,ttot,regi) = vm_fuExtr.l(ttot,regi,"pebiolc","1") + (1 - pm_costsPEtradeMp(ttot,regi"pebiolc")) * vm_Mport.l(ttot,regi,"pebiolc") - vm_Xport.l(ttot,regi"pebiolc");
   
   # "Internal|Price|Biomass|Multfactor ()"
   # remind2::reportPrices.R
@@ -197,9 +197,9 @@ readDataFromGdx <- function(runfolder, allIter = TRUE) {
   items <- tribble(
     ~par                      , ~var                                                    , ~factor,
     "o_p30_pebiolc_pricemag"  , "Internal|Price|Biomass|MAgPIE (US$2017/GJ)"            ,  sm_tdptwyr2dpgj,
-    "o_vm_emiMacSector_co2luc", "Emi|CO2|+|Land-Use Change (Mt CO2/yr)"                 ,  GtC_2_MtCO2,
-    "o_vm_fuExtr_pebiolc"     , "Primary Energy Production|Biomass|Energy Crops (EJ/yr)",  TWa2EJ,
-    "o_PEDem_Bio_ECrops"      , "PE|Biomass|+++|Energy Crops (EJ/yr)"                   ,  TWa2EJ,
+    "o_vm_emiMacSector_co2luc_iter", "Emi|CO2|+|Land-Use Change (Mt CO2/yr)"                 ,  GtC_2_MtCO2,
+    "o_vm_fuExtr_pebiolc_iter"     , "Primary Energy Production|Biomass|Energy Crops (EJ/yr)",  TWa2EJ,
+    "o_PEDem_Bio_ECrops_iter"      , "PE|Biomass|+++|Energy Crops (EJ/yr)"                   ,  TWa2EJ,
     "o_p30_pebiolc_pricmult"  , "Internal|Price|Biomass|Multfactor ()"                  ,  1,
     "pm_taxCO2eq_iter"        , "Price|Carbon (US$2017/t CO2)"                          ,  1000 * 12 / 44,
   )

--- a/scripts/output/single/plotRemMagNash.R
+++ b/scripts/output/single/plotRemMagNash.R
@@ -80,23 +80,23 @@ plot_iterations <- function(dat, runname) {
 
   # ---- Plot: MAgPIE co2luc ----
   
-  p_emi_mag    <- myplot(dat, "o_vm_emiMacSector_co2luc", runname, ylab = "Mt CO2/yr")
-  p_emi_mag_it <- myplot(dat, "o_vm_emiMacSector_co2luc", xaxis = "iteration", color = "ttot", runname, ylab = "Mt CO2/yr")
+  p_emi_mag    <- myplot(dat, "o_vm_emiMacSector_co2luc_iter", runname, ylab = "Mt CO2/yr")
+  p_emi_mag_it <- myplot(dat, "o_vm_emiMacSector_co2luc_iter", xaxis = "iteration", color = "ttot", runname, ylab = "Mt CO2/yr")
   
   
   # ---- Plot: REMIND Production of purpose grown bioenergy ----
   
-  p_fuelex         <- myplot(dat, "o_vm_fuExtr_pebiolc", runname,                                      ylab = "EJ/yr")
-  p_fuelex_it      <- myplot(dat, "o_vm_fuExtr_pebiolc", runname, xaxis = "iteration", color = "ttot", ylab = "EJ/yr")
-  p_fuelex_it_fix  <- myplot(dat, "o_vm_fuExtr_pebiolc", runname, xaxis = "iteration", color = "ttot", ylab = "EJ/yr", scales = "fixed")
+  p_fuelex         <- myplot(dat, "o_vm_fuExtr_pebiolc_iter", runname,                                      ylab = "EJ/yr")
+  p_fuelex_it      <- myplot(dat, "o_vm_fuExtr_pebiolc_iter", runname, xaxis = "iteration", color = "ttot", ylab = "EJ/yr")
+  p_fuelex_it_fix  <- myplot(dat, "o_vm_fuExtr_pebiolc_iter", runname, xaxis = "iteration", color = "ttot", ylab = "EJ/yr", scales = "fixed")
   p_fuelex_it_2060 <- myplot(dat |> filter(ttot == 2060),
-                                  "o_vm_fuExtr_pebiolc", runname, type = "bar", 
+                                  "o_vm_fuExtr_pebiolc_iter", runname, type = "bar", 
                                                                   xaxis = "iteration", color = "ttot", ylab = "EJ/yr", scales = "fixed")
   
   # ---- Plot: REMIND Demand for purpose grown bioenergy ----
   
-  p_demPE    <- myplot(dat, "o_PEDem_Bio_ECrops", runname,                                      ylab = "EJ/yr")
-  p_demPE_it <- myplot(dat, "o_PEDem_Bio_ECrops", runname, xaxis = "iteration", color = "ttot", ylab = "EJ/yr")
+  p_demPE    <- myplot(dat, "o_PEDem_Bio_ECrops_iter", runname,                                      ylab = "EJ/yr")
+  p_demPE_it <- myplot(dat, "o_PEDem_Bio_ECrops_iter", runname, xaxis = "iteration", color = "ttot", ylab = "EJ/yr")
   
   # ---- Plot: REMIND Price scaling factor ----
   
@@ -153,9 +153,9 @@ readDataFromGdx <- function(runfolder, allIter = TRUE) {
   # "Emi|CO2|+|Land-Use Change (Mt CO2/yr)"
   # vm_emiMacSector <- readGDX(gdx, "vm_emiMacSector", field = "l", restore_zeros = FALSE)
   # dimSums(vm_emiMacSector[, , "co2luc"]                 , dim = 3) * GtC_2_MtCO2
-  # "o_vm_emiMacSector_co2luc"
+  # "o_vm_emiMacSector_co2luc_iter"
   # core/postsolve.gms:
-  # o_vm_emiMacSector_co2luc(iteration,ttot,regi) = vm_emiMacSector.l(ttot,regi,"co2luc");
+  # o_vm_emiMacSector_co2luc_iter(iteration,ttot,regi) = vm_emiMacSector.l(ttot,regi,"co2luc");
   
   # "Primary Energy Production|Biomass|Energy Crops (EJ/yr)"
   # remind2::reportExtraction.R
@@ -164,16 +164,16 @@ readDataFromGdx <- function(runfolder, allIter = TRUE) {
   # dimSums(fuelex_bio[, , "pebiolc.1"], dim = 3) * TWa_2_EJ
   #   -> "PE|Production|Biomass|+|Lignocellulosic (EJ/yr)"
   #   -> "Primary Energy Production|Biomass|Energy Crops (EJ/yr)" (used also in coupling interface in MAgPIE)
-  # "o_vm_fuExtr_pebiolc"
+  # "o_vm_fuExtr_pebiolc_iter"
   # core/postsolve.gms:
-  # o_vm_fuExtr_pebiolc = vm_fuExtr.l(ttot,regi,"pebiolc","1");
+  # o_vm_fuExtr_pebiolc_iter = vm_fuExtr.l(ttot,regi,"pebiolc","1");
   
   # "PE|Biomass|+++|Energy Crops (EJ/yr)"
   # remind2::reportPE.R
   # fuelex[,,"pebiolc.1"] + (1-p_costsPEtradeMp[,,"pebiolc"]) * Mport[,,"pebiolc"] - Xport[,,"pebiolc"] -> "PE|Biomass|+++|Energy Crops (EJ/yr)"
-  # "o_PEDem_Bio_ECrops"
+  # "o_PEDem_Bio_ECrops_iter"
   # core/postsolve.gms:
-  # o_PEDem_Bio_ECrops(iteration,ttot,regi) = vm_fuExtr.l(ttot,regi,"pebiolc","1") + (1 - pm_costsPEtradeMp(ttot,regi"pebiolc")) * vm_Mport.l(ttot,regi,"pebiolc") - vm_Xport.l(ttot,regi"pebiolc");
+  # o_PEDem_Bio_ECrops_iter(iteration,ttot,regi) = vm_fuExtr.l(ttot,regi,"pebiolc","1") + (1 - pm_costsPEtradeMp(ttot,regi"pebiolc")) * vm_Mport.l(ttot,regi,"pebiolc") - vm_Xport.l(ttot,regi"pebiolc");
   
   # "Internal|Price|Biomass|Multfactor ()"
   # remind2::reportPrices.R
@@ -199,9 +199,9 @@ readDataFromGdx <- function(runfolder, allIter = TRUE) {
   items <- tribble(
     ~par                      , ~var                                                    , ~factor,
     "o_p30_pebiolc_pricemag"  , "Internal|Price|Biomass|MAgPIE (US$2017/GJ)"            ,  sm_tdptwyr2dpgj,
-    "o_vm_emiMacSector_co2luc", "Emi|CO2|+|Land-Use Change (Mt CO2/yr)"                 ,  GtC_2_MtCO2,
-    "o_vm_fuExtr_pebiolc"     , "Primary Energy Production|Biomass|Energy Crops (EJ/yr)",  TWa2EJ,
-    "o_PEDem_Bio_ECrops"      , "PE|Biomass|+++|Energy Crops (EJ/yr)"                   ,  TWa2EJ,
+    "o_vm_emiMacSector_co2luc_iter", "Emi|CO2|+|Land-Use Change (Mt CO2/yr)"                 ,  GtC_2_MtCO2,
+    "o_vm_fuExtr_pebiolc_iter"     , "Primary Energy Production|Biomass|Energy Crops (EJ/yr)",  TWa2EJ,
+    "o_PEDem_Bio_ECrops_iter"      , "PE|Biomass|+++|Energy Crops (EJ/yr)"                   ,  TWa2EJ,
     "o_p30_pebiolc_pricmult"  , "Internal|Price|Biomass|Multfactor ()"                  ,  1,
     "pm_taxCO2eq_iter"        , "Price|Carbon (US$2017/t CO2)"                          ,  1000 * 12 / 44,
   )


### PR DESCRIPTION
## Purpose of this PR

Add more parameters that track REMIND values over iterations (this time for edgeTransport and the CES tree / energy service demand). Also added `_iter` to a number of output parameters that were built to track variables over iterations.

## Type of change

### Parts concerned
- :ballot_box_with_check: GAMS Code
- :white_medium_square: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :white_medium_square: Bug fix
- :ballot_box_with_check: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

* Runs with these changes are here:
* Comparison of results (what changes by this PR?):  nothing - the PR simply adds some output parameters
