### PR TITLE
Fix fixOnRef sending unintended interactive prompts

### DIFF
--- a/output.R
+++ b/output.R
@@ -264,7 +264,7 @@ runComparisonOrExport <- function(comp, output, outputdirs, aliases, filename_pr
 }
 
 # returns TRUE if any script had errors
-runSingle <- function(output, outputdirs, slurmConfig, test) { # comp = single
+runSingle <- function(output, outputdirs, slurmConfig, interactiveSession, test) { # comp = single
   errors <- FALSE
   # Execute outputscripts for all chosen folders
   for (outputdir in outputdirs) {
@@ -393,6 +393,7 @@ output <- function(args) {
     }
     errors = runComparisonOrExport(comp, output, outputdirs, aliases, filename_prefix, slurmConfig, args[["test"]])
   } else {
+    interactiveSession <- FALSE
     # define slurm class or direct execution
     outputInteractive <- c("plotIterations", "integratedDamageCosts")
     if (!isSlurmAvailable() || exists("source_include") || any(output %in% outputInteractive)) {
@@ -404,11 +405,11 @@ output <- function(args) {
     } else if (args[["slurmConfig"]] %in% c("priority", "short", "standby")) {
       slurmConfig <- paste0("--nodes=1 --tasks-per-node=1 --qos=", args[["slurmConfig"]])
     } else if (isTRUE(args[["slurmConfig"]] %in% "direct")) {
-      interactive = TRUE
+      interactiveSession <- TRUE
     } else {
       slurmConfig = args[["slurmConfig"]]
     }
-    errors = runSingle(output, outputdirs, slurmConfig, args[["test"]])
+    errors = runSingle(output, outputdirs, slurmConfig, interactiveSession, args[["test"]])
   }
   if (errors) {
     quit(status = -1)

--- a/scripts/output/single/fixOnRef.R
+++ b/scripts/output/single/fixOnRef.R
@@ -20,6 +20,9 @@ if(! exists("source_include")) {
   outputdir <- "."
   flags <- lucode2::readArgs("outputdir", .flags = c(i = "--interactive"))
 }
+if(! exists("interactiveSession")) {
+  interactiveSession = exists("flags") && "--interactive" %in% flags
+}
 
 # find the mif file of the reference run automatically by reading from cfg the output folder
 findRefMif <- function(outputdir, envi) {
@@ -113,7 +116,7 @@ fixOnMif <- function(outputdir) {
   if (! isTRUE(fixeddata) && isTRUE(envi$cfg$fixOnRefAuto %in% c(TRUE, "TRUE"))) {
     d <- fixeddata
     update <- "data from reference run because cfg$fixOnRefAuto=TRUE."
-  } else if (! isTRUE(fixeddata) && exists("interactive")) {
+  } else if (! isTRUE(fixeddata) && interactiveSession) {
     message("\nDo you want to fix that by overwriting ", title, " mif with reference run ",
             refname, " for t < ", startyear, "?\nType: y/N")
     if (tolower(gms::getLine()) %in% c("y", "yes")) {


### PR DESCRIPTION
## Purpose of this PR

interactive() is a function that always exists in R, so I renamed the variable and made sure to actually hand it to the right context.

## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :white_medium_square: GAMS Code
- :ballot_box_with_check: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :ballot_box_with_check: Bug fix
- :white_medium_square: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

