### PR TITLE
fix bugs in output scripts

### DIFF
--- a/output.R
+++ b/output.R
@@ -263,7 +263,7 @@ runSingle <- function(output, outputdirs, slurmConfig, test) { # comp = single
       gms <- cfg$gms
       revision <- cfg$inputRevision
     }
-    
+
     # Set value source_include so that loaded scripts know, that they are
     # included as source (instead of a load from command line)
     source_include <- TRUE
@@ -272,47 +272,41 @@ runSingle <- function(output, outputdirs, slurmConfig, test) { # comp = single
     # Execute R scripts
     ###################################################################################
 
-    # output creation for --testOneRegi was switched off in start.R in this commit:
-    # https://github.com/remindmodel/remind/commit/5905d9dd814b4e4a62738d282bf1815e6029c965
-    if (all(output %in% c(NA, "NA"))) {
-      message("\nNo output generation, as output was set to NA, as for example for --testOneRegi or --quick.")
-    } else {
-      message("\nStarting output generation for ", outputdir, "\n")
-      name <- paste0(output, ".R")
-      scriptsfound <- file.exists(paste0("scripts/output/single/", name))
-      if (any(! scriptsfound)) {
-        warning("Skipping output scripts not found in scripts/output/single: ", name[! scriptsfound])
-      }
-      if (test) {
-        message("Test mode, not executing scripts/output/single/", paste(name, collapse = ", "))
-        next
-      }
-      if (slurmConfig == "direct") {
-        # execute output script directly (without sending it to slurm)
-        for (n in name[scriptsfound]) {
-          message("Executing ", n)
-          tmp.env <- new.env()
-          tmp.error <- try(sys.source(paste0("scripts/output/single/", n), envir = tmp.env))
-          #        rm(list=ls(tmp.env),envir=tmp.env)
-          rm(tmp.env)
-          gc()
-          if (!is.null(tmp.error)) {
-            warning("Script ", n, " was stopped by an error and not executed properly!")
-            errors <- TRUE
-          }
-        }
-      } else {
-        # send the output script to slurm
-        timestamp <- format(Sys.time(), "%Y-%m-%d_%H.%M.%S")
-        logfile <- file.path(outputdir, paste0("log_output_", timestamp, ".txt"))
-        Rscripts <- paste0("Rscript scripts/output/single/", name, " --outputdir=", outputdir, collapse = "; ")
-        slurmcmd <- paste0("sbatch ", slurmConfig, " --job-name=", logfile, " --output=", logfile,
-                      " --mail-type=END,FAIL --comment=output.R --wrap='", Rscripts, "'")
-        message("Sending to slurm: ", paste(name, collapse = ", "), ". Find log in ", logfile)
-        system(slurmcmd)
-      }
-      message("\nFinished ", ifelse(slurmConfig == "direct", "", "starting job for "), "output generation for ", outputdir, "!\n")
+    message("\nStarting output generation for ", outputdir, "\n")
+    name <- paste0(output, ".R")
+    scriptsfound <- file.exists(paste0("scripts/output/single/", name))
+    if (any(! scriptsfound)) {
+      warning("Skipping output scripts not found in scripts/output/single: ", name[! scriptsfound])
     }
+    if (test) {
+      message("Test mode, not executing scripts/output/single/", paste(name, collapse = ", "))
+      next
+    }
+    if (slurmConfig == "direct") {
+      # execute output script directly (without sending it to slurm)
+      for (n in name[scriptsfound]) {
+        message("Executing ", n)
+        tmp.env <- new.env()
+        tmp.error <- try(sys.source(paste0("scripts/output/single/", n), envir = tmp.env))
+        #        rm(list=ls(tmp.env),envir=tmp.env)
+        rm(tmp.env)
+        gc()
+        if (!is.null(tmp.error)) {
+          warning("Script ", n, " was stopped by an error and not executed properly!")
+          errors <- TRUE
+        }
+      }
+    } else {
+      # send the output script to slurm
+      timestamp <- format(Sys.time(), "%Y-%m-%d_%H.%M.%S")
+      logfile <- file.path(outputdir, paste0("log_output_", timestamp, ".txt"))
+      Rscripts <- paste0("Rscript scripts/output/single/", name, " --outputdir=", outputdir, collapse = "; ")
+      slurmcmd <- paste0("sbatch ", slurmConfig, " --job-name=", logfile, " --output=", logfile,
+                    " --mail-type=END,FAIL --comment=output.R --wrap='", Rscripts, "'")
+      message("Sending to slurm: ", paste(name, collapse = ", "), ". Find log in ", logfile)
+      system(slurmcmd)
+    }
+    message("\nFinished ", ifelse(slurmConfig == "direct", "", "starting job for "), "output generation for ", outputdir, "!\n")
 
     rm(source_include)
     if (!is.null(warnings())) {
@@ -324,11 +318,19 @@ runSingle <- function(output, outputdirs, slurmConfig, test) { # comp = single
 
 #' main function of the script
 #' prompts the user for all required information to start an output script
-#' 
+#'
 #' @param args parsed command line arguments as a named list, for documentation of the arguments,
 #'        see the command line arguments of this script
 output <- function(args) {
-  remind_dir <- if (is.null(args[["remind_dir"]])) NULL                                           else unlist(strsplit(args[["remind_dir"]], ","))   
+
+  # output creation for --testOneRegi was switched off in start.R in this commit:
+  # https://github.com/remindmodel/remind/commit/5905d9dd814b4e4a62738d282bf1815e6029c965
+  if (args[["output"]] %in% c(NA, "NA")) {
+    message("\nNo output generation, as output was set to NA, as for example for --testOneRegi or --quick.")
+    return()
+  }
+
+  remind_dir <- if (is.null(args[["remind_dir"]])) NULL                                           else unlist(strsplit(args[["remind_dir"]], ","))
   comp       <- if (is.null(args[["comp"]]))       chooseCompMode()                               else args[["comp"]]
   output     <- if (is.null(args[["output"]]))     chooseOutputScript(comp)                       else unlist(strsplit(args[["output"]], ","))
   outputdirs <- if (is.null(args[["outputdirs"]]))  chooseOutputDirs(output, args[["remind_dir"]]) else unlist(strsplit(args[["outputdirs"]], ","))
@@ -353,7 +355,7 @@ output <- function(args) {
     } else {
       filename_prefix = args[["filename_prefix"]]
     }
-    
+
     # choose the slurm options. If you use command line arguments, use slurmConfig=priority or standby
     modulesUsingSlurmConfig <- c("compareScenarios2", "validateScenarios")
     if (isSlurmAvailable() && any(modulesUsingSlurmConfig %in% output)) {

--- a/scripts/output/single/reporting.R
+++ b/scripts/output/single/reporting.R
@@ -14,9 +14,9 @@ library(data.table)
 
 ############################# BASIC CONFIGURATION #############################
 
-gdx_name     <- "fulldata.gdx"
-gdx_ref_name <- "input_ref.gdx"            # name of the ref for < cm_startyear
-gdx_refpolicycost_name <- "input_refpolicycost.gdx"  # name of the reference gdx (for policy cost calculation)
+gdx_name <- "fulldata.gdx"
+gdx_ref_name <- "input_ref.gdx" # name of the ref for < cm_startyear
+gdx_refpolicycost_name <- "input_refpolicycost.gdx" # name of the reference gdx (for policy cost calculation)
 
 if (!exists("source_include")) {
   # Define arguments that can be read from command line
@@ -25,10 +25,10 @@ if (!exists("source_include")) {
 }
 stopifnot(exists("outputdir"))
 
-gdx     <- file.path(outputdir, gdx_name)
+gdx <- file.path(outputdir, gdx_name)
 gdx_ref <- file.path(outputdir, gdx_ref_name)
 gdx_refpolicycost <- file.path(outputdir, gdx_refpolicycost_name)
-if (!file.exists(gdx_ref))           gdx_ref <- NULL
+if (!file.exists(gdx_ref)) gdx_ref <- NULL
 if (!file.exists(gdx_refpolicycost)) gdx_refpolicycost <- NULL
 scenario <- lucode2::getScenNames(outputdir)
 
@@ -51,75 +51,85 @@ if (length(remind_policy_reporting_file) > 0) {
 
 # produce REMIND reporting *.mif based on gdx information ----
 message("### start generation of mif files at ", round(Sys.time()))
-convGDX2MIF(gdx, gdx_refpolicycost = gdx_refpolicycost,
-            file = remind_reporting_file, scenario = scenario, gdx_ref = gdx_ref,
-            extraData = extra_data_path)
+convGDX2MIF(gdx,
+  gdx_refpolicycost = gdx_refpolicycost,
+  file = remind_reporting_file, scenario = scenario, gdx_ref = gdx_ref,
+  extraData = extra_data_path
+)
 
-# generate EDGE-T reporting ----
+# generate EDGE-T reporting and extra emission reporting if available ----
 # the reporting is appended to REMIND_generic_<scenario>.MIF
 # REMIND_generic_<scenario>_withoutPlus.MIF is replaced.
 
 edgetOutputDir <- file.path(outputdir, "EDGE-T")
 
 if (!file.exists(edgetOutputDir)) {
-  stop("EDGE-T folder is missing")
+  message("### start generation of EDGE-T reporting")
+  reporttransport::checkConvergence(outputdir)
+
+  EDGEToutput <- reporttransport::reportEdgeTransport(edgetOutputDir,
+    isTransportExtendedReported = FALSE,
+    modelName = "REMIND",
+    scenarioName = scenario,
+    gdxPath = file.path(outputdir, "fulldata.gdx"),
+    isStored = FALSE,
+    isHarmonized = TRUE
+  )
+
+  # For certain projects, we currently don't want to report EDGE-T results for 2005 and 2010.
+  # If the flag c_edgetReportAfter2010 is set, 2005 and 2010 values get replaced by NAs
+
+  c_edgetReportAfter2010 <- gdx::readGDX(gdx, name = "c_edgetReportAfter2010")
+
+  if (c_edgetReportAfter2010 == 1) {
+    EDGEToutput <- EDGEToutput %>%
+      dplyr::mutate(value = if_else(period %in% c(2005, 2010), NA_real_, value))
+  }
+
+  # Select matching variables
+  REMINDoutput <- as.data.table(read.quitte(file.path(outputdir, paste0("REMIND_generic_", scenario, "_withoutPlus.mif"))))
+
+  quitte::write.mif(EDGEToutput[region %in% unique(REMINDoutput$region)], remind_reporting_file, append = TRUE)
+  piamutils::deletePlus(remind_reporting_file, writemif = TRUE)
+
+  # generate transport extended mif
+  EDGEToutputPriorHarmonization <- reporttransport::reportEdgeTransport(edgetOutputDir,
+    isREMINDinputReported = TRUE,
+    isTransportExtendedReported = TRUE,
+    gdxPath = file.path(outputdir, "fulldata.gdx"),
+    isStored = TRUE
+  )
+
+  # Add ratio of "FE|Transport" (with bunkers) EDGE-T to REMIND before harmonization to the REMIND.mif as an indicator
+  FEratioEDGE <- EDGEToutputPriorHarmonization[variable == "FE|Transport with bunkers"][, c("variable", "model", "scenario") := NULL]
+  setnames(FEratioEDGE, "value", "EDGEfe")
+
+  FEratioREMIND <- REMINDoutput[variable == "FE|Transport"][, variable := NULL]
+  setnames(FEratioREMIND, "value", "REMINDfe")
+  FEratio <- merge(FEratioEDGE[region %in% unique(REMINDoutput$region)], FEratioREMIND, by = intersect(names(FEratioEDGE), names(FEratioREMIND)))
+  FEratio[, value := (EDGEfe / REMINDfe) * 100]
+  FEratio[, variable := "FE|Transport|a - ratio of EDGE-T to REMIND before harmonization"][, unit := "%"]
+  FEratio[, c("EDGEfe", "REMINDfe") := NULL]
+  quitte::write.mif(FEratio, remind_reporting_file, append = TRUE)
+  piamutils::deletePlus(remind_reporting_file, writemif = TRUE)
+
+  message("### end generation of EDGE-T reporting")
+
+
+  # extra emission reporting (depends on REMIND and EDGE-T variables) ----
+
+  message("### report additional emission variables (reportExtraEmissions)")
+  extraEmissions <- remind2::reportExtraEmissions(
+    mif = remind_reporting_file,
+    extraData = extra_data_path,
+    gdx = gdx
+  )
+  quitte::write.mif(extraEmissions, remind_reporting_file, append = TRUE)
+  piamutils::deletePlus(remind_reporting_file, writemif = TRUE)
+} else {
+  message("\nEDGE-T did not seem to run, as there is no 'EDGE-T' folder in the run folder.
+          Skipping EDGE-T reporting and extra emission reporting.")
 }
-
-message("### start generation of EDGE-T reporting")
-reporttransport::checkConvergence(outputdir)
-EDGEToutput <- reporttransport::reportEdgeTransport(edgetOutputDir,
-                                                     isTransportExtendedReported = FALSE,
-                                                     modelName = "REMIND",
-                                                     scenarioName = scenario,
-                                                     gdxPath = file.path(outputdir, "fulldata.gdx"),
-                                                     isStored = FALSE,
-                                                     isHarmonized = TRUE)
-
-# For certain projects, we currently don't want to report EDGE-T results for 2005 and 2010.
-# If the flag c_edgetReportAfter2010 is set, 2005 and 2010 values get replaced by NAs
-
-c_edgetReportAfter2010 <- gdx::readGDX(gdx, name = "c_edgetReportAfter2010")
-
-if (c_edgetReportAfter2010 == 1) {
-  EDGEToutput <- EDGEToutput %>%
-    dplyr::mutate(value = if_else(period %in% c(2005, 2010), NA_real_, value))
-}
- 
-#Select matching variables
-REMINDoutput <- as.data.table(read.quitte(file.path(outputdir, paste0("REMIND_generic_", scenario, "_withoutPlus.mif"))))
-
-quitte::write.mif(EDGEToutput[region %in% unique(REMINDoutput$region)], remind_reporting_file, append = TRUE)
-piamutils::deletePlus(remind_reporting_file, writemif = TRUE)
-
-# generate transport extended mif
-EDGEToutputPriorHarmonization <- reporttransport::reportEdgeTransport(edgetOutputDir,
-                                                                     isREMINDinputReported = TRUE,
-                                     isTransportExtendedReported = TRUE,
-                                     gdxPath = file.path(outputdir, "fulldata.gdx"),
-                                     isStored = TRUE)
-
-#Add ratio of "FE|Transport" (with bunkers) EDGE-T to REMIND before harmonization to the REMIND.mif as an indicator
-FEratioEDGE <- EDGEToutputPriorHarmonization[variable == "FE|Transport with bunkers"][, c("variable", "model", "scenario") := NULL]
-setnames(FEratioEDGE, "value", "EDGEfe")
-
-FEratioREMIND <- REMINDoutput[variable == "FE|Transport"][, variable := NULL]
-setnames(FEratioREMIND, "value", "REMINDfe")
-FEratio <- merge(FEratioEDGE[region %in% unique(REMINDoutput$region)], FEratioREMIND, by = intersect(names(FEratioEDGE), names(FEratioREMIND)))
-FEratio[, value := (EDGEfe / REMINDfe) * 100]
-FEratio[, variable := "FE|Transport|a - ratio of EDGE-T to REMIND before harmonization"][, unit := "%"]
-FEratio[, c("EDGEfe", "REMINDfe") := NULL]
-quitte::write.mif(FEratio, remind_reporting_file, append = TRUE)
-piamutils::deletePlus(remind_reporting_file, writemif = TRUE)
-
-message("### end generation of EDGE-T reporting")
-
-# extra emission reporting (depends on REMIND and EDGE-T variables) ----
-message("### report additional emission variables (reportExtraEmissions)")
-extraEmissions <- remind2::reportExtraEmissions(mif = remind_reporting_file,
-                                                extraData = extra_data_path,
-                                                gdx = gdx)
-quitte::write.mif(extraEmissions, remind_reporting_file, append = TRUE)
-piamutils::deletePlus(remind_reporting_file, writemif = TRUE)
 
 # append MAgPIE reporting if available ----
 
@@ -136,8 +146,10 @@ if (!is.null(magpie_reporting_file)) {
     # remove common variables from magpie reporting to avoid duplication
     sharedvariables <- intersect(tmp_mag$variable, tmp_rem$variable)
     if (length(sharedvariables) > 0) {
-      message("The following variables will be dropped from MAgPIE reporting because they are in REMIND reporting: ",
-              paste(sharedvariables, collapse = ", "))
+      message(
+        "The following variables will be dropped from MAgPIE reporting because they are in REMIND reporting: ",
+        paste(sharedvariables, collapse = ", ")
+      )
       tmp_mag <- dplyr::filter(tmp_mag, !.data$variable %in% sharedvariables)
     }
     # Harmonize scenario names: use the REMIND scenario name also for MAgPIE
@@ -149,7 +161,7 @@ if (!is.null(magpie_reporting_file)) {
     message("A path to a MAgPIE report was specified but the files cannot be found: ", magpie_reporting_file)
   }
 } else {
-  message("Since no path to a MAgPIE report was specified  (which is normal for standalone runs), no MAgPIE report will be appended to the REMIND report.")
+  message("\nSince no path to a MAgPIE report was specified  (which is normal for standalone runs), no MAgPIE report will be appended to the REMIND report.")
 }
 
 # warn if duplicates in mif and incorrect spelling of variables ----

--- a/scripts/output/single/reporting.R
+++ b/scripts/output/single/reporting.R
@@ -63,7 +63,8 @@ convGDX2MIF(gdx,
 
 edgetOutputDir <- file.path(outputdir, "EDGE-T")
 
-if (!file.exists(edgetOutputDir)) {
+if (dir.exists(edgetOutputDir)) {
+
   message("### start generation of EDGE-T reporting")
   reporttransport::checkConvergence(outputdir)
 


### PR DESCRIPTION
## Purpose of this PR

Fix Problems causing many SLURM jobs to return -1 currently (false posivtives)

- bring back handling testOneRegi reporting correctly by handling `cfg$output <- NA` currectly
- if the EDGET folder is not found, write a message instead of crashing and skip infeasible reporting (this is because some runs like calibration runs dont run EDGE-T)

## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :white_medium_square: GAMS Code
- :ballot_box_with_check: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :ballot_box_with_check: Bug fix
- :white_medium_square: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)
 
