### PR TITLE
Allow spaces in CS2 aliases

### DIFF
--- a/output.R
+++ b/output.R
@@ -392,7 +392,7 @@ output <- function(args) {
       }
     }
     errors = runComparisonOrExport(comp, output, outputdirs, aliases, filename_prefix, slurmConfig, args[["test"]])
-  } else {
+  } else if (comp %in% c("single")) {
     interactiveSession <- FALSE
     # define slurm class or direct execution
     outputInteractive <- c("plotIterations", "integratedDamageCosts")
@@ -410,6 +410,8 @@ output <- function(args) {
       slurmConfig = args[["slurmConfig"]]
     }
     errors = runSingle(output, outputdirs, slurmConfig, interactiveSession, args[["test"]])
+  } else {
+    stop("Comparison mode not supported")
   }
   if (errors) {
     quit(status = -1)

--- a/scripts/output/comparison/compareScenarios2.R
+++ b/scripts/output/comparison/compareScenarios2.R
@@ -71,11 +71,11 @@ startComp <- function(
       " --mail-type=END,FAIL --time=200",
       if (!grepl("--mem", slurmConfig)) " --mem=8000",
       " --wrap=\"Rscript ", script,
-      " --outputdirs=", paste(outputdirs, collapse = ","),
-      " --profileName=", profileName,
-      " --outFileName=", outFileName,
-      " --aliases=", paste(aliases, collapse = ","),
-      " --sections=", paste(sections, collapse = ","),
+      " --outputdirs=", shQuote(paste(outputdirs, collapse = ",")),
+      " --profileName=", shQuote(profileName),
+      " --outFileName=", shQuote(outFileName),
+      " --aliases=", shQuote(paste(aliases, collapse = ",")),
+      " --sections=", shQuote(paste(sections, collapse = ",")),
       "\"")
     cat(clcom, "\n")
     system(clcom)


### PR DESCRIPTION
## Purpose of this PR

Previously the CS2 script did not handle spaces well when passing arguments to slurm. shQuote fixes this. Thanks @bennet21 for spotting this. I also added some explicit error handling for the comp argument of output.R.

## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :white_medium_square: GAMS Code
- :ballot_box_with_check: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :ballot_box_with_check: Bug fix
- :white_medium_square: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

