### PR TITLE
fix bug in output script

### DIFF
--- a/output.R
+++ b/output.R
@@ -97,7 +97,7 @@ parseOptions <- function() {
   for (option in additionalScriptOptions) {
     parser <- add_option(parser, paste0("--", option), help="This option is used in an output script, see your script for information.")
   }
-  
+
   return(parse_args(parser))
 }
 
@@ -349,7 +349,7 @@ output <- function(args) {
 
   # output creation for --testOneRegi was switched off in start.R in this commit:
   # https://github.com/remindmodel/remind/commit/5905d9dd814b4e4a62738d282bf1815e6029c965
-  if (!is.null(args[["output"]]) && args[["output"]] %in% c(NA, "NA")) {
+  if (!is.null(args[["output"]]) && all(args[["output"]] %in% c(NA, "NA"))) {
     message("\nNo output generation, as output was set to NA, as for example for --testOneRegi or --quick.")
     return()
   }


### PR DESCRIPTION
## Purpose of this PR

Fix bug that causes crashes when more than one run is passed to output script

## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :white_medium_square: GAMS Code
- :ballot_box_with_check: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :ballot_box_with_check: Bug fix
- :white_medium_square: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

