### PR TITLE
Plot iterations for MAgPIE coupling: Prevent pdf overwriting if multiple PDF files are being created simultaneously

### DIFF
--- a/scripts/output/comparison/plotRemMagNash.R
+++ b/scripts/output/comparison/plotRemMagNash.R
@@ -112,28 +112,64 @@ plot_iterations <- function(dat, runname) {
   
   # ---- Print to pdf ----
   
-  out <- lusweave::swopen(template = "david")
-  
-  lusweave::swfigure(out, print, p_price_mag,         sw_option = "height=9,width=16")
-  lusweave::swfigure(out, print, p_price_mag_it,      sw_option = "height=9,width=16")
-  lusweave::swfigure(out, print, p_fuelex,            sw_option = "height=9,width=16")
-  lusweave::swfigure(out, print, p_fuelex_it,         sw_option = "height=9,width=16")
-  lusweave::swfigure(out, print, p_fuelex_it_fix,     sw_option = "height=9,width=16")
-  lusweave::swfigure(out, print, p_fuelex_it_2060,    sw_option = "height=9,width=16")
-  lusweave::swfigure(out, print, p_demPE_it,          sw_option = "height=9,width=16")
-  lusweave::swfigure(out, print, p_emi_mag,           sw_option = "height=9,width=16")
-  lusweave::swfigure(out, print, p_emi_mag_it,        sw_option = "height=9,width=16")
-  lusweave::swfigure(out, print, p_mult,              sw_option = "height=9,width=16")
-  lusweave::swfigure(out, print, p_mult_it,           sw_option = "height=9,width=16")
-  lusweave::swfigure(out, print, p_price_carbon,      sw_option = "height=9,width=16")
-  lusweave::swfigure(out, print, p_price_carbon_it_1, sw_option = "height=9,width=16")
-  lusweave::swfigure(out, print, p_price_carbon_it_2, sw_option = "height=9,width=16")
-  
-  filename <- paste0("output/", tail(runname$outputdirs, n=1), ifelse(nrow(runname)>1, "-continued", ""))
-  lusweave::swclose(out, outfile = filename, clean_output = TRUE, save_stream = FALSE)
-  file.remove(paste0(filename,c(".log")))
-  # out files have "." replaced with "-_-_-" in their names
-  #file.remove(paste0(gsub("\\.","-_-_-",filename),".out"))
+  filename <- paste0(tail(runname$outputdirs, n = 1), ifelse(nrow(runname) > 1, "-continued", ""))
+
+  # Collect the plots in the order they should appear in the report.
+  # The rmarkdown template (see beloew) reads this list.
+  plots <- list(p_price_mag, p_price_mag_it, p_fuelex, p_fuelex_it,
+                p_fuelex_it_fix, p_fuelex_it_2060, p_demPE_it, p_emi_mag,
+                p_emi_mag_it, p_mult, p_mult_it, p_price_carbon,
+                p_price_carbon_it_1, p_price_carbon_it_2)
+
+  # Use a unique working directory so two plotRemMagNash renders running in
+  # parallel do not overwrite each other's rmarkdown output or knit
+  # artefacts (intermediate .md/.tex files and figure files).
+  intermediates <- tempfile(pattern = "plotRemMagNash-")
+  dir.create(intermediates)
+  on.exit(unlink(intermediates, recursive = TRUE), add = TRUE)
+
+  # rmarkdown template written inline.
+  template <- c(
+    "---",
+    "output:",
+    "  pdf_document:",
+    "    latex_engine: pdflatex",
+    "geometry: a4paper, top=1.5cm, bottom=1.5cm, left=0.5cm, right=0.5cm",
+    "---",
+    "",
+    "```{r setup, include=FALSE}",
+    "knitr::opts_chunk$set(echo = FALSE, message = FALSE, warning = FALSE,",
+    "                      fig.width = 16, fig.height = 9,",
+    "                      out.width = \"20cm\", fig.align = \"center\")",
+    "```",
+    "",
+    "```{r plots, results='asis'}",
+    "# `plots` is provided by plot_iterations() via the render environment.",
+    "for (i in seq_along(plots)) {",
+    "  print(plots[[i]])",
+    "  if (i %% 2 == 1) {",
+    "    # First figure on the page: stretchable space pushes this figure to",
+    "    # the top margin and the next one to the bottom margin.",
+    "    cat(\"\\n\\n\\\\vfill\\n\\n\")",
+    "  } else if (i < length(plots)) {",
+    "    # Second figure on the page: start a new page. This keeps two figures",
+    "    # per page (14 plots -> 7 pages).",
+    "    cat(\"\\n\\n\\\\newpage\\n\\n\")",
+    "  }",
+    "}",
+    "```"
+  )
+  rmd <- file.path(intermediates, "plotRemMagNash.Rmd")
+  writeLines(template, rmd)
+
+  rmarkdown::render(
+    input             = rmd,
+    output_file       = paste0(filename, ".pdf"),
+    output_dir        = "output",
+    intermediates_dir = intermediates,
+    envir             = environment(),
+    quiet             = TRUE
+  )
   
   return("Done\n")
 }  

--- a/scripts/output/comparison/plotRemMagNash.R
+++ b/scripts/output/comparison/plotRemMagNash.R
@@ -105,9 +105,9 @@ plot_iterations <- function(dat, runname) {
   
   p_price_carbon      <- myplot(dat, "pm_taxCO2eq_iter", runname, ylab = "$/tCO2")
   
-  p_price_carbon_it_1 <- myplot(dat |> filter(ttot < 2025), "pm_taxCO2eq_iter", runname,
+  p_price_carbon_it_1 <- myplot(dat |> filter(ttot > 2025, ttot <= 2100), "pm_taxCO2eq_iter", runname,
                                 ylab = "$/tCO2", xaxis = "iteration", color = "ttot")
-  p_price_carbon_it_2 <- myplot(dat |> filter(ttot > 2020, ttot <= 2100), "pm_taxCO2eq_iter", runname,
+  p_price_carbon_it_2 <- myplot(dat |> filter(ttot < 2030), "pm_taxCO2eq_iter", runname,
                                 ylab = "$/tCO2", xaxis = "iteration", color = "ttot")
   
   # ---- Print to pdf ----
@@ -115,9 +115,9 @@ plot_iterations <- function(dat, runname) {
   filename <- paste0(tail(runname$outputdirs, n = 1), ifelse(nrow(runname) > 1, "-continued", ""))
 
   # Collect the plots in the order they should appear in the report.
-  # The rmarkdown template (see beloew) reads this list.
+  # The rmarkdown template (see below) reads this list.
   plots <- list(p_price_mag, p_price_mag_it, p_fuelex, p_fuelex_it,
-                p_fuelex_it_fix, p_fuelex_it_2060, p_demPE_it, p_emi_mag,
+                p_fuelex_it_fix, p_fuelex_it_2060, p_demPE, p_demPE_it, p_emi_mag,
                 p_emi_mag_it, p_mult, p_mult_it, p_price_carbon,
                 p_price_carbon_it_1, p_price_carbon_it_2)
 

--- a/scripts/output/comparison/plotRemMagNash.R
+++ b/scripts/output/comparison/plotRemMagNash.R
@@ -5,6 +5,17 @@
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
 
+############################# DESCRIPTION #############################
+#
+# Diagnostics for the REMIND-MAgPIE coupling. For a set of coupled runs this
+# script reads the per-iteration results and plots the key coupling variables
+# (bioenergy price, production and demand, CO2 land-use-change emissions, price
+# scaling factor and CO2 price), each shown both over time and over iterations
+# to reveal how the coupled models converge. If multiple runs are passed, the 
+# script interprets them in the specified order, treating the successors as 
+# continuations of their predecessors. The plots are compiled into a
+# multi-page PDF (two plots per A4 page) via rmarkdown.
+
 ############################# LOAD LIBRARIES #############################
 
 library(dplyr,    quietly = TRUE, warn.conflicts = FALSE)

--- a/scripts/output/single/plotRemMagNash.R
+++ b/scripts/output/single/plotRemMagNash.R
@@ -5,6 +5,15 @@
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
 
+############################# DESCRIPTION #############################
+#
+# Diagnostics for the REMIND-MAgPIE coupling. For a given coupled run this
+# script reads the per-iteration results and plots the key coupling variables
+# (bioenergy price, production and demand, CO2 land-use-change emissions, price
+# scaling factor and CO2 price), each shown both over time and over iterations
+# to reveal how the coupled models converge. The plots are compiled into a
+# multi-page PDF (two plots per A4 page) via rmarkdown.
+
 ############################# LOAD LIBRARIES #############################
 
 library(dplyr,    quietly = TRUE, warn.conflicts = FALSE)

--- a/scripts/output/single/plotRemMagNash.R
+++ b/scripts/output/single/plotRemMagNash.R
@@ -117,8 +117,7 @@ plot_iterations <- function(dat, runname) {
   filename <- paste0(tail(runname$outputdirs, n = 1), ifelse(nrow(runname) > 1, "-continued", ""))
 
   # Collect the plots in the order they should appear in the report.
-  # The rmarkdown template (see beloew) reads this list.
-  plots <- list(p_price_mag, p_price_mag_it, p_fuelex, p_fuelex_it,
+  # The rmarkdown template (see below) reads this list.
                 p_fuelex_it_fix, p_fuelex_it_2060, p_demPE_it, p_emi_mag,
                 p_emi_mag_it, p_mult, p_mult_it, p_price_carbon,
                 p_price_carbon_it_1, p_price_carbon_it_2)

--- a/scripts/output/single/plotRemMagNash.R
+++ b/scripts/output/single/plotRemMagNash.R
@@ -114,28 +114,64 @@ plot_iterations <- function(dat, runname) {
   
   # ---- Print to pdf ----
   
-  out <- lusweave::swopen(template = "david")
-  
-  lusweave::swfigure(out, print, p_price_mag,         sw_option = "height=9,width=16")
-  lusweave::swfigure(out, print, p_price_mag_it,      sw_option = "height=9,width=16")
-  lusweave::swfigure(out, print, p_fuelex,            sw_option = "height=9,width=16")
-  lusweave::swfigure(out, print, p_fuelex_it,         sw_option = "height=9,width=16")
-  lusweave::swfigure(out, print, p_fuelex_it_fix,     sw_option = "height=9,width=16")
-  lusweave::swfigure(out, print, p_fuelex_it_2060,    sw_option = "height=9,width=16")
-  lusweave::swfigure(out, print, p_demPE_it,          sw_option = "height=9,width=16")
-  lusweave::swfigure(out, print, p_emi_mag,           sw_option = "height=9,width=16")
-  lusweave::swfigure(out, print, p_emi_mag_it,        sw_option = "height=9,width=16")
-  lusweave::swfigure(out, print, p_mult,              sw_option = "height=9,width=16")
-  lusweave::swfigure(out, print, p_mult_it,           sw_option = "height=9,width=16")
-  lusweave::swfigure(out, print, p_price_carbon,      sw_option = "height=9,width=16")
-  lusweave::swfigure(out, print, p_price_carbon_it_1, sw_option = "height=9,width=16")
-  lusweave::swfigure(out, print, p_price_carbon_it_2, sw_option = "height=9,width=16")
-  
-  filename <- paste0("output/", tail(runname$outputdirs, n=1), ifelse(nrow(runname)>1, "-continued", ""))
-  lusweave::swclose(out, outfile = filename, clean_output = TRUE, save_stream = FALSE)
-  file.remove(paste0(filename,c(".log")))
-  # out files have "." replaced with "-_-_-" in their names
-  #file.remove(paste0(gsub("\\.","-_-_-",filename),".out"))
+  filename <- paste0(tail(runname$outputdirs, n = 1), ifelse(nrow(runname) > 1, "-continued", ""))
+
+  # Collect the plots in the order they should appear in the report.
+  # The rmarkdown template (see beloew) reads this list.
+  plots <- list(p_price_mag, p_price_mag_it, p_fuelex, p_fuelex_it,
+                p_fuelex_it_fix, p_fuelex_it_2060, p_demPE_it, p_emi_mag,
+                p_emi_mag_it, p_mult, p_mult_it, p_price_carbon,
+                p_price_carbon_it_1, p_price_carbon_it_2)
+
+  # Use a unique working directory so two plotRemMagNash renders running in
+  # parallel do not overwrite each other's rmarkdown output or knit
+  # artefacts (intermediate .md/.tex files and figure files).
+  intermediates <- tempfile(pattern = "plotRemMagNash-")
+  dir.create(intermediates)
+  on.exit(unlink(intermediates, recursive = TRUE), add = TRUE)
+
+  # rmarkdown template written inline.
+  template <- c(
+    "---",
+    "output:",
+    "  pdf_document:",
+    "    latex_engine: pdflatex",
+    "geometry: a4paper, top=1.5cm, bottom=1.5cm, left=0.5cm, right=0.5cm",
+    "---",
+    "",
+    "```{r setup, include=FALSE}",
+    "knitr::opts_chunk$set(echo = FALSE, message = FALSE, warning = FALSE,",
+    "                      fig.width = 16, fig.height = 9,",
+    "                      out.width = \"20cm\", fig.align = \"center\")",
+    "```",
+    "",
+    "```{r plots, results='asis'}",
+    "# `plots` is provided by plot_iterations() via the render environment.",
+    "for (i in seq_along(plots)) {",
+    "  print(plots[[i]])",
+    "  if (i %% 2 == 1) {",
+    "    # First figure on the page: stretchable space pushes this figure to",
+    "    # the top margin and the next one to the bottom margin.",
+    "    cat(\"\\n\\n\\\\vfill\\n\\n\")",
+    "  } else if (i < length(plots)) {",
+    "    # Second figure on the page: start a new page. This keeps two figures",
+    "    # per page (14 plots -> 7 pages).",
+    "    cat(\"\\n\\n\\\\newpage\\n\\n\")",
+    "  }",
+    "}",
+    "```"
+  )
+  rmd <- file.path(intermediates, "plotRemMagNash.Rmd")
+  writeLines(template, rmd)
+
+  rmarkdown::render(
+    input             = rmd,
+    output_file       = paste0(filename, ".pdf"),
+    output_dir        = "output",
+    intermediates_dir = intermediates,
+    envir             = environment(),
+    quiet             = TRUE
+  )
   
   return("Done\n")
 }  

--- a/scripts/output/single/plotRemMagNash.R
+++ b/scripts/output/single/plotRemMagNash.R
@@ -107,9 +107,9 @@ plot_iterations <- function(dat, runname) {
   
   p_price_carbon      <- myplot(dat, "pm_taxCO2eq_iter", runname, ylab = "$/tCO2")
   
-  p_price_carbon_it_1 <- myplot(dat |> filter(ttot < 2025), "pm_taxCO2eq_iter", runname,
+  p_price_carbon_it_1 <- myplot(dat |> filter(ttot > 2025, ttot <= 2100), "pm_taxCO2eq_iter", runname,
                                 ylab = "$/tCO2", xaxis = "iteration", color = "ttot")
-  p_price_carbon_it_2 <- myplot(dat |> filter(ttot > 2020, ttot <= 2100), "pm_taxCO2eq_iter", runname,
+  p_price_carbon_it_2 <- myplot(dat |> filter(ttot < 2030), "pm_taxCO2eq_iter", runname,
                                 ylab = "$/tCO2", xaxis = "iteration", color = "ttot")
   
   # ---- Print to pdf ----
@@ -119,7 +119,7 @@ plot_iterations <- function(dat, runname) {
   # Collect the plots in the order they should appear in the report.
   # The rmarkdown template (see below) reads this list.
   plots <- list(p_price_mag, p_price_mag_it, p_fuelex, p_fuelex_it,
-                p_fuelex_it_fix, p_fuelex_it_2060, p_demPE_it, p_emi_mag,
+                p_fuelex_it_fix, p_fuelex_it_2060, p_demPE, p_demPE_it, p_emi_mag,
                 p_emi_mag_it, p_mult, p_mult_it, p_price_carbon,
                 p_price_carbon_it_1, p_price_carbon_it_2)
 

--- a/scripts/output/single/plotRemMagNash.R
+++ b/scripts/output/single/plotRemMagNash.R
@@ -118,6 +118,7 @@ plot_iterations <- function(dat, runname) {
 
   # Collect the plots in the order they should appear in the report.
   # The rmarkdown template (see below) reads this list.
+  plots <- list(p_price_mag, p_price_mag_it, p_fuelex, p_fuelex_it,
                 p_fuelex_it_fix, p_fuelex_it_2060, p_demPE_it, p_emi_mag,
                 p_emi_mag_it, p_mult, p_mult_it, p_price_carbon,
                 p_price_carbon_it_1, p_price_carbon_it_2)

--- a/scripts/utils/release.R
+++ b/scripts/utils/release.R
@@ -86,7 +86,7 @@ release <- function(newVersion) {
   message("Please only continue if you already cleaned CHANGELOG.md:\n",
           "In another terminal:\n",
           "1. git add -p\n",
-          "2. git commit -m 'your commit message\n'",
+          "2. git commit -m 'your commit message'\n",
           "3. git push yourRemote yourReleaseCandidateBranch",
           "--> When done press ENTER to create PR")
   gms::getLine()


### PR DESCRIPTION
## Purpose of this PR

For the pdf files that compare MAgPIE iterations: When creating PDF files, use unique temporary file names to prevent overwriting if multiple PDF files are being created simultaneously. To do this, replace “lusweave” with “rmarkdown.” I checked that the resulting pdf files exactly match the old ones.

## Type of change

### Parts concerned
- :white_medium_square: GAMS Code
- :ballot_box_with_check: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :ballot_box_with_check: Bug fix
- :white_medium_square: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)