### PR TITLE
Enable and revise switches on CO2 capture, utilization, and storage assumption 

### DIFF
--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -342,8 +342,9 @@ vm_cap.fx("2010",regi,teCCS,rlf) = 0;
 vm_cap.fx("2020",regi,te,rlf) $ (teBio(te) and teCCS(te)) = 0;
 
 *' switch to deactivate carbon sequestration
-if(c_ccsinjecratescen = 0,
-  vm_co2CCS.fx(t,regi_capturescen,"cco2","ico2",te,rlf) $ teCCS2rlf(te,rlf) = 0;
+if(c_ccsinjecratescen = 0, !! also need to add that there must be no CCU allowed for this to be set? 
+  vm_deltaCap.up(t,regi_CCtech_energy,"ccsinjeon","1") $ (t.val ge cm_startyear) = sm_eps;
+  vm_deltaCap.up(t,regi_CCtech_energy,"ccsinjeoff","1") $ (t.val ge cm_startyear) = sm_eps;
 );
 
 *' Bounds on maximum annual carbon storage by region
@@ -393,15 +394,14 @@ if(cm_emiscen = 1,
 );
 
 
-if(cm_ccapturescen = 2, !! no carbon capture at all
-  vm_cap.fx(t,regi_capturescen,teCCS,rlf) = 0;
-  vm_cap.fx(t,regi_capturescen,te,rlf) $ teCCS2rlf(te,rlf) = 0;
-elseif(cm_ccapturescen = 3), !! no bio carbon capture:
-  vm_cap.fx(t,regi_capturescen,te,rlf) $ (teCCS(te) and teBio(te)) = 0;
-elseif(cm_ccapturescen = 4), !! no carbon capture in the electricity sector
-  loop(emi2te(enty,"seel",te,"cco2") $ ( sum(regi_capturescen, pm_emifac("2020",regi_capturescen,enty,"seel",te,"cco2")) > 0 ),
+if(cm_captureEnergy = 2, !! no carbon capture at all
+  vm_deltaCap.up(t,regi_CCtech_energy,teCCS,rlf) $ (t.val ge cm_startyear) = sm_eps;
+elseif(cm_captureEnergy = 3), !! no bio carbon capture:
+  vm_deltaCap.up(t,regi_CCtech_energy,te,rlf) $ ((t.val ge cm_startyear) and teCCS(te) and teBio(te)) = sm_eps;
+elseif(cm_captureEnergy = 4), !! no carbon capture in the electricity sector
+  loop(emi2te(enty,"seel",te,"cco2") $ ( sum(regi_CCtech_energy, pm_emifac("2020",regi_CCtech_energy,enty,"seel",te,"cco2")) > 0 ),
     loop(te2rlf(te,rlf),
-      vm_cap.fx(t,regi_capturescen,te,rlf) = 0;
+      vm_deltaCap.up(t,regi_CCtech_energy,te,rlf) $ (t.val ge cm_startyear)  = sm_eps;
     );
   );
 );

--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -343,8 +343,7 @@ vm_cap.fx("2020",regi,te,rlf) $ (teBio(te) and teCCS(te)) = 0;
 
 *' switch to deactivate carbon sequestration
 if(c_ccsinjecratescen = 0, 
-  vm_deltaCap.up(t,regi_CCtech_energy,"ccsinjeon","1") $ (t.val ge cm_startyear) = sm_eps;
-  vm_deltaCap.up(t,regi_CCtech_energy,"ccsinjeoff","1") $ (t.val ge cm_startyear) = sm_eps;
+  vm_deltaCap.up(t,regi_CCtech_energy,teccsinje,"1") = sm_eps;
 );
 
 *' Bounds on maximum annual carbon storage by region

--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -394,11 +394,11 @@ if(cm_emiscen = 1,
 );
 
 
-if(c_captureEnergy = 2, !! no carbon capture at all
+if(c_co2captureEnergy = 2, !! no carbon capture at all
   vm_deltaCap.up(t,regi_CCtech_energy,teCCS,rlf) $ (t.val ge cm_startyear) = sm_eps;
-elseif(c_captureEnergy = 3), !! no bio carbon capture:
+elseif(c_co2captureEnergy = 3), !! no bio carbon capture:
   vm_deltaCap.up(t,regi_CCtech_energy,te,rlf) $ ((t.val ge cm_startyear) and teCCS(te) and teBio(te)) = sm_eps;
-elseif(c_captureEnergy = 4), !! no carbon capture in the electricity sector
+elseif(c_co2captureEnergy = 4), !! no carbon capture in the electricity sector
   loop(emi2te(enty,"seel",te,"cco2") $ ( sum(regi_CCtech_energy, pm_emifac("2020",regi_CCtech_energy,enty,"seel",te,"cco2")) > 0 ),
     loop(te2rlf(te,rlf),
       vm_deltaCap.up(t,regi_CCtech_energy,te,rlf) $ (t.val ge cm_startyear)  = sm_eps;

--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -324,7 +324,7 @@ loop(te $ sameas(te, "biopyrliq"), !! does not yet exist commercially
   vm_deltaCap.lo(t,regi,"biopyrliq",rlf) $ (t.val > cm_startyear) = 1e-8; !! initiate a negligible increase to help model find the technology
   vm_deltaCap.up(t,regi,"biopyrliq",rlf) $ (t.val > cm_startyear) = inf; !! revert fixing to small values above
   if(c_biopyrOptions le 1,
-  vm_deltaCap.fx(t,regi,"biopyrliq",rlf) $ (t.val >= cm_startyear) = 0;
+  vm_deltaCap.fx(t,regi,"biopyrliq",rlf) = 0;
   );
 );
 
@@ -343,8 +343,8 @@ vm_cap.fx("2020",regi,te,rlf) $ (teBio(te) and teCCS(te)) = 0;
 
 *' switch to deactivate carbon sequestration
 if(c_ccsinjecratescen = 0, 
-  vm_deltaCap.up(t,regi_CCtech_energy,"ccsinjeon","1") $ (t.val ge cm_startyear) = sm_eps;
-  vm_deltaCap.up(t,regi_CCtech_energy,"ccsinjeoff","1") $ (t.val ge cm_startyear) = sm_eps;
+  vm_deltaCap.up(t,regi_co2captureEnergy,"ccsinjeon","1") = sm_eps;
+  vm_deltaCap.up(t,regi_co2captureEnergy,"ccsinjeoff","1") = sm_eps;
 );
 
 *' Bounds on maximum annual carbon storage by region
@@ -395,13 +395,13 @@ if(cm_emiscen = 1,
 
 
 if(c_co2captureEnergy = 2, !! no carbon capture at all
-  vm_deltaCap.up(t,regi_CCtech_energy,teCCS,rlf) $ (t.val ge cm_startyear) = sm_eps;
+  vm_deltaCap.up(t,regi_co2captureEnergy,teCCS,rlf) = sm_eps;
 elseif(c_co2captureEnergy = 3), !! no bio carbon capture:
-  vm_deltaCap.up(t,regi_CCtech_energy,te,rlf) $ ((t.val ge cm_startyear) and teCCS(te) and teBio(te)) = sm_eps;
+  vm_deltaCap.up(t,regi_co2captureEnergy,te,rlf) $ (teCCS(te) and teBio(te)) = sm_eps;
 elseif(c_co2captureEnergy = 4), !! no carbon capture in the electricity sector
-  loop(emi2te(enty,"seel",te,"cco2") $ ( sum(regi_CCtech_energy, pm_emifac("2020",regi_CCtech_energy,enty,"seel",te,"cco2")) > 0 ),
+  loop(emi2te(enty,"seel",te,"cco2") $ ( sum(regi_co2captureEnergy, pm_emifac("2020",regi_co2captureEnergy,enty,"seel",te,"cco2")) > 0 ),
     loop(te2rlf(te,rlf),
-      vm_deltaCap.up(t,regi_CCtech_energy,te,rlf) $ (t.val ge cm_startyear)  = sm_eps;
+      vm_deltaCap.up(t,regi_co2captureEnergy,te,rlf)  = sm_eps;
     );
   );
 );

--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -342,7 +342,7 @@ vm_cap.fx("2010",regi,teCCS,rlf) = 0;
 vm_cap.fx("2020",regi,te,rlf) $ (teBio(te) and teCCS(te)) = 0;
 
 *' switch to deactivate carbon sequestration
-if(c_ccsinjecratescen = 0, !! also need to add that there must be no CCU allowed for this to be set? 
+if(c_ccsinjecratescen = 0, 
   vm_deltaCap.up(t,regi_CCtech_energy,"ccsinjeon","1") $ (t.val ge cm_startyear) = sm_eps;
   vm_deltaCap.up(t,regi_CCtech_energy,"ccsinjeoff","1") $ (t.val ge cm_startyear) = sm_eps;
 );

--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -394,11 +394,11 @@ if(cm_emiscen = 1,
 );
 
 
-if(cm_captureEnergy = 2, !! no carbon capture at all
+if(c_captureEnergy = 2, !! no carbon capture at all
   vm_deltaCap.up(t,regi_CCtech_energy,teCCS,rlf) $ (t.val ge cm_startyear) = sm_eps;
-elseif(cm_captureEnergy = 3), !! no bio carbon capture:
+elseif(c_captureEnergy = 3), !! no bio carbon capture:
   vm_deltaCap.up(t,regi_CCtech_energy,te,rlf) $ ((t.val ge cm_startyear) and teCCS(te) and teBio(te)) = sm_eps;
-elseif(cm_captureEnergy = 4), !! no carbon capture in the electricity sector
+elseif(c_captureEnergy = 4), !! no carbon capture in the electricity sector
   loop(emi2te(enty,"seel",te,"cco2") $ ( sum(regi_CCtech_energy, pm_emifac("2020",regi_CCtech_energy,enty,"seel",te,"cco2")) > 0 ),
     loop(te2rlf(te,rlf),
       vm_deltaCap.up(t,regi_CCtech_energy,te,rlf) $ (t.val ge cm_startyear)  = sm_eps;

--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -1416,10 +1416,10 @@ $if  "%cm_rcp_scen%" == "none"    sm_budgetCO2eqGlob = 20000.0000;
   );
   if(cm_multigasscen eq 2,
 $if  "%cm_rcp_scen%" == "rcp20"   sm_budgetCO2eqGlob = 500.0000;
-     if(cm_ccapturescen eq 1,
+     if(cm_captureEnergy eq 1,
 $if  "%cm_rcp_scen%" == "rcp26"   sm_budgetCO2eqGlob = 530.0000;
      );
-     if(cm_ccapturescen gt 1,
+     if(cm_captureEnergy gt 1,
 $if  "%cm_rcp_scen%" == "rcp26"   sm_budgetCO2eqGlob = 700.0000;
      );
 $if  "%cm_rcp_scen%" == "rcp37"   sm_budgetCO2eqGlob = 1000.0000;

--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -1416,10 +1416,10 @@ $if  "%cm_rcp_scen%" == "none"    sm_budgetCO2eqGlob = 20000.0000;
   );
   if(cm_multigasscen eq 2,
 $if  "%cm_rcp_scen%" == "rcp20"   sm_budgetCO2eqGlob = 500.0000;
-     if(c_captureEnergy eq 1,
+     if(c_co2captureEnergy eq 1,
 $if  "%cm_rcp_scen%" == "rcp26"   sm_budgetCO2eqGlob = 530.0000;
      );
-     if(c_captureEnergy gt 1,
+     if(c_co2captureEnergy gt 1,
 $if  "%cm_rcp_scen%" == "rcp26"   sm_budgetCO2eqGlob = 700.0000;
      );
 $if  "%cm_rcp_scen%" == "rcp37"   sm_budgetCO2eqGlob = 1000.0000;

--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -1416,10 +1416,10 @@ $if  "%cm_rcp_scen%" == "none"    sm_budgetCO2eqGlob = 20000.0000;
   );
   if(cm_multigasscen eq 2,
 $if  "%cm_rcp_scen%" == "rcp20"   sm_budgetCO2eqGlob = 500.0000;
-     if(cm_captureEnergy eq 1,
+     if(c_captureEnergy eq 1,
 $if  "%cm_rcp_scen%" == "rcp26"   sm_budgetCO2eqGlob = 530.0000;
      );
-     if(cm_captureEnergy gt 1,
+     if(c_captureEnergy gt 1,
 $if  "%cm_rcp_scen%" == "rcp26"   sm_budgetCO2eqGlob = 700.0000;
      );
 $if  "%cm_rcp_scen%" == "rcp37"   sm_budgetCO2eqGlob = 1000.0000;

--- a/core/sets.gms
+++ b/core/sets.gms
@@ -836,11 +836,11 @@ $ELSE.RegScenNuc
   set regi_nucscen(all_regi) "regions which nucscen applies to" / %c_regi_nucscen% /;
 $ENDIF.RegScenNuc
 
-$IFTHEN.RegScenCapt "%c_regi_captureEnergy%" == "all"
-  set regi_CCtech_energy(all_regi) "regions which energy carbon capture scenario c_captureEnergy applies to";
+$IFTHEN.RegScenCapt "%c_regi_co2captureEnergy%" == "all"
+  set regi_CCtech_energy(all_regi) "regions which energy carbon capture scenario c_co2captureEnergy applies to";
   regi_CCtech_energy(all_regi)=YES;
 $ELSE.RegScenCapt
-  set regi_CCtech_energy(all_regi) "regions which energy carbon capture scenario c_captureEnergy applies to" / %c_regi_captureEnergy% /;
+  set regi_CCtech_energy(all_regi) "regions which energy carbon capture scenario c_co2captureEnergy applies to" / %c_regi_co2captureEnergy% /;
 $ENDIF.RegScenCapt
 
 *** definition of set of regions that use alternative FE emission factors from umweltbundesamt

--- a/core/sets.gms
+++ b/core/sets.gms
@@ -837,10 +837,10 @@ $ELSE.RegScenNuc
 $ENDIF.RegScenNuc
 
 $IFTHEN.RegScenCapt "%c_regi_captureEnergy%" == "all"
-  set regi_CCtech_energy(all_regi) "regions which energy carbon capture scenario cm_captureEnergy applies to";
+  set regi_CCtech_energy(all_regi) "regions which energy carbon capture scenario c_captureEnergy applies to";
   regi_CCtech_energy(all_regi)=YES;
 $ELSE.RegScenCapt
-  set regi_CCtech_energy(all_regi) "regions which energy carbon capture scenario cm_captureEnergy applies to" / %c_regi_captureEnergy% /;
+  set regi_CCtech_energy(all_regi) "regions which energy carbon capture scenario c_captureEnergy applies to" / %c_regi_captureEnergy% /;
 $ENDIF.RegScenCapt
 
 *** definition of set of regions that use alternative FE emission factors from umweltbundesamt

--- a/core/sets.gms
+++ b/core/sets.gms
@@ -836,11 +836,11 @@ $ELSE.RegScenNuc
   set regi_nucscen(all_regi) "regions which nucscen applies to" / %c_regi_nucscen% /;
 $ENDIF.RegScenNuc
 
-$IFTHEN.RegScenCapt "%c_regi_capturescen%" == "all"
-  set regi_capturescen(all_regi) "regions which capturescen applies to";
-  regi_capturescen(all_regi)=YES;
+$IFTHEN.RegScenCapt "%c_regi_captureEnergy%" == "all"
+  set regi_CCtech_energy(all_regi) "regions which energy carbon capture scenario cm_captureEnergy applies to";
+  regi_CCtech_energy(all_regi)=YES;
 $ELSE.RegScenCapt
-  set regi_capturescen(all_regi) "regions which capturescen applies to" / %c_regi_capturescen% /;
+  set regi_CCtech_energy(all_regi) "regions which energy carbon capture scenario cm_captureEnergy applies to" / %c_regi_captureEnergy% /;
 $ENDIF.RegScenCapt
 
 *** definition of set of regions that use alternative FE emission factors from umweltbundesamt

--- a/core/sets.gms
+++ b/core/sets.gms
@@ -837,10 +837,10 @@ $ELSE.RegScenNuc
 $ENDIF.RegScenNuc
 
 $IFTHEN.RegScenCapt "%c_regi_co2captureEnergy%" == "all"
-  set regi_CCtech_energy(all_regi) "regions which energy carbon capture scenario c_co2captureEnergy applies to";
-  regi_CCtech_energy(all_regi)=YES;
+  set regi_co2captureEnergy(all_regi) "regions which energy carbon capture scenario c_co2captureEnergy applies to";
+  regi_co2captureEnergy(all_regi)=YES;
 $ELSE.RegScenCapt
-  set regi_CCtech_energy(all_regi) "regions which energy carbon capture scenario c_co2captureEnergy applies to" / %c_regi_co2captureEnergy% /;
+  set regi_co2captureEnergy(all_regi) "regions which energy carbon capture scenario c_co2captureEnergy applies to" / %c_regi_co2captureEnergy% /;
 $ENDIF.RegScenCapt
 
 *** definition of set of regions that use alternative FE emission factors from umweltbundesamt

--- a/main.gms
+++ b/main.gms
@@ -637,9 +637,9 @@ parameter
 *' *  (6): +33% investment costs for tnrs under SSP5, uranium resources increased by a factor of 10
 *'
 parameter
-  c_captureEnergy        "carbon capture option choice for energy conversion technologies. Regions that this is applied to are defined in cm_regi_captureEnergy"
+  c_co2captureEnergy        "carbon capture option choice for energy conversion technologies. Regions that this is applied to are defined in cm_regi_captureEnergy"
 ;
-  c_captureEnergy  = 1;        !! def = 1  !! regexp = [1-4]
+  c_co2captureEnergy  = 1;        !! def = 1  !! regexp = [1-4]
 *' *  (1): all teCCS technologies are available
 *' *  (2): no teCCS technologies are available. Note: this no longer limits geologic CO2 storage! 
 *' *  (3): no bio carbon capture from teCCS technologies
@@ -687,24 +687,24 @@ parameter
   cm_optimisticMAC       = 0;        !! def = 0
 *'
 parameter
-  cm_captureInd             "carbon capture for Industry on/off"
+  cm_co2captureInd             "carbon capture for Industry on/off"
 ;
-  cm_captureInd          = 1;        !! def = 1
+  cm_co2captureInd          = 1;        !! def = 1
 *'
 parameter
-  cm_captureCement             "carbon capture for cement sub-sector on/off"
+  cm_co2captureCement             "carbon capture for cement sub-sector on/off"
 ;
-  cm_captureCement          = 1;        !! def = 1
+  cm_co2captureCement          = 1;        !! def = 1
 *'
 parameter
-  cm_captureChemicals          "carbon capture for chemicals sub-sector on/off"
+  cm_co2captureChemicals          "carbon capture for chemicals sub-sector on/off"
 ;
-  cm_captureChemicals       = 1;        !! def = 1
+  cm_co2captureChemicals       = 1;        !! def = 1
 *'
 parameter
-  cm_captureSteel              "carbon capture for steel sub-sector on/off"
+  cm_co2captureSteel              "carbon capture for steel sub-sector on/off"
 ;
-  cm_captureSteel           = 1;        !! def = 1
+  cm_co2captureSteel           = 1;        !! def = 1
 *'
 parameter
   cm_bioenergy_SustTax      "level of the bioenergy sustainability tax in fraction of bioenergy price"
@@ -1921,14 +1921,14 @@ $setglobal cm_inco0RegiFactor  off  !! def = off
 *'  * (med): new main estimate; 12 USD/tCO2 at all times (similar to ~11.4 USD/tCO2 average of saline formations, on- and offshore DOG fields in Budinis et al 2017)
 *'  * (high): upper estimate; ~20USD/tCO2 (constant), assuming upper end of storage cost and long transport distances
 $setglobal cm_ccsinjeCost high !! def = high !! regexp = med|low|high
-*** cm_captureEnergyMarkup "multiplicative factor for carbon capture technologies (teCCS) cost markup"
+*** cm_co2captureEnergyMarkup "multiplicative factor for carbon capture technologies (teCCS) cost markup"
 ***   def <- "off" = use default CC pm_inco0_t values.
 ***   or number (ex. 0.66), multiply by 0.66 the CSS cost markup
-$setglobal cm_captureEnergyMarkup  off  !! def = off
-*** cm_captureIndMarkup "multiplicative factor for Industry carbon capture cost markup"
+$setglobal cm_co2captureEnergyMarkup  off  !! def = off
+*** cm_co2captureIndMarkup "multiplicative factor for Industry carbon capture cost markup"
 ***   def <- "off"
 ***   or number (ex. 0.66), multiply by 0.66 Industry carbon capture cost markup
-$setglobal cm_captureIndMarkup  off !! def = off
+$setglobal cm_co2captureIndMarkup  off !! def = off
 *' Flag to change learning assumption for established pyrolysis technologies. 0 = not learning; any number = learning rate
 *' Beware: When turned on, policy runs require a NPi that also has learning, otherwise it becomes unbounded.
 *' (0.1): Learning rate of 10%.
@@ -2155,8 +2155,8 @@ $setGlobal c_skip_output  off        !! def = off  !! regexp = off|on
 $setglobal cm_CO2TaxSectorMarkup  off   !! def = off
 *** c_regi_nucscen              "regions to apply cm_nucscen to in case of cm_nucscen = 5 (no new nuclear investments), e.g. c_regi_nucscen <- "JPN,USA"
 $setGlobal c_regi_nucscen  all  !! def = all
-***  c_regi_captureEnergy              "regions to apply c_captureEnergy to (availability of carbon capture technologies), e.g. c_regi_captureEnergy <- "JPN,USA"
-$setGlobal c_regi_captureEnergy  all  !! def = all
+***  c_regi_co2captureEnergy              "regions to apply c_co2captureEnergy to (availability of carbon capture technologies), e.g. c_regi_co2captureEnergy <- "JPN,USA"
+$setGlobal c_regi_co2captureEnergy  all  !! def = all
 *** cm_subsec_model_steel      "switch between ces-based and process-based steel implementation in subsectors realisation of industry module"
 $setglobal cm_subsec_model_steel  processes  !! def = processes  !! regexp = processes|ces
 *** cm_tech_bounds_2025

--- a/main.gms
+++ b/main.gms
@@ -943,7 +943,7 @@ parameter
   c_ccsinjecratescen    = 1;         !! def = 1  !! regexp = [0-6]
 *' This switch determines the upper bound of the annual CCS injection rate.
 *' CCS here refers to carbon sequestration, carbon capture is modelled separately.
-*' *   (0) no "CCS" as in no carbon sequestration at all
+*' *   (0) no "CCS" as in no carbon sequestration at all. Note: there can still be carbon capture unless this is turned off as well.
 *' *   (1) reference case: 0.005; max 19.7 GtCO2/yr globally
 *' *   (2) lower estimate: 0.0025; max 9.8 GtCO2/yr globally
 *' *   (3) upper estimate: 0.0075; max 29.5 GtCO2/yr globally

--- a/main.gms
+++ b/main.gms
@@ -637,9 +637,9 @@ parameter
 *' *  (6): +33% investment costs for tnrs under SSP5, uranium resources increased by a factor of 10
 *'
 parameter
-  cm_captureEnergy        "carbon capture option choice for energy conversion technologies. Regions that this is applied to are defined in cm_regi_captureEnergy"
+  c_captureEnergy        "carbon capture option choice for energy conversion technologies. Regions that this is applied to are defined in cm_regi_captureEnergy"
 ;
-  cm_captureEnergy  = 1;        !! def = 1  !! regexp = [1-4]
+  c_captureEnergy  = 1;        !! def = 1  !! regexp = [1-4]
 *' *  (1): all teCCS technologies are available
 *' *  (2): no teCCS technologies are available. Note: this no longer limits geologic CO2 storage! 
 *' *  (3): no bio carbon capture from teCCS technologies
@@ -2155,7 +2155,7 @@ $setGlobal c_skip_output  off        !! def = off  !! regexp = off|on
 $setglobal cm_CO2TaxSectorMarkup  off   !! def = off
 *** c_regi_nucscen              "regions to apply cm_nucscen to in case of cm_nucscen = 5 (no new nuclear investments), e.g. c_regi_nucscen <- "JPN,USA"
 $setGlobal c_regi_nucscen  all  !! def = all
-***  c_regi_captureEnergy              "regions to apply cm_captureEnergy to (availability of carbon capture technologies), e.g. c_regi_captureEnergy <- "JPN,USA"
+***  c_regi_captureEnergy              "regions to apply c_captureEnergy to (availability of carbon capture technologies), e.g. c_regi_captureEnergy <- "JPN,USA"
 $setGlobal c_regi_captureEnergy  all  !! def = all
 *** cm_subsec_model_steel      "switch between ces-based and process-based steel implementation in subsectors realisation of industry module"
 $setglobal cm_subsec_model_steel  processes  !! def = processes  !! regexp = processes|ces

--- a/main.gms
+++ b/main.gms
@@ -637,15 +637,15 @@ parameter
 *' *  (6): +33% investment costs for tnrs under SSP5, uranium resources increased by a factor of 10
 *'
 parameter
-  c_co2captureEnergy        "carbon capture option choice for energy conversion technologies. Regions that this is applied to are defined in cm_regi_captureEnergy"
+  c_co2captureEnergy        "carbon capture option choice for energy conversion technologies. Regions that this is applied to are defined in c_regi_co2captureEnergy"
 ;
   c_co2captureEnergy  = 1;        !! def = 1  !! regexp = [1-4]
 *' *  (1): all teCCS technologies are available
-*' *  (2): no teCCS technologies are available. Note: this no longer limits geologic CO2 storage! 
+*' *  (2): no teCCS technologies are available. Note: this does not limit geologic CO2 storage! 
 *' *  (3): no bio carbon capture from teCCS technologies
 *' *  (4): no carbon capture in the electricity sector via teCCS technologies
 *' Note: This does not affect carbon capture of emissions in industry, via DAC or OAE! 
-*' Align with other cm_CCtech..., cm_33DAC, cm_33OAE, as well as ccsinje and carbonUtilization assumptions for the intended overall narrative.
+*' Align with other cm_co2capture..., cm_33DAC, cm_33OAE, as well as ccsinje and carbonUtilization assumptions for the intended overall narrative.
 
 parameter
   c_bioliqscen              "2nd generation bioenergy liquids technology choice"
@@ -689,22 +689,22 @@ parameter
 parameter
   cm_co2captureInd             "carbon capture for Industry on/off"
 ;
-  cm_co2captureInd          = 1;        !! def = 1
+  cm_co2captureInd          = 1;        !! def = 1   !! regexp = 0|1
 *'
 parameter
   cm_co2captureCement             "carbon capture for cement sub-sector on/off"
 ;
-  cm_co2captureCement          = 1;        !! def = 1
+  cm_co2captureCement          = 1;        !! def = 1   !! regexp = 0|1
 *'
 parameter
   cm_co2captureChemicals          "carbon capture for chemicals sub-sector on/off"
 ;
-  cm_co2captureChemicals       = 1;        !! def = 1
+  cm_co2captureChemicals       = 1;        !! def = 1   !! regexp = 0|1
 *'
 parameter
   cm_co2captureSteel              "carbon capture for steel sub-sector on/off"
 ;
-  cm_co2captureSteel           = 1;        !! def = 1
+  cm_co2captureSteel           = 1;        !! def = 1   !! regexp = 0|1
 *'
 parameter
   cm_bioenergy_SustTax      "level of the bioenergy sustainability tax in fraction of bioenergy price"
@@ -943,7 +943,7 @@ parameter
   c_ccsinjecratescen    = 1;         !! def = 1  !! regexp = [0-6]
 *' This switch determines the upper bound of the annual CCS injection rate.
 *' CCS here refers to carbon sequestration, carbon capture is modelled separately.
-*' *   (0) no "CCS" as in no carbon sequestration at all. Note: there can still be carbon capture unless this is turned off as well.
+*' *   (0) no "CCS" as in no carbon sequestration at all. Note: there can still be carbon capture unless this is turned off as well via cm_co2capture...
 *' *   (1) reference case: 0.005; max 19.7 GtCO2/yr globally
 *' *   (2) lower estimate: 0.0025; max 9.8 GtCO2/yr globally
 *' *   (3) upper estimate: 0.0075; max 29.5 GtCO2/yr globally
@@ -1921,13 +1921,13 @@ $setglobal cm_inco0RegiFactor  off  !! def = off
 *'  * (med): new main estimate; 12 USD/tCO2 at all times (similar to ~11.4 USD/tCO2 average of saline formations, on- and offshore DOG fields in Budinis et al 2017)
 *'  * (high): upper estimate; ~20USD/tCO2 (constant), assuming upper end of storage cost and long transport distances
 $setglobal cm_ccsinjeCost high !! def = high !! regexp = med|low|high
-*** cm_co2captureEnergyMarkup "multiplicative factor for carbon capture technologies (teCCS) cost markup"
-***   def <- "off" = use default CC pm_inco0_t values.
-***   or number (ex. 0.66), multiply by 0.66 the CSS cost markup
+*** cm_co2captureEnergyMarkup "multiplicative factor for CO2 capture technologies (teCCS) capital cost markup applied to EUR_regi regions"
+*' *  (off): use default pm_inco0_t values for teCCS technologies
+*' *  (any value gt 0): multiply by the capital cost by the given factor. E.g. factor 0.66 reduces the capital cost of carbon capture technologies by 1/3.
 $setglobal cm_co2captureEnergyMarkup  off  !! def = off
-*** cm_co2captureIndMarkup "multiplicative factor for Industry carbon capture cost markup"
-***   def <- "off"
-***   or number (ex. 0.66), multiply by 0.66 Industry carbon capture cost markup
+*** cm_co2captureIndMarkup "multiplicative factor for Industry CO2 capture cost "
+*' * (off): use default co2 capture cost in industry
+*' * (any value gt 0): multiply the CO2 capture cost in industry by the given factor. E.g. factor 0.66 reduces the carbon capture cost in industry by 1/3.'
 $setglobal cm_co2captureIndMarkup  off !! def = off
 *' Flag to change learning assumption for established pyrolysis technologies. 0 = not learning; any number = learning rate
 *' Beware: When turned on, policy runs require a NPi that also has learning, otherwise it becomes unbounded.

--- a/main.gms
+++ b/main.gms
@@ -637,14 +637,16 @@ parameter
 *' *  (6): +33% investment costs for tnrs under SSP5, uranium resources increased by a factor of 10
 *'
 parameter
-  cm_ccapturescen       "carbon capture option choice, no carbon capture only if CCS and CCU are switched off!"
+  cm_captureEnergy        "carbon capture option choice for energy conversion technologies. Regions that this is applied to are defined in cm_regi_captureEnergy"
 ;
-  cm_ccapturescen  = 1;        !! def = 1  !! regexp = [1-4]
-*' *  (1): yes
-*' *  (2): no carbon capture (only if CCS and CCU are switched off!)
-*' *  (3): no bio carbon capture
-*' *  (4): no carbon capture in the electricity sector
-*'
+  cm_captureEnergy  = 1;        !! def = 1  !! regexp = [1-4]
+*' *  (1): all teCCS technologies are available
+*' *  (2): no teCCS technologies are available. Note: this no longer limits geologic CO2 storage! 
+*' *  (3): no bio carbon capture from teCCS technologies
+*' *  (4): no carbon capture in the electricity sector via teCCS technologies
+*' Note: This does not affect carbon capture of emissions in industry, via DAC or OAE! 
+*' Align with other cm_CCtech..., cm_33DAC, cm_33OAE, as well as ccsinje and carbonUtilization assumptions for the intended overall narrative.
+
 parameter
   c_bioliqscen              "2nd generation bioenergy liquids technology choice"
 ;
@@ -680,29 +682,29 @@ parameter
   cm_shSynGas      = 0;        !! def = 0  !! regexp = is.share
 *'
 parameter
-  cm_IndCCSscen             "CCS for Industry"
-;
-  cm_IndCCSscen          = 1;        !! def = 1
-*'
-parameter
   cm_optimisticMAC          "assume optimistic Industry MAC from AR5 Ch. 10?"
 ;
   cm_optimisticMAC       = 0;        !! def = 0
 *'
 parameter
-  cm_CCS_cement             "CCS for cement sub-sector"
+  cm_captureInd             "carbon capture for Industry on/off"
 ;
-  cm_CCS_cement          = 1;        !! def = 1
+  cm_captureInd          = 1;        !! def = 1
 *'
 parameter
-  cm_CCS_chemicals          "CCS for chemicals sub-sector"
+  cm_captureCement             "carbon capture for cement sub-sector on/off"
 ;
-  cm_CCS_chemicals       = 1;        !! def = 1
+  cm_captureCement          = 1;        !! def = 1
 *'
 parameter
-  cm_CCS_steel              "CCS for steel sub-sector"
+  cm_captureChemicals          "carbon capture for chemicals sub-sector on/off"
 ;
-  cm_CCS_steel           = 1;        !! def = 1
+  cm_captureChemicals       = 1;        !! def = 1
+*'
+parameter
+  cm_captureSteel              "carbon capture for steel sub-sector on/off"
+;
+  cm_captureSteel           = 1;        !! def = 1
 *'
 parameter
   cm_bioenergy_SustTax      "level of the bioenergy sustainability tax in fraction of bioenergy price"
@@ -1913,20 +1915,20 @@ $setglobal cm_inco0Factor  off !! def = off
 *' *  or list of techs with respective factor to change p_inco0 value by a multiplication factor. (ex. "windon 0.33, spv 0.33" makes investment costs for windon and spv 3 times cheaper)
 *' *  (note: if %cm_techcosts% == "GLO", switch will not work for policy runs, i.e. cm_startyear > 2005, for pc, ngt and ngcc as this gets overwritten in 05_initialCap module)
 $setglobal cm_inco0RegiFactor  off  !! def = off
-*** cm_CCS_markup "multiplicative factor for CSS cost markup"
-***   def <- "off" = use default CCS pm_inco0_t values.
-***   or number (ex. 0.66), multiply by 0.66 the CSS cost markup
-$setglobal cm_ccsinjeCost high !! def = high !! regexp = med|low|high
 *' switch from standard to low and high CO2 transport & storage cost.
 *' Warning: it applies absolute values; only use it in combination with default c_techAssumptScen SSP2. 
 *'  * (low): old estimate before 03/2024; ~7.5 USD/tCO2 in 2035. Also applies tech_stat=2 and constrTme=0
 *'  * (med): new main estimate; 12 USD/tCO2 at all times (similar to ~11.4 USD/tCO2 average of saline formations, on- and offshore DOG fields in Budinis et al 2017)
 *'  * (high): upper estimate; ~20USD/tCO2 (constant), assuming upper end of storage cost and long transport distances
-$setglobal cm_CCS_markup  off  !! def = off
-*** cm_Industry_CCS_markup "multiplicative factor for Industry CSS cost markup"
+$setglobal cm_ccsinjeCost high !! def = high !! regexp = med|low|high
+*** cm_captureEnergyMarkup "multiplicative factor for carbon capture technologies (teCCS) cost markup"
+***   def <- "off" = use default CC pm_inco0_t values.
+***   or number (ex. 0.66), multiply by 0.66 the CSS cost markup
+$setglobal cm_captureEnergyMarkup  off  !! def = off
+*** cm_captureIndMarkup "multiplicative factor for Industry carbon capture cost markup"
 ***   def <- "off"
-***   or number (ex. 0.66), multiply by 0.66 Industry CSS cost markup
-$setglobal cm_Industry_CCS_markup  off !! def = off
+***   or number (ex. 0.66), multiply by 0.66 Industry carbon capture cost markup
+$setglobal cm_captureIndMarkup  off !! def = off
 *' Flag to change learning assumption for established pyrolysis technologies. 0 = not learning; any number = learning rate
 *' Beware: When turned on, policy runs require a NPi that also has learning, otherwise it becomes unbounded.
 *' (0.1): Learning rate of 10%.
@@ -2153,8 +2155,8 @@ $setGlobal c_skip_output  off        !! def = off  !! regexp = off|on
 $setglobal cm_CO2TaxSectorMarkup  off   !! def = off
 *** c_regi_nucscen              "regions to apply cm_nucscen to in case of cm_nucscen = 5 (no new nuclear investments), e.g. c_regi_nucscen <- "JPN,USA"
 $setGlobal c_regi_nucscen  all  !! def = all
-***  c_regi_capturescen              "regions to apply cm_ccapturescen to (availability of carbon capture technologies), e.g. c_regi_nucscen <- "JPN,USA"
-$setGlobal c_regi_capturescen  all  !! def = all
+***  c_regi_captureEnergy              "regions to apply cm_captureEnergy to (availability of carbon capture technologies), e.g. c_regi_captureEnergy <- "JPN,USA"
+$setGlobal c_regi_captureEnergy  all  !! def = all
 *** cm_subsec_model_steel      "switch between ces-based and process-based steel implementation in subsectors realisation of industry module"
 $setglobal cm_subsec_model_steel  processes  !! def = processes  !! regexp = processes|ces
 *** cm_tech_bounds_2025

--- a/modules/33_carbonRemoval/portfolio/bounds.gms
+++ b/modules/33_carbonRemoval/portfolio/bounds.gms
@@ -7,7 +7,7 @@
 *** SOF ./modules/33_carbonRemoval/portfolio/bounds.gms
 
 vm_emiCdr.fx(t,regi,emi)$(not sameas(emi,"co2")) = 0.0;
-vm_emiCdr.l(t,regi,"co2")$(t.val ge 2025 AND cm_ccapturescen ne 2) = -sm_eps;
+vm_emiCdr.l(t,regi,"co2")$(t.val ge 2025) = -sm_eps;
 
 *** Bounds if there are no technologies in the portfolio
 if(card(te_used33) eq 0,

--- a/modules/37_industry/subsectors/bounds.gms
+++ b/modules/37_industry/subsectors/bounds.gms
@@ -135,7 +135,7 @@ if (cm_startyear eq 2005,
 );
 
 !! Switch to turn off steel CCS
-if (cm_captureSteel ne 1 OR cm_captureInd ne 1,
+if (cm_co2captureSteel ne 1 OR cm_co2captureInd ne 1,
   vm_cap.fx(t,regi,teCCPrc,rlf) = 0.;
 );
 

--- a/modules/37_industry/subsectors/bounds.gms
+++ b/modules/37_industry/subsectors/bounds.gms
@@ -135,7 +135,7 @@ if (cm_startyear eq 2005,
 );
 
 !! Switch to turn off steel CCS
-if (cm_CCS_steel ne 1 OR cm_IndCCSscen ne 1,
+if (cm_captureSteel ne 1 OR cm_captureInd ne 1,
   vm_cap.fx(t,regi,teCCPrc,rlf) = 0.;
 );
 

--- a/modules/37_industry/subsectors/datainput.gms
+++ b/modules/37_industry/subsectors/datainput.gms
@@ -71,8 +71,8 @@ loop ((ttot,steps)$( ttot.val ge 2005 ),
 
   sm_tmp = steps.val * sm_dmac / sm_c_2_co2;   !! CO2 price at MAC step [$/tCO2] 
 
-$ifthen NOT "%cm_captureIndMarkup%" == "off"
-  sm_tmp = sm_tmp / %cm_captureIndMarkup%;
+$ifthen NOT "%cm_co2captureIndMarkup%" == "off"
+  sm_tmp = sm_tmp / %cm_co2captureIndMarkup%;
 $endif
 
   !! short-term (until 2025)
@@ -120,8 +120,8 @@ $endif.cm_subsec_model_steel
 );
 
 
-if (cm_captureInd eq 1,
-  if (cm_captureCement eq 1,
+if (cm_co2captureInd eq 1,
+  if (cm_co2captureCement eq 1,
 
     emiMac2mac("co2cement_process","co2cement") = YES;
      );
@@ -244,8 +244,8 @@ emiMacSector(emiInd37_fuel) = NO;
 pm_macSwitch(ttot,regi,emiInd37)      = NO;
 
 *** turn on CCS for industry emissions
-if (cm_captureInd eq 1,
-  if (cm_captureCement eq 1,
+if (cm_co2captureInd eq 1,
+  if (cm_co2captureCement eq 1,
     emiMacSector("co2cement") = YES;
     pm_macSwitch(ttot,regi,"co2cement") = YES;
     pm_macSwitch(ttot,regi,"co2cement_process") = YES;
@@ -253,14 +253,14 @@ if (cm_captureInd eq 1,
     emiMac2mac("co2cement_process","co2cement") = YES;
   );
 
-  if (cm_captureChemicals eq 1,
+  if (cm_co2captureChemicals eq 1,
     emiMacSector("co2chemicals") = YES;
     pm_macSwitch(ttot,regi,"co2chemicals") = YES;
     emiMac2mac("co2chemicals","co2chemicals") = YES;
   );
 
 $ifthen.cm_subsec_model_steel "%cm_subsec_model_steel%" == "ces"
-  if (cm_captureSteel eq 1,
+  if (cm_co2captureSteel eq 1,
     emiMacSector("co2steel") = YES;
     pm_macSwitch(ttot,regi,"co2steel") = YES;
     emiMac2mac("co2steel","co2steel") = YES;

--- a/modules/37_industry/subsectors/datainput.gms
+++ b/modules/37_industry/subsectors/datainput.gms
@@ -71,8 +71,8 @@ loop ((ttot,steps)$( ttot.val ge 2005 ),
 
   sm_tmp = steps.val * sm_dmac / sm_c_2_co2;   !! CO2 price at MAC step [$/tCO2] 
 
-$ifthen NOT "%cm_Industry_CCS_markup%" == "off"
-  sm_tmp = sm_tmp / %cm_Industry_CCS_markup%;
+$ifthen NOT "%cm_captureIndMarkup%" == "off"
+  sm_tmp = sm_tmp / %cm_captureIndMarkup%;
 $endif
 
   !! short-term (until 2025)
@@ -120,8 +120,8 @@ $endif.cm_subsec_model_steel
 );
 
 
-if (cm_IndCCSscen eq 1,
-  if (cm_CCS_cement eq 1,
+if (cm_captureInd eq 1,
+  if (cm_captureCement eq 1,
 
     emiMac2mac("co2cement_process","co2cement") = YES;
      );
@@ -244,8 +244,8 @@ emiMacSector(emiInd37_fuel) = NO;
 pm_macSwitch(ttot,regi,emiInd37)      = NO;
 
 *** turn on CCS for industry emissions
-if (cm_IndCCSscen eq 1,
-  if (cm_CCS_cement eq 1,
+if (cm_captureInd eq 1,
+  if (cm_captureCement eq 1,
     emiMacSector("co2cement") = YES;
     pm_macSwitch(ttot,regi,"co2cement") = YES;
     pm_macSwitch(ttot,regi,"co2cement_process") = YES;
@@ -253,14 +253,14 @@ if (cm_IndCCSscen eq 1,
     emiMac2mac("co2cement_process","co2cement") = YES;
   );
 
-  if (cm_CCS_chemicals eq 1,
+  if (cm_captureChemicals eq 1,
     emiMacSector("co2chemicals") = YES;
     pm_macSwitch(ttot,regi,"co2chemicals") = YES;
     emiMac2mac("co2chemicals","co2chemicals") = YES;
   );
 
 $ifthen.cm_subsec_model_steel "%cm_subsec_model_steel%" == "ces"
-  if (cm_CCS_steel eq 1,
+  if (cm_captureSteel eq 1,
     emiMacSector("co2steel") = YES;
     pm_macSwitch(ttot,regi,"co2steel") = YES;
     emiMac2mac("co2steel","co2steel") = YES;

--- a/modules/39_carbonUtilization/off/bounds.gms
+++ b/modules/39_carbonUtilization/off/bounds.gms
@@ -6,8 +6,8 @@
 *** |  Contact: remind@pik-potsdam.de
 *** SOF ./modules/39_carbonUtilization/off/bounds.gms
 
-vm_co2CCUshort.fx(t,regi,"cco2","ccuco2short",teCCU2rlf(te2,rlf)) = 0;
-vm_cap.fx(t,regi,"h22ch4",rlf)$te2rlf("h22ch4",rlf) = 0;
-vm_cap.fx(t,regi,"MeOH",rlf)$te2rlf("MeOH",rlf) = 0;
+vm_co2CCUshort.up(t,regi,"cco2","ccuco2short",teCCU2rlf(te2,rlf)) $ (t.val ge cm_startyear) = sm_eps;
+vm_deltaCap.up(t,regi,"h22ch4",rlf) $ (t.val ge cm_startyear and te2rlf("h22ch4",rlf)) = sm_eps;
+vm_deltaCap.up(t,regi,"MeOH",rlf) $ (t.val ge cm_startyear and te2rlf("MeOH",rlf)) = sm_eps;
 
 *** EOF ./modules/39_carbonUtilization/off/bounds.gms

--- a/modules/39_carbonUtilization/off/bounds.gms
+++ b/modules/39_carbonUtilization/off/bounds.gms
@@ -6,8 +6,8 @@
 *** |  Contact: remind@pik-potsdam.de
 *** SOF ./modules/39_carbonUtilization/off/bounds.gms
 
-vm_co2CCUshort.up(t,regi,"cco2","ccuco2short",teCCU2rlf(te2,rlf)) $ (t.val ge cm_startyear) = sm_eps;
-vm_deltaCap.up(t,regi,"h22ch4",rlf) $ (t.val ge cm_startyear and te2rlf("h22ch4",rlf)) = sm_eps;
-vm_deltaCap.up(t,regi,"MeOH",rlf) $ (t.val ge cm_startyear and te2rlf("MeOH",rlf)) = sm_eps;
+vm_co2CCUshort.up(t,regi,"cco2","ccuco2short",teCCU2rlf(te2,rlf)) = sm_eps;
+vm_deltaCap.up(t,regi,"h22ch4",rlf) $ (te2rlf("h22ch4",rlf)) = sm_eps;
+vm_deltaCap.up(t,regi,"MeOH",rlf) $ (te2rlf("MeOH",rlf)) = sm_eps;
 
 *** EOF ./modules/39_carbonUtilization/off/bounds.gms

--- a/modules/39_carbonUtilization/off/not_used.txt
+++ b/modules/39_carbonUtilization/off/not_used.txt
@@ -12,3 +12,4 @@ cm_shSynGas,input,questionnaire
 vm_prodSe,input,questionnaire
 pm_gdp,input,not used
 pm_cf,input,not used
+vm_cap,input,not used

--- a/modules/39_carbonUtilization/on/not_used.txt
+++ b/modules/39_carbonUtilization/on/not_used.txt
@@ -7,4 +7,3 @@
 name,type,reason
 sm_eps,input,not used
 vm_deltaCap,input,not used
-cm_startyear,input,not used

--- a/modules/39_carbonUtilization/on/not_used.txt
+++ b/modules/39_carbonUtilization/on/not_used.txt
@@ -5,3 +5,6 @@
 # |  REMIND License Exception, version 1.0 (see LICENSE file).
 # |  Contact: remind@pik-potsdam.de
 name,type,reason
+sm_eps,input,not used
+vm_deltaCap,input,not used
+cm_startyear,input,not used

--- a/modules/47_regipol/regiCarbonPrice/datainput.gms
+++ b/modules/47_regipol/regiCarbonPrice/datainput.gms
@@ -228,8 +228,8 @@ $endIf.cm_implicitPePriceTarget
 *** Region-specific datainput (with hard-coded regions)
 ***---------------------------------------------------------------------------
 
-$IFTHEN.CCcostMarkup not "%cm_captureEnergyMarkup%" == "off" 
-	pm_inco0_t(ttot,regi,teCCS)$(regi_group("EUR_regi",regi)) = pm_inco0_t(ttot,regi,teCCS)*%cm_captureEnergyMarkup%;
+$IFTHEN.CCcostMarkup not "%cm_co2captureEnergyMarkup%" == "off" 
+	pm_inco0_t(ttot,regi,teCCS)$(regi_group("EUR_regi",regi)) = pm_inco0_t(ttot,regi,teCCS)*%cm_co2captureEnergyMarkup%;
 $ENDIF.CCcostMarkup
 
 $IFTHEN.renewablesFloorCost not "%cm_renewables_floor_cost%" == "off" 

--- a/modules/47_regipol/regiCarbonPrice/datainput.gms
+++ b/modules/47_regipol/regiCarbonPrice/datainput.gms
@@ -228,9 +228,9 @@ $endIf.cm_implicitPePriceTarget
 *** Region-specific datainput (with hard-coded regions)
 ***---------------------------------------------------------------------------
 
-$IFTHEN.CCScostMarkup not "%cm_CCS_markup%" == "off" 
-	pm_inco0_t(ttot,regi,teCCS)$(regi_group("EUR_regi",regi)) = pm_inco0_t(ttot,regi,teCCS)*%cm_CCS_markup%;
-$ENDIF.CCScostMarkup
+$IFTHEN.CCcostMarkup not "%cm_captureEnergyMarkup%" == "off" 
+	pm_inco0_t(ttot,regi,teCCS)$(regi_group("EUR_regi",regi)) = pm_inco0_t(ttot,regi,teCCS)*%cm_captureEnergyMarkup%;
+$ENDIF.CCcostMarkup
 
 $IFTHEN.renewablesFloorCost not "%cm_renewables_floor_cost%" == "off" 
 	parameter p_new_renewables_floor_cost(all_te) / %cm_renewables_floor_cost% /;

--- a/scripts/start/readCheckScenarioConfig.R
+++ b/scripts/start/readCheckScenarioConfig.R
@@ -203,7 +203,16 @@ readCheckScenarioConfig <- function(filename, remindPath = ".", testmode = FALSE
        "cm_DiscRateScen" = "Deleted, not used anymore, see https://github.com/remindmodel/remind/pull/2001",
        "cm_transpGDPscale" = "Deleted, not used anymore, see https://github.com/remindmodel/remind/pull/2092",
        "var_luc" = "Deleted, not used anymore. Land-use CO2 emissions are always RAW now. See https://github.com/remindmodel/remind/pull/2255",
-     NULL)
+       "cm_ccapturescen" = "Rename to c_captureEnergy + adjusted scope, see https://github.com/remindmodel/remind/pull/2424",
+       "cm_IndCCSscen" = "Rename to cm_captureInd, see https://github.com/remindmodel/remind/pull/2424",
+       "cm_CCS_cement" = "Rename to cm_captureCement, see https://github.com/remindmodel/remind/pull/2424",
+       "cm_CCS_chemicals" = "Rename to cm_captureChemicals, see https://github.com/remindmodel/remind/pull/2424",
+       "cm_CCS_steel" = "Rename to cm_captureSteel, see https://github.com/remindmodel/remind/pull/2424",
+       "c_regi_capturescen" = "Rename to c_regi_captureEnergy, see https://github.com/remindmodel/remind/pull/2424",
+       "cm_CCS_markup" = "Rename to cm_captureEnergyMarkup, see https://github.com/remindmodel/remind/pull/2424",
+       "cm_Industry_CCS_markup" = "Rename to cm_captureIndMarkup, see https://github.com/remindmodel/remind/pull/2424"
+     )
+
     for (i in intersect(names(forbiddenColumnNames), unknownColumnNames)) {
       msg <- paste0("Column name ", i, " in remind settings is outdated. ", forbiddenColumnNames[i])
       if (testmode) warning(msg) else message(msg)

--- a/scripts/start/readCheckScenarioConfig.R
+++ b/scripts/start/readCheckScenarioConfig.R
@@ -203,14 +203,14 @@ readCheckScenarioConfig <- function(filename, remindPath = ".", testmode = FALSE
        "cm_DiscRateScen" = "Deleted, not used anymore, see https://github.com/remindmodel/remind/pull/2001",
        "cm_transpGDPscale" = "Deleted, not used anymore, see https://github.com/remindmodel/remind/pull/2092",
        "var_luc" = "Deleted, not used anymore. Land-use CO2 emissions are always RAW now. See https://github.com/remindmodel/remind/pull/2255",
-       "cm_ccapturescen" = "Rename to c_captureEnergy + adjusted scope, see https://github.com/remindmodel/remind/pull/2424",
-       "cm_IndCCSscen" = "Rename to cm_captureInd, see https://github.com/remindmodel/remind/pull/2424",
-       "cm_CCS_cement" = "Rename to cm_captureCement, see https://github.com/remindmodel/remind/pull/2424",
-       "cm_CCS_chemicals" = "Rename to cm_captureChemicals, see https://github.com/remindmodel/remind/pull/2424",
-       "cm_CCS_steel" = "Rename to cm_captureSteel, see https://github.com/remindmodel/remind/pull/2424",
-       "c_regi_capturescen" = "Rename to c_regi_captureEnergy, see https://github.com/remindmodel/remind/pull/2424",
-       "cm_CCS_markup" = "Rename to cm_captureEnergyMarkup, see https://github.com/remindmodel/remind/pull/2424",
-       "cm_Industry_CCS_markup" = "Rename to cm_captureIndMarkup, see https://github.com/remindmodel/remind/pull/2424"
+       "cm_ccapturescen" = "Rename to c_co2captureEnergy + adjusted scope, see https://github.com/remindmodel/remind/pull/2424",
+       "cm_IndCCSscen" = "Rename to cm_co2captureInd, see https://github.com/remindmodel/remind/pull/2424",
+       "cm_CCS_cement" = "Rename to cm_co2captureCement, see https://github.com/remindmodel/remind/pull/2424",
+       "cm_CCS_chemicals" = "Rename to cm_co2captureChemicals, see https://github.com/remindmodel/remind/pull/2424",
+       "cm_CCS_steel" = "Rename to cm_co2captureSteel, see https://github.com/remindmodel/remind/pull/2424",
+       "c_regi_capturescen" = "Rename to c_regi_co2captureEnergy, see https://github.com/remindmodel/remind/pull/2424",
+       "cm_CCS_markup" = "Rename to cm_co2captureEnergyMarkup, see https://github.com/remindmodel/remind/pull/2424",
+       "cm_Industry_CCS_markup" = "Rename to cm_co2captureIndMarkup, see https://github.com/remindmodel/remind/pull/2424"
      )
 
     for (i in intersect(names(forbiddenColumnNames), unknownColumnNames)) {

--- a/standalone/MOFEX/MOFEX.gms
+++ b/standalone/MOFEX/MOFEX.gms
@@ -128,18 +128,18 @@ cm_taxCO2_startyear  "level of co2 tax in start year in $ per t CO2eq"
 cm_taxCO2_expGrowth     "growth rate of carbon tax"
 c_macscen            "use of mac"
 cm_nucscen            "nuclear option choice"
-cm_ccapturescen       "carbon capture option choice"
+cm_captureEnergy       "carbon capture option choice"
 c_bioliqscen          "bioenergy liquids technology choise"
 c_bioh2scen           "bioenergy hydrogen technology choice"
 c_shGreenH2           "lower bound on share of green hydrogen in all hydrogen by 2030"
 c_shBioTrans          "upper bound on share of bioliquids in transport from 2025 onwards"
 cm_shSynTrans         "lower bound on share of synthetic fuels in all transport fuels by 2045"
 cm_shSynGas           "lower bound on share of synthetic gases by 2045"
-cm_IndCCSscen        "CCS for Industry"
-cm_optimisticMAC     "assume optimistic Industry MAC from AR5 Ch. 10?"
-cm_CCS_cement        "CCS for cement sub-sector"
-cm_CCS_chemicals     "CCS for chemicals sub-sector"
-cm_CCS_steel         "CCS for steel sub-sector"
+cm_optimisticMAC      "assume optimistic Industry MAC from AR5 Ch. 10?"
+cm_captureInd        "carbon capture for Industry"
+cm_captureCement          "carbon capture for cement sub-sector"
+cm_captureChemicals       "carbon capture for chemicals sub-sector"
+cm_captureSteel            "carbon capture for steel sub-sector"
 cm_bioenergy_SustTax    "level of the bioenergy sustainability tax in fraction of bioenergy price"
 cm_bioenergy_EF_for_tax "bioenergy emission factor that is used to derive a bioenergy tax [kgCO2 per GJ]"
 cm_maxProdBiolc         "bound on global pebiolc production including residues but excluding traditionally used biomass [EJ per yr]"
@@ -190,7 +190,7 @@ cm_frac_NetNegEmi    "tax on net negative emissions to reflect risk of overshoot
 c_peakBudgYr       "date of net-zero CO2 emissions for peak budget runs without overshoot"
 cm_taxCO2_IncAfterPeakBudgYr "annual increase of CO2 price after the Peak Budget Year in $ per tCO2"
 c_regi_nucscen				"regions to apply nucscen to"
-c_regi_capturescen			"region to apply ccapturescen to"
+c_regi_captureEnergy			"region to apply ccapturescen to"
 c_regi_synfuelscen			"region to apply synfuelscen to"
 cm_TaxConvCheck             "switch for enabling tax convergence check in nash mode"
 c_regi_sensscen				"regions which regional sensitivity parameters apply to"
@@ -240,7 +240,7 @@ cm_taxCO2_expGrowth = 1.05;      !! def = 1.05
 c_macscen         = 1;         !! def = 1
 
 cm_nucscen       = 2;        !! def = 2
-cm_ccapturescen  = 1;        !! def = 1
+cm_captureEnergy  = 1;        !! def = 1
 c_bioliqscen     = 1;        !! def = 1
 c_bioh2scen      = 1;        !! def = 1
 c_shGreenH2      = 0;        !! def = 0
@@ -248,11 +248,11 @@ c_shBioTrans     = 1;        !! def = 1
 cm_shSynTrans    = 0;        !! def = 0
 cm_shSynGas      = 0;        !! def = 0
 
-cm_IndCCSscen          = 1;        !! def = 1
 cm_optimisticMAC       = 0;        !! def = 0
-cm_CCS_cement          = 1;        !! def = 1
-cm_CCS_chemicals       = 1;        !! def = 1
-cm_CCS_steel           = 1;        !! def = 1
+cm_captureInd          = 1;        !! def = 1
+cm_captureCement          = 1;        !! def = 1
+cm_captureChemicals       = 1;        !! def = 1
+cm_captureSteel           = 1;        !! def = 1
 
 $setglobal cm_secondary_steel_bound  none   !! def = "scenario"
 
@@ -334,7 +334,7 @@ $setGlobal cm_reducCostB  none !! def = none
 $setGlobal cm_effHP  5 !! def = 5
 
 $setGlobal c_regi_nucscen  all !! def = all
-$setGlobal c_regi_capturescen  all !! def = all
+$setGlobal c_regi_captureEnergy  all !! def = all
 $setGlobal c_regi_synfuelscen  all !! def = all
 $setGlobal c_regi_sensscen  all !! def = all
 
@@ -443,8 +443,8 @@ $setglobal cm_adj_coeff_multiplier  off
 $setglobal cm_inco0Factor  off !! def = off
 $setglobal cm_inco0RegiFactor  off !! def = off
 
-$setglobal cm_CCS_markup  off !! def = off
-$setglobal cm_Industry_CCS_markup  off !! def = off
+$setglobal cm_captureEnergyMarkup  off !! def = off
+$setglobal cm_captureIndMarkup  off !! def = off
 $setglobal cm_renewables_floor_cost  off !! def = off 
 
 $setglobal cm_sehe_upper  off !! def = off 

--- a/standalone/MOFEX/MOFEX.gms
+++ b/standalone/MOFEX/MOFEX.gms
@@ -128,7 +128,7 @@ cm_taxCO2_startyear  "level of co2 tax in start year in $ per t CO2eq"
 cm_taxCO2_expGrowth     "growth rate of carbon tax"
 c_macscen            "use of mac"
 cm_nucscen            "nuclear option choice"
-c_captureEnergy       "carbon capture option choice"
+c_co2captureEnergy    "carbon capture option choice"
 c_bioliqscen          "bioenergy liquids technology choise"
 c_bioh2scen           "bioenergy hydrogen technology choice"
 c_shGreenH2           "lower bound on share of green hydrogen in all hydrogen by 2030"
@@ -136,10 +136,10 @@ c_shBioTrans          "upper bound on share of bioliquids in transport from 2025
 cm_shSynTrans         "lower bound on share of synthetic fuels in all transport fuels by 2045"
 cm_shSynGas           "lower bound on share of synthetic gases by 2045"
 cm_optimisticMAC      "assume optimistic Industry MAC from AR5 Ch. 10?"
-cm_captureInd        "carbon capture for Industry"
-cm_captureCement          "carbon capture for cement sub-sector"
-cm_captureChemicals       "carbon capture for chemicals sub-sector"
-cm_captureSteel            "carbon capture for steel sub-sector"
+cm_co2captureInd        "carbon capture for Industry"
+cm_co2captureCement          "carbon capture for cement sub-sector"
+cm_co2captureChemicals       "carbon capture for chemicals sub-sector"
+cm_co2captureSteel            "carbon capture for steel sub-sector"
 cm_bioenergy_SustTax    "level of the bioenergy sustainability tax in fraction of bioenergy price"
 cm_bioenergy_EF_for_tax "bioenergy emission factor that is used to derive a bioenergy tax [kgCO2 per GJ]"
 cm_maxProdBiolc         "bound on global pebiolc production including residues but excluding traditionally used biomass [EJ per yr]"
@@ -240,7 +240,7 @@ cm_taxCO2_expGrowth = 1.05;      !! def = 1.05
 c_macscen         = 1;         !! def = 1
 
 cm_nucscen       = 2;        !! def = 2
-c_captureEnergy  = 1;        !! def = 1
+c_co2captureEnergy  = 1;        !! def = 1
 c_bioliqscen     = 1;        !! def = 1
 c_bioh2scen      = 1;        !! def = 1
 c_shGreenH2      = 0;        !! def = 0
@@ -249,10 +249,10 @@ cm_shSynTrans    = 0;        !! def = 0
 cm_shSynGas      = 0;        !! def = 0
 
 cm_optimisticMAC       = 0;        !! def = 0
-cm_captureInd          = 1;        !! def = 1
-cm_captureCement          = 1;        !! def = 1
-cm_captureChemicals       = 1;        !! def = 1
-cm_captureSteel           = 1;        !! def = 1
+cm_co2captureInd          = 1;        !! def = 1
+cm_co2captureCement          = 1;        !! def = 1
+cm_co2captureChemicals       = 1;        !! def = 1
+cm_co2captureSteel           = 1;        !! def = 1
 
 $setglobal cm_secondary_steel_bound  none   !! def = "scenario"
 
@@ -443,8 +443,8 @@ $setglobal cm_adj_coeff_multiplier  off
 $setglobal cm_inco0Factor  off !! def = off
 $setglobal cm_inco0RegiFactor  off !! def = off
 
-$setglobal cm_captureEnergyMarkup  off !! def = off
-$setglobal cm_captureIndMarkup  off !! def = off
+$setglobal cm_co2captureEnergyMarkup  off !! def = off
+$setglobal cm_co2captureIndMarkup  off !! def = off
 $setglobal cm_renewables_floor_cost  off !! def = off 
 
 $setglobal cm_sehe_upper  off !! def = off 

--- a/standalone/MOFEX/MOFEX.gms
+++ b/standalone/MOFEX/MOFEX.gms
@@ -128,7 +128,7 @@ cm_taxCO2_startyear  "level of co2 tax in start year in $ per t CO2eq"
 cm_taxCO2_expGrowth     "growth rate of carbon tax"
 c_macscen            "use of mac"
 cm_nucscen            "nuclear option choice"
-cm_captureEnergy       "carbon capture option choice"
+c_captureEnergy       "carbon capture option choice"
 c_bioliqscen          "bioenergy liquids technology choise"
 c_bioh2scen           "bioenergy hydrogen technology choice"
 c_shGreenH2           "lower bound on share of green hydrogen in all hydrogen by 2030"
@@ -190,7 +190,7 @@ cm_frac_NetNegEmi    "tax on net negative emissions to reflect risk of overshoot
 c_peakBudgYr       "date of net-zero CO2 emissions for peak budget runs without overshoot"
 cm_taxCO2_IncAfterPeakBudgYr "annual increase of CO2 price after the Peak Budget Year in $ per tCO2"
 c_regi_nucscen				"regions to apply nucscen to"
-c_regi_captureEnergy			"region to apply ccapturescen to"
+c_regi_captureEnergy		"region to apply ccapturescen to"
 c_regi_synfuelscen			"region to apply synfuelscen to"
 cm_TaxConvCheck             "switch for enabling tax convergence check in nash mode"
 c_regi_sensscen				"regions which regional sensitivity parameters apply to"
@@ -240,7 +240,7 @@ cm_taxCO2_expGrowth = 1.05;      !! def = 1.05
 c_macscen         = 1;         !! def = 1
 
 cm_nucscen       = 2;        !! def = 2
-cm_captureEnergy  = 1;        !! def = 1
+c_captureEnergy  = 1;        !! def = 1
 c_bioliqscen     = 1;        !! def = 1
 c_bioh2scen      = 1;        !! def = 1
 c_shGreenH2      = 0;        !! def = 0

--- a/standalone/template.gms
+++ b/standalone/template.gms
@@ -128,7 +128,7 @@ cm_taxCO2_startyear    "level of co2 tax in start year in $ per t CO2eq"
 cm_taxCO2_expGrowth     "growth rate of carbon tax"
 c_macscen            "use of mac"
 cm_nucscen            "nuclear option choice"
-cm_captureEnergy       "carbon capture option choice"
+c_captureEnergy       "carbon capture option choice"
 c_bioliqscen          "bioenergy liquids technology choise"
 c_bioh2scen           "bioenergy hydrogen technology choice"
 cm_optimisticMAC     "assume optimistic Industry MAC from AR5 Ch. 10?"
@@ -199,7 +199,7 @@ cm_taxCO2_expGrowth = 1.05;      !! def = 1.05
 c_macscen         = 1;         !! def = 1
 
 cm_nucscen       = 2;        !! def = 2
-cm_captureEnergy  = 1;        !! def = 1
+c_captureEnergy  = 1;        !! def = 1
 c_bioliqscen     = 1;        !! def = 1
 c_bioh2scen      = 1;        !! def = 1
 

--- a/standalone/template.gms
+++ b/standalone/template.gms
@@ -128,14 +128,14 @@ cm_taxCO2_startyear    "level of co2 tax in start year in $ per t CO2eq"
 cm_taxCO2_expGrowth     "growth rate of carbon tax"
 c_macscen            "use of mac"
 cm_nucscen            "nuclear option choice"
-cm_ccapturescen       "carbon capture option choice"
+cm_captureEnergy       "carbon capture option choice"
 c_bioliqscen          "bioenergy liquids technology choise"
 c_bioh2scen           "bioenergy hydrogen technology choice"
-cm_IndCCSscen        "CCS for Industry"
 cm_optimisticMAC     "assume optimistic Industry MAC from AR5 Ch. 10?"
-cm_CCS_cement        "CCS for cement sub-sector"
-cm_CCS_chemicals     "CCS for chemicals sub-sector"
-cm_CCS_steel         "CCS for steel sub-sector"
+cm_captureInd        "carbon capture for Industry"
+cm_captureCement        "carbon capture for cement sub-sector"
+cm_captureChemicals     "carbon capture for chemicals sub-sector"
+cm_captureSteel         "carbon capture for steel sub-sector"
 cm_bioenergy_SustTax    "level of the bioenergy sustainability tax in fraction of bioenergy price"
 cm_bioenergy_EF_for_tax "bioenergy emission factor that is used to derive a bioenergy tax [kgCO2 per GJ]"
 cm_maxProdBiolc         "bound on global pebiolc production including residues but excluding traditionally used biomass [EJ per yr]"
@@ -199,15 +199,15 @@ cm_taxCO2_expGrowth = 1.05;      !! def = 1.05
 c_macscen         = 1;         !! def = 1
 
 cm_nucscen       = 2;        !! def = 2
-cm_ccapturescen  = 1;        !! def = 1
+cm_captureEnergy  = 1;        !! def = 1
 c_bioliqscen     = 1;        !! def = 1
 c_bioh2scen      = 1;        !! def = 1
 
-cm_IndCCSscen          = 1;        !! def = 1
 cm_optimisticMAC       = 0;        !! def = 0
-cm_CCS_cement          = 1;        !! def = 1
-cm_CCS_chemicals       = 1;        !! def = 1
-cm_CCS_steel           = 1;        !! def = 1
+cm_captureInd          = 1;        !! def = 1
+cm_captureCement          = 1;        !! def = 1
+cm_captureChemicals       = 1;        !! def = 1
+cm_captureSteel           = 1;        !! def = 1
 
 
 cm_bioenergy_SustTax    = 1.5;            !! def = 1.5

--- a/standalone/template.gms
+++ b/standalone/template.gms
@@ -128,14 +128,14 @@ cm_taxCO2_startyear    "level of co2 tax in start year in $ per t CO2eq"
 cm_taxCO2_expGrowth     "growth rate of carbon tax"
 c_macscen            "use of mac"
 cm_nucscen            "nuclear option choice"
-c_captureEnergy       "carbon capture option choice"
+c_co2captureEnergy       "carbon capture option choice"
 c_bioliqscen          "bioenergy liquids technology choise"
 c_bioh2scen           "bioenergy hydrogen technology choice"
 cm_optimisticMAC     "assume optimistic Industry MAC from AR5 Ch. 10?"
-cm_captureInd        "carbon capture for Industry"
-cm_captureCement        "carbon capture for cement sub-sector"
-cm_captureChemicals     "carbon capture for chemicals sub-sector"
-cm_captureSteel         "carbon capture for steel sub-sector"
+cm_co2captureInd        "carbon capture for Industry"
+cm_co2captureCement        "carbon capture for cement sub-sector"
+cm_co2captureChemicals     "carbon capture for chemicals sub-sector"
+cm_co2captureSteel         "carbon capture for steel sub-sector"
 cm_bioenergy_SustTax    "level of the bioenergy sustainability tax in fraction of bioenergy price"
 cm_bioenergy_EF_for_tax "bioenergy emission factor that is used to derive a bioenergy tax [kgCO2 per GJ]"
 cm_maxProdBiolc         "bound on global pebiolc production including residues but excluding traditionally used biomass [EJ per yr]"
@@ -199,15 +199,15 @@ cm_taxCO2_expGrowth = 1.05;      !! def = 1.05
 c_macscen         = 1;         !! def = 1
 
 cm_nucscen       = 2;        !! def = 2
-c_captureEnergy  = 1;        !! def = 1
+c_co2captureEnergy  = 1;        !! def = 1
 c_bioliqscen     = 1;        !! def = 1
 c_bioh2scen      = 1;        !! def = 1
 
 cm_optimisticMAC       = 0;        !! def = 0
-cm_captureInd          = 1;        !! def = 1
-cm_captureCement          = 1;        !! def = 1
-cm_captureChemicals       = 1;        !! def = 1
-cm_captureSteel           = 1;        !! def = 1
+cm_co2captureInd          = 1;        !! def = 1
+cm_co2captureCement          = 1;        !! def = 1
+cm_co2captureChemicals       = 1;        !! def = 1
+cm_co2captureSteel           = 1;        !! def = 1
 
 
 cm_bioenergy_SustTax    = 1.5;            !! def = 1.5

--- a/standalone/trade/trade.gms
+++ b/standalone/trade/trade.gms
@@ -194,7 +194,7 @@ cm_frac_NetNegEmi    "tax on net negative emissions to reflect risk of overshoot
 c_peakBudgYr       "date of net-zero CO2 emissions for peak budget runs without overshoot"
 cm_taxCO2_IncAfterPeakBudgYr "annual increase of CO2 price after the Peak Budget Year in $ per tCO2"
 c_regi_nucscen				"regions to apply nucscen to"
-c_regi_captureEnergy			"region to apply cm_captureEnergy to"
+c_regi_captureEnergy			"region to apply c_captureEnergy to"
 c_regi_synfuelscen			"region to apply synfuelscen to"
 cm_TaxConvCheck             "switch for enabling tax convergence check in nash mode"
 c_regi_sensscen				"regions which regional sensitivity parameters apply to"
@@ -244,7 +244,7 @@ cm_taxCO2_expGrowth = 1.05;      !! def = 1.05
 c_macscen         = 1;         !! def = 1
 
 cm_nucscen       = 2;        !! def = 2
-cm_captureEnergy  = 1;        !! def = 1
+c_captureEnergy  = 1;        !! def = 1
 c_bioliqscen     = 1;        !! def = 1
 c_bioh2scen      = 1;        !! def = 1
 c_shGreenH2      = 0;        !! def = 0

--- a/standalone/trade/trade.gms
+++ b/standalone/trade/trade.gms
@@ -140,10 +140,10 @@ c_shBioTrans          "upper bound on share of bioliquids in transport from 2025
 cm_shSynTrans         "lower bound on share of synthetic fuels in all transport fuels by 2045"
 cm_shSynGas           "lower bound on share of synthetic gases by 2045"
 cm_optimisticMAC     "assume optimistic Industry MAC from AR5 Ch. 10?"
-cm_captureInd        "carbon capture for Industry"
-cm_captureCement          "carbon capture for cement sub-sector"
-cm_captureChemicals     "carbon capture for chemicals sub-sector"
-cm_captureSteel         "carbon capture for steel sub-sector"
+cm_co2captureInd        "carbon capture for Industry"
+cm_co2captureCement          "carbon capture for cement sub-sector"
+cm_co2captureChemicals     "carbon capture for chemicals sub-sector"
+cm_co2captureSteel         "carbon capture for steel sub-sector"
 cm_bioenergy_SustTax    "level of the bioenergy sustainability tax in fraction of bioenergy price"
 cm_bioenergy_EF_for_tax "bioenergy emission factor that is used to derive a bioenergy tax [kgCO2 per GJ]"
 cm_maxProdBiolc         "bound on global pebiolc production including residues but excluding traditionally used biomass [EJ per yr]"
@@ -194,7 +194,7 @@ cm_frac_NetNegEmi    "tax on net negative emissions to reflect risk of overshoot
 c_peakBudgYr       "date of net-zero CO2 emissions for peak budget runs without overshoot"
 cm_taxCO2_IncAfterPeakBudgYr "annual increase of CO2 price after the Peak Budget Year in $ per tCO2"
 c_regi_nucscen				"regions to apply nucscen to"
-c_regi_captureEnergy			"region to apply c_captureEnergy to"
+c_regi_co2captureEnergy			"region to apply c_co2captureEnergy to"
 c_regi_synfuelscen			"region to apply synfuelscen to"
 cm_TaxConvCheck             "switch for enabling tax convergence check in nash mode"
 c_regi_sensscen				"regions which regional sensitivity parameters apply to"
@@ -244,7 +244,7 @@ cm_taxCO2_expGrowth = 1.05;      !! def = 1.05
 c_macscen         = 1;         !! def = 1
 
 cm_nucscen       = 2;        !! def = 2
-c_captureEnergy  = 1;        !! def = 1
+c_co2captureEnergy  = 1;        !! def = 1
 c_bioliqscen     = 1;        !! def = 1
 c_bioh2scen      = 1;        !! def = 1
 c_shGreenH2      = 0;        !! def = 0
@@ -253,10 +253,10 @@ cm_shSynTrans    = 0;        !! def = 0
 cm_shSynGas      = 0;        !! def = 0
 
 cm_optimisticMAC       = 0;        !! def = 0
-cm_captureInd          = 1;        !! def = 1
-cm_captureCement          = 1;        !! def = 1
-cm_captureChemicals       = 1;        !! def = 1
-cm_captureSteel           = 1;        !! def = 1
+cm_co2captureInd          = 1;        !! def = 1
+cm_co2captureCement          = 1;        !! def = 1
+cm_co2captureChemicals       = 1;        !! def = 1
+cm_co2captureSteel           = 1;        !! def = 1
 
 $setglobal cm_secondary_steel_bound  none   !! def = "scenario"
 
@@ -447,8 +447,8 @@ $setglobal cm_adj_coeff_multiplier  off
 $setglobal cm_inco0Factor  off !! def = off
 $setglobal cm_inco0RegiFactor  off !! def = off
 
-$setglobal cm_captureEnergyMarkup  off !! def = off
-$setglobal cm_captureIndMarkup  off !! def = off
+$setglobal cm_co2captureEnergyMarkup  off !! def = off
+$setglobal cm_co2captureIndMarkup  off !! def = off
 $setglobal cm_renewables_floor_cost  off !! def = off 
 
 $setglobal cm_sehe_upper  off !! def = off 

--- a/standalone/trade/trade.gms
+++ b/standalone/trade/trade.gms
@@ -139,11 +139,11 @@ c_shGreenH2           "lower bound on share of green hydrogen in all hydrogen by
 c_shBioTrans          "upper bound on share of bioliquids in transport from 2025 onwards"
 cm_shSynTrans         "lower bound on share of synthetic fuels in all transport fuels by 2045"
 cm_shSynGas           "lower bound on share of synthetic gases by 2045"
-cm_IndCCSscen        "CCS for Industry"
 cm_optimisticMAC     "assume optimistic Industry MAC from AR5 Ch. 10?"
-cm_CCS_cement        "CCS for cement sub-sector"
-cm_CCS_chemicals     "CCS for chemicals sub-sector"
-cm_CCS_steel         "CCS for steel sub-sector"
+cm_captureInd        "carbon capture for Industry"
+cm_captureCement          "carbon capture for cement sub-sector"
+cm_captureChemicals     "carbon capture for chemicals sub-sector"
+cm_captureSteel         "carbon capture for steel sub-sector"
 cm_bioenergy_SustTax    "level of the bioenergy sustainability tax in fraction of bioenergy price"
 cm_bioenergy_EF_for_tax "bioenergy emission factor that is used to derive a bioenergy tax [kgCO2 per GJ]"
 cm_maxProdBiolc         "bound on global pebiolc production including residues but excluding traditionally used biomass [EJ per yr]"
@@ -194,7 +194,7 @@ cm_frac_NetNegEmi    "tax on net negative emissions to reflect risk of overshoot
 c_peakBudgYr       "date of net-zero CO2 emissions for peak budget runs without overshoot"
 cm_taxCO2_IncAfterPeakBudgYr "annual increase of CO2 price after the Peak Budget Year in $ per tCO2"
 c_regi_nucscen				"regions to apply nucscen to"
-c_regi_capturescen			"region to apply ccapturescen to"
+c_regi_captureEnergy			"region to apply cm_captureEnergy to"
 c_regi_synfuelscen			"region to apply synfuelscen to"
 cm_TaxConvCheck             "switch for enabling tax convergence check in nash mode"
 c_regi_sensscen				"regions which regional sensitivity parameters apply to"
@@ -244,7 +244,7 @@ cm_taxCO2_expGrowth = 1.05;      !! def = 1.05
 c_macscen         = 1;         !! def = 1
 
 cm_nucscen       = 2;        !! def = 2
-cm_ccapturescen  = 1;        !! def = 1
+cm_captureEnergy  = 1;        !! def = 1
 c_bioliqscen     = 1;        !! def = 1
 c_bioh2scen      = 1;        !! def = 1
 c_shGreenH2      = 0;        !! def = 0
@@ -252,11 +252,11 @@ c_shBioTrans     = 1;        !! def = 1
 cm_shSynTrans    = 0;        !! def = 0
 cm_shSynGas      = 0;        !! def = 0
 
-cm_IndCCSscen          = 1;        !! def = 1
 cm_optimisticMAC       = 0;        !! def = 0
-cm_CCS_cement          = 1;        !! def = 1
-cm_CCS_chemicals       = 1;        !! def = 1
-cm_CCS_steel           = 1;        !! def = 1
+cm_captureInd          = 1;        !! def = 1
+cm_captureCement          = 1;        !! def = 1
+cm_captureChemicals       = 1;        !! def = 1
+cm_captureSteel           = 1;        !! def = 1
 
 $setglobal cm_secondary_steel_bound  none   !! def = "scenario"
 
@@ -340,7 +340,7 @@ $setGlobal cm_reducCostB  none !! def = none
 $setGlobal cm_effHP  5 !! def = 5
 
 $setGlobal c_regi_nucscen  all !! def = all
-$setGlobal c_regi_capturescen  all !! def = all
+$setGlobal c_regi_captureEnergy  all !! def = all
 $setGlobal c_regi_synfuelscen  all !! def = all
 $setGlobal c_regi_sensscen  all !! def = all
 
@@ -447,8 +447,8 @@ $setglobal cm_adj_coeff_multiplier  off
 $setglobal cm_inco0Factor  off !! def = off
 $setglobal cm_inco0RegiFactor  off !! def = off
 
-$setglobal cm_CCS_markup  off !! def = off
-$setglobal cm_Industry_CCS_markup  off !! def = off
+$setglobal cm_captureEnergyMarkup  off !! def = off
+$setglobal cm_captureIndMarkup  off !! def = off
 $setglobal cm_renewables_floor_cost  off !! def = off 
 
 $setglobal cm_sehe_upper  off !! def = off 


### PR DESCRIPTION
## Purpose of this PR

The switches disabling CO2 capture, geologic CO2 storage, and CO2 utilization led to infeasibilities. This PR revises the implementation by avoiding infeasibilities, improving consistency of switch naming, and improving clarity of switches. 

**Refactoring and Standardization of Carbon Capture Parameters:**
* **Renaming of switches:** 
    - `cm_ccapturescen` --> `c_co2captureEnergy`
    - `cm_IndCCSscen` --> `cm_co2captureInd`
    - `cm_CCS_cement`  --> `cm_co2captureCement`
    - `cm_CCS_chemicals`   --> `cm_co2captureChemicals`
    - `cm_CCS_steel`         --> `cm_co2captureSteel`  
    - `c_regi_capturescen` --> `c_regi_co2captureEnergy`
    - `cm_CCS_markup` --> `cm_co2captureEnergyMarkup`
    - `cm_Industry_CCS_markup` -->  `cm_co2captureIndMarkup`
 * **Adjustment of  `cm_ccapturescen` (`c_co2captureEnergy`) application**
Turning off carbon capture via this switch (i.e. `=2`) so far meant that also geologic storage was turned off  and that `vm_emiCDr.l` was set to 0 in `carbonRemoval/portfolio/presolve`.  Now, this switch really just adjusts the carbon capture of the teCCS technologies, i.e. energy conversion technologies with CCS in the core. Any other carbon capture technologies - in industry, dac, and oae - have to be set separately; and geologic storage and CCU are also operated individually.
This is clarified in the switch description, provides greatest flexibility without adding new switches, and avoids unwanted conflicts.

**Updates of bounds to fix infeasibilities when turning off technologies**
Turning off carbon capture, geologic storage, and CO2 utilization led to infeasibilities because the variables were fixed to 0 for all t. Instead of fixing capacities, upper bounds on `vm_deltaCap` are now set to `sm_eps`.

## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :ballot_box_with_check: GAMS Code
- :white_medium_square: R-scripts
- :ballot_box_with_check: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :ballot_box_with_check: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :ballot_box_with_check: Bug fix
- :white_medium_square: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :ballot_box_with_check: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

* Runs with these changes are here: /p/tmp/tabeado/remind_fixes/remind
* Comparison of results (what changes by this PR?): 
