### PR TITLE
Add missing default values when calling cs2 standalone

### DIFF
--- a/scripts/cs2/run_compareScenarios2.R
+++ b/scripts/cs2/run_compareScenarios2.R
@@ -10,6 +10,8 @@ library(piamPlotComparison)
 if (!exists("source_include")) {
   lucode2::readArgs("outputdirs", "outFileName", "profileName", "aliases", "sections")
 }
+if (!exists("aliases"))  { aliases <- NULL }
+if (!exists("sections")) { sections <- "all" }
 
 run_compareScenarios2 <- function(
   outputdirs,


### PR DESCRIPTION
## Purpose of this PR

When calling compareScenarios2 standalone, there were no defaults for aliases and sections. I add them here, so that model test and older scripts don't fail.

## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :white_medium_square: GAMS Code
- :ballot_box_with_check: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :ballot_box_with_check: Bug fix
- :white_medium_square: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

