### PR TITLE
Allow only some CS2 sections to be built

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     [[#2413](https://github.com/remindmodel/remind/pull/2413)]
 
 ### added
--
+- **scripts** Add the possibility to build only some sections of the compareScenarios2 report with `--sections=`
+    [[#2415](https://github.com/remindmodel/remind/pull/2415)]
 
 ### removed
 -

--- a/output.R
+++ b/output.R
@@ -69,7 +69,7 @@ parseOptions <- function() {
                         description="[options] can be the following flags and variables. If variables are not specified but needed, the scripts will ask the user.")
   # these flags appear in the various output scripts and are necessary here
   # if you add a command line argument to a script, add it here as well
-  additionalScriptOptions = list("profileNames", "runs", "folder", "project",
+  additionalScriptOptions = list("profileNames", "runs", "folder", "project", "sections",
     "outputFilename", "model", "mapping", "summationFile", "logFile", "removeFromScen",
     "addToScen", "iiasatemplate", "timesteps", "validationConfig", "interactive")
   for (option in additionalScriptOptions) {
@@ -125,7 +125,7 @@ promptForAliases <- function(outputdirs, scenarios) {
   aliases_str <- gms::getLine()
   aliases_list <- trimws(unlist(strsplit(aliases_str, ",")))
 
-  if (length(scenarios) > length(aliases_list)) {
+  if (length(scenarios) > length(aliases_list) && length(aliases_list) > 0) {
     warning("Not enough aliases supplied. Only renaming first scenarios.")
   }
   for (i in seq_along(aliases_list)) {

--- a/scripts/cs2/run_compareScenarios2.R
+++ b/scripts/cs2/run_compareScenarios2.R
@@ -8,14 +8,15 @@
 library(piamPlotComparison)
 
 if (!exists("source_include")) {
-  lucode2::readArgs("outputdirs", "outFileName", "profileName", "aliases")
+  lucode2::readArgs("outputdirs", "outFileName", "profileName", "aliases", "sections")
 }
 
 run_compareScenarios2 <- function(
   outputdirs,
   outFileName,
   profileName,
-  aliases=NULL
+  aliases,
+  sections
 ) {
 
   stopifnot(length(profileName) == 1 && is.character(profileName) && !is.na(profileName))
@@ -52,7 +53,8 @@ run_compareScenarios2 <- function(
     outputDir = outDir,
     outputFile = outFileName,
     outputFormat = "pdf",
-    mifScenNames = aliases
+    mifScenNames = aliases,
+    sections = sections
   )
 
   # Load cs2 profile and change args.
@@ -94,4 +96,4 @@ run_compareScenarios2 <- function(
   message("Done!\n")
 }
 
-run_compareScenarios2(outputdirs, outFileName, profileName, aliases)
+run_compareScenarios2(outputdirs, outFileName, profileName, aliases, sections)

--- a/scripts/output/comparison/compareScenarios2.R
+++ b/scripts/output/comparison/compareScenarios2.R
@@ -5,6 +5,12 @@
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
 
+#' @title Compare Scenarios 2
+#' @description Creates a PDF document that compares multiple scenarios
+#'
+#' @param sections List of section numbers to be included in the PDF
+#' separated by commas. Default: "all".
+#' Examples: --sections=2 --sections=2,3
 
 
 
@@ -41,7 +47,8 @@ startComp <- function(
   outputdirs,
   nameCore,
   profileName,
-  aliases=NULL
+  aliases,
+  sections
 ) {
   if (!exists("slurmConfig")) {
     slurmConfig <- "--qos=standby"
@@ -68,6 +75,7 @@ startComp <- function(
       " --profileName=", profileName,
       " --outFileName=", outFileName,
       " --aliases=", paste(aliases, collapse = ","),
+      " --sections=", paste(sections, collapse = ","),
       "\"")
     cat(clcom, "\n")
     system(clcom)
@@ -88,7 +96,11 @@ startComp <- function(
 # Load cs2 profiles.
 profiles <- piamPlotComparison::getCs2Profiles()
 
-lucode2::readArgs("profileNames")
+lucode2::readArgs("profileNames", "sections")
+
+if (! exists("sections")) {
+  sections = "all"
+}
 
 # Let user choose cs2 profile(s).
 profileNamesDefault <- determineDefaultProfiles(outputdirs[1])
@@ -118,5 +130,6 @@ for (profileName in profileNames) {
     outputdirs = outputdirs,
     nameCore = nameCore,
     profileName = profileName,
-    aliases = aliases)
+    aliases = aliases,
+    sections = sections)
 }


### PR DESCRIPTION
## Purpose of this PR

Which sections of compareScenarios2 are built by `output.R` are built, can now be controlled with `--sections`. This reduces waiting times if only some sections are required. The parameter for this already existed in piamPlotComparison.

## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :white_medium_square: GAMS Code
- :ballot_box_with_check: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :white_medium_square: Bug fix
- :white_medium_square: Refactoring
- :ballot_box_with_check: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

* Runs with these changes are here:
* Comparison of results (what changes by this PR?): 
