### PR TITLE
Remove missing data workaround on tech bounds

### DIFF
--- a/core/bounds.gms
+++ b/core/bounds.gms
@@ -73,27 +73,7 @@ loop(teRe2rlfDetail(te,rlf),
 loop(t $ (t.val >= 2015 and t.val <= 2025),
 *** fix renewable capacities to real world historical values if available
   vm_cap.lo(t,regi,teVRE(te),"1") $ pm_histCap(t,regi,te) = 0.95 * pm_histCap(t,regi,te);
-  if(t.val <= 2020, !! TODO: activate 2025 upper-bound when consolidated data available
-    vm_cap.up(t,regi,teVRE(te),"1") $ pm_histCap(t,regi,te) = 1.05 * pm_histCap(t,regi,te);
-  );
-*** for 2025: as no 2025 data avaiable yet, fix lower bound to 2024 capacity + 0.5 times the annual growth in 2022-2024
-*** but at least 2024 capacity
-  if(t.val = 2025,
-    vm_cap.lo(t,regi,teVRE(te),"1") $ p_histCapYearly("2024",regi,te) = max(p_histCapYearly("2024",regi,te) 
-                                                                                + 0.5
-                                                                                  * ( p_histCapYearly("2024",regi,te) 
-                                                                                    - p_histCapYearly("2022",regi,te) ) / 2,
-                                                                              p_histCapYearly("2024",regi,te)
-                                                                            );
-*** for 2025: as no 2025 data avaiable yet, fix upper bound to 2024 capacity + 2 times the annual growth in 2022-2024
-*** but at least 10% growth of 2024 capacity
-    vm_cap.up(t,regi,teVRE(te),"1") $ p_histCapYearly("2024",regi,te) = max(p_histCapYearly("2024",regi,te) 
-                                                                                + 2
-                                                                                  * ( p_histCapYearly("2024",regi,te) 
-                                                                                    - p_histCapYearly("2022",regi,te) ) / 2,
-                                                                              1.1 * p_histCapYearly("2024",regi,te)
-                                                                            );
-  );
+  vm_cap.up(t,regi,teVRE(te),"1") $ pm_histCap(t,regi,te) = 1.05 * pm_histCap(t,regi,te);
 *** broader bounds for renewables with lower data quality
   loop(te $ (sameas(te, "hydro") or sameas(te, "geohdr")),
     vm_cap.lo(t,regi,te,"1") $ pm_histCap(t,regi,te) = 0.7 * pm_histCap(t,regi,te);

--- a/core/datainput.gms
+++ b/core/datainput.gms
@@ -684,19 +684,6 @@ pm_histCap("2025",regi,teReNoBio) = max(pm_histCap("2020",regi,teReNoBio), pm_hi
 *** calculate historic capacity additions
 pm_delta_histCap(ttot,regi,te) = pm_histCap(ttot,regi,te) - pm_histCap(ttot-1,regi,te);
 
-*** historical installed capacity for yearly time-steps
-*** (same as pm_histCap, but with yearly time-steps instead of 5-year time-steps)
-$Offlisting
-table   p_histCapYearly(tall,all_regi,all_te) "historical installed capacity in yearly time steps (TW)"
-$ondelim
-$include "./core/input/pm_histCapYearly.cs3r"
-$offdelim
-;
-$Onlisting
-
-
-
-
 *** historical PE installed capacity
 table p_PE_histCap(tall,all_regi,all_enty,all_enty) "historical installed capacity (TW)"
 $ondelim


### PR DESCRIPTION
## Purpose of this PR

With IRENA data available for 2025, we can retire some of the old estimations of the 2025 data. See https://github.com/pik-piam/mrremind/pull/848 for the updated data. 

## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :ballot_box_with_check: GAMS Code
- :white_medium_square: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :ballot_box_with_check: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :white_medium_square: Bug fix
- :white_medium_square: Refactoring
- :white_medium_square: New feature
- :ballot_box_with_check: Change of parameter values or input data (including CES parameters)
- :ballot_box_with_check: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

Here are plots up to 2035 with two runs before (irena2025) and after (irena2026) the change each for SSP2-NPi2025:
[compScen-2026-09-02_18.48.36-H12-to2035.pdf](https://github.com/user-attachments/files/31777068/compScen-2026-09-02_18.48.36-H12-to2035.pdf)
<img width="1532" height="1051" alt="image" src="https://github.com/user-attachments/assets/297b7c50-6b98-4ef4-9a90-f91f696706f4" />
<img width="1511" height="1003" alt="image" src="https://github.com/user-attachments/assets/9a43a29b-33f5-4a36-9056-b14a7799c4f3" />
