### PR TITLE
fix passing folders using remind_dir in output script

### DIFF
--- a/output.R
+++ b/output.R
@@ -44,29 +44,51 @@ invisible(sapply(list.files("scripts/start", pattern = "\\.R$", full.names = TRU
 # parse options from command line and return them as a named list
 parseOptions <- function() {
   options <- list(
-    make_option(c("-t", "--test"), action="store_true", default=FALSE,
-                help="test output.R without actually starting any run"),
-    make_option("--update", action="store_true", default=FALSE,
-                help="update packages in renv first, incompatible with --renv"),
-    make_option("--comp", type="character", default=NULL,
-                help="specify output type: 'single' for single runs (e.g. reporting), 'comparison' for run comparisons (e.g. compareScenarios2), or 'export' to export runs (e.g. xlsx_IIASA)"),
-    make_option("--filename_prefix", type="character", default=NULL,
-                help="string to be added to filenames by some output scripts (compareScenarios, xlsx_IIASA)"),
-    make_option("--output", type="character", default=NULL,
-                help="directly select a specific script (without .R extension)"),
-    make_option("--outputdirs", type="character", default=NULL,
-                help="directly specify output directories as comma-separated list (e.g. ./output/SSP2-Base-rem-1,./output/NDC-rem-1)"),
-    make_option("--aliases", type="character", default=NULL,
-                help="Specify aliases for the runs given in outputdirs as a comma-separated list (e.g. aliases=default,modified)"),
-    make_option("--remind_dir", type="character", default=NULL,
-                help="path to remind or output directories where runs can be found. Defaults to ./output. Can specify multiple comma-separated folders (e.g. .,../otherremind)"),
-    make_option("--renv", type="character", default=NULL,
-                help="load the renv located at <path>, incompatible with --update"),
-    make_option("--slurmConfig", type="character", default=NULL,
-                help="specify SLURM selection: use 'priority', 'short', or 'standby', or pass multiple SLURM arguments (e.g. '--qos=priority --mem=8000')")
+    make_option(c("-t", "--test"),
+      action = "store_true", default = FALSE,
+      help = "test output.R without actually starting any run"
+    ),
+    make_option("--update",
+      action = "store_true", default = FALSE,
+      help = "update packages in renv first, incompatible with --renv"
+    ),
+    make_option("--comp",
+      type = "character", default = NULL,
+      help = "specify output type: 'single' for single runs (e.g. reporting), 'comparison' for run comparisons (e.g. compareScenarios2), or 'export' to export runs (e.g. xlsx_IIASA)"
+    ),
+    make_option("--filename_prefix",
+      type = "character", default = NULL,
+      help = "string to be added to filenames by some output scripts (compareScenarios, xlsx_IIASA)"
+    ),
+    make_option("--output",
+      type = "character", default = NULL,
+      help = "directly select a specific script (without .R extension)"
+    ),
+    make_option("--outputdirs",
+      type = "character", default = NULL,
+      help = "directly specify output directories as comma-separated list (e.g. ./output/SSP2-Base-rem-1,./output/NDC-rem-1)"
+    ),
+    make_option("--aliases",
+      type = "character", default = NULL,
+      help = "Specify aliases for the runs given in outputdirs as a comma-separated list (e.g. aliases=default,modified)"
+    ),
+    make_option("--remind_dir",
+      type = "character", default = NULL,
+      help = "path to remind or output directories where runs can be found. Defaults to ./output. Can specify multiple comma-separated folders (e.g. .,../otherremind)"
+    ),
+    make_option("--renv",
+      type = "character", default = NULL,
+      help = "load the renv located at <path>, incompatible with --update"
+    ),
+    make_option("--slurmConfig",
+      type = "character", default = NULL,
+      help = "specify SLURM selection: use 'priority', 'short', or 'standby', or pass multiple SLURM arguments (e.g. '--qos=priority --mem=8000')"
+    )
   )
-  parser <- OptionParser(usage="Rscript output.R [options prefixed by --, e.g. --comp=single]", option_list=options,
-                        description="[options] can be the following flags and variables. If variables are not specified but needed, the scripts will ask the user.")
+  parser <- OptionParser(
+    usage = "Rscript output.R [options prefixed by --, e.g. --comp=single]", option_list = options,
+    description = "[options] can be the following flags and variables. If variables are not specified but needed, the scripts will ask the user."
+  )
   # these flags appear in the various output scripts and are necessary here
   # if you add a command line argument to a script, add it here as well
   additionalScriptOptions = list("profileNames", "runs", "folder", "project", "sections",
@@ -75,6 +97,7 @@ parseOptions <- function() {
   for (option in additionalScriptOptions) {
     parser <- add_option(parser, paste0("--", option), help="This option is used in an output script, see your script for information.")
   }
+  
   return(parse_args(parser))
 }
 
@@ -168,7 +191,8 @@ chooseOutputDirs <- function(output, remind_dir) {
     defaultcfg <- readDefaultConfig(".")
     dir_folder <- unique(c("output", dirname(defaultcfg$results_folder)))
   } else {
-    dir_folder <- c(file.path(remind_dir, "output"), remind_dir)
+    dir_folder <- trimws(unlist(strsplit(remind_dir, ",")))
+    dir_folder <- c(file.path(dir_folder, "output"), dir_folder)
   }
   dirs <- dirname(Sys.glob(file.path(dir_folder, "*", "fulldata.gdx")))
   if (needingMif) dirs <- intersect(dirs, unique(dirname(Sys.glob(file.path(dir_folder, "*", "REMIND_generic_*.mif")))))
@@ -325,7 +349,7 @@ output <- function(args) {
 
   # output creation for --testOneRegi was switched off in start.R in this commit:
   # https://github.com/remindmodel/remind/commit/5905d9dd814b4e4a62738d282bf1815e6029c965
-  if (args[["output"]] %in% c(NA, "NA")) {
+  if (!is.null(args[["output"]]) && args[["output"]] %in% c(NA, "NA")) {
     message("\nNo output generation, as output was set to NA, as for example for --testOneRegi or --quick.")
     return()
   }
@@ -390,6 +414,7 @@ output <- function(args) {
     quit(status = -1)
   }
 }
+
 
 if (exists("source_include")) {
   output(passedArgs)


### PR DESCRIPTION
## Purpose of this PR

Fix bugs in output script causing reporting failures.

## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :ballot_box_with_check: GAMS Code
- :white_medium_square: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :ballot_box_with_check: Bug fix
- :white_medium_square: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

* Runs with these changes are here:
* Comparison of results (what changes by this PR?): 
