### PR TITLE
Diagnostic plotting for MAgPIE coupling: Don't fail if there is no data to plot

### DIFF
--- a/scripts/output/comparison/plotRemMagNash.R
+++ b/scripts/output/comparison/plotRemMagNash.R
@@ -32,6 +32,11 @@ if (!exists("source_include")) lucode2::readArgs("outputdirs")
 # Plot dimension specified for 'color' over dimension specified for 'xaxis' as line plot or bar plot
 myplot <- function(dat, parName, runName, type = "line", xaxis = "ttot", color = "iteration", scales = "free_y", ylab = NULL, title = "auto") {
   
+  if (nrow(dat |> filter(par %in% parName)) == 0) {
+    message(paste0("No data for ", parName, " in run ", runName$outputdirs))
+    return(NULL)
+  }
+
   # Find last (continuous) iteration per outputDir
   if("outputdirs" %in% names(dat)) last <- dat |> group_by(outputdirs) |> summarise(iteration = max(iteration))
   
@@ -157,7 +162,8 @@ plot_iterations <- function(dat, runname) {
     "```{r plots, results='asis'}",
     "# `plots` is provided by plot_iterations() via the render environment.",
     "for (i in seq_along(plots)) {",
-    "  print(plots[[i]])",
+    "  # Only plot if plot could be generated correctly",
+    "  if (inherits(plots[[i]], 'ggplot')) print(plots[[i]]) ",
     "  if (i %% 2 == 1) {",
     "    # First figure on the page: stretchable space pushes this figure to",
     "    # the top margin and the next one to the bottom margin.",

--- a/scripts/output/comparison/plotRemMagNash.R
+++ b/scripts/output/comparison/plotRemMagNash.R
@@ -32,9 +32,12 @@ if (!exists("source_include")) lucode2::readArgs("outputdirs")
 # Plot dimension specified for 'color' over dimension specified for 'xaxis' as line plot or bar plot
 myplot <- function(dat, parName, runName, type = "line", xaxis = "ttot", color = "iteration", scales = "free_y", ylab = NULL, title = "auto") {
   
-  if (nrow(dat |> filter(par %in% parName)) == 0) {
-    message(paste0("No data for ", parName, " in run ", runName$outputdirs))
-    return(NULL)
+ if (nrow(dat |> filter(ttot > 2000, par %in% parName)) == 0) {
+   message(paste0(
+     "No data for ", paste(parName, collapse = ", "),
+     " in run ", paste(unique(runName$outputdirs), collapse = ", ")
+   ))
+   return(NULL)
   }
 
   # Find last (continuous) iteration per outputDir

--- a/scripts/output/single/plotRemMagNash.R
+++ b/scripts/output/single/plotRemMagNash.R
@@ -31,10 +31,13 @@ outputdirs <- outputdir
 
 # Plot dimension specified for 'color' over dimension specified for 'xaxis' as line plot or bar plot
 myplot <- function(dat, parName, runName, type = "line", xaxis = "ttot", color = "iteration", scales = "free_y", ylab = NULL, title = "auto") {
-  
-  if (nrow(dat |> filter(par %in% parName)) == 0) {
-    message(paste0("No data for ", parName, " in run ", runName$outputdirs))
-    return(NULL)
+	
+ if (nrow(dat |> filter(ttot > 2000, par %in% parName)) == 0) {
+   message(paste0(
+     "No data for ", paste(parName, collapse = ", "),
+     " in run ", paste(unique(runName$outputdirs), collapse = ", ")
+   ))
+   return(NULL)
   }
 
   # Find last (continuous) iteration per outputDir

--- a/scripts/output/single/plotRemMagNash.R
+++ b/scripts/output/single/plotRemMagNash.R
@@ -32,6 +32,11 @@ outputdirs <- outputdir
 # Plot dimension specified for 'color' over dimension specified for 'xaxis' as line plot or bar plot
 myplot <- function(dat, parName, runName, type = "line", xaxis = "ttot", color = "iteration", scales = "free_y", ylab = NULL, title = "auto") {
   
+  if (nrow(dat |> filter(par %in% parName)) == 0) {
+    message(paste0("No data for ", parName, " in run ", runName$outputdirs))
+    return(NULL)
+  }
+
   # Find last (continuous) iteration per outputDir
   if("outputdirs" %in% names(dat)) last <- dat |> group_by(outputdirs) |> summarise(iteration = max(iteration))
   
@@ -157,7 +162,8 @@ plot_iterations <- function(dat, runname) {
     "```{r plots, results='asis'}",
     "# `plots` is provided by plot_iterations() via the render environment.",
     "for (i in seq_along(plots)) {",
-    "  print(plots[[i]])",
+    "  # Only plot if plot could be generated correctly",
+    "  if (inherits(plots[[i]], 'ggplot')) print(plots[[i]]) ",
     "  if (i %% 2 == 1) {",
     "    # First figure on the page: stretchable space pushes this figure to",
     "    # the top margin and the next one to the bottom margin.",


### PR DESCRIPTION
## Purpose of this PR

This PR updates the REMIND–MAgPIE coupling diagnostics plotting scripts (`plotRemMagNash.R`) so that missing data for a plotted parameter no longer aborts report generation, but instead skips the affected plot(s) and continues rendering the PDF.

**Changes:**
- Add an early-return guard in `myplot()` to skip plot generation when the requested parameter has no data.
- Update the inline rmarkdown template to avoid printing non-`ggplot` objects.

## Type of change

### Parts concerned
- :white_medium_square: GAMS Code
- :ballot_box_with_check: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :ballot_box_with_check: Bug fix
- :white_medium_square: Refactoring
- :white_medium_square: New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)