### PR TITLE
Split LCOE reporting into separate script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### changed
 - **scripts** Harmonize command line arguments for output.R: prefix `--` is now required, change `--outputdir` to `--outputdirs`
     [[#2413](https://github.com/remindmodel/remind/pull/2413)]
+- **scripts** Move LCOE reporting into `reoirtingLCOE` instead of `reporting`
+    [[#2416](https://github.com/remindmodel/remind/pull/2416)]
 
 ### added
 - **scripts** Add the possibility to build only some sections of the compareScenarios2 report with `--sections=`

--- a/output.R
+++ b/output.R
@@ -208,10 +208,12 @@ chooseAliases <- function(output, outputdirs) {
   return(aliases)
 }
 
+# returns TRUE if any script had errors
 runComparisonOrExport <- function(comp, output, outputdirs, aliases, filename_prefix, slurmConfig, test) {
   # Set value source_include so that loaded scripts know, that they are
   # included as source (instead of a load from command line)
   source_include <- TRUE
+  errors <- FALSE
 
   # Execute output scripts over all chosen folders
   for (rout in output) {
@@ -227,15 +229,19 @@ runComparisonOrExport <- function(comp, output, outputdirs, aliases, filename_pr
         gc()
         if (!is.null(tmp.error)) {
           warning("Script ", name, " was stopped by an error and not executed properly!")
+          errors <- TRUE
         }
       }
     } else {
       message("\nCould not find ", name)
     }
   }
+  return(errors)
 }
 
+# returns TRUE if any script had errors
 runSingle <- function(output, outputdirs, slurmConfig, test) { # comp = single
+  errors <- FALSE
   # Execute outputscripts for all chosen folders
   for (outputdir in outputdirs) {
     if (exists("cfg")) {
@@ -248,10 +254,11 @@ runSingle <- function(output, outputdirs, slurmConfig, test) { # comp = single
     # Get values of config if output.R is called standalone
     if (!exists("source_include")) {
       magpie_folder <- getwd()
-      message("Load data from ", file.path(outputdir, "config.Rdata"))
+      rdataPath <- file.path(outputdir, "config.Rdata")
+      message("Load data from ", rdataPath)
       # Old .cfg files will not be read anymore
-      stopifnot(file.exists(file.path(outputdir, "config.Rdata")))
-      load(file.path(outputdir, "config.Rdata"))
+      stopifnot(file.exists(rdataPath))
+      load(rdataPath)
       title <- cfg$title
       gms <- cfg$gms
       revision <- cfg$inputRevision
@@ -291,6 +298,7 @@ runSingle <- function(output, outputdirs, slurmConfig, test) { # comp = single
           gc()
           if (!is.null(tmp.error)) {
             warning("Script ", n, " was stopped by an error and not executed properly!")
+            errors <- TRUE
           }
         }
       } else {
@@ -311,6 +319,7 @@ runSingle <- function(output, outputdirs, slurmConfig, test) { # comp = single
       print(warnings())
     }
   }
+  return(errors)
 }
 
 #' main function of the script
@@ -346,8 +355,8 @@ output <- function(args) {
     }
     
     # choose the slurm options. If you use command line arguments, use slurmConfig=priority or standby
-    modules_using_slurmConfig <- c("compareScenarios2", "validateScenarios")
-    if (any(modules_using_slurmConfig %in% output)) {
+    modulesUsingSlurmConfig <- c("compareScenarios2", "validateScenarios")
+    if (isSlurmAvailable() && any(modulesUsingSlurmConfig %in% output)) {
       if (is.null(args[["slurmConfig"]])) {
         slurmConfig <- chooseSlurmConfigOutput(output = output)
       } else if (args[["slurmConfig"]] %in% c("priority", "short", "standby")) {
@@ -356,27 +365,27 @@ output <- function(args) {
         slurmConfig = args[["slurmConfig"]]
       }
     }
-    runComparisonOrExport(comp, output, outputdirs, aliases, filename_prefix, slurmConfig, args[["test"]])
+    errors = runComparisonOrExport(comp, output, outputdirs, aliases, filename_prefix, slurmConfig, args[["test"]])
   } else {
     # define slurm class or direct execution
     outputInteractive <- c("plotIterations", "integratedDamageCosts")
-    if (exists("source_include") || any(output %in% outputInteractive)) {
+    if (!isSlurmAvailable() || exists("source_include") || any(output %in% outputInteractive)) {
       # if being sourced by another script execute the output scripts directly without sending them to the cluster
       slurmConfig <- "direct"
+    } else if (is.null(args[["slurmConfig"]])) {
+      slurmConfig <- chooseSlurmConfigOutput(output = output)
+      if (slurmConfig != "direct") slurmConfig <- combine_slurmConfig("--nodes=1 --tasks-per-node=1 --time=120", slurmConfig)
+    } else if (args[["slurmConfig"]] %in% c("priority", "short", "standby")) {
+      slurmConfig <- paste0("--nodes=1 --tasks-per-node=1 --qos=", args[["slurmConfig"]])
+    } else if (isTRUE(args[["slurmConfig"]] %in% "direct")) {
+      interactive = TRUE
     } else {
-      # if it is called from the command line via Rscript let the user choose the slurm options
-      if (is.null(args[["slurmConfig"]])) {
-        slurmConfig <- chooseSlurmConfigOutput(output = output)
-        if (slurmConfig != "direct") slurmConfig <- combine_slurmConfig("--nodes=1 --tasks-per-node=1 --time=120", slurmConfig)
-      } else if (args[["slurmConfig"]] %in% c("priority", "short", "standby")) {
-        slurmConfig <- paste0("--nodes=1 --tasks-per-node=1 --qos=", args[["slurmConfig"]])
-      } else if (isTRUE(args[["slurmConfig"]] %in% "direct")) {
-        interactive = TRUE
-      } else {
-        slurmConfig = args[["slurmConfig"]]
-      }
+      slurmConfig = args[["slurmConfig"]]
     }
-    runSingle(output, outputdirs, slurmConfig, args[["test"]])
+    errors = runSingle(output, outputdirs, slurmConfig, args[["test"]])
+  }
+  if (errors) {
+    quit(status = -1)
   }
 }
 

--- a/scripts/output/single/reporting.R
+++ b/scripts/output/single/reporting.R
@@ -14,7 +14,7 @@ library(data.table)
 
 ############################# BASIC CONFIGURATION #############################
 
-gdx_name     <- "fulldata.gdx"             # name of the gdx
+gdx_name     <- "fulldata.gdx"
 gdx_ref_name <- "input_ref.gdx"            # name of the ref for < cm_startyear
 gdx_refpolicycost_name <- "input_refpolicycost.gdx"  # name of the reference gdx (for policy cost calculation)
 
@@ -23,6 +23,7 @@ if (!exists("source_include")) {
   outputdir <- "."
   lucode2::readArgs("outputdir", "gdx_name", "gdx_ref_name", "gdx_refpolicycost_name")
 }
+stopifnot(exists("outputdir"))
 
 gdx     <- file.path(outputdir, gdx_name)
 gdx_ref <- file.path(outputdir, gdx_ref_name)
@@ -35,7 +36,6 @@ scenario <- lucode2::getScenNames(outputdir)
 
 # paths of the reporting files
 remind_reporting_file <- file.path(outputdir, paste0("REMIND_generic_", scenario, ".mif"))
-LCOE_reporting_file   <- file.path(outputdir, paste0("REMIND_LCOE_", scenario, ".csv"))
 
 remind_policy_reporting_file <- file.path(outputdir, paste0("REMIND_generic_", scenario, "_adjustedPolicyCosts.mif"))
 remind_policy_reporting_file <- remind_policy_reporting_file[file.exists(remind_policy_reporting_file)]
@@ -157,11 +157,5 @@ mifcontent <- read.quitte(sub("\\.mif$", "_withoutPlus.mif", remind_reporting_fi
 quitte::reportDuplicates(mifcontent)
 
 message("### end generation of mif files at ", round(Sys.time()))
-
-# produce REMIND LCOE reporting *.csv based on gdx information ----
-
-message("### start generation of LCOE reporting at ", round(Sys.time()))
-remind2::convGDX2CSV_LCOE(gdx, file = LCOE_reporting_file, scen = scenario)
-message("### end generation of LCOE reporting at ", round(Sys.time()))
 
 message("### reporting finished.")

--- a/scripts/output/single/reportingLCOE.R
+++ b/scripts/output/single/reportingLCOE.R
@@ -1,0 +1,30 @@
+# |  (C) 2006-2024 Potsdam Institute for Climate Impact Research (PIK)
+# |  authors, and contributors see CITATION.cff file. This file is part
+# |  of REMIND and licensed under AGPL-3.0-or-later. Under Section 7 of
+# |  AGPL-3.0, you are granted additional permissions described in the
+# |  REMIND License Exception, version 1.0 (see LICENSE file).
+# |  Contact: remind@pik-potsdam.de
+
+#' @title Reporting LCOE
+#' @description Creates a csv file with LCOE reporting data
+
+library(remind2)
+library(lucode2)
+
+############################# BASIC CONFIGURATION #############################
+
+gdx_name     <- "fulldata.gdx"
+
+if (!exists("source_include")) {
+  outputdir <- "."
+  lucode2::readArgs("outputdir", "gdx_name")
+}
+stopifnot(exists("outputdir"))
+
+gdx     <- file.path(outputdir, gdx_name)
+scenario <- lucode2::getScenNames(outputdir)
+LCOE_reporting_file   <- file.path(outputdir, paste0("REMIND_LCOE_", scenario, ".csv"))
+
+message("### start LCOE reporting at ", round(Sys.time()))
+remind2::convGDX2CSV_LCOE(gdx, file = LCOE_reporting_file, scen = scenario)
+message("### finish LCOE reporting at ", round(Sys.time()))

--- a/tests/testthat/test_06-output.R
+++ b/tests/testthat/test_06-output.R
@@ -9,12 +9,21 @@ skipIfPreviousFailed()
 
 test_that("output.R -> single -> reporting works", {
   output <- localSystem2("Rscript", c("output.R", "--comp=single", "--output=reporting", "--outputdirs=output/testOneRegi",
-                                      "slurmConfig='--qos=priority --mem=8000 --wait --time=120'"))
+                                      "--slurmConfig='--qos=priority --mem=8000 --wait --time=120'"))
   printIfFailed(output)
   expectSuccessStatus(output)
   remind_reporting_file <- "../../output/testOneRegi/REMIND_generic_testOneRegi.mif"
   expect_true(file.exists(remind_reporting_file))
   expect_no_warning(quitte::reportDuplicates(piamutils::deletePlus(quitte::read.quitte(remind_reporting_file, check.duplicates = FALSE))))
+})
+
+test_that("output.R -> single -> reportingLCOE works", {
+  output <- localSystem2("Rscript", c("output.R", "--comp=single", "--output=reportingLCOE", "--outputdirs=output/testOneRegi",
+                                      "--slurmConfig='--qos=priority --mem=8000 --wait --time=120'"))
+  printIfFailed(output)
+  expectSuccessStatus(output)
+  remind_reporting_LCOE_file <- "../../output/testOneRegi/REMIND_LCOE_testOneRegi.csv"
+  expect_true(file.exists(remind_reporting_LCOE_file))
 })
 
 test_that("output.R -> export -> xlsx_IIASA works", {


### PR DESCRIPTION
## Purpose of this PR

The LCOE reporting is now offered as a separate output script instead of its integration into regular reporting, based n a request from @tabeado . I added a test to `test-full` and made sure that output.R can also be tested locally without Slurm present. Also, output.R returns an error status code now if any scripts fail.


*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :white_medium_square: GAMS Code
- :ballot_box_with_check: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :white_medium_square: Bug fix
- :ballot_box_with_check: Refactoring
- :ballot_box_with_check: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

* Runs with these changes are here:
* Comparison of results (what changes by this PR?): 
