### PR TITLE
Abort GAMS run on coupling Rscript failure

### DIFF
--- a/modules/15_climate/magicc7_ar6/postsolve.gms
+++ b/modules/15_climate/magicc7_ar6/postsolve.gms
@@ -24,8 +24,7 @@ Execute_unload 'fulldata_postsolve';
 
 *** Track runtime
 putclose runtime gyear(jnow):0:0 "-" gmonth(jnow):0:0 "-" gday(jnow):0:0 " " ghour(jnow):0:0 ":" gminute(jnow):0:0 ":" gsecond(jnow):0:0 ",climateAssessmentInterimRun," iteration.val:0;
-
-Execute "Rscript climateAssessmentInterimRun.R";
+execute.checkErrorLevel "Rscript climateAssessmentInterimRun.R";
 
 *** Track runtime
 putclose runtime gyear(jnow):0:0 "-" gmonth(jnow):0:0 "-" gday(jnow):0:0 " " ghour(jnow):0:0 ":" gminute(jnow):0:0 ":" gsecond(jnow):0:0 ",GAMS," iteration.val:0;
@@ -74,7 +73,7 @@ $ifthen.cm_magicc_tirf "%cm_magicc_temperatureImpulseResponse%" == "on"
 * thus only compute TIRF after each of the first 10 iterations, then only every fifth iteration. 
 * runtime is ca 30s, so switching on TIRF adds ca 10min to runtime
 if( ((iteration.val le 10) or ( mod(iteration.val,5 ) eq 0)) ,
-    execute "Rscript climateAssessmentImpulseResponse.R";
+    execute.checkErrorLevel "Rscript climateAssessmentImpulseResponse.R";
     execute_loadpoint 'pm_magicc_temperatureImpulseResponse'  pm_temperatureImpulseResponseCO2 = pm_temperatureImpulseResponse;
 );
 *NOTE the MAGICC results (*.OUT files) are from  the last pulse experiment now, so take care if reading them in after this point.

--- a/modules/35_transport/edge_esm/presolve.gms
+++ b/modules/35_transport/edge_esm/presolve.gms
@@ -11,7 +11,7 @@ if(edgeTransportIter(iteration),
 *** Track runtime
     putclose runtime gyear(jnow):0:0 "-" gmonth(jnow):0:0 "-" gday(jnow):0:0 " " ghour(jnow):0:0 ":" gminute(jnow):0:0 ":" gsecond(jnow):0:0 ",iterativeEdgeTransport," iteration.val:0;
 
-    Execute "Rscript -e 'library(edgeTransport); edgeTransport::iterativeEdgeTransport()'";
+    execute.checkErrorLevel "Rscript -e 'library(edgeTransport); edgeTransport::iterativeEdgeTransport()'";
 *** Track runtime
     putclose runtime gyear(jnow):0:0 "-" gmonth(jnow):0:0 "-" gday(jnow):0:0 " " ghour(jnow):0:0 ":" gminute(jnow):0:0 ":" gsecond(jnow):0:0 ",GAMS," iteration.val:0;
 

--- a/modules/50_damages/KotzWenz/postsolve.gms
+++ b/modules/50_damages/KotzWenz/postsolve.gms
@@ -3,7 +3,7 @@
 *** Track runtime
 putclose runtime gyear(jnow):0:0 "-" gmonth(jnow):0:0 "-" gday(jnow):0:0 " " ghour(jnow):0:0 ":" gminute(jnow):0:0 ":" gsecond(jnow):0:0 ",run_KotzWenz_damages," iteration.val:0;
 
-execute "Rscript run_KotzWenz_damages.R"
+execute.checkErrorLevel "Rscript run_KotzWenz_damages.R"
 
 *** Track runtime
 putclose runtime gyear(jnow):0:0 "-" gmonth(jnow):0:0 "-" gday(jnow):0:0 " " ghour(jnow):0:0 ":" gminute(jnow):0:0 ":" gsecond(jnow):0:0 ",GAMS," iteration.val:0;


### PR DESCRIPTION
## Purpose of this PR

A bare `execute "Rscript ..."` stashes the child's exit code in `errorLevel` but then keeps running. If the R coupling **call fails**, GAMS continues on to `execute_load`. The absence of an associated gdx-file is usually the point of failure then. However, in case the coupling script successfully ran at least once GAMS will pick up a **stale gdx** from a previous iteration. `execute.checkErrorLevel` makes GAMS **abort** on any non-zero exit. This is applies to:

  - `15_climate/magicc7_ar6/postsolve.gms` (interim + impulse response)
  - `35_transport/edge_esm/presolve.gms`
  - `50_damages/KotzWenz/postsolve.gms`

## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :ballot_box_with_check: GAMS Code
- :white_medium_square: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :ballot_box_with_check: Bug fix
- :white_medium_square: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

c.f. attached `mve.gms`, `coupling.R` in [`mve_checkErrorLevel.zip`](https://github.com/user-attachments/files/30985073/mve_checkErrorLevel.zip)

This change is difficult to test in a REMIND run, here's a minimum viable experience. Load the PIAM module, place both files in the same folder

### Usage

```sh
# BUG: bare execute + failed R call -> silently loads the stale gdx (42, not 2)
gams mve.gms --guard=off --fail=1

# FIX: checkErrorLevel + failed R call -> GAMS aborts at the execute call
gams mve.gms --guard=on  --fail=1

# happy path: R call succeeds -> fresh value (2) is loaded
gams mve.gms --fail=0
```

### Expected outcomes

| `--guard` | `--fail` | R call | GAMS result |
|-----------|----------|--------|-------------|
| `off`     | `1`      | exits 1 | continues; loads **stale 42**; **`*** Status: Normal completion`** (+ a `>>> STALE gdx` warning in the log) |
| `on`      | `1`      | exits 1 | **aborts at the `execute` call** (rc =/= 0); `*** Status: Execution error(s)`; never loads |
| any       | `0`      | writes gdx | loads fresh **2**; Normal completion |

The `off/1` runs a bare `execute` and lets a **failed** coupling call finish `mve.gms` with `**** Status: Normal completion on stale data, just logs a non-fatal `>>> STALE gdx` warning. The end of the run looks fine, but isn't. `on/1` uses `execute.checkErrorLevel`, logs `*** Error at line 35: Execution halted: execute.checkErrorLevel returned with 1` and finishes with `*** Status: Execution error(s)`