### PR TITLE
integrate SCI evaluation by making validation report selectable in output scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,10 @@ compScen-*.err
 compScen-*.out
 compScen-*/*
 
+# Ignore validation reports
+validation_*.html
+valScen*.out
+
 # Ignore everything in "doc" folders, except for 3 specific files
 doc/
 !doc/literature.bib

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **scripts** Add the possibility to build only some sections of the compareScenarios2 report with `--sections=`
     [[#2415](https://github.com/remindmodel/remind/pull/2415)]
 - **47_regipol** New (optional) quantity targets for limiting PE lignocellulosic biomass
+- **scripts** Add report template selection to the `validateScenarios` output script: users can now choose a report (e.g. the SCI evaluation) from `piamValidation` in addition to the validation config
+    [[#2456](https://github.com/remindmodel/remind/pull/2456)]
 
 ### removed
 -

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,6 +26,7 @@ Imports:
     gdxdt,
     gdxrrw,
     ggplot2,
+    glue,
     gms (>= 0.33.4),
     goxygen (>= 1.4.4),
     gridExtra,

--- a/scripts/output/comparison/validateScenarios.R
+++ b/scripts/output/comparison/validateScenarios.R
@@ -6,109 +6,108 @@
 # |  Contact: remind@pik-potsdam.de
 
 
-  source("./scripts/start/isSlurmAvailable.R")
+source("./scripts/start/isSlurmAvailable.R")
 
-  # This script expects a variable `outputdirs` to be defined.
-  # Variables `slurmConfig` and `filename_prefix` are used if they defined.
-  if (!exists("outputdirs")) {
-    stop(
-      "Variable outputdirs does not exist. ",
-      "Please call validateScenarios.R via output.R, which defines outputdirs.")
+# This script expects a variable `outputdirs` to be defined.
+# Variables `slurmConfig` and `filename_prefix` are used if they defined.
+if (!exists("outputdirs")) {
+  stop(
+    "Variable outputdirs does not exist. ",
+    "Please call validateScenarios.R via output.R, which defines outputdirs.")
+}
+
+# Start validateScenarios
+startVal <- function(outputDirs, validationConfig, validationReportName) {
+  if (!exists("slurmConfig")) {
+    slurmConfig <- "--qos=standby"
   }
-
-  # Start validateScenarios
-  startVal <- function(outputDirs, validationConfig, validationReportName) {
-    if (!exists("slurmConfig")) {
-      slurmConfig <- "--qos=standby"
-    }
-    jobName <- paste0(
-      "valScen",
-      "-", nameCore
-    )
-    script <- "scripts/vs/run_validateScenarios.R"
-    cat("Starting ", jobName, "\n")
-    if (isSlurmAvailable() && ! identical(slurmConfig, "direct")) {
-      clcom <- paste0(
-        "sbatch ", slurmConfig,
-        " --job-name=", jobName,
-        " --comment=validateScenarios",
-        " --output=", jobName, ".out",
-        " --error=", jobName, ".out",
-        " --mail-type=END --time=200 --mem-per-cpu=8000",
-        " --wrap=\"Rscript ", script,
-        " --outputdirs=", shQuote(paste(outputDirs, collapse = ",")),
-        " --validationConfig=", shQuote(validationConfig),
-        " --validationReportName=", shQuote(validationReportName),
-        "\"")
-      cat(clcom, "\n")
-      system(clcom)
-    } else {
-      tmpEnv <- new.env()
-      tmpError <- try(sys.source(script, envir = tmpEnv))
-      if (!is.null(tmpError))
-        warning("Script ", script,
-                " was stopped by an error and not executed properly!")
-      rm(tmpEnv)
-    }
+  jobName  <- glue::glue("valScen-{nameCore}")
+  script <- "scripts/vs/run_validateScenarios.R"
+  cat("Starting ", jobName, "\n")
+  if (isSlurmAvailable() && ! identical(slurmConfig, "direct")) {
+    clcom <- paste0(
+      "sbatch ", slurmConfig,
+      " --job-name=", jobName,
+      " --comment=validateScenarios",
+      " --output=", jobName, ".out",
+      " --error=", jobName, ".out",
+      " --mail-type=END --time=200 --mem-per-cpu=8000",
+      " --wrap=\"Rscript ", script,
+      " --outputdirs=", shQuote(paste(outputDirs, collapse = ",")),
+      " --validationConfig=", shQuote(validationConfig),
+      " --validationReportName=", shQuote(validationReportName),
+      "\"")
+    cat(clcom, "\n")
+    system(clcom)
+  } else {
+    tmpEnv <- new.env()
+    tmpError <- try(sys.source(script, envir = tmpEnv))
+    if (!is.null(tmpError))
+      warning("Script ", script,
+              " was stopped by an error and not executed properly!")
+    rm(tmpEnv)
   }
+}
 
-  # let the user pick an entry from the package or provide an own file
-  chooseFromPackageOrFile <- function(available, type, fileHint, userinfo = NULL) {
-    ownFile <- paste0("enter path to own file (", fileHint, ")")
-    choice <- gms::chooseFromList(c(available, ownFile),
-                                  type = type,
-                                  userinfo = userinfo,
-                                  multiple = FALSE)
-    if (length(choice) == 0) return("")
-    if (identical(choice, ownFile)) {
-      message("Path to own file (", fileHint, "):")
-      choice <- normalizePath(gms::getLine(), mustWork = FALSE)
-      if (!file.exists(choice)) stop("File not found: ", choice)
-    }
-    choice
+# let the user pick an entry from the package or provide an own file
+chooseFromPackageOrFile <- function(available, type, fileHint, userinfo = NULL) {
+  ownFile <- paste0("enter path to own file (", fileHint, ")")
+  choice <- gms::chooseFromList(c(available, ownFile),
+                                type = type,
+                                userinfo = userinfo,
+                                multiple = FALSE)
+  if (length(choice) == 0) return("")
+  if (identical(choice, ownFile)) {
+    message("Path to own file (", fileHint, "):")
+    choice <- normalizePath(gms::getLine(), mustWork = FALSE)
+    if (!file.exists(choice)) stop("File not found: ", choice)
   }
+  choice
+}
 
-  # choose a config from the package or an own file
-  if (! exists("validationConfig")) {
-    validationConfig <- chooseFromPackageOrFile(
-      piamValidation::listConfigs(),
-      type = "a validation config",
-      fileHint = ".csv/.xlsx",
-      userinfo = "Leave empty to abort.")
-    if (validationConfig == "") {
-      q()
-    }
+# choose a config from the package or an own file
+if (! exists("validationConfig")) {
+  validationConfig <- chooseFromPackageOrFile(
+    piamValidation::listConfigs(),
+    type = "a validation config",
+    fileHint = ".csv/.xlsx",
+    userinfo = "Leave empty to abort.")
+  if (validationConfig == "") {
+    q()
   }
-  # strip prefix/suffix in case validationConfig was predefined as file name
-  if (!file.exists(validationConfig)) {
-    validationConfig <- gsub("\\.csv$", "",
-                             gsub("^validationConfig_", "", validationConfig))
+}
+# strip prefix/suffix in case validationConfig was predefined as file name
+if (!file.exists(validationConfig)) {
+  validationConfig <- gsub("\\.csv$", "",
+                            gsub("^validationConfig_", "", validationConfig))
+}
+
+# choose a report template from the package or an own file
+if (! exists("validationReportName")) {
+  validationReportName <- chooseFromPackageOrFile(
+    piamValidation::listReports(),
+    type = "a validation report template",
+    fileHint = ".Rmd",
+    userinfo = "Leave empty for the default report.")
+  if (validationReportName == "") {
+    validationReportName <- "default"
+    message("Default: default report template.\n")
   }
+}
 
-  # choose a report template from the package or an own file
-  if (! exists("validationReportName")) {
-    validationReportName <- chooseFromPackageOrFile(
-      piamValidation::listReports(),
-      type = "a validation report template",
-      fileHint = ".Rmd",
-      userinfo = "Leave empty for the default report.")
-    if (validationReportName == "") {
-      validationReportName <- "default"
-      message("Default: default report template.\n")
-    }
-  }
+# Create core of file name / job name, "custom" for user-provided files.
+timeStamp <- format(Sys.time(), "%Y-%m-%d_%H.%M.%S")
+if (!exists("filename_prefix")) filename_prefix <- ""
+valName <- if (file.exists(validationConfig)) "custom" else validationConfig
 
-  # Create core of file name / job name, "custom" for user-provided files.
-  timeStamp <- format(Sys.time(), "%Y-%m-%d_%H.%M.%S")
-  if (!exists("filename_prefix")) filename_prefix <- ""
-  valName <- if (file.exists(validationConfig)) "custom" else validationConfig
-  repInfix <- if (identical(validationReportName, "default")) "" else paste0(
-    "-", if (file.exists(validationReportName)) "custom" else validationReportName)
-  nameCore <- paste0(filename_prefix, ifelse(filename_prefix == "", "", "-"),
-                     valName, repInfix, "-", timeStamp)
+reportName <- if (file.exists(validationReportName)) "custom" else validationReportName
+repInfix   <- if (identical(validationReportName, "default")) "" else glue::glue("-{reportName}")
+prefix     <- if (filename_prefix == "") "" else glue::glue("{filename_prefix}-")
 
-  # Start the job
-    startVal(
-      outputDirs = outputdirs,
-      validationConfig = validationConfig,
-      validationReportName = validationReportName)
+nameCore <- glue::glue("{prefix}{valName}{repInfix}-{timeStamp}")
+
+# Start the job
+  startVal(
+    outputDirs = outputdirs,
+    validationConfig = validationConfig,
+    validationReportName = validationReportName)

--- a/scripts/output/comparison/validateScenarios.R
+++ b/scripts/output/comparison/validateScenarios.R
@@ -25,7 +25,6 @@
       "valScen",
       "-", nameCore
     )
-    outFileName <- jobName
     script <- "scripts/vs/run_validateScenarios.R"
     cat("Starting ", jobName, "\n")
     if (isSlurmAvailable() && ! identical(slurmConfig, "direct")) {
@@ -37,9 +36,9 @@
         " --error=", jobName, ".out",
         " --mail-type=END --time=200 --mem-per-cpu=8000",
         " --wrap=\"Rscript ", script,
-        " outputdirs=", paste(outputDirs, collapse = ","),
-        " validationConfig=", validationConfig,
-        " validationReportName=", validationReportName,
+        " --outputdirs=", shQuote(paste(outputDirs, collapse = ",")),
+        " --validationConfig=", shQuote(validationConfig),
+        " --validationReportName=", shQuote(validationReportName),
         "\"")
       cat(clcom, "\n")
       system(clcom)
@@ -53,37 +52,63 @@
     }
   }
 
-  # choose a config file either from the package or your own
-  if (! exists("validationConfig")) {
-    config <- gms::chooseFromList(piamValidation::listConfigs(),
-                                  type = "a validation config",
+  # let the user pick an entry from the package or provide an own file
+  chooseFromPackageOrFile <- function(available, type, fileHint, userinfo = NULL) {
+    ownFile <- paste0("enter path to own file (", fileHint, ")")
+    choice <- gms::chooseFromList(c(available, ownFile),
+                                  type = type,
+                                  userinfo = userinfo,
                                   multiple = FALSE)
-    if (config == "") {
+    if (length(choice) == 0) return("")
+    if (identical(choice, ownFile)) {
+      message("Path to own file (", fileHint, "):")
+      choice <- normalizePath(gms::getLine(), mustWork = FALSE)
+      if (!file.exists(choice)) stop("File not found: ", choice)
+    }
+    choice
+  }
+
+  # choose a config from the package or an own file
+  if (! exists("validationConfig")) {
+    validationConfig <- chooseFromPackageOrFile(
+      piamValidation::listConfigs(),
+      type = "a validation config",
+      fileHint = ".csv/.xlsx",
+      userinfo = "Leave empty to abort.")
+    if (validationConfig == "") {
       q()
-    } else {
-      validationConfig <- config
+    }
+  }
+  # strip prefix/suffix in case validationConfig was predefined as file name
+  if (!file.exists(validationConfig)) {
+    validationConfig <- gsub("\\.csv$", "",
+                             gsub("^validationConfig_", "", validationConfig))
+  }
+
+  # choose a report template from the package or an own file
+  if (! exists("validationReportName")) {
+    validationReportName <- chooseFromPackageOrFile(
+      piamValidation::listReports(),
+      type = "a validation report template",
+      fileHint = ".Rmd",
+      userinfo = "Leave empty for the default report.")
+    if (validationReportName == "") {
+      validationReportName <- "default"
+      message("Default: default report template.\n")
     }
   }
 
-  # choose a report template from the package, empty selection uses default
-  if (! exists("validationReportName")) {
-    validationReportName <- gms::chooseFromList(
-      piamValidation::listReports(),
-      type = "a validation report template (leave empty for default)",
-      multiple = FALSE)
-    if (identical(validationReportName, "")) validationReportName <- "default"
-  }
-
-  # Create core of file name / job name.
+  # Create core of file name / job name, "custom" for user-provided files.
   timeStamp <- format(Sys.time(), "%Y-%m-%d_%H.%M.%S")
-  # strip prefix/suffix in case validationConfig was predefined as file name
-  valName <- gsub("\\.csv$", "", gsub("^validationConfig_", "", validationConfig))
-  repInfix <- if (validationReportName == "default") "" else
-    paste0("-", validationReportName)
-  nameCore <- paste0(valName, repInfix, "-", timeStamp)
+  if (!exists("filename_prefix")) filename_prefix <- ""
+  valName <- if (file.exists(validationConfig)) "custom" else validationConfig
+  repInfix <- if (identical(validationReportName, "default")) "" else paste0(
+    "-", if (file.exists(validationReportName)) "custom" else validationReportName)
+  nameCore <- paste0(filename_prefix, ifelse(filename_prefix == "", "", "-"),
+                     valName, repInfix, "-", timeStamp)
 
   # Start the job
     startVal(
       outputDirs = outputdirs,
-      validationConfig = valName,
+      validationConfig = validationConfig,
       validationReportName = validationReportName)

--- a/scripts/output/comparison/validateScenarios.R
+++ b/scripts/output/comparison/validateScenarios.R
@@ -17,7 +17,7 @@ if (!exists("outputdirs")) {
 }
 
 # Start validateScenarios
-startVal <- function(outputDirs, validationConfig, validationReportName) {
+startVal <- function(outputDirs, validationConfig, validationReportName, nameCore) {
   if (!exists("slurmConfig")) {
     slurmConfig <- "--qos=standby"
   }
@@ -110,4 +110,5 @@ nameCore <- glue::glue("{prefix}{valName}{repInfix}-{timeStamp}")
   startVal(
     outputDirs = outputdirs,
     validationConfig = validationConfig,
-    validationReportName = validationReportName)
+    validationReportName = validationReportName,
+    nameCore = nameCore)

--- a/scripts/output/comparison/validateScenarios.R
+++ b/scripts/output/comparison/validateScenarios.R
@@ -17,7 +17,7 @@
   }
 
   # Start validateScenarios
-  startVal <- function(outputDirs, validationConfig) {
+  startVal <- function(outputDirs, validationConfig, validationReportName) {
     if (!exists("slurmConfig")) {
       slurmConfig <- "--qos=standby"
     }
@@ -39,6 +39,7 @@
         " --wrap=\"Rscript ", script,
         " outputdirs=", paste(outputDirs, collapse = ","),
         " validationConfig=", validationConfig,
+        " validationReportName=", validationReportName,
         "\"")
       cat(clcom, "\n")
       system(clcom)
@@ -54,9 +55,7 @@
 
   # choose a config file either from the package or your own
   if (! exists("validationConfig")) {
-    availableConfigs <- list.files(
-      piamutils::getSystemFile("config/", package = "piamValidation"))
-    config <- gms::chooseFromList(availableConfigs,
+    config <- gms::chooseFromList(piamValidation::listConfigs(),
                                   type = "a validation config",
                                   multiple = FALSE)
     if (config == "") {
@@ -66,12 +65,25 @@
     }
   }
 
+  # choose a report template from the package, empty selection uses default
+  if (! exists("validationReportName")) {
+    validationReportName <- gms::chooseFromList(
+      piamValidation::listReports(),
+      type = "a validation report template (leave empty for default)",
+      multiple = FALSE)
+    if (identical(validationReportName, "")) validationReportName <- "default"
+  }
+
   # Create core of file name / job name.
   timeStamp <- format(Sys.time(), "%Y-%m-%d_%H.%M.%S")
-  valName <- gsub(".csv", "", gsub("validationConfig_", "", validationConfig))
-  nameCore <- paste0(valName, "-", timeStamp)
+  # strip prefix/suffix in case validationConfig was predefined as file name
+  valName <- gsub("\\.csv$", "", gsub("^validationConfig_", "", validationConfig))
+  repInfix <- if (validationReportName == "default") "" else
+    paste0("-", validationReportName)
+  nameCore <- paste0(valName, repInfix, "-", timeStamp)
 
   # Start the job
     startVal(
       outputDirs = outputdirs,
-      validationConfig = valName)
+      validationConfig = valName,
+      validationReportName = validationReportName)

--- a/scripts/vs/run_validateScenarios.R
+++ b/scripts/vs/run_validateScenarios.R
@@ -28,7 +28,8 @@ if (grepl("^SCI(_|$)", validationConfig)) {
 
 # option 1: HTML validation Report
 piamValidation::validationReport(dataPath, validationConfig,
-                                 report = validationReportName)
+                                 report = validationReportName,
+                                 outputDir = ".")
 
 # option 3: export data (TODO: file location + name)
 valiData <- piamValidation::validateScenarios(dataPath, validationConfig)

--- a/scripts/vs/run_validateScenarios.R
+++ b/scripts/vs/run_validateScenarios.R
@@ -30,10 +30,10 @@ if (grepl("^SCI(_|$)", validationConfig)) {
 piamValidation::validationReport(dataPath, validationConfig,
                                  report = validationReportName,
                                  outputDir = ".")
+# ToDo: other output options
 
-# option 3: export data (TODO: file location + name)
-valiData <- piamValidation::validateScenarios(dataPath, validationConfig)
-cat(getwd())
+# option 2: export data
+#valiData <- piamValidation::validateScenarios(dataPath, validationConfig)
 
-# option 2: pass or fail?
-piamValidation::validationPass(valiData)
+# option 3: pass or fail?
+#piamValidation::validationPass(valiData)

--- a/scripts/vs/run_validateScenarios.R
+++ b/scripts/vs/run_validateScenarios.R
@@ -7,21 +7,33 @@
 
 library(piamValidation)
 
-lucode2::readArgs("outputdirs", "validationConfig")
+# default report template, overwritten by a command line argument or by the
+# calling environment when this script is sourced directly
+if (!exists("validationReportName")) validationReportName <- "default"
+
+lucode2::readArgs("outputdirs", "validationConfig", "validationReportName")
 
 # working directory is assumed to be the remind directory
 outputdirs <- normalizePath(outputdirs, mustWork = TRUE)
 mifPath <- remind2::getMifScenPath(outputdirs, mustWork = TRUE)
 histPath <- remind2::getMifHistPath(outputdirs[1], mustWork = TRUE)
+dataPath <- c(mifPath, histPath)
+
+# SCI configs are evaluated against reference data shipped with piamValidation,
+# e.g. config "SCI_REMIND_2026.8.3" -> "SCI_reference_data_REMIND_2026.8.3.rds"
+if (grepl("^SCI(_|$)", validationConfig)) {
+  dataPath <- c(dataPath, piamutils::getSystemFile(
+    paste0("extdata/", sub("^SCI", "SCI_reference_data", validationConfig), ".rds"),
+    package = "piamValidation", mustWork = TRUE))
+}
 
 # option 1: HTML validation Report
-piamValidation::validationReport(c(mifPath, histPath), validationConfig)
+piamValidation::validationReport(dataPath, validationConfig,
+                                 report = validationReportName)
 
 # option 3: export data (TODO: file location + name)
-valiData <- piamValidation::validateScenarios(c(mifPath, histPath), validationConfig)
+valiData <- piamValidation::validateScenarios(dataPath, validationConfig)
 cat(getwd())
 
 # option 2: pass or fail?
 piamValidation::validationPass(valiData)
-
-

--- a/scripts/vs/run_validateScenarios.R
+++ b/scripts/vs/run_validateScenarios.R
@@ -7,11 +7,10 @@
 
 library(piamValidation)
 
-# default report template, overwritten by a command line argument or by the
-# calling environment when this script is sourced directly
+if (!exists("source_include")) {
+  lucode2::readArgs("outputdirs", "validationConfig", "validationReportName")
+}
 if (!exists("validationReportName")) validationReportName <- "default"
-
-lucode2::readArgs("outputdirs", "validationConfig", "validationReportName")
 
 # working directory is assumed to be the remind directory
 outputdirs <- normalizePath(outputdirs, mustWork = TRUE)

--- a/tutorials/05_AnalysingModelOutputs.md
+++ b/tutorials/05_AnalysingModelOutputs.md
@@ -166,9 +166,9 @@ In both cases, you can choose from the list of available model scenarios, for wh
 
 Now, the selected scripts are executed. After completion, the results are written in the respective folder of the run (combination of **model title** name and the **current date** inside the **output** folder of the model).
 
-One recommended script for comparison of different scenarios is `compareScenarios2`, see [the specific tutorial](https://pik-piam.r-universe.dev/articles/remind2/compareScenariosRemind2.html). After you selected folder names, specified a `filename_prefix`, the priority on the cluster, and a *profile* (describes some output parameters) it produces a large PDF (or HTML if a respective profile is chosen) in the `./remind/` folder.
+#### CompareScenarios
 
-Another useful script it `validateScenarios`, which performs an automated check of the scenario data against thresholds defined in a `validationConfig` and returns an html report with interactive heat maps in a traffic-light evaluation format. After choosing `validateScenarios` as a `comparison` script, you are prompted to select one of the configs that are shipped with the `piamValidation` package. The `default` config is a good starting point for any REMIND run and the `AMT` config is specifically tailored towards the automated model testruns. If you want to perform a more personalized validation, follow the instructions in the [vignette](https://pik-piam.r-universe.dev/articles/piamValidation/validateScenarios.html).
+One recommended script for comparison of different scenarios is `compareScenarios2`, see [the specific tutorial](https://pik-piam.r-universe.dev/articles/remind2/compareScenariosRemind2.html). After you selected folder names, specified a `filename_prefix`, the priority on the cluster, and a *profile* (describes some output parameters) it produces a large PDF (or HTML if a respective profile is chosen) in the `./remind/` folder.
 
 You can also specify the parameters in the command line, for example starting a `compareScenario2` run without any prefix as:
 
@@ -179,6 +179,18 @@ If you want to compare runs from different REMIND folders, add `--remind_dir=.,.
 
 How to create new plots is described in the tutorial [8_Advanced_AnalysingModelOutputs.Rmd](./08_Advanced_AnalysingModelOutputs.Rmd).
 Another useful and compatible resource for generating plots (e.g. box plots) from REMIND results is UTokyo's *mipplot* R package: https://github.com/UTokyo-mip/mipplot.
+
+#### ValidateScenarios
+
+Another useful script it `validateScenarios`, which performs an automated check of the scenario data against thresholds defined in a `validationConfig` and returns an html report with interactive heat maps in a traffic-light evaluation format. After choosing `validateScenarios` as a `comparison` script, you are prompted to select one of the validation configs and report templates that are shipped with the `piamValidation` package or specify the path to a config or report of your choosing.
+
+The validation config defines the checks which will be performed on the scenario data, while the report template defines the visualizations in the html output file.
+
+- The `AMT` config is a good starting point for any REMIND run and usually contains the latest near-term estimates based on most recent third party data releases.
+- The `SCI_REMIND` config performs the exact checks as defined by the [Scenario Compass Initiative evaluation](https://scenario-evaluation-criteria.iamconsortium.org/stable/). Selecting the respective `SCI_REMIND` report will render an html document tailored to those checks, including a summary of which scenarios fail or pass the evaluation. If you want to perform the SCI evaluation on scenarios using the SCI variable names (following the [common-definitions](https://github.com/IAMconsortium/common-definitions) template), use the `SCI` config and report.
+
+For any further questions or if you want to perform a more personalized validation, take a look at the [documentation](https://pik-piam.github.io/piamValidation/index.html) of `piamValidation` or follow the instructions in the [vignette](https://pik-piam.r-universe.dev/articles/piamValidation/validateScenarios.html).
+
 
 ## 6. Analysis of outputs with the remind2 R package
 


### PR DESCRIPTION
## Purpose of this PR

Allow running the SCI evaluation via output scripts by adding the option to select report templates and testing reference data availability.

The original SCI data is taken from a specified release of [scenario-evaluation-criteria](https://github.com/IAMconsortium/scenario-evaluation-criteria/) (currently 2026.8.3), translated via [``piamValidation::convertSCIcriteria()``](https://github.com/pweigmann/piamValidation/blob/SCI/R/convertSCIcriteria.R) and saved as config and external data in piamValidation. 

The REMIND output script allows you to apply the SCI criteria to a set of REMIND runs either using the SCI or REMIND variable names and creates an html report which shows you the outcome for all scenarios.

Use via
``Rscript output.R``
 -> ``comparison across runs`` 
-> ``validateScenarios`` 
-> select your run(s)
-> select slurm (short is fine) 
-> select validation config:
--> ``SCI_2026.8.3`` for common-definition variables
--> ``SCI_REMIND_2026.8.3`` for REMIND variables (probably what you want here)
-> select validation report: ``SCI`` or ``SCI_REMIND`` depending on what you chose in the step before

## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :white_medium_square: GAMS Code
- :ballot_box_with_check: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :white_medium_square: Bug fix
- :white_medium_square: Refactoring
- :ballot_box_with_check: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

* Runs with these changes are here: /p/tmp/pascalwe/remind
