### PR TITLE
Make short default report available again in CS2

### DIFF
--- a/scripts/cs2/run_compareScenarios2.R
+++ b/scripts/cs2/run_compareScenarios2.R
@@ -28,6 +28,7 @@ run_compareScenarios2 <- function(
 
   # load cs2 profiles
   profiles <- piamPlotComparison::getCs2Profiles()
+  stopifnot(profileName %in% names(profiles))
 
   # Create temporary folder. This is necessary because each compareScenarios2
   # run creates a folder named 'figure'. If multiple compareScenarios2 run in

--- a/scripts/output/comparison/compareScenarios2.R
+++ b/scripts/output/comparison/compareScenarios2.R
@@ -36,8 +36,8 @@ determineDefaultProfiles <- function(outputDir) {
   defaults <- switch(
     regionMappingFile,
     "default",
-    "regionmappingH12.csv" =  c("H12", "H12-short"),
-    "regionmapping_21_EU11.csv" =  c("H12", "H12-short", "EU27", "EU27-short", "AriadneDEU"))
+    "regionmappingH12.csv" =  c("H12", "H12-to2050"),
+    "regionmapping_21_EU11.csv" =  c("H12", "H12-to2050", "EU27", "EU27-to2050", "AriadneDEU"))
   return(defaults)
 }
 
@@ -105,7 +105,12 @@ if (! exists("sections")) {
 # Let user choose cs2 profile(s).
 profileNamesDefault <- determineDefaultProfiles(outputdirs[1])
 
-if (! exists("profileNames") || ! all(profileNames %in% names(profiles))) {
+stopifnot(all(profileNamesDefault %in% names(profiles)))
+if (exists("profileNames") && !all(profileNames %in% names(profiles))) {
+  stop("At least one supplied profile does not exist in scripts/cs2/profiles.json")
+}
+
+if (! exists("profileNames")) {
   profileNames <- names(profiles)[gms::chooseFromList(
     ifelse(names(profiles) %in% profileNamesDefault, crayon::cyan(names(profiles)), names(profiles)),
     type = "profiles for cs2",


### PR DESCRIPTION
## Purpose of this PR

Previously the default profile `H12-short` and the actual profile `H12-to2050` had different names. I use the more descriptive `H12-to2050` for both now. I also added checks for missing profile names to avoid this problem in the future.

See https://github.com/pik-piam/remind2/pull/827 for a docs update.

This might break downstream users and AMTs if they use non-existent profiles that previously errored silently.

## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :white_medium_square: GAMS Code
- :ballot_box_with_check: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :ballot_box_with_check: Bug fix
- :white_medium_square: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

