### PR TITLE
Fix q_shSeFeSector infeasibility on zero solids demand

### DIFF
--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -533,6 +533,10 @@ vm_demFeSector.up(t,regi,"seh2","feh2s","build",emiMkt) $ (t.val <= cm_H2InBuild
 *' upper bound on bioliquids as a share of transport liquids
 v_shBioTrans.up(t,regi) $ (t.val > 2020) = c_shBioTrans;
 
+*' upper bounds on secondary energy subtype shares in FE demand
+v_shSeFeSector.up(ttot,all_regi,all_enty,all_enty,emi_sectors,all_emiMkt) = 1;
+v_shSeFe.up(ttot,all_regi,all_enty) = 1;
+
 
 *** ==================================================================
 *' #### 7. Assumptions for emissions

--- a/core/equations.gms
+++ b/core/equations.gms
@@ -1090,7 +1090,11 @@ q_shSeFe(t,regi,entySe)$(entySeBio(entySe) OR entySeSyn(entySe) OR entySeFos(ent
       vm_demFeSector_afterTax(t,regi,entySe,entyFe,sector,emiMkt)))
 ;
 
-q_shSeFeSector(t,regi,entySe,entyFe,sector,emiMkt)$((entySeBio(entySe) OR entySeSyn(entySe) OR entySeFos(entySe)) AND (sefe(entySe,entyFe) AND entyFe2Sector(entyFe,sector) AND sector2emiMkt(sector,emiMkt)))..
+q_shSeFeSector(t,regi,entySe,entyFe,sector,emiMkt)$(
+    (sefe(entySe,entyFe) AND entyFe2Sector(entyFe,sector) AND sector2emiMkt(sector,emiMkt)) AND
+    (entySeBio(entySe) OR entySeSyn(entySe)) AND
+    (NOT (sameas(entyFe,"fesos") AND (sameas(sector,"build") OR sameas(sector,"indst")))) !! exclude build/indst solids (not in share penalty; prevents zero-demand infeasibility)
+  )..
   v_shSeFeSector(t,regi,entySe,entyFe,sector,emiMkt) 
   * sum(entySe2$sefe(entySe2,entyFe),
       vm_demFeSector_afterTax(t,regi,entySe2,entyFe,sector,emiMkt)*(1+999$(sameas(sector,"CDR"))))


### PR DESCRIPTION
## Purpose of this PR

- **Fix infeasibility on `fesos` in buildings and industry** for regions/periods with zero demand.
- **Add upper bounds ($= 1$) on share variables** (`v_shSeFeSector`, `v_shSeFe`) to prevent the solver from exploring unphysically large values when demand is small.

### Details

The equation `q_shSeFeSector` triggers a local infeasibility in some REMIND scenarios (e.g., ambitious carbon budget runs where regions like `CHA` have zero industry solid demand by 2150). With zero total final energy demand, the share equation becomes singular ($v \times 0 = 0$).

Because `fesos` in buildings and industry is already explicitly excluded from the downstream penalty equation `q_penSeFeSectorShareDev`, calculating these shares is unnecessary. Excluding them from `q_shSeFeSector` prevents the zero-demand singularity without side effects on model behavior.

## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :ballot_box_with_check: GAMS Code
- :white_medium_square: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :ballot_box_with_check: Bug fix
- :white_medium_square: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)


