### PR TITLE
Add implicit quantity target option for total CDR

### DIFF
--- a/modules/47_regipol/none/not_used.txt
+++ b/modules/47_regipol/none/not_used.txt
@@ -86,3 +86,4 @@ vm_co2CCS,input,not needed
 cm_implicitPriceTarget_tolerance,input,not needed
 cm_implicitPePriceTarget_tolerance,input,not needed
 vm_emiCdrNovel,input,not needed
+vm_emiCdrAll,input,not needed

--- a/modules/47_regipol/none/not_used.txt
+++ b/modules/47_regipol/none/not_used.txt
@@ -86,4 +86,3 @@ vm_co2CCS,input,not needed
 cm_implicitPriceTarget_tolerance,input,not needed
 cm_implicitPePriceTarget_tolerance,input,not needed
 vm_emiCdrNovel,input,not needed
-vm_emiCdrAll,input,not needed

--- a/modules/47_regipol/regiCarbonPrice/datainput.gms
+++ b/modules/47_regipol/regiCarbonPrice/datainput.gms
@@ -157,6 +157,7 @@ $endif.cm_implicitQttyTargetType
   pm_implicitQttyTarget(ttot,ext_regi,taxType,targetType,"CCS",qttyTargetGroup)$pm_implicitQttyTarget(ttot,ext_regi,taxType,targetType,"CCS",qttyTargetGroup) = pm_implicitQttyTarget(ttot,ext_regi,taxType,targetType,"CCS",qttyTargetGroup)/(sm_c_2_co2*1000);
   pm_implicitQttyTarget(ttot,ext_regi,taxType,targetType,"oae",qttyTargetGroup)$pm_implicitQttyTarget(ttot,ext_regi,taxType,targetType,"oae",qttyTargetGroup) = pm_implicitQttyTarget(ttot,ext_regi,taxType,targetType,"oae",qttyTargetGroup)/(sm_c_2_co2*1000);
   pm_implicitQttyTarget(ttot,ext_regi,taxType,targetType,"novelCDR",qttyTargetGroup)$pm_implicitQttyTarget(ttot,ext_regi,taxType,targetType,"novelCDR",qttyTargetGroup) = pm_implicitQttyTarget(ttot,ext_regi,taxType,targetType,"novelCDR",qttyTargetGroup)/(sm_c_2_co2*1000);
+  pm_implicitQttyTarget(ttot,ext_regi,taxType,targetType,"allCDR",qttyTargetGroup)$pm_implicitQttyTarget(ttot,ext_regi,taxType,targetType,"allCDR",qttyTargetGroup) = pm_implicitQttyTarget(ttot,ext_regi,taxType,targetType,"allCDR",qttyTargetGroup)/(sm_c_2_co2*1000);
 	p47_implicitQttyTargetTax0(t,all_regi) = 0;
 $endIf.cm_implicitQttyTarget
 

--- a/modules/47_regipol/regiCarbonPrice/equations.gms
+++ b/modules/47_regipol/regiCarbonPrice/equations.gms
@@ -40,6 +40,10 @@ q47_implicitQttyTargetTax(t,regi)$(t.val ge max(2010,cm_startyear))..
     (
       p47_implicitQttyTargetTax(t,regi,qttyTarget,qttyTargetGroup) * (vm_emiCdrNovel(t,regi))
     )$(sameas(qttyTarget,"novelCDR"))
+          +
+    (
+      p47_implicitQttyTargetTax(t,regi,qttyTarget,qttyTargetGroup) * (vm_emiCdrAll(t,regi))
+    )$(sameas(qttyTarget,"allCDR"))
   )
   -
   p47_implicitQttyTargetTax0(t,regi)

--- a/modules/47_regipol/regiCarbonPrice/postsolve.gms
+++ b/modules/47_regipol/regiCarbonPrice/postsolve.gms
@@ -512,6 +512,9 @@ p47_implicitQttyTargetTax0(t,regi) =
       (vm_emiCdrNovel.l(t,regi)
       )$(sameas(qttyTarget,"novelCDR") AND sameas(qttyTargetGroup,"all"))
       +
+      (vm_emiCdrAll.l(t,regi)
+      )$(sameas(qttyTarget,"allCDR") AND sameas(qttyTargetGroup,"all"))
+      +      
       (( !! Supply side BECCS
         sum(emiBECCS2te(enty,enty2,te,enty3),vm_emiTeDetail.l(t,regi,enty,enty2,te,enty3))
         !! Industry BECCS (using biofuels in Industry with CCS)
@@ -553,9 +556,12 @@ loop((ttot,ext_regi,taxType,targetType,qttyTarget,qttyTargetGroup)$pm_implicitQt
       ( sum(regi$regi_groupExt(ext_regi,regi), sum(te_oae33, -vm_emiCdrTeDetail.l(ttot,regi,te_oae33)))
       )$(sameas(qttyTarget,"oae") AND sameas(qttyTargetGroup,"all"))
       +
-       ( sum(regi$regi_groupExt(ext_regi,regi), vm_emiCdrNovel.l(ttot,regi))
+      ( sum(regi$regi_groupExt(ext_regi,regi), vm_emiCdrNovel.l(ttot,regi))
       )$(sameas(qttyTarget,"novelCDR") AND sameas(qttyTargetGroup,"all"))
       +
+      ( sum(regi$regi_groupExt(ext_regi,regi), vm_emiCdrAll.l(ttot,regi))
+      )$(sameas(qttyTarget,"allCDR") AND sameas(qttyTargetGroup,"all"))
+      +      
       sum(regi$regi_groupExt(ext_regi,regi), ( !! Supply side BECCS
         sum(emiBECCS2te(enty,enty2,te,enty3),vm_emiTeDetail.l(ttot,regi,enty,enty2,te,enty3))
         !! Industry BECCS (using biofuels in Industry with CCS)

--- a/modules/47_regipol/regiCarbonPrice/presolve.gms
+++ b/modules/47_regipol/regiCarbonPrice/presolve.gms
@@ -71,6 +71,8 @@ p47_implicitQttyTargetTax0(t,regi) =
       +
       (vm_emiCdrNovel.l(t,regi)) $ (sameas(qttyTarget,"novelCDR") AND sameas(qttyTargetGroup,"all"))
       +
+      (vm_emiCdrAll.l(t,regi)) $ (sameas(qttyTarget,"allCDR") AND sameas(qttyTargetGroup,"all"))
+      +
       (( !! Supply side BECCS
         sum(emiBECCS2te(enty,enty2,te,enty3),vm_emiTeDetail.l(t,regi,enty,enty2,te,enty3))
         !! Industry BECCS (using biofuels in Industry with CCS)

--- a/modules/47_regipol/regiCarbonPrice/sets.gms
+++ b/modules/47_regipol/regiCarbonPrice/sets.gms
@@ -59,6 +59,7 @@ qttyTarget "quantity target for energy carrier level (primary, secondary, final 
   CCS             "carbon capture and storage"
   oae             "ocean alkalinity enhancement"
   novelCDR         "novel carbon dioxide removal"
+  allCDR          "all CDR including negative LUC emissions"
 /
 
 qttyTargetGroup "quantity target aggregated categories"


### PR DESCRIPTION
## Purpose of this PR

This PR adds the possibility to control total CDR (respecting the fixed contribution of negative LUC emissions) in addition to novel CDR (BECCS, DACCS, OAE, biochar, ERW - all REMIND technologies) using `cm_implicitQttyTarget` in combination with `cm_implicitQttyTargetType` = config.

This PR does not change any default scenarios, but adds utility for project specific scenario design. 

**How to use it?**
A global target on total CDR of 5 GtCO2/yr in 2050 can be set with 
`cm_implicitQttyTarget` ->  2050.GLO.tax.t.allCDR.all 5000

and for a EU+UK target on novel CDR of 300 Mt like this
`cm_implicitQttyTarget` ->  2050.EUR_regi.tax.t.allCDR.all 300

Note that this will overwrite any cm_implicitQttyTarget scenario settings that were predefined.


## Type of change

*Indicate the items relevant for your PR by replacing* :white_medium_square: *with* :ballot_box_with_check:.\
*Do not delete any lines. This makes it easier to understand which areas are affected by your changes and which are not.*

### Parts concerned
- :ballot_box_with_check:.\ GAMS Code
- :white_medium_square: R-scripts
- :white_medium_square: Documentation (GAMS incode documentation, comments, tutorials)
- :white_medium_square: Input data / CES parameters
- :white_medium_square: Tests, CI/CD (continuous integration/deployment)
- :white_medium_square: Configuration (switches in main.gms, default.cfg, and scenario_config*.csv files)
- :white_medium_square: Other (please give a description)

### Impact
- :white_medium_square: Bug fix
- :white_medium_square: Refactoring
- :ballot_box_with_check:.\ New feature
- :white_medium_square: Change of parameter values or input data (including CES parameters)
- :white_medium_square: Minor change (default scenarios show only small differences)
- :white_medium_square: Fundamental change of results of default scenarios

## Checklist

*Do not delete any line. Leave **unfinished** elements unchecked so others know how far along you are.\
In the end all checkboxes must be ticked before you can merge*.

- [x] **I executed the automated model tests (`make test`) after my final commit and all tests pass (`FAIL 0`)**
- [x] **I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) if and where it was needed**
- [x] **I adjusted the madrat packages (mrremind and other packages involved) for input data generation if and where it was needed**
- [x] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [x] I explained my changes within the PR, particularly in hard-to-understand areas
- [x] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [x] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [x] I updated the `CHANGELOG.md` [correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog) (added, changed, fixed, removed, input data/calibration)

## Further information (optional)

* Runs with these changes are here:
* Comparison of results (what changes by this PR?): 
